### PR TITLE
 feat: adding karpenter_state_nodes_total metric and karpenter_state_synced

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -126,7 +126,7 @@ func (c *Cluster) Synced(ctx context.Context) bool {
 	// that exists in the cluster state but not in the apiserver) but it ensures that we have a state
 	// representation for every node/nodeClaim that exists on the apiserver
 	synced := stateNodeClaimNames.IsSuperset(nodeClaimNames) && stateNodeNames.IsSuperset(nodeNames)
-	metrics.ClusterStateIsSynced.With(prometheus.Labels{}).Set(lo.Ternary[float64](synced, 1, 0))
+	metrics.ClusterStateSynced.With(prometheus.Labels{}).Set(lo.Ternary[float64](synced, 1, 0))
 	return synced
 }
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -126,8 +126,8 @@ func (c *Cluster) Synced(ctx context.Context) bool {
 	// that exists in the cluster state but not in the apiserver) but it ensures that we have a state
 	// representation for every node/nodeClaim that exists on the apiserver
 	synced := stateNodeClaimNames.IsSuperset(nodeClaimNames) && stateNodeNames.IsSuperset(nodeNames)
-	    metrics.ClusterStateIsSynced.With(prometheus.Labels{}).Set(lo.Ternary[float64](synced, 1, 0))
-	return synced 
+	metrics.ClusterStateIsSynced.With(prometheus.Labels{}).Set(lo.Ternary[float64](synced, 1, 0))
+	return synced
 }
 
 // ForPodsWithAntiAffinity calls the supplied function once for each pod with required anti affinity terms that is

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -125,9 +125,7 @@ func (c *Cluster) Synced(ctx context.Context) bool {
 	// that exists in the cluster state but not in the apiserver) but it ensures that we have a state
 	// representation for every node/nodeClaim that exists on the apiserver
 	synced := stateNodeClaimNames.IsSuperset(nodeClaimNames) && stateNodeNames.IsSuperset(nodeNames)
-	ClusterStateSynced.With(prometheus.Labels{
-		SyncedKey: fmt.Sprintf("%t", synced),
-	}).Set(lo.Ternary[float64](synced, 1, 0))
+	ClusterStateSynced.With(prometheus.Labels{}).Set(lo.Ternary[float64](synced, 1, 0))
 	return synced
 }
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -272,14 +272,15 @@ func (c *Cluster) UpdateNode(ctx context.Context, node *v1.Node) error {
 	}
 	c.nodes[node.Spec.ProviderID] = n
 	c.nodeNameToProviderID[node.Name] = node.Spec.ProviderID
+	metrics.ClusterStateNodesGauge.WithLabelValues().Set(float64(len(c.nodes)))
 	return nil
 }
 
 func (c *Cluster) DeleteNode(name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
 	c.cleanupNode(name)
+	metrics.ClusterStateNodesGauge.WithLabelValues().Set(float64(len(c.nodes)))
 }
 
 func (c *Cluster) UpdatePod(ctx context.Context, pod *v1.Pod) error {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -237,7 +237,7 @@ func (c *Cluster) UpdateNodeClaim(nodeClaim *v1beta1.NodeClaim) {
 	// If the nodeclaim hasn't launched yet, we want to add it into cluster state to ensure
 	// that we're not racing with the internal cache for the cluster, assuming the node doesn't exist.
 	c.nodeClaimNameToProviderID[nodeClaim.Name] = nodeClaim.Status.ProviderID
-	ClusterStateNodesTotal.WithLabelValues().Set(float64(len(c.nodes)))
+	ClusterStateNodesTotal.Set(float64(len(c.nodes)))
 }
 
 func (c *Cluster) DeleteNodeClaim(name string) {
@@ -245,7 +245,7 @@ func (c *Cluster) DeleteNodeClaim(name string) {
 	defer c.mu.Unlock()
 
 	c.cleanupNodeClaim(name)
-	ClusterStateNodesTotal.WithLabelValues().Set(float64(len(c.nodes)))
+	ClusterStateNodesTotal.Set(float64(len(c.nodes)))
 }
 
 func (c *Cluster) UpdateNode(ctx context.Context, node *v1.Node) error {
@@ -272,7 +272,7 @@ func (c *Cluster) UpdateNode(ctx context.Context, node *v1.Node) error {
 	}
 	c.nodes[node.Spec.ProviderID] = n
 	c.nodeNameToProviderID[node.Name] = node.Spec.ProviderID
-	ClusterStateNodesTotal.WithLabelValues().Set(float64(len(c.nodes)))
+	ClusterStateNodesTotal.Set(float64(len(c.nodes)))
 	return nil
 }
 
@@ -280,7 +280,7 @@ func (c *Cluster) DeleteNode(name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.cleanupNode(name)
-	ClusterStateNodesTotal.WithLabelValues().Set(float64(len(c.nodes)))
+	ClusterStateNodesTotal.Set(float64(len(c.nodes)))
 }
 
 func (c *Cluster) UpdatePod(ctx context.Context, pod *v1.Pod) error {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -124,7 +124,7 @@ func (c *Cluster) Synced(ctx context.Context) bool {
 	// that exists in the cluster state but not in the apiserver) but it ensures that we have a state
 	// representation for every node/nodeClaim that exists on the apiserver
 	synced := stateNodeClaimNames.IsSuperset(nodeClaimNames) && stateNodeNames.IsSuperset(nodeNames)
-	ClusterStateSynced.Set(lo.Ternary[float64](synced, 1, 0))
+	clusterStateSynced.Set(lo.Ternary[float64](synced, 1, 0))
 	return synced
 }
 
@@ -237,7 +237,7 @@ func (c *Cluster) UpdateNodeClaim(nodeClaim *v1beta1.NodeClaim) {
 	// If the nodeclaim hasn't launched yet, we want to add it into cluster state to ensure
 	// that we're not racing with the internal cache for the cluster, assuming the node doesn't exist.
 	c.nodeClaimNameToProviderID[nodeClaim.Name] = nodeClaim.Status.ProviderID
-	ClusterStateNodesTotal.Set(float64(len(c.nodes)))
+	clusterStateNodesCount.Set(float64(len(c.nodes)))
 }
 
 func (c *Cluster) DeleteNodeClaim(name string) {
@@ -245,7 +245,7 @@ func (c *Cluster) DeleteNodeClaim(name string) {
 	defer c.mu.Unlock()
 
 	c.cleanupNodeClaim(name)
-	ClusterStateNodesTotal.Set(float64(len(c.nodes)))
+	clusterStateNodesCount.Set(float64(len(c.nodes)))
 }
 
 func (c *Cluster) UpdateNode(ctx context.Context, node *v1.Node) error {
@@ -272,7 +272,7 @@ func (c *Cluster) UpdateNode(ctx context.Context, node *v1.Node) error {
 	}
 	c.nodes[node.Spec.ProviderID] = n
 	c.nodeNameToProviderID[node.Name] = node.Spec.ProviderID
-	ClusterStateNodesTotal.Set(float64(len(c.nodes)))
+	clusterStateNodesCount.Set(float64(len(c.nodes)))
 	return nil
 }
 
@@ -280,7 +280,7 @@ func (c *Cluster) DeleteNode(name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.cleanupNode(name)
-	ClusterStateNodesTotal.Set(float64(len(c.nodes)))
+	clusterStateNodesCount.Set(float64(len(c.nodes)))
 }
 
 func (c *Cluster) UpdatePod(ctx context.Context, pod *v1.Pod) error {

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -33,7 +33,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "nodes_total",
-			Help:      "total nodes in karpenter's cluster state",
+			Help:      "Total nodes in karpenter's cluster state",
 		},
 		[]string{},
 	)

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	stateSubsystem = "state"
-	SyncedKey      = "synced"
 )
 
 var (
@@ -46,7 +45,7 @@ var (
 			Name:      "synced",
 			Help:      "synced validates that nodeclaims and nodes that are stored in the apiserver have the same representation in karpenter's cluster state",
 		},
-		[]string{SyncedKey},
+		[]string{},
 	)
 )
 

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -32,7 +32,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
-			Name:      "nodes_total",
+			Name:      "nodes_count",
 			Help:      "Total nodes in karpenter's cluster state",
 		},
 	)

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -1,0 +1,58 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state 
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/karpenter/pkg/metrics"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	stateSubsystem = "state"
+	SyncedKey = "synced"
+)
+
+var (
+
+	ClusterStateNodesTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: stateSubsystem,
+			Name:      "nodes_total",
+			Help:      "total nodes in karpenter's cluster state",
+		},
+		[]string{},
+	)
+
+	ClusterStateSynced = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: stateSubsystem,
+			Name:      "synced",
+			Help:      "synced is 1 if the nodeclaims and nodes stored in the apiserver have the same representation in cluster state",
+		},
+		[]string{SyncedKey},
+	)
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(ClusterStateNodesTotal, ClusterStateSynced)
+}
+
+
+

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -38,7 +38,7 @@ var (
 		[]string{},
 	)
 
-	ClusterStateSynced = prometheus.NewGaugeVec(
+	ClusterStateSynced = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -14,21 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package state 
+package state
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"sigs.k8s.io/karpenter/pkg/metrics"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
 const (
 	stateSubsystem = "state"
-	SyncedKey = "synced"
+	SyncedKey      = "synced"
 )
 
 var (
-
 	ClusterStateNodesTotal = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
@@ -44,7 +44,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "synced",
-			Help:      "synced is 1 if the nodeclaims and nodes stored in the apiserver have the same representation in cluster state",
+			Help:      "synced validates that nodeclaims and nodes that are stored in the apiserver have the same representation in karpenter's cluster state",
 		},
 		[]string{SyncedKey},
 	)
@@ -53,6 +53,3 @@ var (
 func init() {
 	crmetrics.Registry.MustRegister(ClusterStateNodesTotal, ClusterStateSynced)
 }
-
-
-

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -32,7 +32,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
-			Name:      "nodes_count",
+			Name:      "node_count",
 			Help:      "Current count of nodes in Karpenter's cluster state",
 		},
 	)

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	ClusterStateNodesTotal = prometheus.NewGauge(
+	clusterStateNodesTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	clusterStateNodesTotal = prometheus.NewGauge(
+	clusterStateNodesCount = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
@@ -37,7 +37,7 @@ var (
 		},
 	)
 
-	ClusterStateSynced = prometheus.NewGauge(
+	clusterStateSynced = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
@@ -48,5 +48,5 @@ var (
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(ClusterStateNodesTotal, ClusterStateSynced)
+	crmetrics.Registry.MustRegister(clusterStateNodesCount, clusterStateSynced)
 }

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -28,14 +28,13 @@ const (
 )
 
 var (
-	ClusterStateNodesTotal = prometheus.NewGaugeVec(
+	ClusterStateNodesTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "nodes_total",
 			Help:      "Total nodes in karpenter's cluster state",
 		},
-		[]string{},
 	)
 
 	ClusterStateSynced = prometheus.NewGauge(

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	stateSubsystem = "state"
+	stateSubsystem = "cluster_state"
 )
 
 var (

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -43,7 +43,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "synced",
-			Help:      "synced validates that nodeclaims and nodes that are stored in the apiserver have the same representation in karpenter's cluster state",
+			Help:      "Synced validates that nodeclaims and nodes that are stored in the apiserver have the same representation as karpenter's cluster state",
 		},
 		[]string{},
 	)

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -33,7 +33,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "node_count",
-			Help:      "Current count of nodes in Karpenter's cluster state",
+			Help:      "Current count of nodes in cluster state",
 		},
 	)
 

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -33,7 +33,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "nodes_count",
-			Help:      "Total nodes in karpenter's cluster state",
+			Help:      "Current count of nodes in Karpenter's cluster state",
 		},
 	)
 

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -42,7 +42,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "synced",
-			Help:      "Whether Karpenter's cluster state is synced. Synced validates that nodeclaims and nodes that are stored in the apiserver have the same representation as Karpenter's cluster state",
+			Help:      "Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state",
 		},
 	)
 )

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -45,7 +45,6 @@ var (
 			Name:      "synced",
 			Help:      "Synced validates that nodeclaims and nodes that are stored in the apiserver have the same representation as karpenter's cluster state",
 		},
-		[]string{},
 	)
 )
 

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -42,7 +42,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "synced",
-			Help:      "Synced validates that nodeclaims and nodes that are stored in the apiserver have the same representation as karpenter's cluster state",
+			Help:      "Whether Karpenter's cluster state is synced. Synced validates that nodeclaims and nodes that are stored in the apiserver have the same representation as Karpenter's cluster state",
 		},
 	)
 )

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -68,14 +68,6 @@ var nodePool *v1beta1.NodePool
 
 const csiProvider = "fake.csi.provider"
 
-var isSyncedTrueLabels = map[string]string{
-	state.SyncedKey: "true",
-}
-
-var isSyncedFalseLabels = map[string]string{
-	state.SyncedKey: "false",
-}
-
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
@@ -1133,7 +1125,7 @@ var _ = Describe("Cluster State Sync", func() {
 		}
 
 		Expect(cluster.Synced(ctx)).To(BeTrue())
-		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, isSyncedTrueLabels)
+		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
 		ExpectMetricGaugeValue("karpenter_state_nodes_total", 1000.0, make(map[string]string))
 	})
 	It("should consider the cluster state synced when nodes don't have provider id", func() {
@@ -1145,7 +1137,7 @@ var _ = Describe("Cluster State Sync", func() {
 			ExpectMetricGaugeValue("karpenter_state_nodes_total", float64(i+1), make(map[string]string))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
-		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, isSyncedTrueLabels)
+		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
 		ExpectMetricGaugeValue("karpenter_state_nodes_total", 1000.0, make(map[string]string))
 
 	})
@@ -1165,7 +1157,7 @@ var _ = Describe("Cluster State Sync", func() {
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodes[i]))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
-		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, isSyncedTrueLabels)
+		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
 		ExpectMetricGaugeValue("karpenter_state_nodes_total", 1000.0, make(map[string]string))
 	})
 	It("should consider the cluster state synced when all nodeclaims are tracked", func() {
@@ -1282,7 +1274,7 @@ var _ = Describe("Cluster State Sync", func() {
 			}
 		}
 		Expect(cluster.Synced(ctx)).To(BeFalse())
-		ExpectMetricGaugeValue("karpenter_state_synced", 0, isSyncedFalseLabels)
+		ExpectMetricGaugeValue("karpenter_state_synced", 0, make(map[string]string))
 	})
 	It("shouldn't consider the cluster state synced if a nodeclaim is added manually with UpdateNodeClaim", func() {
 		nodeClaim := test.NodeClaim()
@@ -1297,17 +1289,17 @@ var _ = Describe("Cluster State Sync", func() {
 
 		cluster.UpdateNodeClaim(nodeClaim)
 		Expect(cluster.Synced(ctx)).To(BeFalse())
-		ExpectMetricGaugeValue("karpenter_state_synced", 0, isSyncedFalseLabels)
+		ExpectMetricGaugeValue("karpenter_state_synced", 0, make(map[string]string))
 
 		ExpectApplied(ctx, env.Client, nodeClaim)
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(cluster.Synced(ctx)).To(BeFalse())
-		ExpectMetricGaugeValue("karpenter_state_synced", 0, isSyncedFalseLabels)
+		ExpectMetricGaugeValue("karpenter_state_synced", 0, make(map[string]string))
 
 		ExpectDeleted(ctx, env.Client, nodeClaim)
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(cluster.Synced(ctx)).To(BeTrue())
-		ExpectMetricGaugeValue("karpenter_state_synced", 1, isSyncedTrueLabels)
+		ExpectMetricGaugeValue("karpenter_state_synced", 1, make(map[string]string))
 	})
 })
 

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -795,7 +795,7 @@ var _ = Describe("Node Resource Level", func() {
 			v1.ResourceCPU:    resource.MustParse("1"),
 			v1.ResourceMemory: resource.MustParse("2Gi"),
 		}, ExpectStateNodeExists(cluster, node).DaemonSetRequests())
-		// count request
+		// total request
 		ExpectResources(v1.ResourceList{
 			v1.ResourceCPU:    resource.MustParse("2.5"),
 			v1.ResourceMemory: resource.MustParse("2Gi"),

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1121,12 +1121,12 @@ var _ = Describe("Cluster State Sync", func() {
 			})
 			ExpectApplied(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
-			ExpectMetricGaugeValue("karpenter_state_nodes_count", float64(i+1), make(map[string]string))
+			ExpectMetricGaugeValue("karpenter_cluster_state_node_count", float64(i+1), nil)
 		}
 
 		Expect(cluster.Synced(ctx)).To(BeTrue())
-		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
-		ExpectMetricGaugeValue("karpenter_state_nodes_count", 1000.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 1.0, nil)
+		ExpectMetricGaugeValue("karpenter_cluster_state_node_count", 1000.0, nil)
 	})
 	It("should consider the cluster state synced when nodes don't have provider id", func() {
 		// Deploy 1000 nodes and sync them all with the cluster
@@ -1134,11 +1134,11 @@ var _ = Describe("Cluster State Sync", func() {
 			node := test.Node()
 			ExpectApplied(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
-			ExpectMetricGaugeValue("karpenter_state_nodes_count", float64(i+1), make(map[string]string))
+			ExpectMetricGaugeValue("karpenter_cluster_state_node_count", float64(i+1), nil)
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
-		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
-		ExpectMetricGaugeValue("karpenter_state_nodes_count", 1000.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 1.0, nil)
+		ExpectMetricGaugeValue("karpenter_cluster_state_node_count", 1000.0, nil)
 
 	})
 	It("should consider the cluster state synced when nodes register provider id", func() {
@@ -1148,7 +1148,7 @@ var _ = Describe("Cluster State Sync", func() {
 			nodes = append(nodes, test.Node())
 			ExpectApplied(ctx, env.Client, nodes[i])
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodes[i]))
-			ExpectMetricGaugeValue("karpenter_state_nodes_count", float64(i+1), make(map[string]string))
+			ExpectMetricGaugeValue("karpenter_cluster_state_node_count", float64(i+1), make(map[string]string))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
 		for i := 0; i < 1000; i++ {
@@ -1157,8 +1157,8 @@ var _ = Describe("Cluster State Sync", func() {
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodes[i]))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
-		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
-		ExpectMetricGaugeValue("karpenter_state_nodes_count", 1000.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 1.0, nil)
+		ExpectMetricGaugeValue("karpenter_cluster_state_node_count", 1000.0, nil)
 	})
 	It("should consider the cluster state synced when all nodeclaims are tracked", func() {
 		// Deploy 1000 nodeClaims and sync them all with the cluster
@@ -1274,7 +1274,7 @@ var _ = Describe("Cluster State Sync", func() {
 			}
 		}
 		Expect(cluster.Synced(ctx)).To(BeFalse())
-		ExpectMetricGaugeValue("karpenter_state_synced", 0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 0, nil)
 	})
 	It("shouldn't consider the cluster state synced if a nodeclaim is added manually with UpdateNodeClaim", func() {
 		nodeClaim := test.NodeClaim()
@@ -1289,17 +1289,17 @@ var _ = Describe("Cluster State Sync", func() {
 
 		cluster.UpdateNodeClaim(nodeClaim)
 		Expect(cluster.Synced(ctx)).To(BeFalse())
-		ExpectMetricGaugeValue("karpenter_state_synced", 0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 0, nil)
 
 		ExpectApplied(ctx, env.Client, nodeClaim)
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(cluster.Synced(ctx)).To(BeFalse())
-		ExpectMetricGaugeValue("karpenter_state_synced", 0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 0, nil)
 
 		ExpectDeleted(ctx, env.Client, nodeClaim)
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(cluster.Synced(ctx)).To(BeTrue())
-		ExpectMetricGaugeValue("karpenter_state_synced", 1, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 1, nil)
 	})
 })
 

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -795,7 +795,7 @@ var _ = Describe("Node Resource Level", func() {
 			v1.ResourceCPU:    resource.MustParse("1"),
 			v1.ResourceMemory: resource.MustParse("2Gi"),
 		}, ExpectStateNodeExists(cluster, node).DaemonSetRequests())
-		// total request
+		// count request
 		ExpectResources(v1.ResourceList{
 			v1.ResourceCPU:    resource.MustParse("2.5"),
 			v1.ResourceMemory: resource.MustParse("2Gi"),
@@ -1121,12 +1121,12 @@ var _ = Describe("Cluster State Sync", func() {
 			})
 			ExpectApplied(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
-			ExpectMetricGaugeValue("karpenter_state_nodes_total", float64(i+1), make(map[string]string))
+			ExpectMetricGaugeValue("karpenter_state_nodes_count", float64(i+1), make(map[string]string))
 		}
 
 		Expect(cluster.Synced(ctx)).To(BeTrue())
 		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
-		ExpectMetricGaugeValue("karpenter_state_nodes_total", 1000.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_state_nodes_count", 1000.0, make(map[string]string))
 	})
 	It("should consider the cluster state synced when nodes don't have provider id", func() {
 		// Deploy 1000 nodes and sync them all with the cluster
@@ -1134,11 +1134,11 @@ var _ = Describe("Cluster State Sync", func() {
 			node := test.Node()
 			ExpectApplied(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
-			ExpectMetricGaugeValue("karpenter_state_nodes_total", float64(i+1), make(map[string]string))
+			ExpectMetricGaugeValue("karpenter_state_nodes_count", float64(i+1), make(map[string]string))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
 		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
-		ExpectMetricGaugeValue("karpenter_state_nodes_total", 1000.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_state_nodes_count", 1000.0, make(map[string]string))
 
 	})
 	It("should consider the cluster state synced when nodes register provider id", func() {
@@ -1148,7 +1148,7 @@ var _ = Describe("Cluster State Sync", func() {
 			nodes = append(nodes, test.Node())
 			ExpectApplied(ctx, env.Client, nodes[i])
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodes[i]))
-			ExpectMetricGaugeValue("karpenter_state_nodes_total", float64(i+1), make(map[string]string))
+			ExpectMetricGaugeValue("karpenter_state_nodes_count", float64(i+1), make(map[string]string))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
 		for i := 0; i < 1000; i++ {
@@ -1158,7 +1158,7 @@ var _ = Describe("Cluster State Sync", func() {
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
 		ExpectMetricGaugeValue("karpenter_state_synced", 1.0, make(map[string]string))
-		ExpectMetricGaugeValue("karpenter_state_nodes_total", 1000.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_state_nodes_count", 1000.0, make(map[string]string))
 	})
 	It("should consider the cluster state synced when all nodeclaims are tracked", func() {
 		// Deploy 1000 nodeClaims and sync them all with the cluster

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1121,8 +1121,12 @@ var _ = Describe("Cluster State Sync", func() {
 			})
 			ExpectApplied(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+			ExpectMetricGaugeValue("karpenter_cluster_state_nodes_total", float64(i+1), make(map[string]string))
 		}
+
 		Expect(cluster.Synced(ctx)).To(BeTrue())
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 1.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_nodes_total", 1000.0, make(map[string]string))
 	})
 	It("should consider the cluster state synced when nodes don't have provider id", func() {
 		// Deploy 1000 nodes and sync them all with the cluster
@@ -1130,8 +1134,12 @@ var _ = Describe("Cluster State Sync", func() {
 			node := test.Node()
 			ExpectApplied(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+			ExpectMetricGaugeValue("karpenter_cluster_state_nodes_total", float64(i+1), make(map[string]string))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 1.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_nodes_total", 1000.0, make(map[string]string))
+
 	})
 	It("should consider the cluster state synced when nodes register provider id", func() {
 		// Deploy 1000 nodes and sync them all with the cluster
@@ -1140,6 +1148,7 @@ var _ = Describe("Cluster State Sync", func() {
 			nodes = append(nodes, test.Node())
 			ExpectApplied(ctx, env.Client, nodes[i])
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodes[i]))
+			ExpectMetricGaugeValue("karpenter_cluster_state_nodes_total", float64(i+1), make(map[string]string))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
 		for i := 0; i < 1000; i++ {
@@ -1148,6 +1157,8 @@ var _ = Describe("Cluster State Sync", func() {
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodes[i]))
 		}
 		Expect(cluster.Synced(ctx)).To(BeTrue())
+		ExpectMetricGaugeValue("karpenter_cluster_state_synced", 1.0, make(map[string]string))
+		ExpectMetricGaugeValue("karpenter_cluster_state_nodes_total", 1000.0, make(map[string]string))
 	})
 	It("should consider the cluster state synced when all nodeclaims are tracked", func() {
 		// Deploy 1000 nodeClaims and sync them all with the cluster

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -132,7 +132,6 @@ var (
 		},
 	)
 
-
 	ClusterStateNodesGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -142,22 +141,13 @@ var (
 		},
 		[]string{},
 	)
-	ClusterStatePodsTotal = prometheus.NewGaugeVec(
-        prometheus.GaugeOpts{
-			Namespace: Namespace, 
-			Subsystem: stateSubsystem,
-            Name: "pods_total",
-            Help: "Total number of pods in the cluster by namespace",
-        },
-        []string{"ns"},
-    )
 
-	ClusterStateIsSynced = prometheus.NewGaugeVec( 
-		prometheus.GaugeOpts{ 
+	ClusterStateIsSynced = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: stateSubsystem,
-			Name: "is_synced", 
-			Help: "Whether the cluster state is synced",
+			Name:      "is_synced",
+			Help:      "Whether the cluster state is synced",
 		},
 		[]string{},
 	)
@@ -166,5 +156,5 @@ var (
 func init() {
 	crmetrics.Registry.MustRegister(NodeClaimsCreatedCounter, NodeClaimsTerminatedCounter, NodeClaimsLaunchedCounter,
 		NodeClaimsRegisteredCounter, NodeClaimsInitializedCounter, NodeClaimsDisruptedCounter, NodeClaimsDriftedCounter,
-		NodesCreatedCounter, NodesTerminatedCounter, ClusterStateNodesGauge, ClusterStatePodsTotal, ClusterStateIsSynced)
+		NodesCreatedCounter, NodesTerminatedCounter, ClusterStateNodesGauge, ClusterStateIsSynced)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,7 +24,6 @@ import (
 const (
 	NodeSubsystem      = "nodes"
 	nodeClaimSubsystem = "nodeclaims"
-	stateSubsystem     = "cluster_state"
 )
 
 var (
@@ -131,30 +130,10 @@ var (
 			NodePoolLabel,
 		},
 	)
-
-	ClusterStateNodesGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: stateSubsystem,
-			Name:      "nodes_total",
-			Help:      "total nodes in karpenter's cluster state",
-		},
-		[]string{},
-	)
-
-	ClusterStateSynced = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Subsystem: stateSubsystem,
-			Name:      "synced",
-			Help:      "synced is 1 if the nodeclaims and nodes stored in the apiserver have the same representation in cluster state",
-		},
-		[]string{},
-	)
 )
 
 func init() {
 	crmetrics.Registry.MustRegister(NodeClaimsCreatedCounter, NodeClaimsTerminatedCounter, NodeClaimsLaunchedCounter,
 		NodeClaimsRegisteredCounter, NodeClaimsInitializedCounter, NodeClaimsDisruptedCounter, NodeClaimsDriftedCounter,
-		NodesCreatedCounter, NodesTerminatedCounter, ClusterStateNodesGauge, ClusterStateSynced)
+		NodesCreatedCounter, NodesTerminatedCounter)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,6 +24,7 @@ import (
 const (
 	NodeSubsystem      = "nodes"
 	nodeClaimSubsystem = "nodeclaims"
+	stateSubsystem     = "cluster_state"
 )
 
 var (
@@ -130,10 +131,40 @@ var (
 			NodePoolLabel,
 		},
 	)
+
+
+	ClusterStateNodesGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: stateSubsystem,
+			Name:      "nodes_total",
+			Help:      "Number of nodes in karpenter's cluster state",
+		},
+		[]string{},
+	)
+	ClusterStatePodsTotal = prometheus.NewGaugeVec(
+        prometheus.GaugeOpts{
+			Namespace: Namespace, 
+			Subsystem: stateSubsystem,
+            Name: "pods_total",
+            Help: "Total number of pods in the cluster by namespace",
+        },
+        []string{"ns"},
+    )
+
+	ClusterStateIsSynced = prometheus.NewGaugeVec( 
+		prometheus.GaugeOpts{ 
+			Namespace: Namespace,
+			Subsystem: stateSubsystem,
+			Name: "is_synced", 
+			Help: "Whether the cluster state is synced",
+		},
+		[]string{},
+	)
 )
 
 func init() {
 	crmetrics.Registry.MustRegister(NodeClaimsCreatedCounter, NodeClaimsTerminatedCounter, NodeClaimsLaunchedCounter,
 		NodeClaimsRegisteredCounter, NodeClaimsInitializedCounter, NodeClaimsDisruptedCounter, NodeClaimsDriftedCounter,
-		NodesCreatedCounter, NodesTerminatedCounter)
+		NodesCreatedCounter, NodesTerminatedCounter, ClusterStateNodesGauge, ClusterStatePodsTotal, ClusterStateIsSynced)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -137,17 +137,17 @@ var (
 			Namespace: Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "nodes_total",
-			Help:      "Number of nodes in karpenter's cluster state",
+			Help:      "total nodes in karpenter's cluster state",
 		},
 		[]string{},
 	)
 
-	ClusterStateIsSynced = prometheus.NewGaugeVec(
+	ClusterStateSynced = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: stateSubsystem,
-			Name:      "is_synced",
-			Help:      "Whether the cluster state is synced",
+			Name:      "synced",
+			Help:      "synced is 1 if the nodeclaims and nodes stored in the apiserver have the same representation in cluster state",
 		},
 		[]string{},
 	)
@@ -156,5 +156,5 @@ var (
 func init() {
 	crmetrics.Registry.MustRegister(NodeClaimsCreatedCounter, NodeClaimsTerminatedCounter, NodeClaimsLaunchedCounter,
 		NodeClaimsRegisteredCounter, NodeClaimsInitializedCounter, NodeClaimsDisruptedCounter, NodeClaimsDriftedCounter,
-		NodesCreatedCounter, NodesTerminatedCounter, ClusterStateNodesGauge, ClusterStateIsSynced)
+		NodesCreatedCounter, NodesTerminatedCounter, ClusterStateNodesGauge, ClusterStateSynced)
 }

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -478,6 +478,7 @@ func FindMetricWithLabelValues(name string, labelValues map[string]string) (*pro
 }
 
 func ExpectMetricGaugeValue(metricName string, expectedValue float64, labels map[string]string) {
+	GinkgoHelper()
 	metric, ok := FindMetricWithLabelValues(metricName, labels)
 	Expect(ok).To(BeTrue(), "Metric "+metricName+" should be available")
 	Expect(lo.FromPtr(metric.Gauge.Value)).To(Equal(expectedValue), "Metric "+metricName+" should have the expected value")

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -477,6 +477,12 @@ func FindMetricWithLabelValues(name string, labelValues map[string]string) (*pro
 	return nil, false
 }
 
+func ExpectMetricGaugeValue(metricName string, expectedValue float64, labels map[string]string) {
+	metric, ok := FindMetricWithLabelValues(metricName, labels)
+	Expect(ok).To(BeTrue(), "Metric "+metricName+" should be available")
+	Expect(lo.FromPtr(metric.Gauge.Value)).To(Equal(expectedValue), "Metric "+metricName+" should have the expected value")
+}
+
 func ExpectManualBinding(ctx context.Context, c client.Client, pod *v1.Pod, node *v1.Node) {
 	GinkgoHelper()
 	Expect(c.Create(ctx, &v1.Binding{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #276 

**Description**
Adding gauge metrics of the cluster state node total that are updated on each UpdateNode, and DeleteNode request, alongside a is_synced metric that is updated in each Synced call. 

**How was this change tested?**
- Unit tests 
- Validated metrics work on AKS + KWOK Cluster
- make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
