### PR TITLE
feat: PreferNoSchedule taint on candidates for disruption

### DIFF
--- a/pkg/apis/v1beta1/taints.go
+++ b/pkg/apis/v1beta1/taints.go
@@ -16,20 +16,24 @@ package v1beta1
 
 import (
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 )
 
 // Karpenter specific taints
 const (
-	DisruptionTaintKey             = Group + "/disruption"
-	DisruptingNoScheduleTaintValue = "disrupting"
-	TerminationTaintKey            = Group + "/termination"
-	TerminationNoExecuteTaintValue = "Termination"
+	DisruptionTaintKey                  = Group + "/disruption"
+	DisruptingNoScheduleTaintValue      = "disrupting"
+	TerminationTaintKey                 = Group + "/termination"
+	TerminationNoExecuteTaintValue      = "termination"
+	CandidateTaintKey                   = Group + "/candidate"
+	CandidatePreferNoScheduleTaintValue = "candidate"
 )
 
 var TaintFuncs = map[v1.Taint]func(taint v1.Taint) bool{
-	DisruptionNoScheduleTaint: IsDisruptingTaint,
-	TerminationNoExecuteTaint: IsTerminatingTaint,
+	DisruptionNoScheduleTaint:      IsDisruptingTaint,
+	TerminationNoExecuteTaint:      IsTerminatingTaint,
+	CandidatePreferNoScheduleTaint: IsCandidateTaint,
 }
 
 var (
@@ -45,6 +49,11 @@ var (
 		Effect: v1.TaintEffectNoExecute,
 		Value:  TerminationNoExecuteTaintValue,
 	}
+	CandidatePreferNoScheduleTaint = v1.Taint{
+		Key:    CandidateTaintKey,
+		Effect: v1.TaintEffectPreferNoSchedule,
+		Value:  CandidatePreferNoScheduleTaintValue,
+	}
 )
 
 func IsDisruptingTaint(taint v1.Taint) bool {
@@ -54,4 +63,8 @@ func IsDisruptingTaint(taint v1.Taint) bool {
 
 func IsTerminatingTaint(taint v1.Taint) bool {
 	return taint.MatchTaint(&TerminationNoExecuteTaint) && taint.Value == TerminationNoExecuteTaintValue
+}
+
+func IsCandidateTaint(taint v1.Taint) bool {
+	return taint.MatchTaint(&CandidatePreferNoScheduleTaint) && taint.Value == CandidatePreferNoScheduleTaintValue
 }

--- a/pkg/apis/v1beta1/taints.go
+++ b/pkg/apis/v1beta1/taints.go
@@ -16,7 +16,6 @@ package v1beta1
 
 import (
 	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -131,6 +131,10 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return reconcile.Result{}, fmt.Errorf("removing taint from nodes, %w", err)
 	}
 
+	if err := c.requireNodeclaimTaint(ctx, false, v1beta1.TerminationNoExecuteTaint, c.cluster.Nodes()...); err != nil {
+		return reconcile.Result{}, fmt.Errorf("removing taint from nodes, %w", err)
+	}
+
 	// Attempt different disruption methods. We'll only let one method perform an action
 	for _, m := range c.methods {
 		c.recordRun(fmt.Sprintf("%T", m))

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -288,6 +288,29 @@ var _ = Describe("Disruption Taints", func() {
 		nodeClaimNode = ExpectNodeExists(ctx, env.Client, nodeClaimNode.Name)
 		Expect(nodeClaimNode.Spec.Taints).ToNot(ContainElement(v1beta1.DisruptionNoScheduleTaint))
 	})
+	It("should add preferNoSchedule taints to NodeClaims as choosen candidates for disruption", func() {
+		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, nodeClaimNode)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{nodeClaimNode}, []*v1beta1.NodeClaim{nodeClaim})
+
+		// Trigger the reconcile loop to start but don't trigger the verify action
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ExpectTriggerVerifyAction(&wg)
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
+		}()
+
+		wg.Wait()
+		nodeClaimNode = ExpectNodeExists(ctx, env.Client, nodeClaimNode.Name)
+		Expect(nodeClaimNode.Spec.Taints).To(ContainElement(v1beta1.CandidatePreferNoScheduleTaint))
+
+	})
+
 	// provision an empty node to get it under consolidation
 	It("should add noExecute taints to NodeClaims before termination", func() {
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -288,7 +288,8 @@ var _ = Describe("Disruption Taints", func() {
 		nodeClaimNode = ExpectNodeExists(ctx, env.Client, nodeClaimNode.Name)
 		Expect(nodeClaimNode.Spec.Taints).ToNot(ContainElement(v1beta1.DisruptionNoScheduleTaint))
 	})
-	FIt("should add noExecute taints to NodeClaims before termination", func() {
+	// provision an empty node to get it under consolidation
+	It("should add noExecute taints to NodeClaims before termination", func() {
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, nodeClaimNode)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #624  Part 2 (Candidate (PreferNoSchedule Taint) )<!-- issue number -->

**Description**

This pr will add ```preferNoSchedule``` taints to nodes that are selected as candidates for disruption and any fails on that operation will remove this taint .

Also this pr is a follow up of pr #626 

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
