### PR TITLE
fix: don't panic on shutdown for nil nodepools for logging budgets

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -251,6 +251,7 @@ func (c *Controller) logInvalidBudgets(ctx context.Context) {
 	nodePoolList, err := nodepoolutil.List(ctx, c.kubeClient)
 	if err != nil {
 		logging.FromContext(ctx).Debugf("listing nodepools, %s", err)
+		return
 	}
 	var buf bytes.Buffer
 	for _, np := range nodePoolList.Items {

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -250,7 +250,7 @@ func (c *Controller) logAbnormalRuns(ctx context.Context) {
 func (c *Controller) logInvalidBudgets(ctx context.Context) {
 	nodePoolList, err := nodepoolutil.List(ctx, c.kubeClient)
 	if err != nil {
-		logging.FromContext(ctx).Debugf("listing nodepools, %s", err)
+		logging.FromContext(ctx).Errorf("listing nodepools, %s", err)
 		return
 	}
 	var buf bytes.Buffer


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
On shutdown, we were getting panics since we weren't returning after a failed nodePool.List call.

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
