### PR TITLE
ci: Enable codeql for github actions

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,47 @@
+name: "CodeQL"
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release-v*'
+  pull_request:
+  schedule:
+    - cron: '0 12 * * *'
+jobs:
+  analyze-go:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # github/codeql-action/init@v2
+      security-events: write # github/codeql-action/init@v2
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: ./.github/actions/install-deps
+      - run: make vulncheck
+      - uses: github/codeql-action/init@df32e399139a3050671466d7d9b3cbacc1cfd034 # v2.22.8
+        with:
+          languages: go
+      - uses: github/codeql-action/autobuild@df32e399139a3050671466d7d9b3cbacc1cfd034 # v2.22.8
+      - uses: github/codeql-action/analyze@df32e399139a3050671466d7d9b3cbacc1cfd034 # v2.22.8
+  # Javascript is added here for evaluating Github Action vulnerabilities
+  # https://github.blog/2023-08-09-four-tips-to-keep-your-github-actions-workflows-secure/#2-enable-code-scanning-for-workflows
+  analyze-github-actions:
+    name: Analyze Github Actions
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # github/codeql-action/init@v2
+      security-events: write # github/codeql-action/init@v2
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: github/codeql-action/init@df32e399139a3050671466d7d9b3cbacc1cfd034 # v2.22.8
+        with:
+          languages: javascript
+          config: |
+            packs:
+              # Use the latest version of 'codeql-javascript' published by 'advanced-security'
+              # This will catch things like actions that aren't pinned to a hash
+              - advanced-security/codeql-javascript
+            paths:
+              - '.github/workflows'
+              - '.github/actions'
+      - uses: github/codeql-action/analyze@df32e399139a3050671466d7d9b3cbacc1cfd034 # v2.22.8

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       discussions: write
       pull-requests: write
-    if: github.repository == 'aws/karpenter-core'
+    if: github.repository == 'kubernetes-sigs/karpenter'
     name: Stale issue bot
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds CodeQL scanning for Github Actions specified in this repo to check for things like Github Action pinning and script injection. More details here: https://github.blog/2023-08-09-four-tips-to-keep-your-github-actions-workflows-secure/#2-enable-code-scanning-for-workflows

**How was this change tested?**

Create script injection vulnerabilities on fork and test that CodeQL can catch these

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
