### PR TITLE
fix: add manual nodeclaim update into cluster state for new nodes

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -359,6 +359,8 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 		metrics.ReasonLabel:   options.Reason,
 		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 	}).Inc()
+	// Update the nodeclaim manually in state to avoid evenutal consistency delay races with our watcher
+	p.cluster.UpdateNodeClaim(nodeClaim)
 	if functional.ResolveOptions(opts...).RecordPodNomination {
 		for _, pod := range n.Pods {
 			p.recorder.Publish(scheduler.NominatePodEvent(pod, nil, nodeClaim))

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -409,10 +409,6 @@ func (c *Cluster) newStateFromNodeClaim(nodeClaim *v1beta1.NodeClaim, oldNode *S
 }
 
 func (c *Cluster) cleanupNodeClaim(name string) {
-	// Delete the node claim from the nodeClaimNameToProviderID in the case that the provider ID hasn't resolved
-	// yet. This ensures that if a nodeClaim is created and then deleted before it was able to launch that
-	// this is cleaned up.
-	delete(c.nodeClaimNameToProviderID, name)
 	if id := c.nodeClaimNameToProviderID[name]; id != "" {
 		if c.nodes[id].Node == nil {
 			delete(c.nodes, id)
@@ -421,6 +417,10 @@ func (c *Cluster) cleanupNodeClaim(name string) {
 		}
 		c.MarkUnconsolidated()
 	}
+	// Delete the node claim from the nodeClaimNameToProviderID in the case that the provider ID hasn't resolved
+	// yet. This ensures that if a nodeClaim is created and then deleted before it was able to launch that
+	// this is cleaned up.
+	delete(c.nodeClaimNameToProviderID, name)
 }
 
 func (c *Cluster) newStateFromNode(ctx context.Context, node *v1.Node, oldNode *StateNode) (*StateNode, error) {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -409,13 +409,13 @@ func (c *Cluster) newStateFromNodeClaim(nodeClaim *v1beta1.NodeClaim, oldNode *S
 }
 
 func (c *Cluster) cleanupNodeClaim(name string) {
+	delete(c.nodeClaimNameToProviderID, name)
 	if id := c.nodeClaimNameToProviderID[name]; id != "" {
 		if c.nodes[id].Node == nil {
 			delete(c.nodes, id)
 		} else {
 			c.nodes[id].NodeClaim = nil
 		}
-		delete(c.nodeClaimNameToProviderID, name)
 		c.MarkUnconsolidated()
 	}
 }

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -409,6 +409,9 @@ func (c *Cluster) newStateFromNodeClaim(nodeClaim *v1beta1.NodeClaim, oldNode *S
 }
 
 func (c *Cluster) cleanupNodeClaim(name string) {
+	// Delete the node claim from the nodeClaimNameToProviderID in the case that the provider ID hasn't resolved
+	// yet. This ensures that if a nodeClaim is created and then deleted before it was able to launch that
+	// this is cleaned up.
 	delete(c.nodeClaimNameToProviderID, name)
 	if id := c.nodeClaimNameToProviderID[name]; id != "" {
 		if c.nodes[id].Node == nil {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -221,11 +221,10 @@ func (c *Cluster) UpdateNodeClaim(nodeClaim *v1beta1.NodeClaim) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if nodeClaim.Status.ProviderID == "" {
-		return // We can't reconcile nodeclaims that don't yet have provider ids
+	if nodeClaim.Status.ProviderID != "" {
+		n := c.newStateFromNodeClaim(nodeClaim, c.nodes[nodeClaim.Status.ProviderID])
+		c.nodes[nodeClaim.Status.ProviderID] = n
 	}
-	n := c.newStateFromNodeClaim(nodeClaim, c.nodes[nodeClaim.Status.ProviderID])
-	c.nodes[nodeClaim.Status.ProviderID] = n
 	c.nodeClaimNameToProviderID[nodeClaim.Name] = nodeClaim.Status.ProviderID
 }
 

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -909,15 +909,6 @@ var _ = Describe("Node Resource Level", func() {
 		time.Sleep(time.Second * 11) // past 20s, node should no longer be nominated
 		Expect(ExpectStateNodeExists(cluster, node).Nominated()).To(BeFalse())
 	})
-	It("should create a state node if the node claim has no provider ID", func() {
-		nodeClaim := test.NodeClaim()
-		nodeClaim.Status.ProviderID = ""
-		ExpectApplied(ctx, env.Client, nodeClaim)
-		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodeClaim))
-
-		ExpectStateNodeCount("==", 1)
-		ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim)
-	})
 	It("should handle a node changing from no providerID to registering a providerID", func() {
 		node := test.Node()
 		ExpectApplied(ctx, env.Client, node)
@@ -1270,6 +1261,15 @@ var _ = Describe("Cluster State Sync", func() {
 				ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 			}
 		}
+		Expect(cluster.Synced(ctx)).To(BeFalse())
+	})
+	It("shouldn't consider the cluster state synced if a nodeclaim isn't launched", func() {
+		// Deploy 1000 nodeClaims and sync them all with the cluster
+		nodeClaim := test.NodeClaim()
+		nodeClaim.Status.ProviderID = ""
+		ExpectApplied(ctx, env.Client, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(cluster.Synced(ctx)).To(BeFalse())
 	})
 })

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1277,7 +1277,11 @@ var _ = Describe("Cluster State Sync", func() {
 		cluster.UpdateNodeClaim(nodeClaim)
 		Expect(cluster.Synced(ctx)).To(BeFalse())
 
-		// Reconcile it without actually creating it, essentially making it deleted.
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		Expect(cluster.Synced(ctx)).To(BeFalse())
+
+		ExpectDeleted(ctx, env.Client, nodeClaim)
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(cluster.Synced(ctx)).To(BeTrue())
 	})

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -909,6 +909,15 @@ var _ = Describe("Node Resource Level", func() {
 		time.Sleep(time.Second * 11) // past 20s, node should no longer be nominated
 		Expect(ExpectStateNodeExists(cluster, node).Nominated()).To(BeFalse())
 	})
+	It("should create a state node if the node claim has no provider ID", func() {
+		nodeClaim := test.NodeClaim()
+		nodeClaim.Status.ProviderID = ""
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodeClaim))
+
+		ExpectStateNodeCount("==", 1)
+		ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim)
+	})
 	It("should handle a node changing from no providerID to registering a providerID", func() {
 		node := test.Node()
 		ExpectApplied(ctx, env.Client, node)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This calls `clusterState.UpdateNodeClaim` when Karpenter creates new node claims to ensure that Karpenter is aware of nodes that are being created immediately, avoiding eventual consistency delay races with the controller-runtime cache. 

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
