### PR TITLE
fix: cloudprovider metrics for List()

### DIFF
--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -33,6 +33,9 @@ const (
 	metricLabelProvider   = "provider"
 )
 
+// decorator implements CloudProvider
+var _ cloudprovider.CloudProvider = (*decorator)(nil)
+
 var methodDurationHistogramVec = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
@@ -79,6 +82,11 @@ func (d *decorator) Delete(ctx context.Context, machine *v1alpha5.Machine) error
 func (d *decorator) Get(ctx context.Context, id string) (*v1alpha5.Machine, error) {
 	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "Get", d.Name()))()
 	return d.CloudProvider.Get(ctx, id)
+}
+
+func (d *decorator) List(ctx context.Context) ([]*v1alpha5.Machine, error) {
+	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "List", d.Name()))()
+	return d.CloudProvider.List(ctx)
 }
 
 func (d *decorator) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

This PR adds the cloudprovider metrics decorator to the `List()` method so that all methods of type CloudProvider have metrics foo. Not sure we expect the interface spec of `CloudProvider` to change, but we include the `var _` trick here to remind us if it does, that we want to evolve its metrics package as well.

**How was this change tested?**

There are no tests for cloudprovider metrics at present. Not manually tested.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
