### PR TITLE
fix: correctly handle non-existent / empty StorageClasses

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2829,8 +2829,9 @@ var _ = Context("NodePool", func() {
 
 			initialPod := test.UnschedulablePod(test.PodOptions{})
 			// Pod has an ephemeral volume claim that has a specified storage class, so it should use the one specified
+			volumeName := "tmp-ephemeral"
 			initialPod.Spec.Volumes = append(initialPod.Spec.Volumes, v1.Volume{
-				Name: "tmp-ephemeral",
+				Name: volumeName,
 				VolumeSource: v1.VolumeSource{
 					Ephemeral: &v1.EphemeralVolumeSource{
 						VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
@@ -2849,7 +2850,14 @@ var _ = Context("NodePool", func() {
 					},
 				},
 			})
-			ExpectApplied(ctx, env.Client, nodePool, sc, sc2, initialPod)
+			pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: initialPod.Namespace,
+					Name:      fmt.Sprintf("%s-%s", initialPod.Name, volumeName),
+				},
+				StorageClassName: lo.ToPtr(sc.Name),
+			})
+			ExpectApplied(ctx, env.Client, nodePool, sc, sc2, pvc, initialPod)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
 			node := ExpectScheduled(ctx, env.Client, initialPod)
 			csiNode := &storagev1.CSINode{
@@ -2881,7 +2889,7 @@ var _ = Context("NodePool", func() {
 			pod := test.UnschedulablePod(test.PodOptions{})
 			// Pod has an ephemeral volume claim that has a specified storage class, so it should use the one specified
 			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-				Name: "tmp-ephemeral",
+				Name: volumeName,
 				VolumeSource: v1.VolumeSource{
 					Ephemeral: &v1.EphemeralVolumeSource{
 						VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
@@ -2900,7 +2908,14 @@ var _ = Context("NodePool", func() {
 					},
 				},
 			})
-			ExpectApplied(ctx, env.Client, nodePool, pod)
+			pvc = test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: pod.Namespace,
+					Name:      fmt.Sprintf("%s-%s", pod.Name, volumeName),
+				},
+				StorageClassName: lo.ToPtr(sc.Name),
+			})
+			ExpectApplied(ctx, env.Client, nodePool, pvc, pod)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			node2 := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Name).ToNot(Equal(node2.Name))
@@ -2919,8 +2934,9 @@ var _ = Context("NodePool", func() {
 
 			initialPod := test.UnschedulablePod(test.PodOptions{})
 			// Pod has an ephemeral volume claim that has NO storage class, so it should use the default one
+			volumeName := "tmp-ephemeral"
 			initialPod.Spec.Volumes = append(initialPod.Spec.Volumes, v1.Volume{
-				Name: "tmp-ephemeral",
+				Name: volumeName,
 				VolumeSource: v1.VolumeSource{
 					Ephemeral: &v1.EphemeralVolumeSource{
 						VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
@@ -2938,7 +2954,13 @@ var _ = Context("NodePool", func() {
 					},
 				},
 			})
-			ExpectApplied(ctx, env.Client, nodePool, sc, initialPod)
+			pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: initialPod.Namespace,
+					Name:      fmt.Sprintf("%s-%s", initialPod.Name, volumeName),
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, sc, initialPod, pvc)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
 			node := ExpectScheduled(ctx, env.Client, initialPod)
 			csiNode := &storagev1.CSINode{
@@ -2963,7 +2985,7 @@ var _ = Context("NodePool", func() {
 			pod := test.UnschedulablePod(test.PodOptions{})
 			// Pod has an ephemeral volume claim that has NO storage class, so it should use the default one
 			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-				Name: "tmp-ephemeral",
+				Name: volumeName,
 				VolumeSource: v1.VolumeSource{
 					Ephemeral: &v1.EphemeralVolumeSource{
 						VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
@@ -2981,8 +3003,14 @@ var _ = Context("NodePool", func() {
 					},
 				},
 			})
+			pvc = test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: pod.Namespace,
+					Name:      fmt.Sprintf("%s-%s", pod.Name, volumeName),
+				},
+			})
 
-			ExpectApplied(ctx, env.Client, sc, nodePool, pod)
+			ExpectApplied(ctx, env.Client, sc, nodePool, pod, pvc)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			node2 := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Name).ToNot(Equal(node2.Name))
@@ -3016,10 +3044,11 @@ var _ = Context("NodePool", func() {
 			time.Sleep(time.Second * 2)
 			ExpectApplied(ctx, env.Client, sc2)
 
+			volumeName := "tmp-ephemeral"
 			initialPod := test.UnschedulablePod(test.PodOptions{})
 			// Pod has an ephemeral volume claim that has NO storage class, so it should use the default one
 			initialPod.Spec.Volumes = append(initialPod.Spec.Volumes, v1.Volume{
-				Name: "tmp-ephemeral",
+				Name: volumeName,
 				VolumeSource: v1.VolumeSource{
 					Ephemeral: &v1.EphemeralVolumeSource{
 						VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
@@ -3037,7 +3066,13 @@ var _ = Context("NodePool", func() {
 					},
 				},
 			})
-			ExpectApplied(ctx, env.Client, nodePool, sc, initialPod)
+			pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: initialPod.Namespace,
+					Name:      fmt.Sprintf("%s-%s", initialPod.Name, volumeName),
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, sc, initialPod, pvc)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
 			node := ExpectScheduled(ctx, env.Client, initialPod)
 			csiNode := &storagev1.CSINode{
@@ -3069,7 +3104,7 @@ var _ = Context("NodePool", func() {
 			pod := test.UnschedulablePod(test.PodOptions{})
 			// Pod has an ephemeral volume claim that has NO storage class, so it should use the default one
 			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-				Name: "tmp-ephemeral",
+				Name: volumeName,
 				VolumeSource: v1.VolumeSource{
 					Ephemeral: &v1.EphemeralVolumeSource{
 						VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
@@ -3087,42 +3122,105 @@ var _ = Context("NodePool", func() {
 					},
 				},
 			})
-			ExpectApplied(ctx, env.Client, sc, nodePool, pod)
+			pvc = test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: pod.Namespace,
+					Name:      fmt.Sprintf("%s-%s", pod.Name, volumeName),
+				},
+			})
+			ExpectApplied(ctx, env.Client, sc, nodePool, pod, pvc)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			node2 := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Name).ToNot(Equal(node2.Name))
 		})
-		It("should not launch nodes for pods with ephemeral volume using a non-existent storage classes", func() {
-			ExpectApplied(ctx, env.Client, nodePool)
-			pod := test.UnschedulablePod(test.PodOptions{})
-			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-				Name: "tmp-ephemeral",
-				VolumeSource: v1.VolumeSource{
-					Ephemeral: &v1.EphemeralVolumeSource{
-						VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
-							Spec: v1.PersistentVolumeClaimSpec{
-								StorageClassName: ptr.String("non-existent"),
-								AccessModes: []v1.PersistentVolumeAccessMode{
-									v1.ReadWriteOnce,
-								},
-								Resources: v1.ResourceRequirements{
-									Requests: v1.ResourceList{
-										v1.ResourceStorage: resource.MustParse("1Gi"),
+		DescribeTable(
+			"should launch nodes for pods with ephemeral volume without a storage class when the PVC is bound",
+			func(storageClassName string) {
+				ExpectApplied(ctx, env.Client, nodePool)
+				volumeName := "tmp-ephemeral"
+				pod := test.UnschedulablePod(test.PodOptions{})
+				pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+					Name: volumeName,
+					VolumeSource: v1.VolumeSource{
+						Ephemeral: &v1.EphemeralVolumeSource{
+							VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
+								Spec: v1.PersistentVolumeClaimSpec{
+									StorageClassName: lo.ToPtr(storageClassName),
+									AccessModes: []v1.PersistentVolumeAccessMode{
+										v1.ReadWriteOnce,
+									},
+									Resources: v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceStorage: resource.MustParse("1Gi"),
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-			})
-			ExpectApplied(ctx, env.Client, nodePool)
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				})
+				pvName := "test-pv"
+				pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: pod.Namespace,
+						Name:      fmt.Sprintf("%s-%s", pod.Name, volumeName),
+					},
+					StorageClassName: lo.ToPtr(storageClassName),
+					VolumeName:       pvName,
+				})
+				pv := test.PersistentVolume(test.PersistentVolumeOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: pod.Namespace,
+						Name:      pvName,
+					},
+				})
+				ExpectApplied(ctx, env.Client, nodePool, pvc, pv)
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 
-			var nodeList v1.NodeList
-			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
-			// no nodes should be created as the storage class doesn't eixst
-			Expect(nodeList.Items).To(HaveLen(0))
-		})
+				var nodeList v1.NodeList
+				Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
+				// no nodes should be created as the storage class doesn't eixst
+				Expect(nodeList.Items).To(HaveLen(1))
+			},
+			Entry("non-existent storage class", "non-existent"),
+			Entry("explicitly disabled storage class (empty string)", ""),
+		)
+		DescribeTable(
+			"should not launch nodes for pods with ephemeral volume without a storage class when the PVC is unbound",
+			func(storageClassName string) {
+				ExpectApplied(ctx, env.Client, nodePool)
+				pod := test.UnschedulablePod(test.PodOptions{})
+				pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+					Name: "tmp-ephemeral",
+					VolumeSource: v1.VolumeSource{
+						Ephemeral: &v1.EphemeralVolumeSource{
+							VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
+								Spec: v1.PersistentVolumeClaimSpec{
+									StorageClassName: lo.ToPtr(storageClassName),
+									AccessModes: []v1.PersistentVolumeAccessMode{
+										v1.ReadWriteOnce,
+									},
+									Resources: v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceStorage: resource.MustParse("1Gi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				})
+				ExpectApplied(ctx, env.Client, nodePool)
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+
+				var nodeList v1.NodeList
+				Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
+				// no nodes should be created as the storage class doesn't eixst
+				Expect(nodeList.Items).To(HaveLen(0))
+			},
+			Entry("non-existent storage class", "non-existent"),
+			Entry("explicitly disabled storage class (empty string)", ""),
+		)
 		Context("CSIMigration", func() {
 			It("should launch nodes for pods with non-dynamic PVC using a migrated PVC/PV", func() {
 				// We should assume that this PVC/PV is using CSI driver implicitly to limit pod scheduling
@@ -3197,8 +3295,9 @@ var _ = Context("NodePool", func() {
 
 				initialPod := test.UnschedulablePod(test.PodOptions{})
 				// Pod has an ephemeral volume claim that references the in-tree storage provider
+				volumeName := "tmp-ephemeral"
 				initialPod.Spec.Volumes = append(initialPod.Spec.Volumes, v1.Volume{
-					Name: "tmp-ephemeral",
+					Name: volumeName,
 					VolumeSource: v1.VolumeSource{
 						Ephemeral: &v1.EphemeralVolumeSource{
 							VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
@@ -3217,7 +3316,13 @@ var _ = Context("NodePool", func() {
 						},
 					},
 				})
-				ExpectApplied(ctx, env.Client, nodePool, sc, initialPod)
+				pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: initialPod.Namespace,
+						Name:      fmt.Sprintf("%s-%s", initialPod.Name, volumeName),
+					},
+				})
+				ExpectApplied(ctx, env.Client, nodePool, sc, initialPod, pvc)
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
 				node := ExpectScheduled(ctx, env.Client, initialPod)
 				csiNode := &storagev1.CSINode{
@@ -3242,7 +3347,7 @@ var _ = Context("NodePool", func() {
 				pod := test.UnschedulablePod(test.PodOptions{})
 				// Pod has an ephemeral volume claim that reference the in-tree storage provider
 				pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-					Name: "tmp-ephemeral",
+					Name: volumeName,
 					VolumeSource: v1.VolumeSource{
 						Ephemeral: &v1.EphemeralVolumeSource{
 							VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
@@ -3261,8 +3366,14 @@ var _ = Context("NodePool", func() {
 						},
 					},
 				})
+				pvc = test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: pod.Namespace,
+						Name:      fmt.Sprintf("%s-%s", pod.Name, volumeName),
+					},
+				})
 				// Pod should not schedule to the first node since we should realize that we have hit our volume limits
-				ExpectApplied(ctx, env.Client, pod)
+				ExpectApplied(ctx, env.Client, pod, pvc)
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 				node2 := ExpectScheduled(ctx, env.Client, pod)
 				Expect(node.Name).ToNot(Equal(node2.Name))

--- a/pkg/controllers/provisioning/scheduling/volumetopology.go
+++ b/pkg/controllers/provisioning/scheduling/volumetopology.go
@@ -23,10 +23,9 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/karpenter/pkg/scheduling"
+	volumeutil "sigs.k8s.io/karpenter/pkg/utils/volume"
 )
 
 func NewVolumeTopology(kubeClient client.Client) *VolumeTopology {
@@ -76,30 +75,15 @@ func (v *VolumeTopology) Inject(ctx context.Context, pod *v1.Pod) error {
 }
 
 func (v *VolumeTopology) getRequirements(ctx context.Context, pod *v1.Pod, volume v1.Volume) ([]v1.NodeSelectorRequirement, error) {
-	defaultStorageClassName, err := scheduling.DiscoverDefaultStorageClassName(ctx, v.kubeClient)
+	pvc, err := volumeutil.GetPersistentVolumeClaim(ctx, v.kubeClient, pod, volume)
 	if err != nil {
-		return nil, fmt.Errorf("discovering default storage class, %w", err)
+		return nil, fmt.Errorf("discovering persistent volume claim, %w", err)
 	}
-
-	// Get VolumeName and StorageClass name from PVC
-	pvc := &v1.PersistentVolumeClaim{}
-	switch {
-	case volume.PersistentVolumeClaim != nil:
-		if err = v.kubeClient.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: volume.PersistentVolumeClaim.ClaimName}, pvc); err != nil {
-			return nil, fmt.Errorf("discovering persistent volume claim, %w", err)
-		}
-	case volume.Ephemeral != nil:
-		// generated name per https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#persistentvolumeclaim-naming
-		if err = v.kubeClient.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: fmt.Sprintf("%s-%s", pod.Name, volume.Name)}, pvc); err != nil {
-			return nil, fmt.Errorf("discovering persistent volume claim for ephemeral volume, %w", err)
-		}
-	default:
+	// Not all volume types have PVCs, e.g. emptyDir, hostPath, etc.
+	if pvc == nil {
 		return nil, nil
 	}
-	storageClassName := lo.FromPtr(pvc.Spec.StorageClassName)
-	if storageClassName == "" {
-		storageClassName = defaultStorageClassName
-	}
+
 	// Persistent Volume Requirements
 	if pvc.Spec.VolumeName != "" {
 		requirements, err := v.getPersistentVolumeRequirements(ctx, pod, pvc.Spec.VolumeName)
@@ -109,8 +93,8 @@ func (v *VolumeTopology) getRequirements(ctx context.Context, pod *v1.Pod, volum
 		return requirements, nil
 	}
 	// Storage Class Requirements
-	if storageClassName != "" {
-		requirements, err := v.getStorageClassRequirements(ctx, storageClassName)
+	if sc := lo.FromPtr(pvc.Spec.StorageClassName); sc != "" {
+		requirements, err := v.getStorageClassRequirements(ctx, sc)
 		if err != nil {
 			return nil, err
 		}
@@ -153,45 +137,33 @@ func (v *VolumeTopology) getPersistentVolumeRequirements(ctx context.Context, po
 	return requirements, nil
 }
 
-func (v *VolumeTopology) getPersistentVolumeClaim(ctx context.Context, pod *v1.Pod, volume v1.Volume) (*v1.PersistentVolumeClaim, error) {
-	if volume.PersistentVolumeClaim == nil {
-		return nil, nil
-	}
-	pvc := &v1.PersistentVolumeClaim{}
-	if err := v.kubeClient.Get(ctx, types.NamespacedName{Name: volume.PersistentVolumeClaim.ClaimName, Namespace: pod.Namespace}, pvc); err != nil {
-		return nil, fmt.Errorf("getting persistent volume claim %q, %w", volume.PersistentVolumeClaim.ClaimName, err)
-	}
-	return pvc, nil
-}
-
 // ValidatePersistentVolumeClaims returns an error if the pod doesn't appear to be valid with respect to
 // PVCs (e.g. the PVC is not found or references an unknown storage class).
 func (v *VolumeTopology) ValidatePersistentVolumeClaims(ctx context.Context, pod *v1.Pod) error {
 	for _, volume := range pod.Spec.Volumes {
-		var storageClassName *string
-		var volumeName string
-		if volume.PersistentVolumeClaim != nil {
-			// validate the PVC if it exists
-			pvc, err := v.getPersistentVolumeClaim(ctx, pod, volume)
-			if err != nil {
-				return err
-			}
-			// may not have a PVC
-			if pvc == nil {
-				continue
-			}
-
-			storageClassName = pvc.Spec.StorageClassName
-			volumeName = pvc.Spec.VolumeName
-		} else if volume.Ephemeral != nil {
-			storageClassName = volume.Ephemeral.VolumeClaimTemplate.Spec.StorageClassName
+		pvc, err := volumeutil.GetPersistentVolumeClaim(ctx, v.kubeClient, pod, volume)
+		if err != nil {
+			return err
+		}
+		// Not all volume types have PVCs, e.g. emptyDir, hostPath, etc.
+		if pvc == nil {
+			continue
 		}
 
+		if pvc.Spec.VolumeName != "" {
+			if err := v.validateVolume(ctx, pvc.Spec.VolumeName); err != nil {
+				return fmt.Errorf("failed to validate pvc %q with volume %q, %w", pvc.Name, pvc.Spec.VolumeName, err)
+			}
+			continue
+		}
+
+		// PVC is unbound, we can't schedule unless the pod defines a valid storage class
+		storageClassName := lo.FromPtr(pvc.Spec.StorageClassName)
+		if storageClassName == "" {
+			return fmt.Errorf("unbound pvc %s must define a storage class", pvc.Name)
+		}
 		if err := v.validateStorageClass(ctx, storageClassName); err != nil {
-			return err
-		}
-		if err := v.validateVolume(ctx, volumeName); err != nil {
-			return err
+			return fmt.Errorf("failed to validate pvc %q with storage class %q, %w", pvc.Name, storageClassName, err)
 		}
 	}
 	return nil
@@ -208,13 +180,10 @@ func (v *VolumeTopology) validateVolume(ctx context.Context, volumeName string) 
 	return nil
 }
 
-func (v *VolumeTopology) validateStorageClass(ctx context.Context, storageClassName *string) error {
-	// we have a storage class name, so ensure that it exists
-	if ptr.StringValue(storageClassName) != "" {
-		storageClass := &storagev1.StorageClass{}
-		if err := v.kubeClient.Get(ctx, types.NamespacedName{Name: ptr.StringValue(storageClassName)}, storageClass); err != nil {
-			return err
-		}
+func (v *VolumeTopology) validateStorageClass(ctx context.Context, storageClassName string) error {
+	storageClass := &storagev1.StorageClass{}
+	if err := v.kubeClient.Get(ctx, types.NamespacedName{Name: storageClassName}, storageClass); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -1163,7 +1163,27 @@ var _ = Describe("Provisioning", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
-		It("should schedule with an empty storage class", func() {
+		It("should schedule with an empty storage class if the pvc is bound", func() {
+			storageClass := ""
+			volumeName := "test-volume"
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				StorageClassName: &storageClass,
+				VolumeName:       volumeName,
+			})
+			persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: volumeName,
+				},
+				StorageClassName: storageClass,
+			})
+			ExpectApplied(ctx, env.Client, test.NodePool(), persistentVolumeClaim, persistentVolume)
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+		})
+		It("should not schedule with an empty storage class if the pvc is not bound", func() {
 			storageClass := ""
 			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass})
 			ExpectApplied(ctx, env.Client, test.NodePool(), persistentVolumeClaim)
@@ -1171,7 +1191,39 @@ var _ = Describe("Provisioning", func() {
 				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
 			})
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+		})
+		It("should schedule with a missing storage class if the pvc is bound", func() {
+			missingStorageClass := "missing-storage-class"
+			volumeName := "test-volume"
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				StorageClassName: &missingStorageClass,
+				VolumeName:       volumeName,
+			})
+			persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: volumeName,
+				},
+				StorageClassName: missingStorageClass,
+			})
+			ExpectApplied(ctx, env.Client, test.NodePool(), persistentVolumeClaim, persistentVolume)
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
+		})
+		It("should not schedule with a missing storage class if the pvc is not bound", func() {
+			missingStorageClass := "missing-storage-class"
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				StorageClassName: &missingStorageClass,
+			})
+			ExpectApplied(ctx, env.Client, test.NodePool(), persistentVolumeClaim)
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should schedule valid pods when a pod with an invalid pvc is encountered (pvc)", func() {
 			ExpectApplied(ctx, env.Client, test.NodePool())

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -21,12 +21,15 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	csitranslation "k8s.io/csi-translation-lib"
 	"k8s.io/csi-translation-lib/plugins"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	volumeutil "sigs.k8s.io/karpenter/pkg/utils/volume"
 )
 
 //go:generate controller-gen object:headerFile="../../hack/boilerplate.go.txt" paths="."
@@ -77,39 +80,32 @@ func (u Volumes) Insert(volumes Volumes) {
 func GetVolumes(ctx context.Context, kubeClient client.Client, pod *v1.Pod) (Volumes, error) {
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("pod", pod.Name))
 	podPVCs := Volumes{}
-	defaultStorageClassName, err := DiscoverDefaultStorageClassName(ctx, kubeClient)
-	if err != nil {
-		return nil, fmt.Errorf("discovering default storage class, %w", err)
-	}
 	for _, volume := range pod.Spec.Volumes {
 		ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("volume", volume.Name))
-		var pvcID, storageClassName, volumeName string
-		var pvc v1.PersistentVolumeClaim
-		if volume.PersistentVolumeClaim != nil {
-			if err = kubeClient.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: volume.PersistentVolumeClaim.ClaimName}, &pvc); err != nil {
-				return nil, err
+		pvc, err := volumeutil.GetPersistentVolumeClaim(ctx, kubeClient, pod, volume)
+		// If the PVC is not found it was manually deleted and its finalizer removed. We should ignore this volume when
+		// computing limits, otherwise Karpenter may never be able to update its cluster state.
+		if err != nil {
+			if errors.IsNotFound(err) {
+				logging.FromContext(ctx).Errorf("failed updating volume limits for volume, %w", err)
+				continue
 			}
-			pvcID = fmt.Sprintf("%s/%s", pod.Namespace, volume.PersistentVolumeClaim.ClaimName)
-			storageClassName = lo.FromPtr(pvc.Spec.StorageClassName)
-			volumeName = pvc.Spec.VolumeName
-		} else if volume.Ephemeral != nil {
-			// generated name per https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#persistentvolumeclaim-naming
-			pvcID = fmt.Sprintf("%s/%s-%s", pod.Namespace, pod.Name, volume.Name)
-			storageClassName = lo.FromPtr(volume.Ephemeral.VolumeClaimTemplate.Spec.StorageClassName)
-			volumeName = volume.Ephemeral.VolumeClaimTemplate.Spec.VolumeName
-		} else {
+			return nil, fmt.Errorf("failed updating volume limits, %w", err)
+		}
+		// Not all volume types have PVCs, e.g. emptyDir, hostPath, etc.
+		if pvc == nil {
 			continue
 		}
-		if storageClassName == "" {
-			storageClassName = defaultStorageClassName
-		}
-		driverName, err := resolveDriver(ctx, kubeClient, volumeName, storageClassName)
+		ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("pvc", pvc.Name))
+
+		storageClassName := lo.FromPtr(pvc.Spec.StorageClassName)
+		driverName, err := resolveDriver(ctx, kubeClient, pvc.Spec.VolumeName, storageClassName)
 		if err != nil {
 			return nil, err
 		}
 		// might be a non-CSI driver, something we don't currently handle
 		if driverName != "" {
-			podPVCs.Add(driverName, pvcID)
+			podPVCs.Add(driverName, client.ObjectKeyFromObject(pvc).String())
 		}
 	}
 	return podPVCs, nil
@@ -130,18 +126,30 @@ func resolveDriver(ctx context.Context, kubeClient client.Client, volumeName str
 			return driverName, nil
 		}
 	}
-	if storageClassName != "" {
-		driverName, err := driverFromSC(ctx, kubeClient, storageClassName)
-		if err != nil {
-			return "", err
-		}
-		if driverName != "" {
-			return driverName, nil
-		}
+
+	// This can occur in two scenarios:
+	//  1. The storage class was explicitly set to "" to disable dynamic provisioning
+	//  2. The storage class was not set but the cluster doesn't have a default storage class
+	// In either of these cases, a PV must have been previously bound to the PVC and has since been removed. We can
+	// ignore this PVC while computing limits and continue.
+	if storageClassName == "" {
+		logging.FromContext(ctx).Errorf("failed updating volume limits for volume with unbound PVC, no storage class specified")
+		return "", nil
 	}
-	// Driver name wasn't able to resolve for this volume. In this case, we just ignore the
-	// volume and move on to the other volumes that the pod has
-	return "", nil
+
+	driverName, err := driverFromSC(ctx, kubeClient, storageClassName)
+	if err != nil {
+		// There are two scenarios where a StorageClass may be defined but not found:
+		//  1. The StorageClass was manually deleted and the finalizer removed
+		//  2. The StorageClass never existed and was used to bind the PVC to an existing PV, but that PV was removed
+		// In either of these cases, we should ignore the PVC while computing limits and continue.
+		if errors.IsNotFound(err) {
+			logging.FromContext(ctx).With("storageclass", storageClassName).Errorf("failed updating volume limits for volume with unbound PVC, %w", err)
+			return "", nil
+		}
+		return "", err
+	}
+	return driverName, nil
 }
 
 // driverFromSC resolves the storage driver name by getting the Provisioner name from the StorageClass

--- a/pkg/test/storage.go
+++ b/pkg/test/storage.go
@@ -66,7 +66,7 @@ func PersistentVolume(overrides ...PersistentVolumeOptions) *v1.PersistentVolume
 		}}}}}
 	}
 	return &v1.PersistentVolume{
-		ObjectMeta: NamespacedObjectMeta(metav1.ObjectMeta{}),
+		ObjectMeta: NamespacedObjectMeta(options.ObjectMeta),
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: source,
 			StorageClassName:       options.StorageClassName,

--- a/pkg/utils/volume/volume.go
+++ b/pkg/utils/volume/volume.go
@@ -1,0 +1,43 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetPersistentVolumeClaim(ctx context.Context, kubeClient client.Client, pod *v1.Pod, volume v1.Volume) (*v1.PersistentVolumeClaim, error) {
+	var pvcName string
+	switch {
+	case volume.PersistentVolumeClaim != nil:
+		pvcName = volume.PersistentVolumeClaim.ClaimName
+	case volume.Ephemeral != nil:
+		// generated name per https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#persistentvolumeclaim-naming
+		pvcName = fmt.Sprintf("%s-%s", pod.Name, volume.Name)
+	default:
+		return nil, nil
+	}
+
+	pvc := &v1.PersistentVolumeClaim{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pvcName}, pvc); err != nil {
+		return nil, fmt.Errorf("getting persistent volume claim %q, %w", pvcName, err)
+	}
+	return pvc, nil
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #664 

**Description**
Karpenter doesn't correctly handle two StorageClass cases: when the StorageClass is **explicitly** `""` and when the StorageClass does not exist. A pod with a PVC that falls into one of these cases should be able to successfully schedule if the PVC is already bound to a PV. Additionally, currently Karpenter treats both a `nil` StorageClass and `""` StorageClass as the default StorageClass. This should only be the case when the StorageClass is `nil`.

**How was this change tested?**
`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
