### PR TITLE
ci: Add SBOM generation to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,3 +16,9 @@ jobs:
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
+      - name: Install bom and test presence in path
+        uses: kubernetes-sigs/release-actions/setup-bom@main
+        with:
+          bom-release: '0.5.1'
+      - name: Check install!
+        run: bom version


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

## Description

I'm currently participated in the Security Slam, focusing on the issue related to **ensuring SBOMs are generated by the Kubernetes BOM**. This PR addresses the issue in the `kubernetes-sigs/karpenter` repository. The changes include the integration of SIG Release’s GitHub Action for SBOM generation in the release workflow.

### Changes Made

- Updated the release workflow (`release.yaml`) to incorporate the necessary steps for SBOM generation using SIG Release’s GitHub Action for BOM.
- Added the `Install bom` and `Check bom installation` steps to validate the installation of the `bom` tool.

### Testing

The changes were tested comprehensively to ensure their correctness and effectiveness:
 **Release Workflow Testing:**
   - Created a dedicated [test branch](https://github.com/YashPimple/karpenter/actions/runs/7225673429/job/19689595736) (`test-release`).
   - Tagged a test release (`v0.34.0]`) to simulate the release process.
   - Checked the GitHub Actions workflow for successful execution.
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
