### PR TITLE
ci(workflows): least privileged token permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
   schedule:
     - cron: '0 12 * * *'
+permissions:
+  contents: read
 jobs:
   analyze-go:
     name: Analyze Go

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   presubmit:
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,8 @@ name: Release
 on:
   push:
     tags: ['v*.*.*']
+permissions:
+  contents: read
 jobs:
   release:
     permissions:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * *'
+permissions:
+  contents: read
 jobs:
   StaleBot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

Ref. https://github.com/kubernetes-sigs/karpenter/issues/876

**Description**

The `GITHUB_TOKEN` is an automatically generated secret to make authenticated calls to the GitHub API. GitHub recommends setting minimum token permissions for the `GITHUB_TOKEN`. Current configuration seems to be secure, but there is a chance that when a new job is added to one of the workflows, its job permissions could be left undefined because of human error. We can prevent that by setting permissions definitions in each workflow's yaml file as read-only at the [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions).

- [GitHub Security Guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)
- [The Open Source Security Foundation (OpenSSF) Security Guide](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.