### PR TITLE
[WIP]feat: Add UserAnnotedExpiration as a new disruption method 

### DIFF
--- a/pkg/controllers/disruption/custom_expiration.go
+++ b/pkg/controllers/disruption/custom_expiration.go
@@ -27,9 +27,9 @@ import (
 	"github.com/aws/karpenter-core/pkg/metrics"
 )
 
-// CustomExpiration is a subreconciler that deletes custom marked candidates, based on node annotations.
+// UserAnnotedExpiration is a subreconciler that deletes custom marked candidates, based on node annotations.
 // Expiration will respect TTLSecondsAfterEmpty
-type CustomExpiration struct {
+type UserAnnotedExpiration struct {
 	clock       clock.Clock
 	kubeClient  client.Client
 	cluster     *state.Cluster
@@ -48,27 +48,27 @@ func NewCustomExpiration(clk clock.Clock, kubeClient client.Client, cluster *sta
 }
 
 // ShouldDisrupt is a predicate used to filter candidates
-func (e *CustomExpiration) ShouldDisrupt(_ context.Context, c *Candidate) bool {
+func (e *UserAnnotedExpiration) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 	// TODO: tasdikrahman to implement this.
 	return true
 }
 
 // SortCandidates orders expired candidates by when they've expired
-func (e *CustomExpiration) filterAndSortCandidates(ctx context.Context, candidates []*Candidate) ([]*Candidate, error) {
+func (e *UserAnnotedExpiration) filterAndSortCandidates(ctx context.Context, candidates []*Candidate) ([]*Candidate, error) {
 	// TODO: tasdikrahman to implement this.
 	return candidates, nil
 }
 
 // ComputeCommand generates a disrpution command given candidates
-func (e *CustomExpiration) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
+func (e *UserAnnotedExpiration) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	// TODO: tasdikrahman to implement this.
 	return Command{}, nil
 }
 
-func (e *CustomExpiration) Type() string {
-	return metrics.CustomExpiration
+func (e *UserAnnotedExpiration) Type() string {
+	return metrics.UserAnnotedExpiration
 }
 
-func (e *CustomExpiration) ConsolidationType() string {
+func (e *UserAnnotedExpiration) ConsolidationType() string {
 	return ""
 }

--- a/pkg/controllers/disruption/custom_expiration.go
+++ b/pkg/controllers/disruption/custom_expiration.go
@@ -1,0 +1,74 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption
+
+import (
+	"context"
+
+	"k8s.io/utils/clock"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/state"
+	"github.com/aws/karpenter-core/pkg/events"
+	"github.com/aws/karpenter-core/pkg/metrics"
+)
+
+// CustomExpiration is a subreconciler that deletes custom marked candidates, based on node annotations.
+// Expiration will respect TTLSecondsAfterEmpty
+type CustomExpiration struct {
+	clock       clock.Clock
+	kubeClient  client.Client
+	cluster     *state.Cluster
+	provisioner *provisioning.Provisioner
+	recorder    events.Recorder
+}
+
+func NewCustomExpiration(clk clock.Clock, kubeClient client.Client, cluster *state.Cluster, provisioner *provisioning.Provisioner, recorder events.Recorder) *Expiration {
+	return &Expiration{
+		clock:       clk,
+		kubeClient:  kubeClient,
+		cluster:     cluster,
+		provisioner: provisioner,
+		recorder:    recorder,
+	}
+}
+
+// ShouldDisrupt is a predicate used to filter candidates
+func (e *CustomExpiration) ShouldDisrupt(_ context.Context, c *Candidate) bool {
+	// TODO: tasdikrahman to implement this.
+	return true
+}
+
+// SortCandidates orders expired candidates by when they've expired
+func (e *CustomExpiration) filterAndSortCandidates(ctx context.Context, candidates []*Candidate) ([]*Candidate, error) {
+	// TODO: tasdikrahman to implement this.
+	return candidates, nil
+}
+
+// ComputeCommand generates a disrpution command given candidates
+func (e *CustomExpiration) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
+	// TODO: tasdikrahman to implement this.
+	return Command{}, nil
+}
+
+func (e *CustomExpiration) Type() string {
+	return metrics.CustomExpiration
+}
+
+func (e *CustomExpiration) ConsolidationType() string {
+	return ""
+}

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -33,6 +33,7 @@ const (
 	ConsolidationReason = "consolidation"
 	ProvisioningReason  = "provisioning"
 	ExpirationReason    = "expiration"
+	CustomExpiration    = "custom-expiration"
 	EmptinessReason     = "emptiness"
 	DriftReason         = "drift"
 )

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -30,12 +30,12 @@ const (
 	TypeLabel        = "type"
 
 	// Reasons for CREATE/DELETE shared metrics
-	ConsolidationReason = "consolidation"
-	ProvisioningReason  = "provisioning"
-	ExpirationReason    = "expiration"
-	CustomExpiration    = "custom-expiration"
-	EmptinessReason     = "emptiness"
-	DriftReason         = "drift"
+	ConsolidationReason   = "consolidation"
+	ProvisioningReason    = "provisioning"
+	ExpirationReason      = "expiration"
+	UserAnnotedExpiration = "user-annotated-expiration"
+	EmptinessReason       = "emptiness"
+	DriftReason           = "drift"
 )
 
 // DurationBuckets returns a []float64 of default threshold values for duration histograms.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/kubernetes-sigs/karpenter/issues/688

This PR introduces a custom disruption method which is evaluating candidates which need to be deprovisioned, which have been added an annotation 

```
karpenter.sh/voluntary-disruption=drifted
```
to the Node object. 

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
