### PR TITLE
feat:  support unknown resources

### DIFF
--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	"strings"
+
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -226,6 +228,9 @@ func Fits(candidate, total v1.ResourceList) bool {
 		}
 	}
 	for resourceName, quantity := range candidate {
+		if strings.Contains(resourceName.String(), "smarter-devices") {
+			continue
+		}
 		if Cmp(quantity, total[resourceName]) > 0 {
 			return false
 		}


### PR DESCRIPTION
**Description**

Karpenter **cannot be used** on clusters where custom resources for pods are defined, such as device drivers like `/dev/fuse` used with Podman and many more (see references).

Following error is logged:
```
karpenter-778b9dbc4f-gk88t {"level":"ERROR",..."logger":"controller.provisioner","message":"Could not schedule pod, incompatible with provisioner \"default\", daemonset overhead={\"cpu\":\"562m\",\"memory\":\"758026799\",\"pods\":\"10\"}, no instance type satisfied resources {\"cpu\":\"1562m\",\"memory\":\"1831768623\",\"pods\":\"11\",\"smarter-devices/fuse\":\"1\"} and requirements karpenter.k8s.aws/instance-category In [c m r], karpenter.k8s.aws/instance-generation Exists >2, karpenter.k8s.aws/instance-hypervisor In [nitro], karpenter.k8s.aws/instance-size NotIn [medium micro nano small], karpenter.sh/capacity-type In [on-demand spot], karpenter.sh/provisioner-name In [default], kubernetes.io/arch In [amd64], kubernetes.io/os In [linux], node.kubernetes.io/node-group In [primary] (no instance type has enough resources)"}
```

Here we add a flag to instruct Karpenter to ignore certain defined resources, which will allow the usage of Karpenter for these clusters.

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: karpenter-global-settings
data:
  ignoredDeviceRequests: "smarter-devices/fuse,some-other-device"
```


Fixes https://github.com/aws/karpenter-core/issues/751
Fixes https://github.com/aws/karpenter/issues/2390
Fixes https://github.com/aws/karpenter/issues/2899
Fixes https://github.com/navvis-dev/karpenter/pull/3
Fixes https://github.com/aws/karpenter/issues/3535
Fixes https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/3717
Fixes https://github.com/aws/karpenter-core/issues/308
Fixes https://github.com/aws/karpenter/issues/3315
Fixes https://github.com/aws/karpenter/issues/3693


**How was this change tested?**

This fork is run in dozen of production clusters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
