### PR TITLE
chore: Drop `setFlags` from options parsing

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -59,8 +58,6 @@ type Options struct {
 	BatchMaxDuration     time.Duration
 	BatchIdleDuration    time.Duration
 	FeatureGates         FeatureGates
-
-	setFlags map[string]bool
 }
 
 type FlagSet struct {
@@ -114,19 +111,6 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 		return fmt.Errorf("parsing feature gates, %w", err)
 	}
 	o.FeatureGates = gates
-
-	o.setFlags = map[string]bool{}
-	fs.VisitAll(func(f *flag.Flag) {
-		// NOTE: This assumes all CLI flags can be transformed into their corresponding environment variable. If a cli
-		// flag / env var pair does not follow this pattern, this will break.
-		envName := strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_")
-		_, ok := os.LookupEnv(envName)
-		o.setFlags[f.Name] = ok
-	})
-	fs.Visit(func(f *flag.Flag) {
-		o.setFlags[f.Name] = true
-	})
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This drops the unneeded `setFlags` parameter from the options parsing now

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
