### PR TITLE
feat: add metric for disruption budgets

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -161,6 +161,12 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 3))
+
 			// Execute command, thus deleting 3 nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(7))
@@ -197,6 +203,12 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 10))
+
 			// Execute command, thus deleting all nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(0))
@@ -232,6 +244,12 @@ var _ = Describe("Consolidation", func() {
 
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
+
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 0))
 
 			// Execute command, thus deleting all nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
@@ -417,6 +435,14 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			for _, np := range nps {
+				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+					"nodepool": np.Name,
+				})
+				Expect(found).To(BeTrue())
+				Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 2))
+			}
+
 			// Execute the command in the queue, only deleting 20 node claims
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(10))
@@ -472,6 +498,14 @@ var _ = Describe("Consolidation", func() {
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
+
+			for _, np := range nps {
+				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+					"nodepool": np.Name,
+				})
+				Expect(found).To(BeTrue())
+				Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 3))
+			}
 
 			// Execute the command in the queue, deleting all node claims
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -157,6 +157,13 @@ func (c *Controller) disrupt(ctx context.Context, disruption Method) (bool, erro
 		return false, fmt.Errorf("building disruption budgets, %w", err)
 	}
 
+	// Emit metrics before we disrupt for allowed disruptions for each loop.
+	for nodePoolName, budget := range disruptionBudgetMapping {
+		disruptionBudgetsAllowedDisruptionsGauge.With(map[string]string{
+			metrics.NodePoolLabel: nodePoolName,
+		}).Set(float64(budget))
+	}
+
 	// Determine the disruption action
 	cmd, err := disruption.ComputeCommand(ctx, disruptionBudgetMapping, candidates...)
 	if err != nil {

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -125,6 +125,12 @@ var _ = Describe("Drift", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 10))
+
 			// Execute command, thus deleting all nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(0))
@@ -162,6 +168,12 @@ var _ = Describe("Drift", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 0))
+
 			// Execute command, thus deleting no nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(numNodes))
@@ -198,6 +210,12 @@ var _ = Describe("Drift", func() {
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
+
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 3))
 
 			// Execute command, thus deleting 3 nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
@@ -333,6 +351,14 @@ var _ = Describe("Drift", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			for _, np := range nps {
+				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+					"nodepool": np.Name,
+				})
+				Expect(found).To(BeTrue())
+				Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 2))
+			}
+
 			// Execute the command in the queue, only deleting 20 nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(10))
@@ -390,6 +416,14 @@ var _ = Describe("Drift", func() {
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
+
+			for _, np := range nps {
+				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+					"nodepool": np.Name,
+				})
+				Expect(found).To(BeTrue())
+				Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 3))
+			}
 
 			// Execute the command in the queue, deleting all nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})

--- a/pkg/controllers/disruption/emptiness_test.go
+++ b/pkg/controllers/disruption/emptiness_test.go
@@ -145,6 +145,12 @@ var _ = Describe("Emptiness", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 10))
+
 			// Execute command, thus deleting 10 nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(0))
@@ -185,6 +191,12 @@ var _ = Describe("Emptiness", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 0))
+
 			// Execute command, thus deleting no nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(numNodes))
@@ -224,6 +236,12 @@ var _ = Describe("Emptiness", func() {
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
+
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 3))
 
 			// Execute command, thus deleting 3 nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
@@ -288,6 +306,14 @@ var _ = Describe("Emptiness", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			for _, np := range nps {
+				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+					"nodepool": np.Name,
+				})
+				Expect(found).To(BeTrue())
+				Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 2))
+			}
+
 			// Execute the command in the queue, only deleting 20 nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(10))
@@ -349,6 +375,14 @@ var _ = Describe("Emptiness", func() {
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
+
+			for _, np := range nps {
+				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+					"nodepool": np.Name,
+				})
+				Expect(found).To(BeTrue())
+				Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 3))
+			}
 
 			// Execute the command in the queue, deleting all nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})

--- a/pkg/controllers/disruption/expiration_test.go
+++ b/pkg/controllers/disruption/expiration_test.go
@@ -126,6 +126,12 @@ var _ = Describe("Expiration", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 10))
+
 			// Execute command, thus deleting all nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(0))
@@ -167,6 +173,12 @@ var _ = Describe("Expiration", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 0))
+
 			// Execute command, thus deleting no nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(numNodes))
@@ -207,6 +219,12 @@ var _ = Describe("Expiration", func() {
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
+
+			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				"nodepool": nodePool.Name,
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 3))
 
 			// Execute command, thus deleting 3 nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
@@ -341,6 +359,14 @@ var _ = Describe("Expiration", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
+			for _, np := range nps {
+				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+					"nodepool": np.Name,
+				})
+				Expect(found).To(BeTrue())
+				Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 2))
+			}
+
 			// Execute the command in the queue, only deleting 20 nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(10))
@@ -397,6 +423,14 @@ var _ = Describe("Expiration", func() {
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
+
+			for _, np := range nps {
+				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+					"nodepool": np.Name,
+				})
+				Expect(found).To(BeTrue())
+				Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 3))
+			}
 
 			// Execute the command in the queue, deleting all nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})

--- a/pkg/controllers/disruption/metrics.go
+++ b/pkg/controllers/disruption/metrics.go
@@ -25,7 +25,7 @@ import (
 
 func init() {
 	crmetrics.Registry.MustRegister(disruptionEvaluationDurationHistogram, disruptionActionsPerformedCounter,
-		disruptionEligibleNodesGauge, disruptionConsolidationTimeoutTotalCounter)
+		disruptionEligibleNodesGauge, disruptionConsolidationTimeoutTotalCounter, disruptionBudgetsAllowedDisruptionsGauge)
 }
 
 const (
@@ -72,5 +72,14 @@ var (
 			Help:      "Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.",
 		},
 		[]string{consolidationTypeLabel},
+	)
+	disruptionBudgetsAllowedDisruptionsGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: disruptionSubsystem,
+			Name:      "budgets_allowed_disruptions",
+			Help:      "The number of nodes for a given NodePool that can be disrupted at a point in time. Labeled by NodePool. Note that disruption budgets this can change very rapidly, as new nodes may be created and others may be deleted at any point.",
+		},
+		[]string{metrics.NodePoolLabel},
 	)
 )

--- a/pkg/controllers/disruption/metrics.go
+++ b/pkg/controllers/disruption/metrics.go
@@ -78,7 +78,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: disruptionSubsystem,
 			Name:      "budgets_allowed_disruptions",
-			Help:      "The number of nodes for a given NodePool that can be disrupted at a point in time. Labeled by NodePool. Note that disruption budgets this can change very rapidly, as new nodes may be created and others may be deleted at any point.",
+			Help:      "The number of nodes for a given NodePool that can be disrupted at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.",
 		},
 		[]string{metrics.NodePoolLabel},
 	)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds metric to track how many disruptions are allowed for each disruption loop. 

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
