### PR TITLE
perf: order pods by deleting first

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -23,7 +23,9 @@ import (
 	"sort"
 	"time"
 
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,6 +35,7 @@ import (
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption/orchestration"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
+	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
@@ -115,15 +118,15 @@ func (c *consolidation) ShouldDisrupt(_ context.Context, cn *Candidate) bool {
 // computeConsolidation computes a consolidation action to take
 //
 // nolint:gocyclo
-func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...*Candidate) (Command, error) {
+func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...*Candidate) (Command, sets.Set[*pscheduling.ExistingNode], error) {
 	// Run scheduling simulation to compute consolidation option
 	results, err := simulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, candidates...)
 	if err != nil {
 		// if a candidate node is now deleting, just retry
 		if errors.Is(err, errCandidateDeleting) {
-			return Command{}, nil
+			return Command{}, nil, nil
 		}
-		return Command{}, err
+		return Command{}, nil, err
 	}
 
 	// if not all of the pods were scheduled, we can't do anything
@@ -132,14 +135,18 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, results.NonPendingPodSchedulingErrors())...)
 		}
-		return Command{}, nil
+		return Command{}, nil, nil
 	}
+	// Only return the existing nodes that had pods scheduled to it
+	nominatedNodes := sets.New[*pscheduling.ExistingNode](lo.Filter(results.ExistingNodes, func(n *pscheduling.ExistingNode, _ int) bool {
+		return len(n.Pods) > 0
+	})...)
 
 	// were we able to schedule all the pods on the inflight candidates?
 	if len(results.NewNodeClaims) == 0 {
 		return Command{
 			candidates: candidates,
-		}, nil
+		}, nominatedNodes, nil
 	}
 
 	// we're not going to turn a single node into multiple candidates
@@ -147,14 +154,14 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, fmt.Sprintf("Can't remove without creating %d candidates", len(results.NewNodeClaims)))...)
 		}
-		return Command{}, nil
+		return Command{}, nil, nil
 	}
 
 	// get the current node price based on the offering
 	// fallback if we can't find the specific zonal pricing data
 	candidatePrice, err := getCandidatePrices(candidates)
 	if err != nil {
-		return Command{}, fmt.Errorf("getting offering price from candidate node, %w", err)
+		return Command{}, nil, fmt.Errorf("getting offering price from candidate node, %w", err)
 	}
 	results.NewNodeClaims[0].InstanceTypeOptions = filterByPrice(results.NewNodeClaims[0].InstanceTypeOptions, results.NewNodeClaims[0].Requirements, candidatePrice)
 	if len(results.NewNodeClaims[0].InstanceTypeOptions) == 0 {
@@ -162,7 +169,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, "Can't replace with a cheaper node")...)
 		}
 		// no instance types remain after filtering by price
-		return Command{}, nil
+		return Command{}, nil, nil
 	}
 
 	// If the existing candidates are all spot and the replacement is spot, we don't consolidate.  We don't have a reliable
@@ -180,7 +187,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, "Can't replace a spot node with a spot node")...)
 		}
-		return Command{}, nil
+		return Command{}, nil, nil
 	}
 
 	// We are consolidating a node from OD -> [OD,Spot] but have filtered the instance types by cost based on the
@@ -195,7 +202,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 	return Command{
 		candidates:   candidates,
 		replacements: results.NewNodeClaims,
-	}, nil
+	}, nominatedNodes, nil
 }
 
 // getCandidatePrices returns the sum of the prices of the given candidates

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -212,7 +212,6 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command, 
 			return multierr.Append(fmt.Errorf("launching replacement nodeclaim, %w", err), state.RequireNoScheduleTaint(ctx, c.kubeClient, false, stateNodes...))
 		}
 	}
-
 	// Nominate each node for scheduling and emit pod nomination events
 	for node := range nominatedNodes {
 		c.cluster.NominateNodeForPod(ctx, node.ProviderID())

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -22,11 +22,14 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
+	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
@@ -72,10 +75,10 @@ func (d *Drift) filterAndSortCandidates(ctx context.Context, candidates []*Candi
 // ComputeCommand generates a disruption command given candidates
 //
 //nolint:gocyclo
-func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, error) {
+func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, sets.Set[*pscheduling.ExistingNode], error) {
 	candidates, err := d.filterAndSortCandidates(ctx, candidates)
 	if err != nil {
-		return Command{}, err
+		return Command{}, nil, err
 	}
 	disruptionEligibleNodesGauge.With(map[string]string{
 		methodLabel:            d.Type(),
@@ -101,7 +104,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[
 	if len(empty) > 0 {
 		return Command{
 			candidates: empty,
-		}, nil
+		}, nil, nil
 	}
 
 	for _, candidate := range candidates {
@@ -118,24 +121,23 @@ func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[
 			if errors.Is(err, errCandidateDeleting) {
 				continue
 			}
-			return Command{}, err
+			return Command{}, nil, err
 		}
 		// Emit an event that we couldn't reschedule the pods on the node.
 		if !results.AllNonPendingPodsScheduled() {
 			d.recorder.Publish(disruptionevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
 			continue
 		}
-		if len(results.NewNodeClaims) == 0 {
-			return Command{
-				candidates: []*Candidate{candidate},
-			}, nil
-		}
+		// Only return the existing nodes that had pods scheduled to it
+		nominatedNodes := sets.New[*pscheduling.ExistingNode](lo.Filter(results.ExistingNodes, func(n *pscheduling.ExistingNode, _ int) bool {
+			return len(n.Pods) > 0
+		})...)
 		return Command{
 			candidates:   []*Candidate{candidate},
 			replacements: results.NewNodeClaims,
-		}, nil
+		}, nominatedNodes, nil
 	}
-	return Command{}, nil
+	return Command{}, nil, nil
 }
 
 func (d *Drift) Type() string {

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,10 +38,14 @@ import (
 
 type Method interface {
 	ShouldDisrupt(context.Context, *Candidate) bool
-	ComputeCommand(context.Context, map[string]int, ...*Candidate) (Command, error)
+	ComputeCommand(context.Context, map[string]int, ...*Candidate) (Command, sets.Set[*scheduling.ExistingNode], error)
 	Type() string
 	ConsolidationType() string
 }
+
+// NominatedNodes is a set of node/nodeclaim provider IDs that were nominated for a scheduling simulation.
+// This is used to emit nomination events when we finish executing a command.
+type NominatedNodes sets.Set[*scheduling.ExistingNode]
 
 type CandidateFilter func(context.Context, *Candidate) bool
 

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -86,10 +86,11 @@ func NodeEventHandlerToPods(c client.Client) handler.EventHandler {
 			return []reconcile.Request{}
 		}
 		return lo.FilterMap(podList.Items, func(p v1.Pod, _ int) (reconcile.Request, bool) {
+			isReschedulable := !pod.IsTerminal(&p) && !pod.IsTerminating(&p) && !pod.IsOwnedByDaemonSet(&p) && !pod.IsOwnedByNode(&p)
 			return reconcile.Request{
 				NamespacedName: client.ObjectKeyFromObject(&p),
 				// return only pods that are reschedulable
-			}, !pod.IsTerminal(&p) && !pod.IsTerminating(&p) && !pod.IsOwnedByDaemonSet(&p) && !pod.IsOwnedByNode(&p)
+			}, isReschedulable
 		})
 	})
 }

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -32,6 +32,7 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
 // PodEventHandler is a watcher on v1.Pods that maps Pods to NodeClaim based on the node names
@@ -70,6 +71,25 @@ func NodeEventHandler(c client.Client) handler.EventHandler {
 			return reconcile.Request{
 				NamespacedName: client.ObjectKeyFromObject(&n),
 			}
+		})
+	})
+}
+
+func NodeEventHandlerToPods(c client.Client) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		node := o.(*v1.Node)
+		if ok := lo.Contains(node.Spec.Taints, v1beta1.DisruptionNoScheduleTaint); !ok {
+			return []reconcile.Request{}
+		}
+		podList := &v1.PodList{}
+		if err := c.List(ctx, podList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
+			return []reconcile.Request{}
+		}
+		return lo.FilterMap(podList.Items, func(p v1.Pod, _ int) (reconcile.Request, bool) {
+			return reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(&p),
+				// return only pods that are reschedulable
+			}, !pod.IsTerminal(&p) && !pod.IsTerminating(&p) && !pod.IsOwnedByDaemonSet(&p) && !pod.IsOwnedByNode(&p)
 		})
 	})
 }

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -26,8 +26,8 @@ import (
 )
 
 func IsProvisionable(pod *v1.Pod) bool {
-	return !IsScheduled(pod) &&
-		!IsPreempting(pod) &&
+	// return !IsScheduled(pod) &&
+	return !IsPreempting(pod) &&
 		FailedToSchedule(pod) &&
 		!IsOwnedByDaemonSet(pod) &&
 		!IsOwnedByNode(pod)

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -25,9 +25,16 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
-func IsProvisionable(pod *v1.Pod) bool {
-	// return !IsScheduled(pod) &&
+func CanTriggerProvisioning(pod *v1.Pod) bool {
 	return !IsPreempting(pod) &&
+		FailedToSchedule(pod) &&
+		!IsOwnedByDaemonSet(pod) &&
+		!IsOwnedByNode(pod)
+}
+
+func IsProvisionable(pod *v1.Pod) bool {
+	return !IsScheduled(pod) &&
+		!IsPreempting(pod) &&
 		FailedToSchedule(pod) &&
 		!IsOwnedByDaemonSet(pod) &&
 		!IsOwnedByNode(pod)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This orders pods for disruption scheduling simulations so that we order pods that are on deleting nodes first. This ensures that our bin-packing will put pods from previous disruption actions on the same nodes that they've been scheduled to. This allows future disruption actions to rely on purely a new node for a replacement action.

This actually speeds up disruption performance depending on the flexibility of the budgets. With a tightly packed cluster with all nodes constantly expired, before this change, we could only expire one node per 30s (as we wait for the replacement to be initialized before being able to do another disruption action). After this, I was able to see at least 5 nodes being disrupted at a time with a budget of 100%. 

**How was this change tested?**
Testing here

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
