### PR TITLE
Improved visibility on pod failing to schedule 

### DIFF
--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -84,7 +84,7 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 	// node, which at this point can't be increased in size
 	requests := resources.Merge(n.requests, resources.RequestsForPods(pod))
 
-	fits,_ := resources.Fits(requests, n.Available())
+	fits, _ := resources.Fits(requests, n.Available())
 	if !fits {
 		return fmt.Errorf("exceeds node resources")
 	}

--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -84,7 +84,8 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 	// node, which at this point can't be increased in size
 	requests := resources.Merge(n.requests, resources.RequestsForPods(pod))
 
-	if !resources.Fits(requests, n.Available()) {
+	fits,_ := resources.Fits(requests, n.Available())
+	if !fits {
 		return fmt.Errorf("exceeds node resources")
 	}
 

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -218,23 +218,13 @@ func fits(instanceType *cloudprovider.InstanceType, requests v1.ResourceList) (b
 	return resources.Fits(requests, instanceType.Allocatable())
 }
 
-func hasOffering(instanceType *cloudprovider.InstanceType, requirements scheduling.Requirements) (bool, string) {
-	var reason string
-
+func hasOffering(instanceType *cloudprovider.InstanceType, requirements scheduling.Requirements) (bool,string) {
 	for _, offering := range instanceType.Offerings.Available() {
-		if !requirements.Has(v1.LabelTopologyZone) || !requirements.Get(v1.LabelTopologyZone).Has(offering.Zone) {
-			reason += fmt.Sprintf("%s does not satisfy the requirement %s ", instanceType.Name, offering.Zone)
-		}
-		if !requirements.Has(v1beta1.CapacityTypeLabelKey) || !requirements.Get(v1beta1.CapacityTypeLabelKey).Has(offering.CapacityType) {
-			reason += fmt.Sprintf("%s does not satisfy the requirement %s ", instanceType.Name, offering.CapacityType)
-		}
-
-		if reason != "" {
-			// If any requirement is not met, return with the reason
-			return false, reason
+		if (!requirements.Has(v1.LabelTopologyZone) || requirements.Get(v1.LabelTopologyZone).Has(offering.Zone)) &&
+			(!requirements.Has(v1beta1.CapacityTypeLabelKey) || requirements.Get(v1beta1.CapacityTypeLabelKey).Has(offering.CapacityType)) {
+			return true,""
 		}
 	}
-
-	// No offerings available
-	return true, ""
+	return false,fmt.Sprintf("no offering found for requirements %s", requirements)
 }
+

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -156,7 +156,6 @@ type filterResults struct {
 	reason   string
 }
 
-
 //nolint:gocyclo
 func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceType, requirements scheduling.Requirements, requests v1.ResourceList) filterResults {
 	results := filterResults{
@@ -234,11 +233,8 @@ func hasOffering(instanceType *cloudprovider.InstanceType, requirements scheduli
 			// If any requirement is not met, return with the reason
 			return false, reason
 		}
-
-		// All requirements are satisfied
-		return true, ""
 	}
 
 	// No offerings available
-	return false, "no offering available"
+	return true, ""
 }

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -102,7 +102,7 @@ func (n *NodeClaim) Add(pod *v1.Pod) error {
 	requests := resources.Merge(n.Spec.Resources.Requests, resources.RequestsForPods(pod))
 	filtered := filterInstanceTypesByRequirements(n.InstanceTypeOptions, nodeClaimRequirements, requests)
 	if len(filtered.remaining) == 0 {
-		return fmt.Errorf(filtered.reason)
+		return fmt.Errorf("no instance type satisfied resources and requirements")
 	}
 
 	// Update node
@@ -191,19 +191,19 @@ func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceTy
 			results.remaining = append(results.remaining, it)
 		} else {
 			if !itFits && !itHasOffering && !results.requirementsMet {
-				results.reason = fmt.Sprintf("%s, %s, %s, %s", it.Name, itUnfitReason, offeringReason, it.Requirements.Intersects(requirements))
+				fmt.Printf("%s, %s, %s, %s", it.Name, itUnfitReason, offeringReason, it.Requirements.Intersects(requirements))
 			} else if !itFits && !itHasOffering {
-				results.reason = fmt.Sprintf("%s, %s, %s", it.Name, itUnfitReason, offeringReason)
+				fmt.Printf("%s, %s, %s", it.Name, itUnfitReason, offeringReason)
 			} else if !itCompat && !itHasOffering {
-				results.reason = fmt.Sprintf("%s, %s, %s", it.Name, it.Requirements.Intersects(requirements), offeringReason)
+				fmt.Printf("%s, %s, %s", it.Name, it.Requirements.Intersects(requirements), offeringReason)
 			} else if !itCompat && !itFits {
-				results.reason = fmt.Sprintf("%s, %s, %s", it.Name, it.Requirements.Intersects(requirements), itUnfitReason)
+				fmt.Printf("%s, %s, %s", it.Name, it.Requirements.Intersects(requirements), itUnfitReason)
 			} else if !itCompat {
-				results.reason = fmt.Sprintf("%s, %s", it.Name, it.Requirements.Intersects(requirements))
+				fmt.Printf("%s, %s", it.Name, it.Requirements.Intersects(requirements))
 			} else if !itFits {
-				results.reason = fmt.Sprintf("%s, %s", it.Name, itUnfitReason)
+				fmt.Printf("%s, %s", it.Name, itUnfitReason)
 			} else if !itHasOffering {
-				results.reason = fmt.Sprintf("%s, %s", it.Name, offeringReason)
+				fmt.Printf("%s, %s", it.Name, offeringReason)
 			}
 		}
 	}

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -218,13 +218,12 @@ func fits(instanceType *cloudprovider.InstanceType, requests v1.ResourceList) (b
 	return resources.Fits(requests, instanceType.Allocatable())
 }
 
-func hasOffering(instanceType *cloudprovider.InstanceType, requirements scheduling.Requirements) (bool,string) {
+func hasOffering(instanceType *cloudprovider.InstanceType, requirements scheduling.Requirements) (bool, string) {
 	for _, offering := range instanceType.Offerings.Available() {
 		if (!requirements.Has(v1.LabelTopologyZone) || requirements.Get(v1.LabelTopologyZone).Has(offering.Zone)) &&
 			(!requirements.Has(v1beta1.CapacityTypeLabelKey) || requirements.Get(v1beta1.CapacityTypeLabelKey).Has(offering.CapacityType)) {
-			return true,""
+			return true, ""
 		}
 	}
-	return false,fmt.Sprintf("no offering found for requirements %s", requirements)
+	return false, fmt.Sprintf("no offering found for requirements %s", requirements)
 }
-

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -270,7 +270,7 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 		}
 		nodeClaim := NewNodeClaim(nodeClaimTemplate, s.topology, s.daemonOverhead[nodeClaimTemplate], instanceTypes)
 		if err := nodeClaim.Add(pod); err != nil {
-			errs = multierr.Append(errs, fmt.Errorf("incompatible with nodepool %q, %s",nodeClaimTemplate.NodePoolName, err))
+			errs = multierr.Append(errs, fmt.Errorf("incompatible with nodepool %q, %w", nodeClaimTemplate.NodePoolName, err))
 			continue
 		}
 		// we will launch this nodeClaim and need to track its maximum possible resource usage against our remaining resources

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -49,8 +49,8 @@ type SchedulerOptions struct {
 func NewScheduler(ctx context.Context, kubeClient client.Client, nodeClaimTemplates []*NodeClaimTemplate,
 	nodePools []v1beta1.NodePool, cluster *state.Cluster, stateNodes []*state.StateNode, topology *Topology,
 	instanceTypes map[string][]*cloudprovider.InstanceType, daemonSetPods []*v1.Pod,
-	recorder events.Recorder, opts SchedulerOptions) *Scheduler {
-
+	recorder events.Recorder, opts SchedulerOptions,
+) *Scheduler {
 	// if any of the nodePools add a taint with a prefer no schedule effect, we add a toleration for the taint
 	// during preference relaxation
 	toleratePreferNoSchedule := false
@@ -270,10 +270,7 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 		}
 		nodeClaim := NewNodeClaim(nodeClaimTemplate, s.topology, s.daemonOverhead[nodeClaimTemplate], instanceTypes)
 		if err := nodeClaim.Add(pod); err != nil {
-			errs = multierr.Append(errs, fmt.Errorf("incompatible with nodepool %q, daemonset overhead=%s, %w",
-				nodeClaimTemplate.NodePoolName,
-				resources.String(s.daemonOverhead[nodeClaimTemplate]),
-				err))
+			errs = multierr.Append(errs, fmt.Errorf("incompatible with nodepool %q, %s",nodeClaimTemplate.NodePoolName, err))
 			continue
 		}
 		// we will launch this nodeClaim and need to track its maximum possible resource usage against our remaining resources

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -170,8 +170,8 @@ func Fits(candidate, total v1.ResourceList) (bool, string) {
 	}
 	for resourceName, quantity := range candidate {
 		if Cmp(quantity, total[resourceName]) > 0 {
-			return false, fmt.Sprintf("required resource %s (%s) is greater than total resource %s (%s)",
-				resourceName, quantity.String(), resourceName.String(), total[resourceName].Format)
+			return false, fmt.Sprintf("required resource %s (%s) is greater than total resource %s (%v)",
+				resourceName, quantity.String(), resourceName.String(), total[resourceName])
 		}
 	}
 	return true, ""

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -159,19 +161,20 @@ func Cmp(lhs resource.Quantity, rhs resource.Quantity) int {
 }
 
 // Fits returns true if the candidate set of resources is less than or equal to the total set of resources.
-func Fits(candidate, total v1.ResourceList) bool {
+func Fits(candidate, total v1.ResourceList) (bool, string) {
 	// If any of the total resource values are negative then the resource will never fit
 	for _, quantity := range total {
 		if Cmp(resource.MustParse("0"), quantity) > 0 {
-			return false
+			return false, ""
 		}
 	}
 	for resourceName, quantity := range candidate {
 		if Cmp(quantity, total[resourceName]) > 0 {
-			return false
+			return false, fmt.Sprintf("required resource %s (%s) is greater than total resource %s (%s)",
+				resourceName, quantity.String(), resourceName.String(), total[resourceName].Format)
 		}
 	}
-	return true
+	return true, ""
 }
 
 // String returns a string version of the resource list suitable for presenting in a log


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #686  <!-- issue number -->

**Description**

before this pr the error message would contain 

```
karpenter/karpenter-9d8575fb-hmrf7[controller]: 2023-07-24T09:45:37.841Z	ERROR	controller.provisioner	Could not schedule pod, incompatible with provisioner "arm", did not tolerate arch=arm64:NoSchedule; incompatible with provisioner "x86", no instance type satisfied resources {"cpu":"16","memory":"32Gi","pods":"1"} and requirements karpenter.k8s.aws/instance-category In [c m r], karpenter.k8s.aws/instance-generation Exists >3, karpenter.k8s.aws/instance-hypervisor In [nitro], kubernetes.io/os In [linux], karpenter.sh/capacity-type In [on-demand], kubernetes.io/arch In [amd64], karpenter.sh/provisioner-name In [x86]	{"commit": "dc3af1a", "pod": "canda/canda-avstock-7bbc89bb7b-8t9lk"}```
```
after this pr the error message would 

```
karpenter/karpenter-9d8575fb-hmrf7[controller]: 2023-07-24T09:45:37.841Z	ERROR	controller.provisioner	Could not schedule pod, incompatible with provisioner "arm", did not tolerate arch=arm64:NoSchedule; incompatible with provisioner "x86", required resource cpu 100m is greater than total resource cpu 50m"
```

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
