### PR TITLE
ci: Drop `kind/support` from exempt and only use kind labels for exemption

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been inactive for 14 days. StaleBot will close this stale issue after 14 more days of inactivity.'
-          exempt-issue-labels: 'bug,chore,feature,documentation,testing,operational-excellence,automation,roadmap,kind/cleanup,kind/documentation,kind/regression,kind/flake,kind/bug,kind/deprecation,kind/support,kind/feature,kind/failing-test,kind/api-change'
+          exempt-issue-labels: 'kind/cleanup,kind/testing,kind/documentation,kind/regression,kind/flake,kind/bug,kind/deprecation,kind/feature,kind/failing-test,kind/api-change,kind/automation'
           stale-issue-label: 'lifecycle/stale'
           close-issue-label: 'lifecycle/closed'
           stale-pr-message: 'This PR has been inactive for 14 days. StaleBot will close this stale PR after 14 more days of inactivity.'


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Drops `kind/support` from the set of exempt labels to close-out stale questions and use only `kind/*` labels for staleness categorization

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
