### PR TITLE
[WIP] ci: rebase PR for presubmit workflow

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -14,6 +14,16 @@ jobs:
           k8sVersion: ["1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x", "1.28.x"]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Rebase PR onto main
+      run: |
+          git fetch origin
+          echo "branch: $(git rev-parse --abbrev-ref HEAD)"
+          echo "head: $(git rev-parse origin/main)"
+          git rebase origin/main || true
+          cat .github/workflows/presubmit.yaml
+          exit 1
     - uses: ./.github/actions/install-deps
       with:
         k8sVersion: ${{ matrix.k8sVersion }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR configures the presubmit workflow to rebase the PR against main before running CI. This addresses cases like the one in https://github.com/kubernetes-sigs/karpenter/pull/783 where CI passed before it was merged but failed when it was merged onto main.

**How was this change tested?**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
