### PR TITLE
chore: Add goarch label to karpenter_build_info Prometheus metric

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -74,7 +74,7 @@ var BuildInfo = prometheus.NewGaugeVec(
 		Name:      "build_info",
 		Help:      "A metric with a constant '1' value labeled by version from which karpenter was built.",
 	},
-	[]string{"version", "goversion", "commit"},
+	[]string{"version", "goversion", "goarch", "commit"},
 )
 
 // Version is the karpenter app version injected during compilation
@@ -83,7 +83,7 @@ var Version = "unspecified"
 
 func init() {
 	crmetrics.Registry.MustRegister(BuildInfo)
-	BuildInfo.WithLabelValues(Version, runtime.Version(), changeset.Get()).Set(1)
+	BuildInfo.WithLabelValues(Version, runtime.Version(), runtime.GOARCH, changeset.Get()).Set(1)
 }
 
 type Operator struct {

--- a/pkg/operator/suite_test.go
+++ b/pkg/operator/suite_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Operator", func() {
 		m, found := FindMetricWithLabelValues("karpenter_build_info", map[string]string{})
 		Expect(found).To(BeTrue())
 
-		for _, label := range []string{"version", "goversion", "commit"} {
+		for _, label := range []string{"version", "goversion", "goarch", "commit"} {
 			_, ok := lo.Find(m.GetLabel(), func(l *prometheusmodel.LabelPair) bool { return lo.FromPtr(l.Name) == label })
 			Expect(ok).To(BeTrue())
 		}


### PR DESCRIPTION
Fixes #665

**Description**

This is small improvement to karpenter_build_info Prometheus metric, added in https://github.com/aws/karpenter-provider-aws/pull/5213 and then moved to common Karpenter code https://github.com/kubernetes-sigs/karpenter/pull/851

I think it might be useful to have also arch of the node on which Karpenter runs.

**How was this change tested?**

Ran `go test` in `pkg/operator`, all passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
