### PR TITLE
chore: Release leader election in manager config

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -137,12 +137,13 @@ func NewOperator() (context.Context, *Operator) {
 
 	// Manager
 	mgrOpts := controllerruntime.Options{
-		Logger:                     logging.IgnoreDebugEvents(zapr.NewLogger(logger.Desugar())),
-		LeaderElection:             options.FromContext(ctx).EnableLeaderElection,
-		LeaderElectionID:           "karpenter-leader-election",
-		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-		LeaderElectionNamespace:    system.Namespace(),
-		Scheme:                     scheme.Scheme,
+		Logger:                        logging.IgnoreDebugEvents(zapr.NewLogger(logger.Desugar())),
+		LeaderElection:                options.FromContext(ctx).EnableLeaderElection,
+		LeaderElectionID:              "karpenter-leader-election",
+		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+		LeaderElectionNamespace:       system.Namespace(),
+		LeaderElectionReleaseOnCancel: true,
+		Scheme:                        scheme.Scheme,
 		Metrics: server.Options{
 			BindAddress: fmt.Sprintf(":%d", options.FromContext(ctx).MetricsPort),
 		},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the leader election to actively release the lease when it is shutting down using controller-runtime's `LeaderElectionReleaseOnCancel`. This ensures that if one of the Karpenter pods ever dies, as long as the pods is able to still communicate with the apiserver, the lease hand-off is dropped down to milliseconds.

### Before PR

#### Previous Pod

```
{"level":"INFO","time":"2023-12-20T05:13:18.270Z","logger":"controller","message":"Wait completed, proceeding to shutdown the manager","commit":"403f1ad"}
```

#### New Pod

```
{"level":"INFO","time":"2023-12-20T05:20:11.608Z","logger":"controller","message":"successfully acquired lease kube-system/karpenter-leader-election","commit":"403f1ad"}
```

__Total Time Between Handoff__: ~7s

### After PR

#### Previous Pod

```
{"level":"INFO","time":"2023-12-20T05:13:18.270Z","logger":"controller","message":"Wait completed, proceeding to shutdown the manager","commit":"403f1ad"}
```

#### New Pod

```
{"level":"INFO","time":"2023-12-20T05:13:18.900Z","logger":"controller","message":"successfully acquired lease kube-system/karpenter-leader-election","commit":"403f1ad"}
```

__Total Time Between Handoff__: ~600ms

**How was this change tested?**

Manually applied and validated hand-off

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
