### PR TITLE
chore: Update ephemeral taints logic and drop unmanaged check on nodes

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2382,7 +2382,9 @@ var _ = Context("NodePool", func() {
 				},
 			})
 			ExpectApplied(ctx, env.Client, node)
+			ExpectMakeNodesInitialized(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
+
 			opts := test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU: resource.MustParse("10m"),
@@ -2406,7 +2408,9 @@ var _ = Context("NodePool", func() {
 				},
 			})
 			ExpectApplied(ctx, env.Client, node)
+			ExpectMakeNodesInitialized(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
+
 			opts := test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU: resource.MustParse("10m"),

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -176,6 +176,9 @@ func (in *StateNode) Labels() map[string]string {
 }
 
 func (in *StateNode) Taints() []v1.Taint {
+	// If we have a managed node that isn't registered, we should use its NodeClaim
+	// representation of taints. Likewise, if we don't have a Node representation for this
+	// providerID in our state, we should also just use the NodeClaim since this is all that we have
 	var taints []v1.Taint
 	if (!in.Registered() && in.Managed()) || in.Node == nil {
 		taints = in.NodeClaim.Spec.Taints
@@ -200,9 +203,8 @@ func (in *StateNode) Taints() []v1.Taint {
 			}
 			return false
 		})
-	} else {
-		return taints
 	}
+	return taints
 }
 
 func (in *StateNode) Registered() bool {

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -307,8 +307,7 @@ func (in *StateNode) Nominated() bool {
 }
 
 func (in *StateNode) Managed() bool {
-	return in.NodeClaim != nil ||
-		(in.Node != nil && in.Node.Labels[v1beta1.NodePoolLabelKey] != "")
+	return in.NodeClaim != nil
 }
 
 func (in *StateNode) updateForPod(ctx context.Context, kubeClient client.Client, pod *v1.Pod) error {

--- a/pkg/scheduling/taints.go
+++ b/pkg/scheduling/taints.go
@@ -25,6 +25,9 @@ import (
 	cloudproviderapi "k8s.io/cloud-provider/api"
 )
 
+// KnownEphemeralTaints are taints that are expected to be added to a node while it's initializing
+// If the node is a Karpenter-managed node, we don't consider these taints while the node is uninitialized
+// since we expect these taints to eventually be removed
 var KnownEphemeralTaints = []v1.Taint{
 	{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoSchedule},
 	{Key: v1.TaintNodeUnreachable, Effect: v1.TaintEffectNoSchedule},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR changes the ephemeral taints logic that we use for removing certain taints for consideration when nodes managed by Karpenter haven't yet initialized. This changes the logic so that this logic doesn't also apply to unmanaged nodes as well as ensuring that we only consider these taints _up_ to the point that the node initializes. Once a node has reached its initialization point, we will begin considering these taints.

This PR drops an additional check that is unneeded now that we are no longer on a migration path. Nodes that would fall under the additional check (that is -- nodes that would have the `karpenter.sh/nodepool` label but don't have an associated NodeClaim) will only exist when the NodeClaim is deleted _immediately_ after creation (since the node would exist for a bit of time while the instance is terminating). In this case, we shouldn't consider the node managed since the instance is going away and the node will get deleted soon by CCM.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
