### PR TITLE
fix: remove event filter for nodepool hash controller

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
+	"knative.dev/pkg/apis"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -127,6 +128,14 @@ func (c *Controller) Builder(_ context.Context, m manager.Manager) operatorcontr
 						// One of the status conditions that affects disruption has changed
 						// which means that we should re-consider this for disruption
 						for _, cond := range v1beta1.LivingConditions {
+							if !equality.Semantic.DeepEqual(
+								oldNodeClaim.StatusConditions().GetCondition(cond),
+								newNodeClaim.StatusConditions().GetCondition(cond),
+							) {
+								return true
+							}
+						}
+						for _, cond := range []apis.ConditionType{v1beta1.Expired, v1beta1.Empty, v1beta1.Drifted} {
 							if !equality.Semantic.DeepEqual(
 								oldNodeClaim.StatusConditions().GetCondition(cond),
 								newNodeClaim.StatusConditions().GetCondition(cond),

--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -25,14 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/apis"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -117,37 +113,7 @@ func (c *Controller) Name() string {
 func (c *Controller) Builder(_ context.Context, m manager.Manager) operatorcontroller.Builder {
 	return operatorcontroller.Adapt(controllerruntime.
 		NewControllerManagedBy(m).
-		For(&v1beta1.NodeClaim{}, builder.WithPredicates(
-			predicate.Or(
-				predicate.GenerationChangedPredicate{},
-				predicate.Funcs{
-					UpdateFunc: func(e event.UpdateEvent) bool {
-						oldNodeClaim := e.ObjectOld.(*v1beta1.NodeClaim)
-						newNodeClaim := e.ObjectNew.(*v1beta1.NodeClaim)
-
-						// One of the status conditions that affects disruption has changed
-						// which means that we should re-consider this for disruption
-						for _, cond := range v1beta1.LivingConditions {
-							if !equality.Semantic.DeepEqual(
-								oldNodeClaim.StatusConditions().GetCondition(cond),
-								newNodeClaim.StatusConditions().GetCondition(cond),
-							) {
-								return true
-							}
-						}
-						for _, cond := range []apis.ConditionType{v1beta1.Expired, v1beta1.Empty, v1beta1.Drifted} {
-							if !equality.Semantic.DeepEqual(
-								oldNodeClaim.StatusConditions().GetCondition(cond),
-								newNodeClaim.StatusConditions().GetCondition(cond),
-							) {
-								return true
-							}
-						}
-						return false
-					},
-				},
-			),
-		)).
+		For(&v1beta1.NodeClaim{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		Watches(
 			&v1beta1.NodePool{},

--- a/pkg/controllers/nodepool/hash/controller.go
+++ b/pkg/controllers/nodepool/hash/controller.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -67,7 +66,6 @@ func (c *Controller) Name() string {
 func (c *Controller) Builder(_ context.Context, m manager.Manager) operatorcontroller.Builder {
 	return operatorcontroller.Adapt(controllerruntime.
 		NewControllerManagedBy(m).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		For(&v1beta1.NodePool{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}),
 	)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
If a user removes the hash from the nodepool, the hash won't be added again until another event occurs, this could prevent drift from happening

There are four other controllers that filter out update events that don't modify the spec, which are all the correct behavior. One difference is we'll now enqueue for the nodeclaim/disruption controller so that if a user removes the status condition on a nodeclaim, we'll add it back in if necessary.

**How was this change tested?**
tested manually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
