### PR TITLE
feat: support new topologySpread scheduling constraints

### DIFF
--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -67,7 +67,7 @@ func NewExistingNode(n *state.StateNode, topology *Topology, taints []v1.Taint, 
 
 func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v1.Pod, podData *PodData) error {
 	// Check Taints
-	if err := scheduling.Taints(n.cachedTaints).Tolerates(pod); err != nil {
+	if err := scheduling.Taints(n.cachedTaints).ToleratesPod(pod); err != nil {
 		return err
 	}
 	// determine the volumes that will be mounted if the pod schedules

--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -100,7 +100,7 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 	nodeRequirements.Add(podData.Requirements.Values()...)
 
 	// Check Topology Requirements
-	topologyRequirements, err := n.topology.AddRequirements(podData.StrictRequirements, nodeRequirements, pod)
+	topologyRequirements, err := n.topology.AddRequirements(pod, n.cachedTaints, podData.StrictRequirements, nodeRequirements)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 	n.Pods = append(n.Pods, pod)
 	n.requests = requests
 	n.requirements = nodeRequirements
-	n.topology.Record(pod, nodeRequirements)
+	n.topology.Record(pod, n.cachedTaints, nodeRequirements)
 	n.HostPortUsage().Add(pod, hostPorts)
 	n.VolumeUsage().Add(pod, volumes)
 	return nil

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -84,7 +84,7 @@ func (n *NodeClaim) Add(pod *v1.Pod, podData *PodData) error {
 	nodeClaimRequirements.Add(podData.Requirements.Values()...)
 
 	// Check Topology Requirements
-	topologyRequirements, err := n.topology.AddRequirements(podData.StrictRequirements, nodeClaimRequirements, pod, scheduling.AllowUndefinedWellKnownLabels)
+	topologyRequirements, err := n.topology.AddRequirements(pod, n.NodeClaimTemplate.Spec.Taints, podData.StrictRequirements, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (n *NodeClaim) Add(pod *v1.Pod, podData *PodData) error {
 	n.InstanceTypeOptions = remaining
 	n.Spec.Resources.Requests = requests
 	n.Requirements = nodeClaimRequirements
-	n.topology.Record(pod, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
+	n.topology.Record(pod, n.NodeClaim.Spec.Taints, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
 	n.hostPortUsage.Add(pod, hostPorts)
 	return nil
 }

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -66,7 +66,7 @@ func NewNodeClaim(nodeClaimTemplate *NodeClaimTemplate, topology *Topology, daem
 
 func (n *NodeClaim) Add(pod *v1.Pod, podData *PodData) error {
 	// Check Taints
-	if err := scheduling.Taints(n.Spec.Taints).Tolerates(pod); err != nil {
+	if err := scheduling.Taints(n.Spec.Taints).ToleratesPod(pod); err != nil {
 		return err
 	}
 

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -345,7 +345,7 @@ func (s *Scheduler) calculateExistingNodeClaims(stateNodes []*state.StateNode, d
 		taints := node.Taints()
 		var daemons []*corev1.Pod
 		for _, p := range daemonSetPods {
-			if err := scheduling.Taints(taints).Tolerates(p); err != nil {
+			if err := scheduling.Taints(taints).ToleratesPod(p); err != nil {
 				continue
 			}
 			if err := scheduling.NewLabelRequirements(node.Labels()).Compatible(scheduling.NewPodRequirements(p)); err != nil {
@@ -388,7 +388,7 @@ func isDaemonPodCompatible(nodeClaimTemplate *NodeClaimTemplate, pod *corev1.Pod
 	preferences := &Preferences{}
 	// Add a toleration for PreferNoSchedule since a daemon pod shouldn't respect the preference
 	_ = preferences.toleratePreferNoScheduleTaints(pod)
-	if err := scheduling.Taints(nodeClaimTemplate.Spec.Taints).Tolerates(pod); err != nil {
+	if err := scheduling.Taints(nodeClaimTemplate.Spec.Taints).ToleratesPod(pod); err != nil {
 		return false
 	}
 	for {

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -22,6 +22,7 @@ import (
 	"math"
 
 	"github.com/awslabs/operatorpkg/option"
+	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
@@ -40,31 +43,41 @@ import (
 
 type Topology struct {
 	kubeClient client.Client
-	// Both the topologies and inverseTopologies are maps of the hash from TopologyGroup.Hash() to the topology group
+	// Both the topologyGroups and inverseTopologies are maps of the hash from TopologyGroup.Hash() to the topology group
 	// itself. This is used to allow us to store one topology group that tracks the topology of many pods instead of
 	// having a 1<->1 mapping between topology groups and pods owned/selected by that group.
-	topologies map[uint64]*TopologyGroup
+	topologyGroups map[uint64]*TopologyGroup
 	// Anti-affinity works both ways (if a zone has a pod foo with anti-affinity to a pod bar, we can't schedule bar to
 	// that zone, even though bar has no anti affinity terms on it. For this to work, we need to separately track the
 	// topologies of pods with anti-affinity terms, so we can prevent scheduling the pods they have anti-affinity to
 	// in some cases.
-	inverseTopologies map[uint64]*TopologyGroup
+	inverseTopologyGroups map[uint64]*TopologyGroup
 	// The universe of domains by topology key
 	domainGroups map[string]TopologyDomainGroup
 	// excludedPods are the pod UIDs of pods that are excluded from counting.  This is used so we can simulate
 	// moving pods to prevent them from being double counted.
 	excludedPods sets.Set[string]
 	cluster      *state.Cluster
+	stateNodes   []*state.StateNode
 }
 
-func NewTopology(ctx context.Context, kubeClient client.Client, cluster *state.Cluster, domainGroups map[string]TopologyDomainGroup, pods []*corev1.Pod) (*Topology, error) {
+func NewTopology(
+	ctx context.Context,
+	kubeClient client.Client,
+	cluster *state.Cluster,
+	stateNodes []*state.StateNode,
+	nodePools []*v1.NodePool,
+	instanceTypes map[string][]*cloudprovider.InstanceType,
+	pods []*corev1.Pod,
+) (*Topology, error) {
 	t := &Topology{
-		kubeClient:        kubeClient,
-		cluster:           cluster,
-		domainGroups:      domainGroups,
-		topologies:        map[uint64]*TopologyGroup{},
-		inverseTopologies: map[uint64]*TopologyGroup{},
-		excludedPods:      sets.New[string](),
+		kubeClient:            kubeClient,
+		cluster:               cluster,
+		stateNodes:            stateNodes,
+		domainGroups:          buildDomainGroups(nodePools, instanceTypes),
+		topologyGroups:        map[uint64]*TopologyGroup{},
+		inverseTopologyGroups: map[uint64]*TopologyGroup{},
+		excludedPods:          sets.New[string](),
 	}
 
 	// these are the pods that we intend to schedule, so if they are currently in the cluster we shouldn't count them for
@@ -81,6 +94,46 @@ func NewTopology(ctx context.Context, kubeClient client.Client, cluster *state.C
 		return nil, errs
 	}
 	return t, nil
+}
+
+func buildDomainGroups(nodePools []*v1.NodePool, instanceTypes map[string][]*cloudprovider.InstanceType) map[string]TopologyDomainGroup {
+	nodePoolIndex := lo.SliceToMap(nodePools, func(np *v1.NodePool) (string, *v1.NodePool) {
+		return np.Name, np
+	})
+	domainGroups := map[string]TopologyDomainGroup{}
+	for npName, its := range instanceTypes {
+		np := nodePoolIndex[npName]
+		for _, it := range its {
+			// We need to intersect the instance type requirements with the current nodePool requirements.  This
+			// ensures that something like zones from an instance type don't expand the universe of valid domains.
+			requirements := scheduling.NewNodeSelectorRequirementsWithMinValues(np.Spec.Template.Spec.Requirements...)
+			requirements.Add(scheduling.NewLabelRequirements(np.Spec.Template.Labels).Values()...)
+			requirements.Add(it.Requirements.Values()...)
+
+			for topologyKey, requirement := range requirements {
+				if _, ok := domainGroups[topologyKey]; !ok {
+					domainGroups[topologyKey] = NewTopologyDomainGroup()
+				}
+				for _, domain := range requirement.Values() {
+					domainGroups[topologyKey].Insert(domain, np.Spec.Template.Spec.Taints...)
+				}
+			}
+		}
+
+		requirements := scheduling.NewNodeSelectorRequirementsWithMinValues(np.Spec.Template.Spec.Requirements...)
+		requirements.Add(scheduling.NewLabelRequirements(np.Spec.Template.Labels).Values()...)
+		for key, requirement := range requirements {
+			if requirement.Operator() == corev1.NodeSelectorOpIn {
+				if _, ok := domainGroups[key]; !ok {
+					domainGroups[key] = NewTopologyDomainGroup()
+				}
+				for _, value := range requirement.Values() {
+					domainGroups[key].Insert(value, np.Spec.Template.Spec.Taints...)
+				}
+			}
+		}
+	}
+	return domainGroups
 }
 
 // topologyError allows lazily generating the error string in the topology error.  If a pod fails to schedule, most often
@@ -101,7 +154,7 @@ func (t topologyError) Error() string {
 // relaxation of a preference to properly break the topology <-> owner relationship so that the preferred topology will
 // no longer influence scheduling.
 func (t *Topology) Update(ctx context.Context, p *corev1.Pod) error {
-	for _, topology := range t.topologies {
+	for _, topology := range t.topologyGroups {
 		topology.RemoveOwner(p.UID)
 	}
 
@@ -120,11 +173,11 @@ func (t *Topology) Update(ctx context.Context, p *corev1.Pod) error {
 	for _, tg := range append(topologies, affinities...) {
 		hash := tg.Hash()
 		// Avoid recomputing topology counts if we've already seen this group
-		if existing, ok := t.topologies[hash]; !ok {
+		if existing, ok := t.topologyGroups[hash]; !ok {
 			if err := t.countDomains(ctx, tg); err != nil {
 				return err
 			}
-			t.topologies[hash] = tg
+			t.topologyGroups[hash] = tg
 		} else {
 			tg = existing
 		}
@@ -134,27 +187,27 @@ func (t *Topology) Update(ctx context.Context, p *corev1.Pod) error {
 }
 
 // Record records the topology changes given that pod p schedule on a node with the given requirements
-func (t *Topology) Record(p *corev1.Pod, requirements scheduling.Requirements, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) {
+func (t *Topology) Record(p *corev1.Pod, taints []corev1.Taint, requirements scheduling.Requirements, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) {
 	// once we've committed to a domain, we record the usage in every topology that cares about it
-	for _, tc := range t.topologies {
-		if tc.Counts(p, requirements, compatabilityOptions...) {
-			domains := requirements.Get(tc.Key)
-			if tc.Type == TopologyTypePodAntiAffinity {
+	for _, tg := range t.topologyGroups {
+		if tg.Counts(p, taints, requirements, compatabilityOptions...) {
+			domains := requirements.Get(tg.Key)
+			if tg.Type == TopologyTypePodAntiAffinity {
 				// for anti-affinity topologies we need to block out all possible domains that the pod could land in
-				tc.Record(domains.Values()...)
+				tg.Record(domains.Values()...)
 			} else {
 				// but for affinity & topology spread, we can only record the domain if we know the specific domain we land in
 				if domains.Len() == 1 {
-					tc.Record(domains.Values()[0])
+					tg.Record(domains.Values()[0])
 				}
 			}
 		}
 	}
 	// for anti-affinities, we record where the pods could be, even if
 	// requirements haven't collapsed to a single value.
-	for _, tc := range t.inverseTopologies {
-		if tc.IsOwnedBy(p.UID) {
-			tc.Record(requirements.Get(tc.Key).Values()...)
+	for _, tg := range t.inverseTopologyGroups {
+		if tg.IsOwnedBy(p.UID) {
+			tg.Record(requirements.Get(tg.Key).Values()...)
 		}
 	}
 }
@@ -163,9 +216,9 @@ func (t *Topology) Record(p *corev1.Pod, requirements scheduling.Requirements, c
 // affinities, anti-affinities or inverse anti-affinities.  The nodeHostname is the hostname that we are currently considering
 // placing the pod on.  It returns these newly tightened requirements, or an error in the case of a set of requirements that
 // cannot be satisfied.
-func (t *Topology) AddRequirements(podRequirements, nodeRequirements scheduling.Requirements, p *corev1.Pod, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) (scheduling.Requirements, error) {
+func (t *Topology) AddRequirements(p *corev1.Pod, taints []corev1.Taint, podRequirements, nodeRequirements scheduling.Requirements, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) (scheduling.Requirements, error) {
 	requirements := scheduling.NewRequirements(nodeRequirements.Values()...)
-	for _, topology := range t.getMatchingTopologies(p, nodeRequirements, compatabilityOptions...) {
+	for _, topology := range t.getMatchingTopologies(p, taints, nodeRequirements, compatabilityOptions...) {
 		podDomains := scheduling.NewRequirement(topology.Key, corev1.NodeSelectorOpExists)
 		if podRequirements.Has(topology.Key) {
 			podDomains = podRequirements.Get(topology.Key)
@@ -189,26 +242,26 @@ func (t *Topology) AddRequirements(podRequirements, nodeRequirements scheduling.
 
 // Register is used to register a domain as available across topologies for the given topology key.
 func (t *Topology) Register(topologyKey string, domain string) {
-	for _, topology := range t.topologies {
-		if topology.Key == topologyKey {
-			topology.Register(domain)
+	for _, tg := range t.topologyGroups {
+		if tg.Key == topologyKey {
+			tg.Register(domain)
 		}
 	}
-	for _, topology := range t.inverseTopologies {
-		if topology.Key == topologyKey {
-			topology.Register(domain)
+	for _, tg := range t.inverseTopologyGroups {
+		if tg.Key == topologyKey {
+			tg.Register(domain)
 		}
 	}
 }
 
 // Unregister is used to unregister a domain as available across topologies for the given topology key.
 func (t *Topology) Unregister(topologyKey string, domain string) {
-	for _, topology := range t.topologies {
+	for _, topology := range t.topologyGroups {
 		if topology.Key == topologyKey {
 			topology.Unregister(domain)
 		}
 	}
-	for _, topology := range t.inverseTopologies {
+	for _, topology := range t.inverseTopologyGroups {
 		if topology.Key == topologyKey {
 			topology.Unregister(domain)
 		}
@@ -248,8 +301,8 @@ func (t *Topology) updateInverseAntiAffinity(ctx context.Context, pod *corev1.Po
 		tg := NewTopologyGroup(TopologyTypePodAntiAffinity, term.TopologyKey, pod, namespaces, term.LabelSelector, math.MaxInt32, nil, nil, nil, t.domainGroups[term.TopologyKey])
 
 		hash := tg.Hash()
-		if existing, ok := t.inverseTopologies[hash]; !ok {
-			t.inverseTopologies[hash] = tg
+		if existing, ok := t.inverseTopologyGroups[hash]; !ok {
+			t.inverseTopologyGroups[hash] = tg
 		} else {
 			tg = existing
 		}
@@ -280,25 +333,26 @@ func (t *Topology) countDomains(ctx context.Context, tg *TopologyGroup) error {
 
 	// capture new domain values from existing nodes that may not have any pods selected by the topology group
 	// scheduled to them already
-	t.cluster.ForEachNode(func(n *state.StateNode) bool {
+	// Note: long term we should handle this when constructing the domain groups, but that would require domain groups
+	// to handle affinity in addition to taints / tolerations.
+	for _, n := range t.stateNodes {
 		// ignore state nodes which are tracking in-flight NodeClaims
 		if n.Node == nil {
-			return true
+			continue
 		}
 		// ignore the node if it doesn't match the topology group
-		if !tg.nodeFilter.Matches(n.Node) {
-			return true
+		if !tg.nodeFilter.Matches(n.Node.Spec.Taints, scheduling.NewLabelRequirements(n.Node.Labels)) {
+			continue
 		}
 		domain, exists := n.Labels()[tg.Key]
 		if !exists {
-			return true
+			continue
 		}
-		// ensure we at least have a count of zero for this potentially new topology domain
-		if _, countExists := tg.domains[domain]; !countExists {
+		if _, ok := tg.domains[domain]; !ok {
 			tg.domains[domain] = 0
+			tg.emptyDomains.Insert(domain)
 		}
-		return true
-	})
+	}
 
 	for i, p := range pods {
 		if IgnoredForTopology(&pods[i]) {
@@ -334,7 +388,7 @@ func (t *Topology) countDomains(ctx context.Context, tg *TopologyGroup) error {
 		}
 		// nodes may or may not be considered for counting purposes for topology spread constraints depending on if they
 		// are selected by the pod's node selectors and required node affinities.  If these are unset, the node always counts.
-		if !tg.nodeFilter.Matches(node) {
+		if !tg.nodeFilter.Matches(node.Spec.Taints, scheduling.NewLabelRequirements(node.Labels)) {
 			continue
 		}
 		tg.Record(domain)
@@ -344,18 +398,28 @@ func (t *Topology) countDomains(ctx context.Context, tg *TopologyGroup) error {
 
 func (t *Topology) newForTopologies(p *corev1.Pod) []*TopologyGroup {
 	var topologyGroups []*TopologyGroup
-	for _, cs := range p.Spec.TopologySpreadConstraints {
-		for _, key := range cs.MatchLabelKeys {
-			if value, ok := p.ObjectMeta.Labels[key]; ok {
-				cs.LabelSelector.MatchExpressions = append(cs.LabelSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+	for _, tsc := range p.Spec.TopologySpreadConstraints {
+		for _, key := range tsc.MatchLabelKeys {
+			if value, ok := p.Labels[key]; ok {
+				tsc.LabelSelector.MatchExpressions = append(tsc.LabelSelector.MatchExpressions, metav1.LabelSelectorRequirement{
 					Key:      key,
 					Operator: metav1.LabelSelectorOpIn,
 					Values:   []string{value},
 				})
 			}
 		}
-		topologyGroups = append(topologyGroups, NewTopologyGroup(TopologyTypeSpread, cs.TopologyKey, p, sets.New(p.Namespace),
-			cs.LabelSelector, cs.MaxSkew, cs.MinDomains, cs.NodeTaintsPolicy, cs.NodeAffinityPolicy, t.domainGroups[cs.TopologyKey]))
+		topologyGroups = append(topologyGroups, NewTopologyGroup(
+			TopologyTypeSpread,
+			tsc.TopologyKey,
+			p,
+			sets.New(p.Namespace),
+			tsc.LabelSelector,
+			tsc.MaxSkew,
+			tsc.MinDomains,
+			tsc.NodeTaintsPolicy,
+			tsc.NodeAffinityPolicy,
+			t.domainGroups[tsc.TopologyKey],
+		))
 	}
 	return topologyGroups
 }
@@ -425,16 +489,16 @@ func (t *Topology) buildNamespaceList(ctx context.Context, namespace string, nam
 
 // getMatchingTopologies returns a sorted list of topologies that either control the scheduling of pod p, or for which
 // the topology selects pod p and the scheduling of p affects the count per topology domain
-func (t *Topology) getMatchingTopologies(p *corev1.Pod, requirements scheduling.Requirements, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) []*TopologyGroup {
+func (t *Topology) getMatchingTopologies(p *corev1.Pod, taints []corev1.Taint, requirements scheduling.Requirements, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) []*TopologyGroup {
 	var matchingTopologies []*TopologyGroup
-	for _, tc := range t.topologies {
-		if tc.IsOwnedBy(p.UID) {
-			matchingTopologies = append(matchingTopologies, tc)
+	for _, tg := range t.topologyGroups {
+		if tg.IsOwnedBy(p.UID) {
+			matchingTopologies = append(matchingTopologies, tg)
 		}
 	}
-	for _, tc := range t.inverseTopologies {
-		if tc.Counts(p, requirements, compatabilityOptions...) {
-			matchingTopologies = append(matchingTopologies, tc)
+	for _, tg := range t.inverseTopologyGroups {
+		if tg.Counts(p, taints, requirements, compatabilityOptions...) {
+			matchingTopologies = append(matchingTopologies, tg)
 		}
 	}
 	return matchingTopologies

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -345,9 +345,13 @@ func (t *Topology) countDomains(ctx context.Context, tg *TopologyGroup) error {
 func (t *Topology) newForTopologies(p *corev1.Pod) []*TopologyGroup {
 	var topologyGroups []*TopologyGroup
 	for _, cs := range p.Spec.TopologySpreadConstraints {
-		for _, label := range cs.MatchLabelKeys {
-			if value, ok := p.ObjectMeta.Labels[label]; ok {
-				cs.LabelSelector.MatchLabels[label] = value
+		for _, key := range cs.MatchLabelKeys {
+			if value, ok := p.ObjectMeta.Labels[key]; ok {
+				cs.LabelSelector.MatchExpressions = append(cs.LabelSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+					Key:      key,
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{value},
+				})
 			}
 		}
 		topologyGroups = append(topologyGroups, NewTopologyGroup(TopologyTypeSpread, cs.TopologyKey, p, sets.New(p.Namespace),

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -345,6 +345,11 @@ func (t *Topology) countDomains(ctx context.Context, tg *TopologyGroup) error {
 func (t *Topology) newForTopologies(p *corev1.Pod) []*TopologyGroup {
 	var topologyGroups []*TopologyGroup
 	for _, cs := range p.Spec.TopologySpreadConstraints {
+		for _, label := range cs.MatchLabelKeys {
+			if value, ok := p.ObjectMeta.Labels[label]; ok {
+				cs.LabelSelector.MatchLabels[label] = value
+			}
+		}
 		topologyGroups = append(topologyGroups, NewTopologyGroup(TopologyTypeSpread, cs.TopologyKey, p, sets.New(p.Namespace),
 			cs.LabelSelector, cs.MaxSkew, cs.MinDomains, cs.NodeTaintsPolicy, cs.NodeAffinityPolicy, t.domainGroups[cs.TopologyKey]))
 	}

--- a/pkg/controllers/provisioning/scheduling/topology_test.go
+++ b/pkg/controllers/provisioning/scheduling/topology_test.go
@@ -1499,6 +1499,7 @@ var _ = Describe("Topology", func() {
 				NodeTaintsPolicy:  lo.ToPtr(corev1.NodeInclusionPolicyHonor),
 			}}
 
+			// Create two pods which tolerate the first nodepool's taint, and four which tolerate the second's
 			pods := lo.Flatten(lo.Map(nodePools, func(np *v1.NodePool, i int) []*corev1.Pod {
 				return test.UnschedulablePods(test.PodOptions{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/provisioning/scheduling/topologydomaingroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologydomaingroup.go
@@ -33,32 +33,35 @@ func NewTopologyDomainGroup() TopologyDomainGroup {
 
 // Insert either adds a new domain to the TopologyDomainGroup or updates an existing domain.
 func (t TopologyDomainGroup) Insert(domain string, taints ...v1.Taint) {
+	// If the domain is not currently tracked, insert it with the associated taints. Additionally, if there are no taints
+	// provided, override the taints associated with the domain. Generally, we could remove any sets of taints for which
+	// the provided set is a proper subset. This is because if a pod tolerates the supersets, it will also tolerate the
+	// proper subset, and removing the superset reduces the number of taint sets we need to traverse. For now we only
+	// implement the simplest case, the empty set, but we could do additional performance testing to determine if
+	// implementing the general case is worth the precomputation cost.
 	if _, ok := t[domain]; !ok || len(taints) == 0 {
 		t[domain] = [][]v1.Taint{taints}
 		return
 	}
 	if len(t[domain][0]) == 0 {
-		// The domain already contains a set of taints which is the empty set, therefore this domain can be considered
-		// by all pods, regardless of their tolerations. There is no longer a need to track new sets of taints.
-		// This could potentially be generalized by removing any set for which the new set of taints is a proper subset, but
-		// for now this is just handled for the empty set.
+		// This is the base case, where we're already tracking the empty set of taints for the domain. Pods will always
+		// be eligible for NodeClaims with this domain (based on taints), so there is no need to track additional taints.
 		return
 	}
 	t[domain] = append(t[domain], taints)
 }
 
-// ForEachDomain calls f on each domain tracked by the topology group
-func (t TopologyDomainGroup) ForEachDomain(f func(domain string)) {
-	for domain := range t {
-		f(domain)
-	}
-}
-
-// ForEachToleratedDomain calls f on each domain tracked by the TopologyDomainGroup which are also tolerated by the provided pod.
-func (t TopologyDomainGroup) ForEachToleratedDomain(pod *v1.Pod, f func(domain string)) {
-	// Could potentially improve performance by hashing the pod's tolerations and storing a map from toleration hash to
-	// eligible domains.
+// ForEachDomain calls f on each domain tracked by the topology group. If the taintHonorPolicy is honor, only domains
+// available on nodes tolerated by the provided pod will be included.
+func (t TopologyDomainGroup) ForEachDomain(pod *v1.Pod, taintHonorPolicy v1.NodeInclusionPolicy, f func(domain string)) {
 	for domain, taintGroups := range t {
+		if taintHonorPolicy == v1.NodeInclusionPolicyIgnore {
+			f(domain)
+			continue
+		}
+		// Since the taint policy is honor, we should only call f if there is a set of taints associated with the domain which
+		// the pod tolerates.
+		// Perf Note: We could consider hashing the pod's tolerations and using that to look up a set of tolerated domains.
 		for _, taints := range taintGroups {
 			if err := scheduling.Taints(taints).ToleratesPod(pod); err == nil {
 				f(domain)

--- a/pkg/controllers/provisioning/scheduling/topologydomaingroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologydomaingroup.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+)
+
+// TopologyDomainGroup tracks the domains for a single topology. Additionally, it tracks the taints associated with
+// each of these domains. This enables us to determine which domains should be considered by a pod if its
+// NodeTaintPolicy is honor.
+type TopologyDomainGroup map[string][][]v1.Taint
+
+func NewTopologyDomainGroup() TopologyDomainGroup {
+	return map[string][][]v1.Taint{}
+}
+
+// Insert either adds a new domain to the TopologyDomainGroup or updates an existing domain.
+func (t TopologyDomainGroup) Insert(domain string, taints ...v1.Taint) {
+	// Note: This could potentially be improved by removing any set of which the new set of taints is a proper subset.
+	// Currently this is only handled when the incoming set is the empty set.
+	if _, ok := t[domain]; !ok || len(taints) == 0 {
+		t[domain] = [][]v1.Taint{taints}
+		return
+	}
+	if len(t[domain][0]) == 0 {
+		// The domain already contains a set of taints which is the empty set, therefore this domain can be considered
+		// by all pods, regardless of their tolerations. There is no longer a need to track new sets of taints.
+		return
+	}
+	t[domain] = append(t[domain], taints)
+}
+
+// ForEachDomain calls f on each domain tracked by the topology group
+func (t TopologyDomainGroup) ForEachDomain(f func(domain string)) {
+	for domain := range t {
+		f(domain)
+	}
+}
+
+// ForEachToleratedDomain calls f on each domain tracked by the TopologyDomainGroup which are also tolerated by the provided pod.
+func (t TopologyDomainGroup) ForEachToleratedDomain(pod *v1.Pod, f func(domain string)) {
+	for domain, taintGroups := range t {
+		for _, taints := range taintGroups {
+			if err := scheduling.Taints(taints).ToleratesPod(pod); err == nil {
+				f(domain)
+				break
+			}
+		}
+	}
+}

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -69,11 +69,7 @@ type TopologyGroup struct {
 	emptyDomains sets.Set[string]       // domains for which we know that no pod exists
 }
 
-func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod, namespaces sets.Set[string], labelSelector *metav1.LabelSelector, maxSkew int32, minDomains *int32, taintPolicy *v1.NodeInclusionPolicy, affinityPolicy *v1.NodeInclusionPolicy, domains sets.Set[string]) *TopologyGroup {
-	domainCounts := map[string]int32{}
-	for domain := range domains {
-		domainCounts[domain] = 0
-	}
+func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod, namespaces sets.Set[string], labelSelector *metav1.LabelSelector, maxSkew int32, minDomains *int32, taintPolicy *v1.NodeInclusionPolicy, affinityPolicy *v1.NodeInclusionPolicy, domainGroup TopologyDomainGroup) *TopologyGroup {
 	// the nil *TopologyNodeFilter always passes which is what we need for affinity/anti-affinity
 	var nodeSelector TopologyNodeFilter
 	if topologyType == TopologyTypeSpread {
@@ -87,10 +83,28 @@ func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod
 		}
 		nodeSelector = MakeTopologyNodeFilter(pod, nodeTaintsPolicy, nodeAffinityPolicy)
 	}
+
 	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
 	if err != nil {
 		selector = labels.Nothing()
 	}
+
+	domains := map[string]int32{}
+	if nodeSelector.TaintPolicy == v1.NodeInclusionPolicyHonor {
+		domainGroup.ForEachToleratedDomain(pod, func(domain string) {
+			domains[domain] = 0
+		})
+	} else {
+		domainGroup.ForEachDomain(func(domain string) {
+			domains[domain] = 0
+		})
+	}
+
+	emptyDomains := sets.New[string]()
+	domainGroup.ForEachDomain(func(domain string) {
+		emptyDomains.Insert(domain)
+	})
+
 	return &TopologyGroup{
 		Type:         topologyType,
 		Key:          topologyKey,
@@ -99,8 +113,8 @@ func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod
 		rawSelector:  labelSelector,
 		nodeFilter:   nodeSelector,
 		maxSkew:      maxSkew,
-		domains:      domainCounts,
-		emptyDomains: domains.Clone(),
+		domains:      domains,
+		emptyDomains: emptyDomains,
 		owners:       map[types.UID]struct{}{},
 		minDomains:   minDomains,
 	}

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -101,19 +101,11 @@ func NewTopologyGroup(
 	}
 
 	domains := map[string]int32{}
-	if nodeFilter.TaintPolicy == corev1.NodeInclusionPolicyHonor {
-		domainGroup.ForEachToleratedDomain(pod, func(domain string) {
-			domains[domain] = 0
-		})
-	} else {
-		domainGroup.ForEachDomain(func(domain string) {
-			domains[domain] = 0
-		})
-	}
 	emptyDomains := sets.New[string]()
-	for domain := range domains {
+	domainGroup.ForEachDomain(pod, nodeFilter.TaintPolicy, func(domain string) {
+		domains[domain] = 0
 		emptyDomains.Insert(domain)
-	}
+	})
 
 	return &TopologyGroup{
 		Type:         topologyType,

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -69,9 +69,20 @@ type TopologyGroup struct {
 	emptyDomains sets.Set[string]       // domains for which we know that no pod exists
 }
 
-func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod, namespaces sets.Set[string], labelSelector *metav1.LabelSelector, maxSkew int32, minDomains *int32, taintPolicy *v1.NodeInclusionPolicy, affinityPolicy *v1.NodeInclusionPolicy, domainGroup TopologyDomainGroup) *TopologyGroup {
+func NewTopologyGroup(
+	topologyType TopologyType,
+	topologyKey string,
+	pod *v1.Pod,
+	namespaces sets.Set[string],
+	labelSelector *metav1.LabelSelector,
+	maxSkew int32,
+	minDomains *int32,
+	taintPolicy *v1.NodeInclusionPolicy,
+	affinityPolicy *v1.NodeInclusionPolicy,
+	domainGroup TopologyDomainGroup,
+) *TopologyGroup {
 	// the nil *TopologyNodeFilter always passes which is what we need for affinity/anti-affinity
-	var nodeSelector TopologyNodeFilter
+	var nodeFilter TopologyNodeFilter
 	if topologyType == TopologyTypeSpread {
 		nodeTaintsPolicy := v1.NodeInclusionPolicyIgnore
 		if taintPolicy != nil {
@@ -81,7 +92,7 @@ func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod
 		if affinityPolicy != nil {
 			nodeAffinityPolicy = *affinityPolicy
 		}
-		nodeSelector = MakeTopologyNodeFilter(pod, nodeTaintsPolicy, nodeAffinityPolicy)
+		nodeFilter = MakeTopologyNodeFilter(pod, nodeTaintsPolicy, nodeAffinityPolicy)
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
@@ -90,7 +101,7 @@ func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod
 	}
 
 	domains := map[string]int32{}
-	if nodeSelector.TaintPolicy == v1.NodeInclusionPolicyHonor {
+	if nodeFilter.TaintPolicy == v1.NodeInclusionPolicyHonor {
 		domainGroup.ForEachToleratedDomain(pod, func(domain string) {
 			domains[domain] = 0
 		})
@@ -99,11 +110,10 @@ func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod
 			domains[domain] = 0
 		})
 	}
-
 	emptyDomains := sets.New[string]()
-	domainGroup.ForEachDomain(func(domain string) {
+	for domain := range domains {
 		emptyDomains.Insert(domain)
-	})
+	}
 
 	return &TopologyGroup{
 		Type:         topologyType,
@@ -111,7 +121,7 @@ func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod
 		namespaces:   namespaces,
 		selector:     selector,
 		rawSelector:  labelSelector,
-		nodeFilter:   nodeSelector,
+		nodeFilter:   nodeFilter,
 		maxSkew:      maxSkew,
 		domains:      domains,
 		emptyDomains: emptyDomains,

--- a/pkg/controllers/provisioning/scheduling/topologynodefilter.go
+++ b/pkg/controllers/provisioning/scheduling/topologynodefilter.go
@@ -28,23 +28,36 @@ import (
 // included for topology counting purposes. This is only used with topology spread constraints as affinities/anti-affinities
 // always count across all nodes. A nil or zero-value TopologyNodeFilter behaves well and the filter returns true for
 // all nodes.
-type TopologyNodeFilter []scheduling.Requirements
+type TopologyNodeFilter struct {
+	Requirements   []scheduling.Requirements
+	TaintPolicy    v1.NodeInclusionPolicy
+	AffinityPolicy v1.NodeInclusionPolicy
+	Tolerations    []v1.Toleration
+}
 
-func MakeTopologyNodeFilter(p *v1.Pod) TopologyNodeFilter {
+func MakeTopologyNodeFilter(p *v1.Pod, taintPolicy v1.NodeInclusionPolicy, affinityPolicy v1.NodeInclusionPolicy) TopologyNodeFilter {
 	nodeSelectorRequirements := scheduling.NewLabelRequirements(p.Spec.NodeSelector)
 	// if we only have a label selector, that's the only requirement that must match
 	if p.Spec.Affinity == nil || p.Spec.Affinity.NodeAffinity == nil || p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-		return TopologyNodeFilter{nodeSelectorRequirements}
+		return TopologyNodeFilter{
+			Requirements:   []scheduling.Requirements{nodeSelectorRequirements},
+			TaintPolicy:    taintPolicy,
+			AffinityPolicy: affinityPolicy,
+			Tolerations:    p.Spec.Tolerations,
+		}
 	}
 
 	// otherwise, we need to match the combination of label selector and any term of the required node affinities since
 	// those terms are OR'd together
-	var filter TopologyNodeFilter
+	filter := TopologyNodeFilter{
+		TaintPolicy:    taintPolicy,
+		AffinityPolicy: affinityPolicy,
+	}
 	for _, term := range p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
 		requirements := scheduling.NewRequirements()
 		requirements.Add(nodeSelectorRequirements.Values()...)
 		requirements.Add(scheduling.NewNodeSelectorRequirements(term.MatchExpressions...).Values()...)
-		filter = append(filter, requirements)
+		filter.Requirements = append(filter.Requirements, requirements)
 	}
 
 	return filter
@@ -52,7 +65,17 @@ func MakeTopologyNodeFilter(p *v1.Pod) TopologyNodeFilter {
 
 // Matches returns true if the TopologyNodeFilter doesn't prohibit node from the participating in the topology
 func (t TopologyNodeFilter) Matches(node *v1.Node) bool {
-	return t.MatchesRequirements(scheduling.NewLabelRequirements(node.Labels))
+	matchesAffinity := true
+	if t.AffinityPolicy == v1.NodeInclusionPolicyHonor {
+		matchesAffinity = t.MatchesRequirements(scheduling.NewLabelRequirements(node.Labels))
+	}
+	matchesTaints := true
+	if t.TaintPolicy == v1.NodeInclusionPolicyHonor {
+		if err := scheduling.Taints(node.Spec.Taints).Tolerates(t.Tolerations); err != nil {
+			matchesTaints = false
+		}
+	}
+	return matchesAffinity && matchesTaints
 }
 
 // MatchesRequirements returns true if the TopologyNodeFilter doesn't prohibit a node with the requirements from
@@ -60,11 +83,11 @@ func (t TopologyNodeFilter) Matches(node *v1.Node) bool {
 // node we will soon create participates in this topology.
 func (t TopologyNodeFilter) MatchesRequirements(requirements scheduling.Requirements, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) bool {
 	// no requirements, so it always matches
-	if len(t) == 0 {
+	if len(t.Requirements) == 0 || t.AffinityPolicy == v1.NodeInclusionPolicyIgnore {
 		return true
 	}
 	// these are an OR, so if any passes the filter passes
-	for _, req := range t {
+	for _, req := range t.Requirements {
 		if err := requirements.Compatible(req, compatabilityOptions...); err == nil {
 			return true
 		}

--- a/pkg/scheduling/taints.go
+++ b/pkg/scheduling/taints.go
@@ -42,12 +42,17 @@ var KnownEphemeralTaints = []corev1.Taint{
 // Taints is a decorated alias type for []corev1.Taint
 type Taints []corev1.Taint
 
-// Tolerates returns true if the pod tolerates all taints.
-func (ts Taints) Tolerates(pod *corev1.Pod) (errs error) {
+// ToleratesPod returns true if the pod tolerates all taints.
+func (ts Taints) ToleratesPod(pod *corev1.Pod) error {
+	return ts.Tolerates(pod.Spec.Tolerations)
+}
+
+// Tolerates returns true if the toleration slice tolerate all taints.
+func (ts Taints) Tolerates(tolerations []corev1.Toleration) (errs error) {
 	for i := range ts {
 		taint := ts[i]
 		tolerates := false
-		for _, t := range pod.Spec.Tolerations {
+		for _, t := range tolerations {
 			tolerates = tolerates || t.ToleratesTaint(&taint)
 		}
 		if !tolerates {

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -180,9 +180,14 @@ func HasDoNotDisrupt(pod *corev1.Pod) bool {
 	return pod.Annotations[v1.DoNotDisruptAnnotationKey] == "true"
 }
 
-// ToleratesDisruptedNoScheduleTaint returns true if the pod tolerates karpenter.sh/disrupted:NoSchedule taint
+// ToleratesUnschedulableTaint returns true if the pod tolerates node.kubernetes.io/unschedulable taint
+func ToleratesUnschedulableTaint(pod *corev1.Pod) bool {
+	return (scheduling.Taints{{Key: corev1.TaintNodeUnschedulable, Effect: corev1.TaintEffectNoSchedule}}).ToleratesPod(pod) == nil
+}
+
+// ToleratesDisruptionNoScheduleTaint returns true if the pod tolerates karpenter.sh/disruption:NoSchedule=Disrupting taint
 func ToleratesDisruptedNoScheduleTaint(pod *corev1.Pod) bool {
-	return scheduling.Taints([]corev1.Taint{v1.DisruptedNoScheduleTaint}).Tolerates(pod) == nil
+	return scheduling.Taints([]corev1.Taint{v1.DisruptedNoScheduleTaint}).ToleratesPod(pod) == nil
 }
 
 // HasRequiredPodAntiAffinity returns true if a non-empty PodAntiAffinity/RequiredDuringSchedulingIgnoredDuringExecution

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -180,7 +180,7 @@ func HasDoNotDisrupt(pod *corev1.Pod) bool {
 	return pod.Annotations[v1.DoNotDisruptAnnotationKey] == "true"
 }
 
-// ToleratesDisruptionNoScheduleTaint returns true if the pod tolerates karpenter.sh/disruption:NoSchedule=Disrupting taint
+// ToleratesDisruptedNoScheduleTaint returns true if the pod tolerates karpenter.sh/disruption:NoSchedule taint
 func ToleratesDisruptedNoScheduleTaint(pod *corev1.Pod) bool {
 	return scheduling.Taints([]corev1.Taint{v1.DisruptedNoScheduleTaint}).ToleratesPod(pod) == nil
 }

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -180,11 +180,6 @@ func HasDoNotDisrupt(pod *corev1.Pod) bool {
 	return pod.Annotations[v1.DoNotDisruptAnnotationKey] == "true"
 }
 
-// ToleratesUnschedulableTaint returns true if the pod tolerates node.kubernetes.io/unschedulable taint
-func ToleratesUnschedulableTaint(pod *corev1.Pod) bool {
-	return (scheduling.Taints{{Key: corev1.TaintNodeUnschedulable, Effect: corev1.TaintEffectNoSchedule}}).ToleratesPod(pod) == nil
-}
-
 // ToleratesDisruptionNoScheduleTaint returns true if the pod tolerates karpenter.sh/disruption:NoSchedule=Disrupting taint
 func ToleratesDisruptedNoScheduleTaint(pod *corev1.Pod) bool {
 	return scheduling.Taints([]corev1.Taint{v1.DisruptedNoScheduleTaint}).ToleratesPod(pod) == nil

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -861,7 +861,7 @@ func (env *Environment) GetDaemonSetCount(np *v1.NodePool) int {
 	return lo.CountBy(daemonSetList.Items, func(d appsv1.DaemonSet) bool {
 		p := &corev1.Pod{Spec: d.Spec.Template.Spec}
 		nodeClaimTemplate := pscheduling.NewNodeClaimTemplate(np)
-		if err := scheduling.Taints(nodeClaimTemplate.Spec.Taints).Tolerates(p); err != nil {
+		if err := scheduling.Taints(nodeClaimTemplate.Spec.Taints).ToleratesPod(p); err != nil {
 			return false
 		}
 		if err := nodeClaimTemplate.Requirements.Compatible(scheduling.NewPodRequirements(p), scheduling.AllowUndefinedWellKnownLabels); err != nil {
@@ -882,7 +882,7 @@ func (env *Environment) GetDaemonSetOverhead(np *v1.NodePool) corev1.ResourceLis
 	return resources.RequestsForPods(lo.FilterMap(daemonSetList.Items, func(ds appsv1.DaemonSet, _ int) (*corev1.Pod, bool) {
 		p := &corev1.Pod{Spec: ds.Spec.Template.Spec}
 		nodeClaimTemplate := pscheduling.NewNodeClaimTemplate(np)
-		if err := scheduling.Taints(nodeClaimTemplate.Spec.Taints).Tolerates(p); err != nil {
+		if err := scheduling.Taints(nodeClaimTemplate.Spec.Taints).ToleratesPod(p); err != nil {
 			return nil, false
 		}
 		if err := nodeClaimTemplate.Requirements.Compatible(scheduling.NewPodRequirements(p), scheduling.AllowUndefinedWellKnownLabels); err != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #430 

**Description**
This PR adds support for the following topology spread constraint fields:
- `matchLabelKeys`
- `nodeAffinityPolicy`
- `nodeTaintsPolicy`

**How was this change tested?**
`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
