### PR TITLE
feat: add kwok install hack script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ deflake: ## Run randomized, racing tests until the test fails to catch flakes
 		-v \
 		./pkg/...
 
+install-kwok: ## Install kwok into cluster
+	UNINSTALL_KWOK=false ./hack/install-kwok.sh
+uninstall-kwok: ## Install kwok provider
+	UNINSTALL_KWOK=true ./hack/install-kwok.sh
+
 vulncheck: ## Verify code vulnerabilities
 	@govulncheck ./pkg/...
 

--- a/hack/install-kwok.sh
+++ b/hack/install-kwok.sh
@@ -28,7 +28,7 @@ spec:
   template:
     spec:
       tolerations:
-      - operator: "Equals"
+      - operator: "Equal"
         key: CriticalAddonsOnly 
         effect: NoSchedule
       affinity:

--- a/hack/install-kwok.sh
+++ b/hack/install-kwok.sh
@@ -1,0 +1,102 @@
+set -euo pipefail
+
+# get the latest version
+KWOK_REPO=kubernetes-sigs/kwok
+# KWOK_LATEST_RELEASE=$(curl "https://api.github.com/repos/${KWOK_REPO}/releases/latest" | jq -r '.tag_name')
+KWOK_LATEST_RELEASE="v0.3.0"
+
+# make a base directory for multi-base kustomization
+HOME_DIR=$(mktemp -d)
+BASE=${HOME_DIR}/base
+mkdir ${BASE}
+
+# allow it to tolerate everything, but not run on nodes that kwok launches
+cat <<EOF > "${BASE}/tolerate-all.yaml"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kwok-controller
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      tolerations:
+      - operator: "Exists"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kwok.x-k8s.io/node
+                operator: DoesNotExist
+EOF
+
+cat <<EOF > "${BASE}/kustomization.yaml"
+  apiVersion: kustomize.config.k8s.io/v1beta1
+  kind: Kustomization
+  images:
+  - name: registry.k8s.io/kwok/kwok
+    newTag: "${KWOK_LATEST_RELEASE}"
+  resources:
+  - "https://github.com/${KWOK_REPO}/kustomize/kwok?ref=${KWOK_LATEST_RELEASE}"
+  patchesStrategicMerge:
+  - tolerate-all.yaml
+EOF
+
+# Define 10 different kwok controllers to handle large load
+for let in partition-a partition-b partition-c partition-d partition-e partition-f partition-g partition-h partition-i partition-j
+do
+  SUB_LET_DIR=$HOME_DIR/${let}
+  mkdir ${SUB_LET_DIR}
+
+  cat <<EOF > "${SUB_LET_DIR}/patch.yaml"
+  - op: replace
+    path: /spec/template/spec/containers/0/args/2
+    value: --manage-nodes-with-label-selector=kwok-partition=${let}
+EOF
+
+cat <<EOF > "${SUB_LET_DIR}/kustomization.yaml"
+  apiVersion: kustomize.config.k8s.io/v1beta1
+  kind: Kustomization
+  images:
+  - name: registry.k8s.io/kwok/kwok
+    newTag: "${KWOK_LATEST_RELEASE}"
+  resources:
+  - ./../base
+  nameSuffix: -${let}
+  patches:
+    - path: ${SUB_LET_DIR}/patch.yaml
+      target:
+        group: apps
+        version: v1
+        kind: Deployment
+        name: kwok-controller
+EOF
+
+done
+
+
+
+cat <<EOF > "${HOME_DIR}/kustomization.yaml"
+resources:
+- ./partition-a
+- ./partition-b
+- ./partition-c
+- ./partition-d
+- ./partition-e
+- ./partition-f
+- ./partition-g
+- ./partition-h
+- ./partition-i
+- ./partition-j
+EOF
+
+kubectl kustomize "${HOME_DIR}" > "${HOME_DIR}/kwok.yaml"
+
+# Set UNINSTALL_KWOK=true if you want to uninstall.
+if [[ ${UNINSTALL_KWOK} = "true" ]]
+then
+  kubectl delete -f ${HOME_DIR}/kwok.yaml
+else
+  kubectl apply -f ${HOME_DIR}/kwok.yaml
+fi


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This adds in a hack/kwok-install.sh script that will allow users to install Kwok with 10 partitions in their cluster. 10 partitions are needed as Kwok has [scalability limitations](https://github.com/kubernetes-sigs/kwok#:~:text=Lightweight%3A%20You%20can%20simulate%20thousands%20of%20nodes%20on%20your%20laptop%20without%20significant%20consumption%20of%20CPU%20or%20memory%20resources.%20Currently%2C%20KWOK%20can%20reliably%20maintain%201k%20nodes%20and%20100k%20pods%20easily.)

This kwok-install.sh script can be improved by doing kustomization to only apply 10 different deployments, rather than 10 copies of all objects associated with the manifest. 

Related: https://github.com/kubernetes-sigs/karpenter/issues/895

**How was this change tested?**
`make install-kwok` and `make uninstall-kwok`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
