### PR TITLE
chore: remove nodeclaim disruption controller node watcher

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -145,10 +145,6 @@ func (c *Controller) Builder(_ context.Context, m manager.Manager) operatorcontr
 			nodeclaimutil.NodePoolEventHandler(c.kubeClient),
 		).
 		Watches(
-			&v1.Node{},
-			nodeclaimutil.NodeEventHandler(c.kubeClient),
-		).
-		Watches(
 			&v1.Pod{},
 			nodeclaimutil.PodEventHandler(c.kubeClient),
 		),

--- a/pkg/controllers/nodeclaim/disruption/expiration.go
+++ b/pkg/controllers/nodeclaim/disruption/expiration.go
@@ -49,16 +49,8 @@ func (e *Expiration) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, 
 		}
 		return reconcile.Result{}, nil
 	}
-	// 2. If NodeClaim is not launched, remove the expired status condition
-	if launchCond := nodeClaim.StatusConditions().GetCondition(v1beta1.Launched); launchCond == nil || launchCond.IsFalse() {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Expired)
-		if hasExpiredCondition {
-			logging.FromContext(ctx).Debugf("removing expired status condition, isn't launched")
-		}
-		return reconcile.Result{}, nil
-	}
 	expirationTime := nodeClaim.CreationTimestamp.Add(*nodePool.Spec.Disruption.ExpireAfter.Duration)
-	// 3. If the NodeClaim isn't expired, remove the status condition.
+	// 2. If the NodeClaim isn't expired, remove the status condition.
 	if e.clock.Now().Before(expirationTime) {
 		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Expired)
 		if hasExpiredCondition {
@@ -68,7 +60,7 @@ func (e *Expiration) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, 
 		// Use t.Sub(clock.Now()) instead of time.Until() to ensure we're using the injected clock.
 		return reconcile.Result{RequeueAfter: expirationTime.Sub(e.clock.Now())}, nil
 	}
-	// 4. Otherwise, if the NodeClaim is expired, but doesn't have the status condition, add it.
+	// 3. Otherwise, if the NodeClaim is expired, but doesn't have the status condition, add it.
 	nodeClaim.StatusConditions().SetCondition(apis.Condition{
 		Type:     v1beta1.Expired,
 		Status:   v1.ConditionTrue,

--- a/pkg/controllers/nodeclaim/disruption/expiration_test.go
+++ b/pkg/controllers/nodeclaim/disruption/expiration_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -45,8 +44,6 @@ var _ = Describe("Expiration", func() {
 				Labels: map[string]string{v1beta1.NodePoolLabelKey: nodePool.Name},
 			},
 		})
-		// NodeClaims are required to be launched before they can be evaluated for expiration
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Launched)
 	})
 
 	It("should remove the status condition from the NodeClaims when expiration is disabled", func() {
@@ -100,18 +97,5 @@ var _ = Describe("Expiration", func() {
 
 		result := ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(result.RequeueAfter).To(BeNumerically("~", time.Second*100, time.Second))
-	})
-	It("should remove the status condition from the nodeClaim when the nodeClaim launch condition doesn't exist", func() {
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Expired)
-		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
-		nodeClaim.Status.Conditions = lo.Reject(nodeClaim.Status.Conditions, func(s apis.Condition, _ int) bool {
-			return s.Type == v1beta1.Launched
-		})
-		ExpectApplied(ctx, env.Client, nodeClaim)
-
-		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
-
-		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired)).To(BeNil())
 	})
 })

--- a/pkg/controllers/nodeclaim/disruption/expiration_test.go
+++ b/pkg/controllers/nodeclaim/disruption/expiration_test.go
@@ -45,6 +45,8 @@ var _ = Describe("Expiration", func() {
 				Labels: map[string]string{v1beta1.NodePoolLabelKey: nodePool.Name},
 			},
 		})
+		// NodeClaims are required to be launched before they can be evaluated for expiration
+		nodeClaim.StatusConditions().MarkTrue(v1beta1.Launched)
 	})
 
 	It("should remove the status condition from the NodeClaims when expiration is disabled", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This changes the expiration to refer to the nodeclaim creation timestamp rather than conditionally referring to the node if it exists. This follows the model of emptiness and drift, where we only reason about the nodeclaim as the source of truth for the node for the purpose of disruption conditions.

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
