### PR TITLE
chore: Fix `karpenter_nodeclaims_drifted` metric

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -86,7 +86,7 @@ func (d *Drift) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nodeC
 		Reason:   string(driftedReason),
 	})
 	if !hasDriftedCondition {
-		logging.FromContext(ctx).Debugf("marking drifted")
+		logging.FromContext(ctx).With("reason", string(driftedReason)).Debugf("marking drifted")
 		nodeclaimutil.DisruptedCounter(nodeClaim, metrics.DriftReason).Inc()
 		nodeclaimutil.DriftedCounter(nodeClaim, string(driftedReason)).Inc()
 	}

--- a/pkg/controllers/nodeclaim/disruption/emptiness_test.go
+++ b/pkg/controllers/nodeclaim/disruption/emptiness_test.go
@@ -51,7 +51,24 @@ var _ = Describe("Emptiness", func() {
 			},
 		})
 	})
+	Context("Metrics", func() {
+		It("should fire a karpenter_nodeclaims_disrupted metric when empty", func() {
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
+			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue()).To(BeTrue())
+
+			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_disrupted", map[string]string{
+				"type":     "emptiness",
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+		})
+	})
 	It("should mark NodeClaims as empty", func() {
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)

--- a/pkg/controllers/nodeclaim/disruption/expiration_test.go
+++ b/pkg/controllers/nodeclaim/disruption/expiration_test.go
@@ -45,7 +45,26 @@ var _ = Describe("Expiration", func() {
 			},
 		})
 	})
+	Context("Metrics", func() {
+		It("should fire a karpenter_nodeclaims_disrupted metric when expired", func() {
+			nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 30)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
+			// step forward to make the node expired
+			fakeClock.Step(60 * time.Second)
+			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired).IsTrue()).To(BeTrue())
+
+			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_disrupted", map[string]string{
+				"type":     "expiration",
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+		})
+	})
 	It("should remove the status condition from the NodeClaims when expiration is disabled", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
 		nodeClaim.StatusConditions().MarkTrue(v1beta1.Expired)

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -276,7 +276,7 @@ func DisruptedCounter(nodeClaim *v1beta1.NodeClaim, disruptionType string) prome
 }
 
 func DriftedCounter(nodeClaim *v1beta1.NodeClaim, driftType string) prometheus.Counter {
-	return metrics.NodeClaimsDisruptedCounter.With(prometheus.Labels{
+	return metrics.NodeClaimsDriftedCounter.With(prometheus.Labels{
 		metrics.TypeLabel:     driftType,
 		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 	})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The `karpenter_nodeclaims_drifted` metric was coming through the `karpenter_nodeclaims_disrupted` metric due to a typo and a lack of testing around these metrics.

This change adds testing around the disruption metrics and ensures that we correctly fire the `karpenter_nodeclaims_drifted` metric

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
