### PR TITLE
fix: Create Generic Pod Filtering in Utils and Collapse Disruption Filtering

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/samber/lo"
@@ -72,20 +71,6 @@ func MakeConsolidation(clock clock.Clock, cluster *state.Cluster, kubeClient cli
 		cloudProvider: cloudProvider,
 		recorder:      recorder,
 	}
-}
-
-// sortAndFilterCandidates orders candidates by the disruptionCost, removing any that we already know won't
-// be viable consolidation options.
-func (c *consolidation) sortAndFilterCandidates(ctx context.Context, candidates []*Candidate) ([]*Candidate, error) {
-	candidates, err := filterCandidates(ctx, c.kubeClient, c.recorder, candidates)
-	if err != nil {
-		return nil, fmt.Errorf("filtering candidates, %w", err)
-	}
-
-	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].disruptionCost < candidates[j].disruptionCost
-	})
-	return candidates, nil
 }
 
 // IsConsolidated returns true if nothing has changed since markConsolidated was called.

--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/samber/lo"
@@ -101,6 +102,14 @@ func (c *consolidation) ShouldDisrupt(_ context.Context, cn *Candidate) bool {
 		return false
 	}
 	return true
+}
+
+// sortCandidates sorts candidates by disruption cost (where the lowest disruption cost is first) and returns the result
+func (c *consolidation) sortCandidates(candidates []*Candidate) []*Candidate {
+	sort.Slice(candidates, func(i int, j int) bool {
+		return candidates[i].disruptionCost < candidates[j].disruptionCost
+	})
+	return candidates
 }
 
 // computeConsolidation computes a consolidation action to take

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -1016,9 +1016,6 @@ var _ = Describe("Consolidation", func() {
 			// Evict the pods off of the node
 			for _, p := range pods {
 				// Trigger an eviction to set the deletion timestamp but not delete the pod
-				Expect(env.KubernetesInterface.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policyv1.Eviction{
-					ObjectMeta: metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace},
-				})).To(Succeed())
 				ExpectEvicted(ctx, env.Client, p)
 				ExpectExists(ctx, env.Client, p)
 			}
@@ -1080,9 +1077,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, pod, node)
 
 			// Trigger an eviction to set the deletion timestamp but not delete the pod
-			Expect(env.KubernetesInterface.PolicyV1().Evictions(pod.Namespace).Evict(ctx, &policyv1.Eviction{
-				ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
-			})).To(Succeed())
 			ExpectEvicted(ctx, env.Client, pod)
 			ExpectExists(ctx, env.Client, pod)
 

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -919,6 +919,194 @@ var _ = Describe("Consolidation", func() {
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
+		It("will consider a node with a DaemonSet pod as empty", func() {
+			// assign the nodeclaims to the least expensive offering so we don't get a replacement
+			nodeClaim.Labels = lo.Assign(nodeClaim.Labels, map[string]string{
+				v1.LabelInstanceTypeStable:   leastExpensiveInstance.Name,
+				v1beta1.CapacityTypeLabelKey: leastExpensiveOffering.CapacityType,
+				v1.LabelTopologyZone:         leastExpensiveOffering.Zone,
+			})
+			node.Labels = lo.Assign(node.Labels, map[string]string{
+				v1.LabelInstanceTypeStable:   leastExpensiveInstance.Name,
+				v1beta1.CapacityTypeLabelKey: leastExpensiveOffering.CapacityType,
+				v1.LabelTopologyZone:         leastExpensiveOffering.Zone,
+			})
+
+			ds := test.DaemonSet()
+			ExpectApplied(ctx, env.Client, ds, nodeClaim, node, nodePool)
+
+			// Pods owned by a Deployment
+			pod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "DaemonSet",
+							Name:               ds.Name,
+							UID:                ds.UID,
+							Controller:         ptr.Bool(true),
+							BlockOwnerDeletion: ptr.Bool(true),
+						},
+					},
+				},
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			})
+			ExpectApplied(ctx, env.Client, pod)
+
+			ExpectManualBinding(ctx, env.Client, pod, node)
+
+			// inform cluster state about nodes and nodeclaims
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+			ExpectTriggerVerifyAction(&wg)
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
+			wg.Wait()
+
+			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
+
+			// Cascade any deletion of the nodeclaim to the node
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
+
+			// we should delete the empty node
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
+			ExpectNotFound(ctx, env.Client, nodeClaim, node)
+		})
+		It("will consider a node with terminating Deployment pods as empty", func() {
+			// assign the nodeclaims to the least expensive offering so we don't get a replacement
+			nodeClaim.Labels = lo.Assign(nodeClaim.Labels, map[string]string{
+				v1.LabelInstanceTypeStable:   leastExpensiveInstance.Name,
+				v1beta1.CapacityTypeLabelKey: leastExpensiveOffering.CapacityType,
+				v1.LabelTopologyZone:         leastExpensiveOffering.Zone,
+			})
+			node.Labels = lo.Assign(node.Labels, map[string]string{
+				v1.LabelInstanceTypeStable:   leastExpensiveInstance.Name,
+				v1beta1.CapacityTypeLabelKey: leastExpensiveOffering.CapacityType,
+				v1.LabelTopologyZone:         leastExpensiveOffering.Zone,
+			})
+
+			rs := test.ReplicaSet()
+			ExpectApplied(ctx, env.Client, rs, nodeClaim, node, nodePool)
+
+			// Pod owned by a Deployment
+			pods := test.Pods(3, test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "ReplicaSet",
+							Name:               rs.Name,
+							UID:                rs.UID,
+							Controller:         ptr.Bool(true),
+							BlockOwnerDeletion: ptr.Bool(true),
+						},
+					},
+				},
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			})
+			ExpectApplied(ctx, env.Client, lo.Map(pods, func(p *v1.Pod, _ int) client.Object { return p })...)
+
+			for _, p := range pods {
+				ExpectManualBinding(ctx, env.Client, p, node)
+			}
+
+			// Evict the pods off of the node
+			for _, p := range pods {
+				// Trigger an eviction to set the deletion timestamp but not delete the pod
+				Expect(env.KubernetesInterface.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policyv1.Eviction{
+					ObjectMeta: metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace},
+				})).To(Succeed())
+				ExpectEvicted(ctx, env.Client, p)
+				ExpectExists(ctx, env.Client, p)
+			}
+
+			// inform cluster state about nodes and nodeclaims
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+			ExpectTriggerVerifyAction(&wg)
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
+			wg.Wait()
+
+			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
+
+			// Cascade any deletion of the nodeclaim to the node
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
+
+			// we should delete the empty node
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
+			ExpectNotFound(ctx, env.Client, nodeClaim, node)
+		})
+		It("will not consider a node with a terminating StatefulSet pod as empty", func() {
+			// assign the nodeclaims to the least expensive offering so we don't get a replacement
+			nodeClaim.Labels = lo.Assign(nodeClaim.Labels, map[string]string{
+				v1.LabelInstanceTypeStable:   leastExpensiveInstance.Name,
+				v1beta1.CapacityTypeLabelKey: leastExpensiveOffering.CapacityType,
+				v1.LabelTopologyZone:         leastExpensiveOffering.Zone,
+			})
+			node.Labels = lo.Assign(node.Labels, map[string]string{
+				v1.LabelInstanceTypeStable:   leastExpensiveInstance.Name,
+				v1beta1.CapacityTypeLabelKey: leastExpensiveOffering.CapacityType,
+				v1.LabelTopologyZone:         leastExpensiveOffering.Zone,
+			})
+
+			ss := test.StatefulSet()
+			ExpectApplied(ctx, env.Client, ss, nodeClaim, node, nodePool)
+
+			// Pod owned by a StatefulSet
+			pod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "StatefulSet",
+							Name:               ss.Name,
+							UID:                ss.UID,
+							Controller:         ptr.Bool(true),
+							BlockOwnerDeletion: ptr.Bool(true),
+						},
+					},
+				},
+				Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			})
+			ExpectApplied(ctx, env.Client, pod)
+
+			ExpectManualBinding(ctx, env.Client, pod, node)
+
+			// Trigger an eviction to set the deletion timestamp but not delete the pod
+			Expect(env.KubernetesInterface.PolicyV1().Evictions(pod.Namespace).Evict(ctx, &policyv1.Eviction{
+				ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+			})).To(Succeed())
+			ExpectEvicted(ctx, env.Client, pod)
+			ExpectExists(ctx, env.Client, pod)
+
+			// inform cluster state about nodes and nodeclaims
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+			ExpectTriggerVerifyAction(&wg)
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
+			wg.Wait()
+
+			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
+
+			// Cascade any deletion of the nodeclaim to the node
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
+
+			// we shouldn't delete the node due to emptiness with a statefulset terminating pod
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+			ExpectExists(ctx, env.Client, nodeClaim)
+			ExpectExists(ctx, env.Client, node)
+		})
 	})
 	Context("Replace", func() {
 		DescribeTable("can replace node",

--- a/pkg/controllers/disruption/emptiness.go
+++ b/pkg/controllers/disruption/emptiness.go
@@ -64,7 +64,7 @@ func (e *Emptiness) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 func (e *Emptiness) ComputeCommand(_ context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, error) {
 	// First check how many nodes are empty so that we can emit a metric on how many nodes are eligible
 	emptyCandidates := lo.Filter(candidates, func(cn *Candidate, _ int) bool {
-		return cn.NodeClaim.DeletionTimestamp.IsZero() && len(cn.pods) == 0
+		return cn.NodeClaim.DeletionTimestamp.IsZero() && len(cn.reschedulablePods) == 0
 	})
 
 	disruptionEligibleNodesGauge.With(map[string]string{
@@ -74,7 +74,7 @@ func (e *Emptiness) ComputeCommand(_ context.Context, disruptionBudgetMapping ma
 
 	empty := make([]*Candidate, 0, len(emptyCandidates))
 	for _, candidate := range emptyCandidates {
-		if len(candidate.pods) > 0 {
+		if len(candidate.reschedulablePods) > 0 {
 			continue
 		}
 		// If there's disruptions allowed for the candidate's nodepool,
@@ -84,7 +84,6 @@ func (e *Emptiness) ComputeCommand(_ context.Context, disruptionBudgetMapping ma
 			disruptionBudgetMapping[candidate.nodePool.Name]--
 		}
 	}
-
 	return Command{
 		candidates: empty,
 	}, nil

--- a/pkg/controllers/disruption/emptynodeconsolidation.go
+++ b/pkg/controllers/disruption/emptynodeconsolidation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"knative.dev/pkg/logging"
 
@@ -42,10 +43,9 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	if c.IsConsolidated() {
 		return Command{}, nil
 	}
-	candidates, err := c.sortAndFilterCandidates(ctx, candidates)
-	if err != nil {
-		return Command{}, fmt.Errorf("sorting candidates, %w", err)
-	}
+	sort.Slice(candidates, func(i int, j int) bool {
+		return candidates[i].disruptionCost < candidates[j].disruptionCost
+	})
 	disruptionEligibleNodesGauge.With(map[string]string{
 		methodLabel:            c.Type(),
 		consolidationTypeLabel: c.ConsolidationType(),
@@ -54,7 +54,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	empty := make([]*Candidate, 0, len(candidates))
 	constrainedByBudgets := false
 	for _, candidate := range candidates {
-		if len(candidate.pods) > 0 {
+		if len(candidate.reschedulablePods) > 0 {
 			continue
 		}
 		if disruptionBudgetMapping[candidate.nodePool.Name] == 0 {
@@ -109,7 +109,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	// 2. The node isn't a target of a recent scheduling simulation
 	// 3. the number of candidates for a given nodepool can no longer be disrupted as it would violate the budget
 	for _, n := range candidatesToDelete {
-		if len(n.pods) != 0 || c.cluster.IsNodeNominated(n.ProviderID()) || postValidationMapping[n.nodePool.Name] == 0 {
+		if len(n.reschedulablePods) != 0 || c.cluster.IsNodeNominated(n.ProviderID()) || postValidationMapping[n.nodePool.Name] == 0 {
 			logging.FromContext(ctx).Debugf("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
 			return Command{}, nil
 		}

--- a/pkg/controllers/disruption/emptynodeconsolidation.go
+++ b/pkg/controllers/disruption/emptynodeconsolidation.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 
 	"knative.dev/pkg/logging"
 
@@ -43,9 +42,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	if c.IsConsolidated() {
 		return Command{}, nil
 	}
-	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].disruptionCost < candidates[j].disruptionCost
-	})
+	candidates = c.sortCandidates(candidates)
 	disruptionEligibleNodesGauge.With(map[string]string{
 		methodLabel:            c.Type(),
 		consolidationTypeLabel: c.ConsolidationType(),

--- a/pkg/controllers/disruption/expiration.go
+++ b/pkg/controllers/disruption/expiration.go
@@ -60,7 +60,7 @@ func (e *Expiration) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 		c.NodeClaim.StatusConditions().GetCondition(v1beta1.Expired).IsTrue()
 }
 
-// ComputeCommand generates a disrpution command given candidates
+// ComputeCommand generates a disruption command given candidates
 func (e *Expiration) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, error) {
 	sort.Slice(candidates, func(i int, j int) bool {
 		return candidates[i].NodeClaim.StatusConditions().GetCondition(v1beta1.Expired).LastTransitionTime.Inner.Time.Before(

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -158,7 +158,7 @@ func GetCandidates(ctx context.Context, cluster *state.Cluster, kubeClient clien
 	if err != nil {
 		return nil, err
 	}
-	pdbs, err := NewPDBLimits(ctx, kubeClient)
+	pdbs, err := NewPDBLimits(ctx, clk, kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
 	}

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -23,10 +23,9 @@ import (
 	"strconv"
 
 	"github.com/samber/lo"
-	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
-	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -26,6 +26,8 @@ import (
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 
+	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -90,7 +90,7 @@ func simulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	}
 
 	// We get the pods that are on nodes that are deleting
-	deletingNodePods, err := deletingNodes.Pods(ctx, kubeClient)
+	deletingNodePods, err := deletingNodes.ReschedulablePods(ctx, kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
 	}

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -73,7 +73,6 @@ func simulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	if err != nil {
 		return nil, fmt.Errorf("determining pending pods, %w", err)
 	}
-
 	for _, n := range candidates {
 		pods = append(pods, n.reschedulablePods...)
 	}

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -158,8 +158,12 @@ func GetCandidates(ctx context.Context, cluster *state.Cluster, kubeClient clien
 	if err != nil {
 		return nil, err
 	}
+	pdbs, err := NewPDBLimits(ctx, kubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
+	}
 	candidates := lo.FilterMap(cluster.Nodes(), func(n *state.StateNode, _ int) (*Candidate, bool) {
-		cn, e := NewCandidate(ctx, kubeClient, recorder, clk, n, nodePoolMap, nodePoolToInstanceTypesMap, queue)
+		cn, e := NewCandidate(ctx, kubeClient, recorder, clk, n, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue)
 		return cn, e == nil
 	})
 	// Filter only the valid candidates that we should disrupt

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
 	"time"
 
 	"github.com/samber/lo"
@@ -46,9 +45,7 @@ func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	if m.IsConsolidated() {
 		return Command{}, nil
 	}
-	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].disruptionCost < candidates[j].disruptionCost
-	})
+	candidates = m.sortCandidates(candidates)
 	disruptionEligibleNodesGauge.With(map[string]string{
 		methodLabel:            m.Type(),
 		consolidationTypeLabel: m.ConsolidationType(),

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/samber/lo"
@@ -45,10 +46,9 @@ func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	if m.IsConsolidated() {
 		return Command{}, nil
 	}
-	candidates, err := m.sortAndFilterCandidates(ctx, candidates)
-	if err != nil {
-		return Command{}, fmt.Errorf("sorting candidates, %w", err)
-	}
+	sort.Slice(candidates, func(i int, j int) bool {
+		return candidates[i].disruptionCost < candidates[j].disruptionCost
+	})
 	disruptionEligibleNodesGauge.With(map[string]string{
 		methodLabel:            m.Type(),
 		consolidationTypeLabel: m.ConsolidationType(),

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -19,7 +19,6 @@ package disruption
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"knative.dev/pkg/logging"
@@ -44,9 +43,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 	if s.IsConsolidated() {
 		return Command{}, nil
 	}
-	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].disruptionCost < candidates[j].disruptionCost
-	})
+	candidates = s.sortCandidates(candidates)
 	disruptionEligibleNodesGauge.With(map[string]string{
 		methodLabel:            s.Type(),
 		consolidationTypeLabel: s.ConsolidationType(),

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -19,6 +19,7 @@ package disruption
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"knative.dev/pkg/logging"
@@ -43,10 +44,9 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 	if s.IsConsolidated() {
 		return Command{}, nil
 	}
-	candidates, err := s.sortAndFilterCandidates(ctx, candidates)
-	if err != nil {
-		return Command{}, fmt.Errorf("sorting candidates, %w", err)
-	}
+	sort.Slice(candidates, func(i int, j int) bool {
+		return candidates[i].disruptionCost < candidates[j].disruptionCost
+	})
 	disruptionEligibleNodesGauge.With(map[string]string{
 		methodLabel:            s.Type(),
 		consolidationTypeLabel: s.ConsolidationType(),

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -533,7 +533,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod %q has "karpenter.sh/do-not-disrupt" annotation`, client.ObjectKeyFromObject(pod))))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Cannot disrupt Node: Pod %q has "karpenter.sh/do-not-disrupt" annotation`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
-	It("should not consider candidates that have do-not-disrupt pods scheduled to mirror pods", func() {
+	It("should not consider candidates that have do-not-disrupt mirror pods scheduled", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -571,7 +571,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod %q has "karpenter.sh/do-not-disrupt" annotation`, client.ObjectKeyFromObject(pod))))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Cannot disrupt Node: Pod %q has "karpenter.sh/do-not-disrupt" annotation`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
-	It("should not consider candidates that have do-not-disrupt pods scheduled to DaemonSet pods", func() {
+	It("should not consider candidates that have do-not-disrupt daemonset pods scheduled", func() {
 		daemonSet := test.DaemonSet()
 		nodeClaim, node := test.NodeClaimAndNode(v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
@@ -610,7 +610,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod %q has "karpenter.sh/do-not-disrupt" annotation`, client.ObjectKeyFromObject(pod))))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Cannot disrupt Node: Pod %q has "karpenter.sh/do-not-disrupt" annotation`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
-	It("should consider candidates that have do-not-disrupt pods on terminating pods", func() {
+	It("should consider candidates that have do-not-disrupt terminating pods", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -640,7 +640,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(c.NodeClaim).ToNot(BeNil())
 		Expect(c.Node).ToNot(BeNil())
 	})
-	It("should consider candidates that have do-not-disrupt pods on terminal pods", func() {
+	It("should consider candidates that have do-not-disrupt terminal pods", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -943,7 +943,7 @@ var _ = Describe("Candidate Filtering", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
-		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{}, []*v1beta1.NodeClaim{nodeClaim})
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nil, []*v1beta1.NodeClaim{nodeClaim})
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, cluster.Nodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue)
@@ -1134,7 +1134,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(err.Error()).To(Equal(`instance type "" can't be resolved`))
 		Expect(recorder.DetectedEvent(`Cannot disrupt Node: Instance type "" not found`)).To(BeTrue())
 	})
-	It("should not consider candidates who's instance type cannot be resolved", func() {
+	It("should not consider candidates that have an instance type that cannot be resolved", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -1157,7 +1157,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(err.Error()).To(Equal(fmt.Sprintf("instance type %q can't be resolved", mostExpensiveInstance.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf("Cannot disrupt Node: Instance type %q not found", mostExpensiveInstance.Name))).To(BeTrue())
 	})
-	It("should not consider candidates who are actively being processed in the queue", func() {
+	It("should not consider candidates that are actively being processed in the queue", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -1172,7 +1172,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
-		Expect(queue.Add(orchestration.NewCommand([]string{}, []*state.StateNode{cluster.Nodes()[0]}, "", ""))).To(Succeed())
+		Expect(queue.Add(orchestration.NewCommand([]string{}, []*state.StateNode{cluster.Nodes()[0]}, "", "test-method", "fake-type"))).To(Succeed())
 
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, cluster.Nodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue)
 		Expect(err).To(HaveOccurred())

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -486,6 +486,66 @@ var _ = Describe("Pod Eviction Cost", func() {
 	})
 })
 
+var _ = Describe("Candidate Filtering", func() {
+	It("should not consider candidates that have do-not-disrupt pods scheduled", func() {
+
+	})
+	It("should not consider candidates that have do-not-disrupt pods scheduled to mirror pods", func() {
+
+	})
+	It("should consider candidates that have do-not-disrupt pods on terminating pods", func() {
+
+	})
+	It("should consider candidates that have do-not-disrupt pods on terminal pods", func() {
+
+	})
+	It("should not consider candidates that have do-not-disrupt pods scheduled to DaemonSet pods", func() {
+
+	})
+	It("should not consider candidates that have do-not-disrupt on nodes", func() {
+
+	})
+	It("should not consider candidates that have fully blocking PDBs", func() {
+
+	})
+	It("should not consider candidates that have fully blocking PDBs on mirror pods", func() {
+
+	})
+	It("should not consider candidates that have fully blocking PDBs on daemonset pods", func() {
+
+	})
+	It("should not consider candidates that do not have both Node and NodeClaim representations", func() {
+
+	})
+	It("should not consider candidates that are nominated", func() {
+
+	})
+	It("should not consider candidates that are deleting", func() {
+
+	})
+	It("should not consider candidates that aren't yet initialized", func() {
+
+	})
+	It("should not consider candidates that are not owned by a NodePool", func() {
+
+	})
+	It("should not consider candidates that are have a non-existent NodePool", func() {
+
+	})
+	It("should not consider candidates that do not have the karpenter.sh/capacity-type label", func() {
+
+	})
+	It("should not consider candidates that do not have the topology.kubernetes.io/zone label", func() {
+
+	})
+	It("should not consider candidates that do not have the node.kubernetes.io/instance-type label", func() {
+
+	})
+	It("should not consider candidates who's instance type cannot be resolved", func() {
+
+	})
+})
+
 func leastExpensiveInstanceWithZone(zone string) *cloudprovider.InstanceType {
 	for _, elem := range onDemandInstances {
 		if len(elem.Offerings.Compatible(scheduling.NewRequirements(scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, zone)))) > 0 {

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -502,7 +502,7 @@ var _ = Describe("Candidate Filtering", func() {
 			}),
 		}
 		var err error
-		pdbLimits, err = disruption.NewPDBLimits(ctx, env.Client)
+		pdbLimits, err = disruption.NewPDBLimits(ctx, fakeClock, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 	})
 	It("should not consider candidates that have do-not-disrupt pods scheduled", func() {
@@ -728,7 +728,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = disruption.NewPDBLimits(ctx, env.Client)
+		pdbLimits, err = disruption.NewPDBLimits(ctx, fakeClock, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -775,7 +775,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = disruption.NewPDBLimits(ctx, env.Client)
+		pdbLimits, err = disruption.NewPDBLimits(ctx, fakeClock, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -821,7 +821,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = disruption.NewPDBLimits(ctx, env.Client)
+		pdbLimits, err = disruption.NewPDBLimits(ctx, fakeClock, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -865,7 +865,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = disruption.NewPDBLimits(ctx, env.Client)
+		pdbLimits, err = disruption.NewPDBLimits(ctx, fakeClock, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -903,7 +903,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = disruption.NewPDBLimits(ctx, env.Client)
+		pdbLimits, err = disruption.NewPDBLimits(ctx, fakeClock, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -116,7 +116,6 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 		logging.FromContext(ctx).Errorf("Determining node pods, %s", err)
 		return nil, fmt.Errorf("getting pods from state node, %w", err)
 	}
-
 	cn := &Candidate{
 		StateNode:    node.DeepCopy(),
 		instanceType: instanceType,
@@ -125,7 +124,6 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 		zone:         node.Labels()[v1.LabelTopologyZone],
 		pods:         pods,
 	}
-
 	cn.disruptionCost = disruptionCost(ctx, pods) * cn.lifetimeRemaining(clk)
 	return cn, nil
 }

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -87,10 +87,7 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 	// Get the current representation of the proposed candidates from before the validation timeout
 	// We do this so that we can re-validate that the candidates that were computed before we made the decision are the same
 	// We perform filtering here to ensure that none of the proposed candidates have blocking PDBs or do-not-evict/do-not-disrupt pods scheduled to them
-	validationCandidates, err = filterCandidates(ctx, v.kubeClient, v.recorder, mapCandidates(cmd.candidates, validationCandidates))
-	if err != nil {
-		return false, fmt.Errorf("filtering candidates, %w", err)
-	}
+	validationCandidates = mapCandidates(cmd.candidates, validationCandidates)
 	// If we filtered out any candidates, return false as some NodeClaims in the consolidation decision have changed.
 	if len(validationCandidates) != len(cmd.candidates) {
 		return false, nil

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -80,13 +80,13 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 		case <-v.clock.After(waitDuration):
 		}
 	}
+	// Get the current representation of the proposed candidates from before the validation timeout
+	// We do this so that we can re-validate that the candidates that were computed before we made the decision are the same
+	// We perform filtering here to ensure that none of the proposed candidates have blocking PDBs or do-not-evict/do-not-disrupt pods scheduled to them
 	validationCandidates, err := GetCandidates(ctx, v.cluster, v.kubeClient, v.recorder, v.clock, v.cloudProvider, v.ShouldDisrupt, v.queue)
 	if err != nil {
 		return false, fmt.Errorf("constructing validation candidates, %w", err)
 	}
-	// Get the current representation of the proposed candidates from before the validation timeout
-	// We do this so that we can re-validate that the candidates that were computed before we made the decision are the same
-	// We perform filtering here to ensure that none of the proposed candidates have blocking PDBs or do-not-evict/do-not-disrupt pods scheduled to them
 	validationCandidates = mapCandidates(cmd.candidates, validationCandidates)
 	// If we filtered out any candidates, return false as some NodeClaims in the consolidation decision have changed.
 	if len(validationCandidates) != len(cmd.candidates) {

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(ctx, env.Client, podEvict)
+			EventuallyExpectTerminating(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Reconcile to delete node
@@ -208,7 +208,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(ctx, env.Client, podEvict)
+			EventuallyExpectTerminating(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			ExpectNotEnqueuedForEviction(queue, podSkip)
@@ -236,7 +236,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(ctx, env.Client, podEvict)
+			EventuallyExpectTerminating(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Reconcile to delete node
@@ -259,7 +259,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect pod with no owner ref to be enqueued for eviction
-			ExpectEvicted(ctx, env.Client, pod)
+			EventuallyExpectTerminating(ctx, env.Client, pod)
 
 			// Expect node to exist and be draining
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
@@ -379,7 +379,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(ctx, env.Client, podEvict)
+			EventuallyExpectTerminating(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Expect the noncritical Daemon pod to be evicted
@@ -387,7 +387,7 @@ var _ = Describe("Termination", func() {
 			ExpectPodExists(ctx, env.Client, podDaemonEvict.Name, podDaemonEvict.Namespace)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
-			ExpectEvicted(ctx, env.Client, podDaemonEvict)
+			EventuallyExpectTerminating(ctx, env.Client, podDaemonEvict)
 			ExpectDeleted(ctx, env.Client, podDaemonEvict)
 
 			// Expect the critical pods to be evicted and deleted
@@ -397,8 +397,8 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
-			ExpectEvicted(ctx, env.Client, podNodeCritical)
-			ExpectEvicted(ctx, env.Client, podClusterCritical)
+
+			EventuallyExpectTerminating(ctx, env.Client, podNodeCritical, podClusterCritical)
 			ExpectDeleted(ctx, env.Client, podNodeCritical)
 			ExpectDeleted(ctx, env.Client, podClusterCritical)
 
@@ -409,8 +409,8 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
-			ExpectEvicted(ctx, env.Client, podDaemonNodeCritical)
-			ExpectEvicted(ctx, env.Client, podDaemonClusterCritical)
+
+			EventuallyExpectTerminating(ctx, env.Client, podDaemonNodeCritical, podDaemonClusterCritical)
 			ExpectDeleted(ctx, env.Client, podDaemonNodeCritical)
 			ExpectDeleted(ctx, env.Client, podDaemonClusterCritical)
 
@@ -436,7 +436,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(ctx, env.Client, podEvict)
+			EventuallyExpectTerminating(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Expect the critical pods to be evicted and deleted
@@ -444,8 +444,8 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
-			ExpectEvicted(ctx, env.Client, podNodeCritical)
-			ExpectEvicted(ctx, env.Client, podClusterCritical)
+
+			EventuallyExpectTerminating(ctx, env.Client, podNodeCritical, podClusterCritical)
 			ExpectDeleted(ctx, env.Client, podNodeCritical)
 			ExpectDeleted(ctx, env.Client, podClusterCritical)
 
@@ -481,7 +481,7 @@ var _ = Describe("Termination", func() {
 			ExpectNotEnqueuedForEviction(queue, podNoEvict)
 
 			// Expect podEvict to be enqueued for eviction then be successful
-			ExpectEvicted(ctx, env.Client, podEvict)
+			EventuallyExpectTerminating(ctx, env.Client, podEvict)
 
 			// Expect node to exist and be draining
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
@@ -511,7 +511,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect the pods to be evicted
-			ExpectEvicted(ctx, env.Client, pods[0], pods[1])
+			EventuallyExpectTerminating(ctx, env.Client, pods[0], pods[1])
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
@@ -544,7 +544,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect the pods to be evicted
-			ExpectEvicted(ctx, env.Client, pods[0], pods[1])
+			EventuallyExpectTerminating(ctx, env.Client, pods[0], pods[1])
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
@@ -572,7 +572,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectEvicted(ctx, env.Client, pod)
+			EventuallyExpectTerminating(ctx, env.Client, pod)
 
 			// After grace period, node should delete. The deletion timestamps are from etcd which we can't control, so
 			// to eliminate test-flakiness we reset the time to current time + 90 seconds instead of just advancing
@@ -618,6 +618,6 @@ func ExpectNodeWithNodeClaimDraining(c client.Client, nodeName string) *v1.Node 
 	node := ExpectNodeExists(ctx, c, nodeName)
 	Expect(node.Spec.Taints).To(ContainElement(v1beta1.DisruptionNoScheduleTaint))
 	Expect(lo.Contains(node.Finalizers, v1beta1.TerminationFinalizer)).To(BeTrue())
-	Expect(node.DeletionTimestamp.IsZero()).To(BeFalse())
+	Expect(node.DeletionTimestamp).ToNot(BeNil())
 	return node
 }

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -18,7 +18,6 @@ package termination_test
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -181,7 +180,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(env.Client, podEvict)
+			ExpectEvicted(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Reconcile to delete node
@@ -209,7 +208,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(env.Client, podEvict)
+			ExpectEvicted(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			ExpectNotEnqueuedForEviction(queue, podSkip)
@@ -237,7 +236,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(env.Client, podEvict)
+			ExpectEvicted(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Reconcile to delete node
@@ -260,7 +259,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect pod with no owner ref to be enqueued for eviction
-			ExpectEvicted(env.Client, pod)
+			ExpectEvicted(ctx, env.Client, pod)
 
 			// Expect node to exist and be draining
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
@@ -380,7 +379,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(env.Client, podEvict)
+			ExpectEvicted(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Expect the noncritical Daemon pod to be evicted
@@ -388,7 +387,7 @@ var _ = Describe("Termination", func() {
 			ExpectPodExists(ctx, env.Client, podDaemonEvict.Name, podDaemonEvict.Namespace)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
-			ExpectEvicted(env.Client, podDaemonEvict)
+			ExpectEvicted(ctx, env.Client, podDaemonEvict)
 			ExpectDeleted(ctx, env.Client, podDaemonEvict)
 
 			// Expect the critical pods to be evicted and deleted
@@ -398,8 +397,8 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
-			ExpectEvicted(env.Client, podNodeCritical)
-			ExpectEvicted(env.Client, podClusterCritical)
+			ExpectEvicted(ctx, env.Client, podNodeCritical)
+			ExpectEvicted(ctx, env.Client, podClusterCritical)
 			ExpectDeleted(ctx, env.Client, podNodeCritical)
 			ExpectDeleted(ctx, env.Client, podClusterCritical)
 
@@ -410,8 +409,8 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
-			ExpectEvicted(env.Client, podDaemonNodeCritical)
-			ExpectEvicted(env.Client, podDaemonClusterCritical)
+			ExpectEvicted(ctx, env.Client, podDaemonNodeCritical)
+			ExpectEvicted(ctx, env.Client, podDaemonClusterCritical)
 			ExpectDeleted(ctx, env.Client, podDaemonNodeCritical)
 			ExpectDeleted(ctx, env.Client, podDaemonClusterCritical)
 
@@ -437,7 +436,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podEvict to be evicting, and delete it
-			ExpectEvicted(env.Client, podEvict)
+			ExpectEvicted(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Expect the critical pods to be evicted and deleted
@@ -445,8 +444,8 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
-			ExpectEvicted(env.Client, podNodeCritical)
-			ExpectEvicted(env.Client, podClusterCritical)
+			ExpectEvicted(ctx, env.Client, podNodeCritical)
+			ExpectEvicted(ctx, env.Client, podClusterCritical)
 			ExpectDeleted(ctx, env.Client, podNodeCritical)
 			ExpectDeleted(ctx, env.Client, podClusterCritical)
 
@@ -482,7 +481,7 @@ var _ = Describe("Termination", func() {
 			ExpectNotEnqueuedForEviction(queue, podNoEvict)
 
 			// Expect podEvict to be enqueued for eviction then be successful
-			ExpectEvicted(env.Client, podEvict)
+			ExpectEvicted(ctx, env.Client, podEvict)
 
 			// Expect node to exist and be draining
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
@@ -512,7 +511,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect the pods to be evicted
-			ExpectEvicted(env.Client, pods[0], pods[1])
+			ExpectEvicted(ctx, env.Client, pods[0], pods[1])
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
@@ -545,7 +544,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect the pods to be evicted
-			ExpectEvicted(env.Client, pods[0], pods[1])
+			ExpectEvicted(ctx, env.Client, pods[0], pods[1])
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
@@ -573,7 +572,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectEvicted(env.Client, pod)
+			ExpectEvicted(ctx, env.Client, pod)
 
 			// After grace period, node should delete. The deletion timestamps are from etcd which we can't control, so
 			// to eliminate test-flakiness we reset the time to current time + 90 seconds instead of just advancing
@@ -611,17 +610,6 @@ func ExpectNotEnqueuedForEviction(e *terminator.Queue, pods ...*v1.Pod) {
 	GinkgoHelper()
 	for _, pod := range pods {
 		Expect(e.Contains(client.ObjectKeyFromObject(pod))).To(BeFalse())
-	}
-}
-
-func ExpectEvicted(c client.Client, pods ...*v1.Pod) {
-	GinkgoHelper()
-	for _, pod := range pods {
-		Eventually(func() bool {
-			return ExpectPodExists(ctx, c, pod.Name, pod.Namespace).GetDeletionTimestamp().IsZero()
-		}, ReconcilerPropagationTime, RequestInterval).Should(BeFalse(), func() string {
-			return fmt.Sprintf("expected %s/%s to be evicting, but it isn't", pod.Namespace, pod.Name)
-		})
 	}
 }
 

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -19,7 +19,6 @@ package terminator
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
@@ -27,6 +26,8 @@ import (
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nodeutil "sigs.k8s.io/karpenter/pkg/utils/node"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	podutil "sigs.k8s.io/karpenter/pkg/utils/pod"
@@ -79,32 +80,14 @@ func (t *Terminator) Taint(ctx context.Context, node *v1.Node) error {
 // Drain evicts pods from the node and returns true when all pods are evicted
 // https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 func (t *Terminator) Drain(ctx context.Context, node *v1.Node) error {
-	// Get evictable pods
-	pods := &v1.PodList{}
-	if err := t.kubeClient.List(ctx, pods, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
+	pods, err := nodeutil.GetEvictablePods(ctx, t.kubeClient, node)
+	if err != nil {
 		return fmt.Errorf("listing pods on node, %w", err)
 	}
-
-	// Skip node due to pods that are not able to be evicted
-	podsToEvict := lo.FilterMap(pods.Items, func(po v1.Pod, _ int) (*v1.Pod, bool) {
-		p := lo.ToPtr(po)
-		// Ignore pods that tolerate the karpenter.sh/disruption taint.
-		if podutil.ToleratesDisruptionNoScheduleTaint(p) ||
-			// Ignore static mirror pods
-			podutil.IsOwnedByNode(p) ||
-			// Ignore if the pod is complete and doesn't need to be evicted
-			podutil.IsTerminal(p) ||
-			// Ignore if kubelet is partitioned and pods are beyond graceful termination window
-			t.isStuckTerminating(p) {
-			return nil, false
-		}
-		return p, true
-	})
 	// Enqueue for eviction
-	t.Evict(podsToEvict)
-
-	if len(podsToEvict) > 0 {
-		return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", len(podsToEvict)))
+	t.Evict(pods)
+	if len(pods) > 0 {
+		return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", len(pods)))
 	}
 	return nil
 }
@@ -144,11 +127,4 @@ func (t *Terminator) Evict(pods []*v1.Pod) {
 	} else if len(criticalDaemon) != 0 {
 		t.evictionQueue.Add(criticalDaemon...)
 	}
-}
-
-func (t *Terminator) isStuckTerminating(pod *v1.Pod) bool {
-	if pod.DeletionTimestamp == nil {
-		return false
-	}
-	return t.clock.Now().After(pod.DeletionTimestamp.Time.Add(1 * time.Minute))
 }

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -80,7 +80,7 @@ func (t *Terminator) Taint(ctx context.Context, node *v1.Node) error {
 // Drain evicts pods from the node and returns true when all pods are evicted
 // https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 func (t *Terminator) Drain(ctx context.Context, node *v1.Node) error {
-	pods, err := nodeutil.GetEvictablePods(ctx, t.kubeClient, node)
+	pods, err := nodeutil.GetEvictablePods(ctx, t.kubeClient, t.clock.Now(), node)
 	if err != nil {
 		return fmt.Errorf("listing pods on node, %w", err)
 	}

--- a/pkg/controllers/nodeclaim/consistency/controller.go
+++ b/pkg/controllers/nodeclaim/consistency/controller.go
@@ -70,7 +70,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, recorder events.Re
 		recorder:    recorder,
 		lastScanned: cache.New(scanPeriod, 1*time.Minute),
 		checks: []Check{
-			NewTermination(kubeClient),
+			NewTermination(clk, kubeClient),
 			NewNodeShape(provider),
 		},
 	})

--- a/pkg/controllers/nodeclaim/consistency/suite_test.go
+++ b/pkg/controllers/nodeclaim/consistency/suite_test.go
@@ -120,7 +120,7 @@ var _ = Describe("NodeClaimController", func() {
 			ExpectManualBinding(ctx, env.Client, p, node)
 			_ = env.Client.Delete(ctx, nodeClaim)
 			ExpectReconcileSucceeded(ctx, nodeClaimConsistencyController, client.ObjectKeyFromObject(nodeClaim))
-			Expect(recorder.DetectedEvent(fmt.Sprintf("can't drain node, PDB %s/%s is blocking evictions", pdb.Namespace, pdb.Name))).To(BeTrue())
+			Expect(recorder.DetectedEvent(fmt.Sprintf("can't drain node, PDB %q is blocking evictions", client.ObjectKeyFromObject(pdb)))).To(BeTrue())
 		})
 	})
 

--- a/pkg/controllers/nodeclaim/consistency/termination.go
+++ b/pkg/controllers/nodeclaim/consistency/termination.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -30,11 +31,13 @@ import (
 
 // Termination detects nodes that are stuck terminating and reports why.
 type Termination struct {
+	clk        clock.Clock
 	kubeClient client.Client
 }
 
-func NewTermination(kubeClient client.Client) Check {
+func NewTermination(clk clock.Clock, kubeClient client.Client) Check {
 	return &Termination{
+		clk:        clk,
 		kubeClient: kubeClient,
 	}
 }
@@ -44,7 +47,7 @@ func (t *Termination) Check(ctx context.Context, node *v1.Node, nodeClaim *v1bet
 	if nodeClaim.DeletionTimestamp.IsZero() {
 		return nil, nil
 	}
-	pdbs, err := disruption.NewPDBLimits(ctx, t.kubeClient)
+	pdbs, err := disruption.NewPDBLimits(ctx, t.clk, t.kubeClient)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +56,8 @@ func (t *Termination) Check(ctx context.Context, node *v1.Node, nodeClaim *v1bet
 		return nil, err
 	}
 	var issues []Issue
-	if pdb, ok := pdbs.CanEvictPods(pods); !ok {
-		issues = append(issues, Issue(fmt.Sprintf("can't drain node, PDB %s is blocking evictions", pdb)))
+	if pdbKey, ok := pdbs.CanEvictPods(pods); !ok {
+		issues = append(issues, Issue(fmt.Sprintf("can't drain node, PDB %q is blocking evictions", pdbKey)))
 	}
 	return issues, nil
 }

--- a/pkg/controllers/nodeclaim/consistency/termination.go
+++ b/pkg/controllers/nodeclaim/consistency/termination.go
@@ -48,7 +48,7 @@ func (t *Termination) Check(ctx context.Context, node *v1.Node, nodeClaim *v1bet
 	if err != nil {
 		return nil, err
 	}
-	pods, err := nodeutils.GetReschedulablePods(ctx, t.kubeClient, node)
+	pods, err := nodeutils.GetPods(ctx, t.kubeClient, node)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/nodeclaim/consistency/termination.go
+++ b/pkg/controllers/nodeclaim/consistency/termination.go
@@ -48,7 +48,7 @@ func (t *Termination) Check(ctx context.Context, node *v1.Node, nodeClaim *v1bet
 	if err != nil {
 		return nil, err
 	}
-	pods, err := nodeutils.GetNodePods(ctx, t.kubeClient, node)
+	pods, err := nodeutils.GetReschedulablePods(ctx, t.kubeClient, node)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/nodeclaim/disruption/emptiness.go
+++ b/pkg/controllers/nodeclaim/disruption/emptiness.go
@@ -90,7 +90,7 @@ func (e *Emptiness) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, n
 		}
 		return reconcile.Result{RequeueAfter: time.Second * 30}, nil
 	}
-	pods, err := node.GetNodePods(ctx, e.kubeClient, n)
+	pods, err := node.GetReschedulablePods(ctx, e.kubeClient, n)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("retrieving node pods, %w", err)
 	}

--- a/pkg/controllers/nodeclaim/disruption/emptiness_test.go
+++ b/pkg/controllers/nodeclaim/disruption/emptiness_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
@@ -108,9 +107,6 @@ var _ = Describe("Emptiness", func() {
 
 		for _, p := range pods {
 			// Trigger an eviction to set the deletion timestamp but not delete the pod
-			Expect(env.KubernetesInterface.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policyv1.Eviction{
-				ObjectMeta: metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace},
-			})).To(Succeed())
 			ExpectEvicted(ctx, env.Client, p)
 			ExpectExists(ctx, env.Client, p)
 		}
@@ -241,9 +237,6 @@ var _ = Describe("Emptiness", func() {
 		ExpectApplied(ctx, env.Client, pod)
 
 		// Trigger an eviction to set the deletion timestamp but not delete the pod
-		Expect(env.KubernetesInterface.PolicyV1().Evictions(pod.Namespace).Evict(ctx, &policyv1.Eviction{
-			ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
-		})).To(Succeed())
 		ExpectEvicted(ctx, env.Client, pod)
 		ExpectExists(ctx, env.Client, pod)
 

--- a/pkg/controllers/nodeclaim/disruption/emptiness_test.go
+++ b/pkg/controllers/nodeclaim/disruption/emptiness_test.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -72,6 +74,77 @@ var _ = Describe("Emptiness", func() {
 	It("should mark NodeClaims as empty", func() {
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue()).To(BeTrue())
+	})
+	It("should mark NodeClaims as empty that have only pods in terminating state", func() {
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
+
+		// Pod owned by a Deployment
+		pods := test.Pods(3, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			NodeName:   node.Name,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		})
+		ExpectApplied(ctx, env.Client, lo.Map(pods, func(p *v1.Pod, _ int) client.Object { return p })...)
+
+		for _, p := range pods {
+			// Trigger an eviction to set the deletion timestamp but not delete the pod
+			Expect(env.KubernetesInterface.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policyv1.Eviction{
+				ObjectMeta: metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace},
+			})).To(Succeed())
+			ExpectEvicted(ctx, env.Client, p)
+			ExpectExists(ctx, env.Client, p)
+		}
+
+		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue()).To(BeTrue())
+	})
+	It("should mark NodeClaims as empty that have only DaemonSet pods", func() {
+		ds := test.DaemonSet()
+		ExpectApplied(ctx, env.Client, ds)
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
+
+		// Pod owned by a DaemonSet
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "DaemonSet",
+						Name:               ds.Name,
+						UID:                ds.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			NodeName:   node.Name,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		})
+		ExpectApplied(ctx, env.Client, pod)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
@@ -137,6 +210,45 @@ var _ = Describe("Emptiness", func() {
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
+	})
+	It("should remove the status condition from NodeClaims that have a StatefulSet pod in terminating state", func() {
+		ss := test.StatefulSet()
+		ExpectApplied(ctx, env.Client, ss)
+
+		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
+
+		// Pod owned by a StatefulSet
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "StatefulSet",
+						Name:               ss.Name,
+						UID:                ss.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			NodeName:   node.Name,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+		})
+		ExpectApplied(ctx, env.Client, pod)
+
+		// Trigger an eviction to set the deletion timestamp but not delete the pod
+		Expect(env.KubernetesInterface.PolicyV1().Evictions(pod.Namespace).Evict(ctx, &policyv1.Eviction{
+			ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+		})).To(Succeed())
+		ExpectEvicted(ctx, env.Client, pod)
+		ExpectExists(ctx, env.Client, pod)
+
+		// The node isn't empty even though it only has terminating pods
+		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
 	})

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -179,14 +179,14 @@ func (p *Provisioner) consolidationWarnings(ctx context.Context, po *v1.Pod) {
 	if po.Spec.Affinity != nil && po.Spec.Affinity.PodAntiAffinity != nil {
 		if len(po.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0 {
 			if p.cm.HasChanged(string(po.UID), "pod-antiaffinity") {
-				logging.FromContext(ctx).Infof("pod %s has a preferred Anti-Affinity which can prevent consolidation", client.ObjectKeyFromObject(po))
+				logging.FromContext(ctx).Infof("pod %q has a preferred Anti-Affinity which can prevent consolidation", client.ObjectKeyFromObject(po))
 			}
 		}
 	}
 	for _, tsc := range po.Spec.TopologySpreadConstraints {
 		if tsc.WhenUnsatisfiable == v1.ScheduleAnyway {
 			if p.cm.HasChanged(string(po.UID), "pod-topology-spread") {
-				logging.FromContext(ctx).Infof("pod %s has a preferred TopologySpreadConstraint which can prevent consolidation", client.ObjectKeyFromObject(po))
+				logging.FromContext(ctx).Infof("pod %q has a preferred TopologySpreadConstraint which can prevent consolidation", client.ObjectKeyFromObject(po))
 			}
 		}
 	}

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -3431,9 +3430,6 @@ var _ = Context("NodePool", func() {
 			cluster.MarkForDeletion(node.Spec.ProviderID)
 
 			// Trigger an eviction to set the deletion timestamp but not delete the pod
-			Expect(env.KubernetesInterface.PolicyV1().Evictions(pod.Namespace).Evict(ctx, &policyv1.Eviction{
-				ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
-			})).To(Succeed())
 			ExpectEvicted(ctx, env.Client, pod)
 			ExpectExists(ctx, env.Client, pod)
 
@@ -3491,9 +3487,6 @@ var _ = Context("NodePool", func() {
 			cluster.MarkForDeletion(node.Spec.ProviderID)
 
 			// Trigger an eviction to set the deletion timestamp but not delete the pod
-			Expect(env.KubernetesInterface.PolicyV1().Evictions(pod.Namespace).Evict(ctx, &policyv1.Eviction{
-				ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
-			})).To(Succeed())
 			ExpectEvicted(ctx, env.Client, pod)
 			ExpectExists(ctx, env.Client, pod)
 
@@ -3538,9 +3531,6 @@ var _ = Context("NodePool", func() {
 			cluster.MarkForDeletion(node.Spec.ProviderID)
 
 			// Trigger an eviction to set the deletion timestamp but not delete the pod
-			Expect(env.KubernetesInterface.PolicyV1().Evictions(pod.Namespace).Evict(ctx, &policyv1.Eviction{
-				ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
-			})).To(Succeed())
 			ExpectEvicted(ctx, env.Client, pod)
 			ExpectExists(ctx, env.Client, pod)
 
@@ -3585,9 +3575,6 @@ var _ = Context("NodePool", func() {
 			cluster.MarkForDeletion(node.Spec.ProviderID)
 
 			// Trigger an eviction to set the deletion timestamp but not delete the pod
-			Expect(env.KubernetesInterface.PolicyV1().Evictions(pod.Namespace).Evict(ctx, &policyv1.Eviction{
-				ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
-			})).To(Succeed())
 			ExpectEvicted(ctx, env.Client, pod)
 			ExpectExists(ctx, env.Client, pod)
 

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -70,6 +70,18 @@ func (n StateNodes) Pods(ctx context.Context, c client.Client) ([]*v1.Pod, error
 	return pods, nil
 }
 
+func (n StateNodes) ReschedulablePods(ctx context.Context, c client.Client) ([]*v1.Pod, error) {
+	var pods []*v1.Pod
+	for _, node := range n {
+		p, err := node.ReschedulablePods(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+		pods = append(pods, p...)
+	}
+	return pods, nil
+}
+
 // StateNode is a cached version of a node in the cluster that maintains state which is expensive to compute every time it's
 // needed.  This currently contains node utilization across all the allocatable resources, but will soon be used to
 // compute topology information.
@@ -135,7 +147,15 @@ func (in *StateNode) Pods(ctx context.Context, c client.Client) ([]*v1.Pod, erro
 	if in.Node == nil {
 		return nil, nil
 	}
-	return nodeutils.GetNodePods(ctx, c, in.Node)
+	return nodeutils.GetPods(ctx, c, in.Node)
+}
+
+// ReschedulablePods gets the pods assigned to the Node that are reschedulable based on the kubernetes api-server bindings
+func (in *StateNode) ReschedulablePods(ctx context.Context, c client.Client) ([]*v1.Pod, error) {
+	if in.Node == nil {
+		return nil, nil
+	}
+	return nodeutils.GetReschedulablePods(ctx, c, in.Node)
 }
 
 func (in *StateNode) HostName() string {

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -178,7 +178,7 @@ func ExpectDeletionTimestampSet(ctx context.Context, c client.Client, objects ..
 		DeferCleanup(func(obj client.Object) {
 			mergeFrom := client.MergeFrom(obj.DeepCopyObject().(client.Object))
 			obj.SetFinalizers([]string{})
-			Expect(c.Patch(ctx, obj, mergeFrom)).To(Succeed())
+			Expect(client.IgnoreNotFound(c.Patch(ctx, obj, mergeFrom))).To(Succeed())
 		}, object)
 	}
 }

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -588,3 +588,14 @@ func ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx context.Context,
 		ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(m))
 	}
 }
+
+func ExpectEvicted(ctx context.Context, c client.Client, pods ...*v1.Pod) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		for _, pod := range pods {
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+			g.Expect(pod.DeletionTimestamp.IsZero()).ToNot(BeTrue())
+		}
+	})
+}

--- a/pkg/test/statefulsets.go
+++ b/pkg/test/statefulsets.go
@@ -26,15 +26,15 @@ import (
 	"knative.dev/pkg/ptr"
 )
 
-type DeploymentOptions struct {
+type StatefulSetOptions struct {
 	metav1.ObjectMeta
 	Labels     map[string]string
 	Replicas   int32
 	PodOptions PodOptions
 }
 
-func Deployment(overrides ...DeploymentOptions) *appsv1.Deployment {
-	options := DeploymentOptions{}
+func StatefulSet(overrides ...StatefulSetOptions) *appsv1.StatefulSet {
+	options := StatefulSetOptions{}
 	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
 			panic(fmt.Sprintf("Failed to merge deployment options: %s", err))
@@ -52,9 +52,9 @@ func Deployment(overrides ...DeploymentOptions) *appsv1.Deployment {
 		}
 	}
 	pod := Pod(options.PodOptions)
-	return &appsv1.Deployment{
+	return &appsv1.StatefulSet{
 		ObjectMeta: objectMeta,
-		Spec: appsv1.DeploymentSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: ptr.Int32(options.Replicas),
 			Selector: &metav1.LabelSelector{MatchLabels: options.PodOptions.Labels},
 			Template: v1.PodTemplateSpec{

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -19,7 +19,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
@@ -51,17 +50,6 @@ func GetReschedulablePods(ctx context.Context, kubeClient client.Client, nodes .
 	}
 	return lo.Filter(pods, func(p *v1.Pod, _ int) bool {
 		return pod.IsReschedulable(p)
-	}), nil
-}
-
-// GetEvictablePods grabs all pods from the passed nodes that satisfy the IsEvictable criteria
-func GetEvictablePods(ctx context.Context, kubeClient client.Client, now time.Time, nodes ...*v1.Node) ([]*v1.Pod, error) {
-	pods, err := GetPods(ctx, kubeClient, nodes...)
-	if err != nil {
-		return nil, fmt.Errorf("listing pods, %w", err)
-	}
-	return lo.Filter(pods, func(p *v1.Pod, _ int) bool {
-		return pod.IsEvictable(p, now)
 	}), nil
 }
 

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
+// GetPods grabs all pods that are currently bound to the passed nodes
 func GetPods(ctx context.Context, kubeClient client.Client, nodes ...*v1.Node) ([]*v1.Pod, error) {
 	var pods []*v1.Pod
 	for _, node := range nodes {
@@ -41,43 +43,30 @@ func GetPods(ctx context.Context, kubeClient client.Client, nodes ...*v1.Node) (
 	return pods, nil
 }
 
-// GetReschedulablePods gets the list of schedulable pods from a variadic list of nodes
-// It ignores pods that are owned by the node, a daemonset or are in a terminal
-// or terminating state
+// GetReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
 func GetReschedulablePods(ctx context.Context, kubeClient client.Client, nodes ...*v1.Node) ([]*v1.Pod, error) {
-	var pods []*v1.Pod
-	for _, node := range nodes {
-		var podList v1.PodList
-		if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
-			return nil, fmt.Errorf("listing pods, %w", err)
-		}
-		for i := range podList.Items {
-			// these pods don't need to be rescheduled
-			if pod.IsReschedulable(&podList.Items[i]) {
-				pods = append(pods, &podList.Items[i])
-			}
-		}
+	pods, err := GetPods(ctx, kubeClient, nodes...)
+	if err != nil {
+		return nil, fmt.Errorf("listing pods, %w", err)
 	}
-	return pods, nil
+	return lo.Filter(pods, func(p *v1.Pod, _ int) bool {
+		return pod.IsReschedulable(p)
+	}), nil
 }
 
+// GetEvictablePods grabs all pods from the passed nodes that satisfy the IsEvictable criteria
 func GetEvictablePods(ctx context.Context, kubeClient client.Client, now time.Time, nodes ...*v1.Node) ([]*v1.Pod, error) {
-	var pods []*v1.Pod
-	for _, node := range nodes {
-		var podList v1.PodList
-		if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
-			return nil, fmt.Errorf("listing pods, %w", err)
-		}
-		for i := range podList.Items {
-			// these pods don't need to be rescheduled
-			if pod.IsEvictable(&podList.Items[i], now) {
-				pods = append(pods, &podList.Items[i])
-			}
-		}
+	pods, err := GetPods(ctx, kubeClient, nodes...)
+	if err != nil {
+		return nil, fmt.Errorf("listing pods, %w", err)
 	}
-	return pods, nil
+	return lo.Filter(pods, func(p *v1.Pod, _ int) bool {
+		return pod.IsEvictable(p, now)
+	}), nil
 }
 
+// GetProvisionablePods grabs all the pods on the cluster that are not currently bound to nodes and
+// satisfy the IsProvisionable criteria
 func GetProvisionablePods(ctx context.Context, kubeClient client.Client) ([]*v1.Pod, error) {
 	var pods []*v1.Pod
 	var podList v1.PodList

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -105,7 +105,7 @@ func IsStuckTerminating(pod *v1.Pod, now time.Time) bool {
 	if pod.DeletionTimestamp.IsZero() {
 		return false
 	}
-	// The PodDeletion timestamp will be set to the time the pod was deleted plus its
+	// The pod DeletionTimestamp will be set to the time the pod was deleted plus its
 	// grace period in seconds. We give an additional minute as a buffer
 	return now.After(pod.DeletionTimestamp.Time.Add(time.Minute))
 }
@@ -141,11 +141,6 @@ func HasDoNotDisrupt(pod *v1.Pod) bool {
 	// TODO Remove checking do-not-evict as part of v1
 	return pod.Annotations[v1alpha5.DoNotEvictPodAnnotationKey] == "true" ||
 		pod.Annotations[v1beta1.DoNotDisruptAnnotationKey] == "true"
-}
-
-// ToleratesUnschedulableTaint returns true if the pod tolerates node.kubernetes.io/unschedulable taint
-func ToleratesUnschedulableTaint(pod *v1.Pod) bool {
-	return (scheduling.Taints{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}).Tolerates(pod) == nil
 }
 
 // ToleratesDisruptionNoScheduleTaint returns true if the pod tolerates karpenter.sh/disruption:NoSchedule=Disrupting taint

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -51,7 +51,7 @@ func IsReschedulable(pod *v1.Pod) bool {
 
 // IsEvictable checks if a pod is evictable by Karpenter by ensuring that the pod:
 // - Is an active pod (isn't terminal or actively terminating)
-// - Doesn't tolerate the "karepnter.sh/disruption=disrupting" taint
+// - Doesn't tolerate the "karpenter.sh/disruption=disrupting" taint
 // - Isn't a mirror pod (https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/)
 func IsEvictable(pod *v1.Pod) bool {
 	return IsActive(pod) &&
@@ -62,7 +62,7 @@ func IsEvictable(pod *v1.Pod) bool {
 // IsWaitingEviction checks if this is a pod that we are waiting to be removed from the node by ensuring that the pod:
 // - Isn't a terminal pod (Failed or Succeeded)
 // - Isn't a pod that has been terminating past its terminationGracePeriodSeconds
-// - Doesn't tolerate the "karepnter.sh/disruption=disrupting" taint
+// - Doesn't tolerate the "karpenter.sh/disruption=disrupting" taint
 // - Isn't a mirror pod (https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/)
 func IsWaitingEviction(pod *v1.Pod, clk clock.Clock) bool {
 	return !IsTerminal(pod) &&
@@ -123,7 +123,9 @@ func IsTerminating(pod *v1.Pod) bool {
 
 func IsStuckTerminating(pod *v1.Pod, clk clock.Clock) bool {
 	// The pod DeletionTimestamp will be set to the time the pod was deleted plus its
-	// grace period in seconds. We give an additional minute as a buffer
+	// grace period in seconds. We give an additional minute as a buffer to allow
+	// pods to force delete off the node before we actually go and terminate the node
+	// so that we get less pod leaking on the cluster.
 	return IsTerminating(pod) && clk.Since(pod.DeletionTimestamp.Time) > time.Minute
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #643
Fixes #863

**Description**

This PR creates the following node helper functions to grab the pods on the cluster or attached to nodes:
1. `IsActive()` - This filtering function is used for PDBs and `karpenter.sh/do-not-disrupt` checking to evaluate if a node can be determined based on the active pods that are running on it
2. `IsReschedulable()` - This filtering function is used by the provisioner to determine the pods that we should attempt to reschedule based on the pods that are currently scheduled to the existing node
3. `IsEvictable()` - This filtering function is used by the node terminator and for PDB evaluation to determine the pods that can be evicted based on whether the pod is a mirror pod, is terminating, is already completed, or tolerates the disruption taint such that it would reschedule after being evicted
4. `IsWaitingEviction()` - This filtering function is used by the node terminator to determine the pods that are waiting to be evicted from the node based on whether the pod is a mirror pod, is past its termination grace period, is already completed, or tolerates the disruption taint such that it would reschedule after being evicted
5. `IsProvisionable()` - This filtering function is used to filter all pods on the cluster to determine which pods are marked in a `Pending` state and need to be scheduled by the provsioner

This PR resolves the following issues that were present in the karpenter code:
1. Karpenter was evaluating the reschedulable pods for `karpenter.sh/do-not-disrupt`. This meant that any DaemonSet pods or Mirror pods were not considered for `karpenter.sh/do-not-disrupt`. Though this isn't a common scenario for using this annotation on pods, there were asks in #863 for support for mirror pods, which would have already been the case had we been getting all of the active pods that were bound to a candidate node
2. Karpenter was evaluating the reschedulable pods for PDBs. This mean that any DaemonSet pods or mirror pods were not considered for PDBs. This isn't a problem for mirror pods, since mirror pods aren't evaluated for eviction, which means that we won't check for PDB evaluation when we are draining the node and going through the node termination; however, this is a problem for DaemonSet pods. You can create a PDB against DaemonSets. Though this isn't a common use-case at all for using PDBs, we should strive to be correct here. Since we evaluate PDBs when we drain, we should also do the same check when we are evaluating for disruption. This PR changes the logic to consider all pods (including DaemonSet pods) as long as we will run the same pods through the eviction API when we terminate (this means that mirror pods or any pod that tolerates `karpenter.sh/disruption=disrupting` shouldn't be evaluated here). 
3. Adds common pods functions for evaluating each of the conditions above. This should help anyone who is looking at changing the relevant areas of this code to better-understand what filtering is done pods that are bound to nodes and why that filtering is done.

**How was this change tested?**

`make presubmit`
Manual validation of consistency between the eviction API and Karpenter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
