### PR TITLE
feat: add metric on pod evicted during node termination

### DIFF
--- a/pkg/controllers/node/termination/metrics.go
+++ b/pkg/controllers/node/termination/metrics.go
@@ -34,8 +34,17 @@ var (
 		},
 		[]string{metrics.NodePoolLabel},
 	)
+	PodEvictionCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "karpenter",
+			Subsystem: "pods",
+			Name:      "evicted_pods",
+			Help:      "Number of pods evicted by Karpenter during node termination",
+		},
+		[]string{},
+	)
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(TerminationSummary)
+	crmetrics.Registry.MustRegister(TerminationSummary, PodEvictionCounter)
 }

--- a/pkg/controllers/node/termination/metrics.go
+++ b/pkg/controllers/node/termination/metrics.go
@@ -34,11 +34,11 @@ var (
 		},
 		[]string{metrics.NodePoolLabel},
 	)
-	PodEvictionCounter = prometheus.NewCounterVec(
+	PodEvictedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "karpenter",
 			Subsystem: "pods",
-			Name:      "evicted_pods",
+			Name:      "evicted",
 			Help:      "Number of pods evicted by Karpenter during node termination",
 		},
 		[]string{},

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	terminationmetrics "sigs.k8s.io/karpenter/pkg/controllers/node/termination/metrics"
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
 	"sigs.k8s.io/karpenter/pkg/operator/controller"
 
@@ -144,6 +145,7 @@ func (q *Queue) Evict(ctx context.Context, nn types.NamespacedName) bool {
 		logging.FromContext(ctx).Errorf("evicting pod, %s", err)
 		return false
 	}
+	terminationmetrics.PodEvictionCounter.With(prometheus.Labels{}).Inc()
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace}}))
 	return true
 }

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	set "github.com/deckarep/golang-set"
+	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"sigs.k8s.io/karpenter/pkg/controllers/node/termination"
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
 	"sigs.k8s.io/karpenter/pkg/operator/controller"
 
@@ -145,7 +145,7 @@ func (q *Queue) Evict(ctx context.Context, nn types.NamespacedName) bool {
 		logging.FromContext(ctx).Errorf("evicting pod, %s", err)
 		return false
 	}
-	termination.PodEvictedCounter.With(prometheus.Labels{}).Inc()
+	podEvictedCounter.With(prometheus.Labels{}).Inc()
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace}}))
 	return true
 }

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -145,7 +145,7 @@ func (q *Queue) Evict(ctx context.Context, nn types.NamespacedName) bool {
 		logging.FromContext(ctx).Errorf("evicting pod, %s", err)
 		return false
 	}
-	terminationmetrics.PodEvictionCounter.With(prometheus.Labels{}).Inc()
+	terminationmetrics.PodEvictedCounter.With(prometheus.Labels{}).Inc()
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace}}))
 	return true
 }

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -145,7 +145,7 @@ func (q *Queue) Evict(ctx context.Context, nn types.NamespacedName) bool {
 		logging.FromContext(ctx).Errorf("evicting pod, %s", err)
 		return false
 	}
-	podEvictedCounter.With(prometheus.Labels{}).Inc()
+	PodEvictedCounter.With(prometheus.Labels{}).Inc()
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace}}))
 	return true
 }

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	terminationmetrics "sigs.k8s.io/karpenter/pkg/controllers/node/termination/metrics"
+	"sigs.k8s.io/karpenter/pkg/controllers/node/termination"
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
 	"sigs.k8s.io/karpenter/pkg/operator/controller"
 
@@ -145,7 +145,7 @@ func (q *Queue) Evict(ctx context.Context, nn types.NamespacedName) bool {
 		logging.FromContext(ctx).Errorf("evicting pod, %s", err)
 		return false
 	}
-	terminationmetrics.PodEvictedCounter.With(prometheus.Labels{}).Inc()
+	termination.PodEvictedCounter.With(prometheus.Labels{}).Inc()
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace}}))
 	return true
 }

--- a/pkg/controllers/node/termination/terminator/metrics.go
+++ b/pkg/controllers/node/termination/terminator/metrics.go
@@ -14,28 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package termination
+package terminator
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
-
-	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
 var (
-	TerminationSummary = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Namespace:  "karpenter",
-			Subsystem:  "nodes",
-			Name:       "termination_time_seconds",
-			Help:       "The time taken between a node's deletion request and the removal of its finalizer",
-			Objectives: metrics.SummaryObjectives(),
+	podEvictedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "karpenter",
+			Subsystem: "pods",
+			Name:      "evicted",
+			Help:      "Number of pods evicted by Karpenter during node termination",
 		},
-		[]string{metrics.NodePoolLabel},
+		[]string{},
 	)
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(TerminationSummary)
+	crmetrics.Registry.MustRegister(podEvictedCounter)
 }

--- a/pkg/controllers/node/termination/terminator/metrics.go
+++ b/pkg/controllers/node/termination/terminator/metrics.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	podEvictedCounter = prometheus.NewCounterVec(
+	PodEvictedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "karpenter",
 			Subsystem: "pods",
@@ -34,5 +34,5 @@ var (
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(podEvictedCounter)
+	crmetrics.Registry.MustRegister(PodEvictedCounter)
 }

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectApplied(ctx, env.Client, pdb)
 			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeTrue())
 
-			_, ok := FindMetricWithLabelValues("karpenter_pods_evicted"), make(map[string]string))
+			_, ok := FindMetricWithLabelValues("karpenter_pods_evicted", make(map[string]string))
 			Expect(ok).To(BeFalse())
 		})
 		It("should fire the podEvictedCounter when there are no PDBs", func() {

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Eviction/Queue", func() {
 
 	AfterEach(func() {
 		// Reset the metrics collectors
-		PodEvictedCounter.Reset()
+		terminator.PodEvictedCounter.Reset()
 	})
 
 	Context("Eviction API", func() {

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -134,14 +134,14 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectApplied(ctx, env.Client, pdb)
 			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeTrue())
 
-			_, ok := FindMetricWithLabelValues("karpenter_pods_evicted")
+			_, ok := FindMetricWithLabelValues("karpenter_pods_evicted"), make(map[string]string))
 			Expect(ok).To(BeFalse())
 		})
 		It("should fire the podEvictedCounter when there are no PDBs", func() {
 			ExpectApplied(ctx, env.Client, pod)
 			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeTrue())
 
-			m, ok := FindMetricWithLabelValues("karpenter_pods_evicted")
+			m, ok := FindMetricWithLabelValues("karpenter_pods_evicted", make(map[string]string))
 			Expect(ok).To(BeTrue())
 			Expect(lo.FromPtr(m.GetCounter().Value)).To(BeNumerically("==", 1))
 		})
@@ -153,7 +153,7 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectApplied(ctx, env.Client, pod)
 			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeTrue())
 
-			m, ok := FindMetricWithLabelValues("karpenter_pods_evicted")
+			m, ok := FindMetricWithLabelValues("karpenter_pods_evicted", make(map[string]string))
 			Expect(ok).To(BeTrue())
 			Expect(lo.FromPtr(m.GetCounter().Value)).To(BeNumerically("==", 1))
 		})
@@ -161,7 +161,7 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectApplied(ctx, env.Client, pdb, pod)
 			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeFalse())
 
-			_, ok := FindMetricWithLabelValues("karpenter_pods_evicted")
+			_, ok := FindMetricWithLabelValues("karpenter_pods_evicted", make(map[string]string))
 			Expect(ok).To(BeFalse())
 		})
 		It("should not fire the podEvictedCounter when two PDBs refer to the same pod", func() {
@@ -172,7 +172,7 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectApplied(ctx, env.Client, pdb, pdb2, pod)
 			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeFalse())
 
-			_, ok := FindMetricWithLabelValues("karpenter_pods_evicted")
+			_, ok := FindMetricWithLabelValues("karpenter_pods_evicted", make(map[string]string))
 			Expect(ok).To(BeFalse())
 		})
 	})

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Eviction/Queue", func() {
 
 	AfterEach(func() {
 		// Reset the metrics collectors
-		termination.PodEvictedCounter.Reset()
+		podEvictedCounter.Reset()
 	})
 
 	Context("Eviction API", func() {

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Eviction/Queue", func() {
 
 	AfterEach(func() {
 		// Reset the metrics collectors
-		podEvictedCounter.Reset()
+		PodEvictedCounter.Reset()
 	})
 
 	Context("Eviction API", func() {


### PR DESCRIPTION
Description

Emit metric on number of pods evicted during node termination

How was this change tested?

`make verify`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
