### PR TITLE
feat: add support for shutdownGracePeriod and shutdownGracePeriodCriticalPods

### DIFF
--- a/pkg/apis/crds/karpenter.sh_machines.yaml
+++ b/pkg/apis/crds/karpenter.sh_machines.yaml
@@ -68,6 +68,16 @@ spec:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits.
                     type: boolean
+                  shutdownGracePeriod:
+                    description: ShutdownGracePeriod specifies the total duration
+                      that the node should delay the shutdown and total grace period
+                      for pod termination during a node shutdown.
+                    type: string
+                  shutdownGracePeriodCriticalPods:
+                    description: ShutdownGracePeriodCriticalPods specifies the duration
+                      used to terminate critical pods during a node shutdown.
+                      This should be less than ShutdownGracePeriod.
+                    type: string
                   evictionHard:
                     additionalProperties:
                       type: string

--- a/pkg/apis/crds/karpenter.sh_provisioners.yaml
+++ b/pkg/apis/crds/karpenter.sh_provisioners.yaml
@@ -71,6 +71,16 @@ spec:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits.
                     type: boolean
+                  shutdownGracePeriod:
+                    description: ShutdownGracePeriod specifies the total duration
+                      that the node should delay the shutdown and total grace period
+                      for pod termination during a node shutdown.
+                    type: string
+                  shutdownGracePeriodCriticalPods:
+                    description: ShutdownGracePeriodCriticalPods specifies the duration
+                      used to terminate critical pods during a node shutdown.
+                      This should be less than ShutdownGracePeriod.
+                    type: string
                   evictionHard:
                     additionalProperties:
                       type: string

--- a/pkg/apis/v1alpha5/machine.go
+++ b/pkg/apis/v1alpha5/machine.go
@@ -104,6 +104,12 @@ type KubeletConfiguration struct {
 	// CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
 	// +optional
 	CPUCFSQuota bool `json:"cpuCFSQuota,omitempty"`
+	// ShutdownGracePeriod specifies the total duration that the node should delay the shutdown and total grace period for pod termination during a node shutdown.
+	// +optional
+	ShutdownGracePeriod *string `json:"shutdownGracePeriod,omitempty"`
+	// ShutdownGracePeriodCriticalPods specifies the duration used to terminate critical pods during a node shutdown. This should be less than ShutdownGracePeriod.
+	// +optional
+	ShutdownGracePeriodCriticalPods *string `json:"shutdownGracePeriodCriticalPods,omitempty"`
 }
 
 type MachineTemplateRef struct {


### PR DESCRIPTION
`ALB (target-type: instance) -> nodeport -> pod` or `NLB -> pod` configuration is assumed.

For example, if you have an EKS cluster with vxlan etc. instead of IPAM mode: eni, this is the best practice.

If you have multiple Nodes that only have DaemonSet, you will naturally want to terminate them.
However, if you terminate them, the TCP connection from ELB -> Node to be terminated will be broken.

Therefore, the Node is removed from the target group in advance, but in the case of ALB, the currently connected connection can be maintained for up to 3600 seconds.
In other words, the survival period of a Node must be longer than the time to maintain the current connection.

Also, for example, if you are using NLB, you may want to keep a Node alive for a longer period of time if it has been used beyond the 3600 second barrier.
