### PR TITLE
chore: Fix consistent ordering of NodePools and Provisioners

### DIFF
--- a/pkg/apis/v1beta1/suite_test.go
+++ b/pkg/apis/v1beta1/suite_test.go
@@ -16,16 +16,20 @@ package v1beta1_test
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	. "knative.dev/pkg/logging/testing"
 
 	"github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 )
 
 var ctx context.Context
@@ -47,4 +51,125 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("OrderByWeight", func() {
+	It("should order the NodePools by weight", func() {
+		// Generate 10 NodePools that have random weights, some might have the same weights
+		var nodePools []v1beta1.NodePool
+		for i := 0; i < 10; i++ {
+			np := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Weight: lo.ToPtr[int32](int32(rand.Intn(100) + 1)), //nolint:gosec
+				},
+			})
+			nodePools = append(nodePools, *np)
+		}
+
+		nodePools = lo.Shuffle(nodePools)
+		nodePoolList := v1beta1.NodePoolList{Items: nodePools}
+		nodePoolList.OrderByWeight()
+
+		lastWeight := 101 // This is above the allowed weight values
+		for _, np := range nodePoolList.Items {
+			Expect(lo.FromPtr(np.Spec.Weight)).To(BeNumerically("<=", lastWeight))
+			lastWeight = int(lo.FromPtr(np.Spec.Weight))
+		}
+	})
+	It("should order the NodePools by name when the weights are the same", func() {
+		// Generate 10 NodePools with the same weight
+		var nodePools []v1beta1.NodePool
+		for i := 0; i < 10; i++ {
+			np := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Weight: lo.ToPtr[int32](10),
+				},
+			})
+			nodePools = append(nodePools, *np)
+		}
+
+		nodePools = lo.Shuffle(nodePools)
+		nodePoolList := v1beta1.NodePoolList{Items: nodePools}
+		nodePoolList.OrderByWeight()
+
+		lastName := "zzzzzzzzzzzzzzzzzzzzzzzz" // large string value
+		for _, np := range nodePoolList.Items {
+			Expect(np.Name < lastName).To(BeTrue())
+			lastName = np.Name
+		}
+	})
+	It("should order the NodePools in front of the Provisioners when the weights are the same", func() {
+		var nodePools []v1beta1.NodePool
+
+		for i := 0; i < 10; i++ {
+			np := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Weight: lo.ToPtr[int32](10),
+				},
+			})
+			nodePools = append(nodePools, *np)
+		}
+		for i := 0; i < 10; i++ {
+			p := test.Provisioner(test.ProvisionerOptions{
+				Weight: lo.ToPtr[int32](10),
+			})
+			// These are converted NodePools
+			nodePools = append(nodePools, *nodepoolutil.New(p))
+		}
+		nodePools = lo.Shuffle(nodePools)
+		nodePoolList := v1beta1.NodePoolList{Items: nodePools}
+		nodePoolList.OrderByWeight()
+
+		// Once we find a Provisioner in this list, we expect to just find provisioners since they are all equal weight
+		foundProvisioner := false
+		for _, np := range nodePoolList.Items {
+			if np.IsProvisioner {
+				foundProvisioner = true
+			}
+			if foundProvisioner {
+				Expect(np.IsProvisioner).To(BeTrue())
+			} else {
+				Expect(np.IsProvisioner).To(BeFalse())
+			}
+		}
+	})
+	It("should order the NodePools in front of Provisioners when weight are different throughout the list", func() {
+		var nodePools []v1beta1.NodePool
+
+		for i := 0; i < 10; i++ {
+			np := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Weight: lo.ToPtr[int32](int32(i)),
+				},
+			})
+			nodePools = append(nodePools, *np)
+		}
+		for i := 0; i < 10; i++ {
+			p := test.Provisioner(test.ProvisionerOptions{
+				Weight: lo.ToPtr[int32](int32(i)),
+			})
+			// These are converted NodePools
+			nodePools = append(nodePools, *nodepoolutil.New(p))
+		}
+		nodePools = lo.Shuffle(nodePools)
+		nodePoolList := v1beta1.NodePoolList{Items: nodePools}
+		nodePoolList.OrderByWeight()
+
+		// Once we find a Provisioner weight in the list, we don't expect to find a NodePool that has the same weight or higher
+		lowestFoundProvisionerWeight := 101 // This is above the allowed weight values
+		lowestFoundNodePoolWeight := 101    // This is above the allowed weight values
+		for _, np := range nodePoolList.Items {
+			// If we find a provisioner, this is now the lowest weight that we have seen as a provisioner
+			// If we find multiple provisioner values in a low, the values should be equal or less than the previous value
+			if np.IsProvisioner {
+				Expect(int(lo.FromPtr(np.Spec.Weight))).To(BeNumerically("<=", lowestFoundProvisionerWeight))
+				Expect(int(lo.FromPtr(np.Spec.Weight))).To(BeNumerically("<=", lowestFoundNodePoolWeight))
+				lowestFoundProvisionerWeight = int(lo.FromPtr(np.Spec.Weight))
+			} else {
+				Expect(int(lo.FromPtr(np.Spec.Weight))).To(BeNumerically("<=", lowestFoundNodePoolWeight))
+				Expect(int(lo.FromPtr(np.Spec.Weight))).To(BeNumerically("<", lowestFoundProvisionerWeight))
+				lowestFoundNodePoolWeight = int(lo.FromPtr(np.Spec.Weight))
+			}
+		}
+	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This changes the ordering of NodePools and their sorting so that NodePools of equal weight are always moved in front of Provisioners. This particularly helps with the migration story, where we want the same NodePool that has the same weight as Provisioner to always come first

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
