### PR TITLE
chore: Move the `karpenter_build_info` metric to karpenter

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -21,11 +21,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"runtime"
 	"runtime/debug"
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	coordinationv1 "k8s.io/api/coordination/v1"
+	"knative.dev/pkg/changeset"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/karpenter/pkg/metrics"
 
 	"github.com/go-logr/zapr"
 	"github.com/samber/lo"
@@ -62,9 +68,23 @@ const (
 	component = "controller"
 )
 
+var BuildInfo = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: metrics.Namespace,
+		Name:      "build_info",
+		Help:      "A metric with a constant '1' value labeled by version from which karpenter was built.",
+	},
+	[]string{"version", "goversion", "commit"},
+)
+
 // Version is the karpenter app version injected during compilation
 // when using the Makefile
 var Version = "unspecified"
+
+func init() {
+	crmetrics.Registry.MustRegister(BuildInfo)
+	BuildInfo.WithLabelValues(Version, runtime.Version(), changeset.Get()).Set(1)
+}
 
 type Operator struct {
 	manager.Manager

--- a/pkg/operator/suite_test.go
+++ b/pkg/operator/suite_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	prometheusmodel "github.com/prometheus/client_model/go"
+
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+)
+
+func TestOperator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator")
+}
+
+var _ = Describe("Operator", func() {
+	It("should fire a metric with the build_info", func() {
+		m, found := FindMetricWithLabelValues("karpenter_build_info", map[string]string{})
+		Expect(found).To(BeTrue())
+
+		for _, label := range []string{"version", "goversion", "commit"} {
+			_, ok := lo.Find(m.GetLabel(), func(l *prometheusmodel.LabelPair) bool { return lo.FromPtr(l.Name) == label })
+			Expect(ok).To(BeTrue())
+		}
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change moves a merged PR from `aws/karpenter-provider-aws` into the common `karpenter` code. This change exposes build information through a Prometheus metric. The change was originally merged with: https://github.com/aws/karpenter-provider-aws/pull/5213 and is being transported into the common surface.

**How was this change tested?**

`make apply` on AWS with Prometheus

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
