### PR TITLE
ci: Fix tejolote release attestation step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,26 +6,28 @@ permissions:
   contents: read
 jobs:
   release:
+    env:
+      TAG: ${{ github.ref_name }}
     permissions:
-      contents: write
+      contents: write # Needed for creating and editing releases
+      id-token: write # Needed for cosigning build attestation files with tejolote
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-
-      - name: Install tejolote
-        uses: kubernetes-sigs/release-actions/setup-tejolote@dd08496c83441d6477114cc0555b96d404dacff7 # v0.1.2
-
-      - name: Run tejolote 
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          tejolote attest --artifacts github://kubernetes-sigs/karpenter/"${TAG}" github://kubernetes-sigs/karpenter/"${{ github.run_id }}" --output karpenter.intoto.json --sign
-
       - name: Create Github Release
         uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
         with:
-          files: karpenter.intoto.json
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
+      - name: Install tejolote
+        uses: kubernetes-sigs/release-actions/setup-tejolote@dd08496c83441d6477114cc0555b96d404dacff7 # v0.1.2
+      - name: Run tejolote
+        run: |
+          tejolote attest "github://kubernetes-sigs/karpenter/${{ github.run_id }}" --artifacts "github://kubernetes-sigs/karpenter/$TAG" --output karpenter.intoto.json --sign
+      - name: Add the tejolote provenance attestation to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$TAG" karpenter.intoto.json


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fixes a failure generated by the release attestation added here: #889 by ensuring that we generate the attestation for the release after we have created the release.

**How was this change tested?**

Manually tagging and generate attestation in fork

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
