### PR TITLE
chore: Drop additional managed check for nodes that don't have NodeClaims

### DIFF
--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -307,8 +307,7 @@ func (in *StateNode) Nominated() bool {
 }
 
 func (in *StateNode) Managed() bool {
-	return in.NodeClaim != nil ||
-		(in.Node != nil && in.Node.Labels[v1beta1.NodePoolLabelKey] != "")
+	return in.NodeClaim != nil
 }
 
 func (in *StateNode) updateForPod(ctx context.Context, kubeClient client.Client, pod *v1.Pod) error {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR drops an additional check that is unneeded now that we are no longer on a migration path. Nodes that would fall under the additional check (that is -- nodes that would have the `karpenter.sh/nodepool` label but don't have an associated NodeClaim) will only exist when the NodeClaim is deleted _immediately_ after creation (since the node would exist for a bit of time while the instance is terminating). In this case, we shouldn't consider the node managed since the instance is going away and the node will get deleted soon by CCM.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
