### PR TITLE
chore: Fix configmap waiter for `karpenter-global-settings`

### DIFF
--- a/pkg/operator/injection/injection.go
+++ b/pkg/operator/injection/injection.go
@@ -81,7 +81,7 @@ func WithSettingsOrDie(ctx context.Context, kubernetesInterface kubernetes.Inter
 	factory.Start(cancelCtx.Done())
 
 	for _, setting := range settings {
-		cm, err := WaitForConfigMap(ctx, setting.ConfigMap(), informer)
+		cm, err := WaitForConfigMap(cancelCtx, setting.ConfigMap(), informer)
 		if client.IgnoreNotFound(err) != nil {
 			panic(fmt.Errorf("failed to get configmap %s, %w", setting.ConfigMap(), err))
 		}

--- a/pkg/operator/logging/suite_test.go
+++ b/pkg/operator/logging/suite_test.go
@@ -1,0 +1,89 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/system"
+
+	"github.com/aws/karpenter-core/pkg/operator/logging"
+	"github.com/aws/karpenter-core/pkg/operator/options"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	"github.com/aws/karpenter-core/pkg/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "knative.dev/pkg/logging/testing"
+
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+)
+
+var ctx context.Context
+var cancel context.CancelFunc
+var env *test.Environment
+var defaultConfigMap *v1.ConfigMap
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logging")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(scheme.Scheme)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed())
+})
+
+var _ = BeforeEach(func() {
+	defaultConfigMap = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config-logging",
+			Namespace: system.Namespace(),
+		},
+	}
+	ctx, cancel = context.WithCancel(context.Background())
+	ctx = options.ToContext(ctx, test.Options())
+	ExpectApplied(ctx, env.Client, defaultConfigMap)
+})
+
+var _ = AfterEach(func() {
+	ExpectDeleted(ctx, env.Client, defaultConfigMap.DeepCopy())
+	cancel()
+})
+
+var _ = Describe("Logging", func() {
+	It("should timeout if the config-logging doesn't exist", func() {
+		ExpectDeleted(ctx, env.Client, defaultConfigMap)
+
+		finished := atomic.Bool{}
+		go func() {
+			// This won't succeed to exit in time if the waiter isn't using the correct context
+			logging.NewLogger(ctx, "controller", env.KubernetesInterface)
+			finished.Store(true)
+		}()
+		Eventually(func() bool {
+			return finished.Load()
+		}, time.Second*10, time.Second).Should(BeTrue())
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #827

**Description**

This PR fixes the ConfigMap waiter so that it's using the correct context (the cancelContext) when it's checking for the existence of the `karpenter-global-settings` ConfigMap. This should allow timeout so that we can proceed to run Karpenter without the existence of this ConfigMap.

**How was this change tested?**

`make apply`
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
