### PR TITLE
chore: bumping length of the message we store on the nodeclaim

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -148,8 +148,8 @@ func PopulateNodeClaimDetails(nodeClaim, retrieved *v1beta1.NodeClaim) *v1beta1.
 }
 
 func truncateMessage(msg string) string {
-	if len(msg) < 300 {
+	if len(msg) < 1000 {
 		return msg
 	}
-	return msg[:300] + "..."
+	return msg[:1000] + "..."
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Azure Returns back long errors on the nodeclaim, and they are truncated to 300 characters. The Azure SDK For Go error messages have some wrappers around them that add quite a few additional characters onto the error message. 

So as a result, we get a very abruptly truncated error message. 
```
Status:
  Conditions:
    Last Transition Time:  2023-11-21T22:06:39Z
    Message:               Node not launched
    Reason:                NotLaunched
    Status:                False
    Type:                  Initialized
    Last Transition Time:  2023-11-21T22:06:39Z
    Message:               creating instance, virtualMachine.BeginCreateOrUpdate for VM "aks-general-purpose-ljm95" failed: PUT https://management.azure.com/subscriptions/xxxxxxx1/resourceGroups/MC_sillygoose-rg-2_sillygoose-nap-cluster_uksouth/providers/Microsoft.Compute/virtualMachines/aks-genera...
    Reason:                LaunchFailed
    Status:                False
    Type:                  Launched
    Last Transition Time:  2023-11-21T22:06:39Z
```
    
    I would prefer to extend this to 1000 characters to show the important bits of the azure errors. 
    


**How was this change tested?**
- make presubmit
- inflate scale up to view nodeclaim. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
