### PR TITLE
ci: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,11 +1,11 @@
 name: Bug
 description: Report a bug
-labels: bug
-body: 
+labels: ['kind/bug', 'needs-triage']
+body:
 - type: textarea
   attributes:
     label: Description
-    value: | 
+    value: |
       **Observed Behavior**:
 
       **Expected Behavior**:
@@ -13,8 +13,8 @@ body:
       **Reproduction Steps** (Please include YAML):
 
       **Versions**:
-      - Chart Version: 
-      - Kubernetes Version (`kubectl version`): 
+      - Chart Version:
+      - Kubernetes Version (`kubectl version`):
 
       * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
       * Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,7 +1,7 @@
 name: Feature
 description: Suggest an idea for a new feature
-labels: feature
-body: 
+labels: ['kind/feature', 'needs-triage']
+body:
 - type: textarea
   attributes:
     label: Description


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updates the issue templates to use the `kind/*` labels and add the `needs-triage` label by default.

**How was this change tested?**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
