### PR TITLE
chore: add initialization buffer to disruptable nodes

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -89,6 +89,8 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, pod, node)
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -104,6 +106,8 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, pod, node)
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -154,6 +158,8 @@ var _ = Describe("Consolidation", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -196,6 +202,8 @@ var _ = Describe("Consolidation", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -238,6 +246,8 @@ var _ = Describe("Consolidation", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -306,6 +316,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -367,6 +379,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			// Reconcile 5 times, enqueuing 3 commands total.
@@ -429,6 +443,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -493,6 +509,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -540,8 +558,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -563,8 +581,9 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
-			fakeClock.Step(10 * time.Minute)
 			wg := sync.WaitGroup{}
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
@@ -631,6 +650,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
@@ -670,8 +691,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
@@ -731,8 +752,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
@@ -804,8 +825,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
@@ -877,8 +898,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
@@ -948,8 +969,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// consolidation won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
@@ -1030,8 +1051,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, annotatedNode}, []*v1beta1.NodeClaim{nodeClaim, annotatedNodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1109,8 +1130,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, annotatedNode}, []*v1beta1.NodeClaim{nodeClaim, annotatedNodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1187,8 +1208,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1265,8 +1286,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1366,8 +1387,9 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
-			fakeClock.Step(10 * time.Minute)
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
@@ -1477,8 +1499,9 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
-			fakeClock.Step(10 * time.Minute)
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
@@ -1559,8 +1582,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1609,8 +1632,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1666,8 +1689,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, unmanagedNode}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1731,8 +1754,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1787,8 +1810,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1839,8 +1862,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1893,8 +1916,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1945,8 +1968,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -1994,8 +2017,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -2045,6 +2068,8 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 			ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nodeClaim))
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node2}, []*v1beta1.NodeClaim{nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -2147,6 +2172,8 @@ var _ = Describe("Consolidation", func() {
 					ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
 				}
 			}
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// Create a pod and nodeclaim/node that will eventually be scheduled onto the initialized node
 			consolidatableNodeClaim, consolidatableNode := test.NodeClaimAndNode(v1beta1.NodeClaim{
@@ -2194,6 +2221,8 @@ var _ = Describe("Consolidation", func() {
 			ExpectApplied(ctx, env.Client, consolidatableNodeClaim, consolidatableNode, consolidatablePod)
 			ExpectManualBinding(ctx, env.Client, consolidatablePod, consolidatableNode)
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{consolidatableNode}, []*v1beta1.NodeClaim{consolidatableNodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -2251,8 +2280,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -2312,8 +2341,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
@@ -2368,8 +2397,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -2434,6 +2463,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -2453,7 +2484,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectExists(ctx, env.Client, nodeClaim1)
 
 			// advance the clock so that the timeout expires
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 			// controller should finish
 			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
 			wg.Wait()
@@ -2522,6 +2553,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1, node2}, []*v1beta1.NodeClaim{nodeClaim1, nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -2541,7 +2574,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectExists(ctx, env.Client, nodeClaim2)
 
 			// advance the clock so that the timeout expires
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 
 			// controller should finish
 			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
@@ -2591,6 +2624,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -2635,7 +2670,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
 			// advance the clock so that the timeout expires
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 			// controller should finish
 			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
 			wg.Wait()
@@ -2655,6 +2690,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -2678,7 +2715,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
 			// advance the clock so that the timeout expires
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 			// controller should finish
 			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
 			wg.Wait()
@@ -2697,8 +2734,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 
@@ -2745,8 +2782,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 
@@ -2793,8 +2830,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 
@@ -2847,8 +2884,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 
@@ -2898,8 +2935,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 
@@ -2949,8 +2986,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 
@@ -3055,6 +3092,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -3149,6 +3188,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -3262,8 +3303,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1, node2, node3}, []*v1beta1.NodeClaim{nodeClaim1, nodeClaim2, nodeClaim3})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -3333,8 +3374,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1, node2}, []*v1beta1.NodeClaim{nodeClaim1, nodeClaim2})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -3389,6 +3430,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1, node2}, []*v1beta1.NodeClaim{nodeClaim1, nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
@@ -3411,7 +3454,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectExists(ctx, env.Client, nodeClaim2)
 
 			// advance the clock so that the timeout expires
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 
 			// controller should finish
 			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
@@ -3451,6 +3494,8 @@ var _ = Describe("Consolidation", func() {
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodeClaim1, node1, nodeClaim2, node2, nodeClaim3, node3, nodePool)
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1, node2, node3}, []*v1beta1.NodeClaim{nodeClaim1, nodeClaim2, nodeClaim3})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -3481,11 +3526,11 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node3))
 			// advance the clock so that the timeout expires for emptiness
 			Eventually(fakeClock.HasWaiters, time.Second*5).Should(BeTrue())
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 
 			// Succeed on multi node consolidation
 			Eventually(fakeClock.HasWaiters, time.Second*5).Should(BeTrue())
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
 			wg.Wait()
@@ -3531,6 +3576,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1, node2, node3}, []*v1beta1.NodeClaim{nodeClaim1, nodeClaim2, nodeClaim3})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -3571,12 +3618,12 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 
 			// advance the clock so that the timeout expires for multi-nodeclaim consolidation
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 
 			// wait for the controller to block on the validation timeout for single nodeclaim consolidation
 			Eventually(fakeClock.HasWaiters, time.Second*5).Should(BeTrue())
 			// advance the clock so that the timeout expires for single nodeclaim consolidation
-			fakeClock.Step(31 * time.Second)
+			fakeClock.Step(1 * time.Minute)
 
 			// controller should finish
 			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
@@ -3670,8 +3717,11 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1, node2}, []*v1beta1.NodeClaim{nodeClaim1, nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
-			fakeClock.SetTime(time.Now())
+			// TODO Check if this is right?
+			// fakeClock.SetTime(time.Now())
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -3784,6 +3834,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{zone1Node, zone2Node, zone3Node}, []*v1beta1.NodeClaim{zone1NodeClaim, zone2NodeClaim, zone3NodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectSkew(ctx, env.Client, "default", &tsc).To(ConsistOf(1, 1, 1))
 
@@ -3875,8 +3927,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{zone1Node, zone2Node, zone3Node}, []*v1beta1.NodeClaim{zone1NodeClaim, zone2NodeClaim, zone3NodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -3927,8 +3979,8 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// Run the processing loop in parallel in the background with environment context
 			var wg sync.WaitGroup
@@ -4005,9 +4057,9 @@ var _ = Describe("Consolidation", func() {
 			newNode, _ := lo.Find(nodes, func(n *v1.Node) bool { return n.Name != oldNodeName })
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nil)
-
-			// Wait for the nomination cache to expire
-			time.Sleep(time.Second * 11)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			// Also wait for nomination cache to expire
+			fakeClock.Step(1 * time.Minute)
 
 			// Re-create the pods to re-bind them
 			for i := 0; i < 2; i++ {

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -119,6 +119,8 @@ var _ = Describe("Drift", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -162,6 +164,8 @@ var _ = Describe("Drift", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -205,6 +209,8 @@ var _ = Describe("Drift", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -277,6 +283,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -345,6 +353,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -411,6 +421,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -438,8 +450,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -470,6 +482,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			nodeClaim2, node2 := test.NodeClaimAndNode(v1beta1.NodeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -494,6 +508,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node2}, []*v1beta1.NodeClaim{nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
@@ -517,8 +533,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -532,6 +548,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -553,6 +571,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -574,6 +594,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -588,8 +610,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -602,8 +624,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -648,6 +670,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -692,8 +716,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// disruption won't delete the old nodeClaim until the new nodeClaim is ready
 			var wg sync.WaitGroup
@@ -749,6 +773,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -838,8 +864,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
@@ -914,6 +940,8 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup

--- a/pkg/controllers/disruption/emptiness_test.go
+++ b/pkg/controllers/disruption/emptiness_test.go
@@ -81,6 +81,8 @@ var _ = Describe("Emptiness", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim, nodePool)
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -94,6 +96,8 @@ var _ = Describe("Emptiness", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim, nodePool)
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -139,6 +143,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -185,6 +191,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -231,6 +239,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -300,6 +310,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -370,6 +382,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -395,6 +409,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			fakeClock.Step(10 * time.Minute)
 			wg := sync.WaitGroup{}
@@ -417,6 +433,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -431,6 +449,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -452,6 +472,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -473,6 +495,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -487,8 +511,8 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 

--- a/pkg/controllers/disruption/expiration_test.go
+++ b/pkg/controllers/disruption/expiration_test.go
@@ -120,6 +120,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -167,6 +169,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -214,6 +218,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -286,6 +292,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -353,6 +361,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -418,6 +428,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -445,6 +457,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -459,6 +473,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -480,6 +496,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -501,6 +519,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -529,6 +549,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			nodeClaim2, node2 := test.NodeClaimAndNode(v1beta1.NodeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -553,6 +575,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node2}, []*v1beta1.NodeClaim{nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
@@ -576,8 +600,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
@@ -590,6 +614,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -634,6 +660,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -703,6 +731,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
@@ -752,6 +782,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
@@ -806,6 +838,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
@@ -894,6 +928,8 @@ var _ = Describe("Expiration", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+			// Advance the clock so the nodes can be initialized for long enough to be considered for candidacy.
+			fakeClock.Step(1 * time.Minute)
 
 			// disruption won't delete the old nodeClaim until the new nodeClaim is ready
 			var wg sync.WaitGroup

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -240,6 +240,8 @@ var _ = Describe("Disruption Taints", func() {
 		// inform cluster state about nodes and nodeClaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
+		// Advance the clock so that
+		fakeClock.Step(30 * time.Second)
 		// Trigger the reconcile loop to start but don't trigger the verify action
 		wg := sync.WaitGroup{}
 		wg.Add(1)

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -67,8 +67,8 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	if node.MarkedForDeletion() {
 		return nil, fmt.Errorf("state node is marked for deletion")
 	}
-	// skip candidates that aren't initialized
-	if !node.Initialized() {
+	// skip candidates that haven't been initialized for a period time
+	if !node.Disruptable(clk) {
 		return nil, fmt.Errorf("state node isn't initialized")
 	}
 	// If the orchestration queue is already considering a candidate we want to disrupt, don't consider it a candidate.

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -232,7 +232,7 @@ func (in *StateNode) Disruptable(clock clock.Clock) bool {
 	// chosen for disruption as soon as they're initialized. We only need a small time frame
 	// to get one pod nomination event, as that will block candidacy further.
 	cond := in.NodeClaim.StatusConditions().GetCondition(v1beta1.Initialized)
-	return cond.IsTrue() && clock.Since(cond.LastTransitionTime.Inner.Time) < (30*time.Second)
+	return cond.IsTrue() && clock.Since(cond.LastTransitionTime.Inner.Time) >= (30*time.Second)
 }
 
 func (in *StateNode) Capacity() v1.ResourceList {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a 30s initialization buffer into candidacy for nodes for disruption. Only nodes that have been initialized for 30 seconds can be considered candidates for disruption, ensuring that since we're able to do multiple commands in parallel, that we don't disrupt replacement nodes for a previous action in a future action. 

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
