### PR TITLE
feat: add support for ContainerLogMaxSize and ContainerLogMaxFiles

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -113,6 +113,14 @@ spec:
                       maximum: 100
                       minimum: 0
                       type: integer
+                    containerLogMaxSize:
+                      description: ContainerLogMaxSize is a quantity defining the maximum size of the container log file before it is rotated.
+                      type: string
+                    containerLogMaxFiles:
+                      description: ContainerLogMaxFiles specifies the maximum number of container log files that can be present for a container.
+                      format: int32
+                      minimum: 2
+                      type: integer
                     kubeReserved:
                       additionalProperties:
                         anyOf:

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -191,6 +191,14 @@ spec:
                               maximum: 100
                               minimum: 0
                               type: integer
+                            containerLogMaxSize:
+                              description: ContainerLogMaxSize is a quantity defining the maximum size of the container log file before it is rotated.
+                              type: string
+                            containerLogMaxFiles:
+                              description: ContainerLogMaxFiles specifies the maximum number of container log files that can be present for a container.
+                              format: int32
+                              minimum: 2
+                              type: integer
                             kubeReserved:
                               additionalProperties:
                                 anyOf:

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -126,6 +126,14 @@ type KubeletConfiguration struct {
 	// +kubebuilder:validation:Maximum:=100
 	// +optional
 	ImageGCLowThresholdPercent *int32 `json:"imageGCLowThresholdPercent,omitempty"`
+	// Set the maximum size (e.g. 10Mi) of container log file before it is rotated.
+	// +kubebuilder:validation:Minimum:=0
+	// +optional
+	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty"`
+	// Set the maximum number of container log files that can be present for a container. The number must be >= 2. 
+	// +kubebuilder:validation:Minimum:=2
+	// +optional
+	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty"`
 	// CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
 	// +optional
 	CPUCFSQuota *bool `json:"cpuCFSQuota,omitempty"`

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -129,7 +129,7 @@ type KubeletConfiguration struct {
 	// Set the maximum size (e.g. 10Mi) of container log file before it is rotated.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	ContainerLogMaxSize *string `json:"containerLogMaxSize,omitempty"`
+	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty"`
 	// Set the maximum number of container log files that can be present for a container. The number must be >= 2. 
 	// +kubebuilder:validation:Minimum:=2
 	// +optional

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -129,7 +129,7 @@ type KubeletConfiguration struct {
 	// Set the maximum size (e.g. 10Mi) of container log file before it is rotated.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty"`
+	ContainerLogMaxSize *string `json:"containerLogMaxSize,omitempty"`
 	// Set the maximum number of container log files that can be present for a container. The number must be >= 2. 
 	// +kubebuilder:validation:Minimum:=2
 	// +optional


### PR DESCRIPTION
**Description**
Add support for ContainerLogMaxSize and ContainerLogMaxFiles.  
We'll be adding this to the bootstrap code in the near future. https://github.com/aws/karpenter-provider-aws   
To set log rotation the current workaround with AWS Node Template is to use jq on node start to insert these args into the /etc/kubernetes/kubelet/kubelet-config.json.   

This method is hard to manage the kubelet config file as a manifest and I think we need to add the args feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
