### PR TITLE
chore: Fix getting suffix after first slash

### DIFF
--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -220,10 +220,8 @@ func editDistance(s, t string) int {
 }
 
 func getSuffix(key string) string {
-	if strings.Contains(key, "/") {
-		return strings.Split(key, "/")[1]
-	}
-	return key
+	before, after, found := strings.Cut(key, "/")
+	return lo.Ternary(found, after, before)
 }
 
 func labelHint(r Requirements, key string, allowedUndefined sets.Set[string]) string {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change fixes the `getSuffix` call implemented by #554 to only split after the first `/`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
