### PR TITLE
BREAKING CHANGE: Disallow resources to be in the `NodePool`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ verify: ## Verify code. Includes codegen, dependencies, linting, formatting, etc
 	hack/validation/taint.sh
 	hack/validation/requirements.sh
 	hack/validation/labels.sh
+	hack/validation/resources.sh
 	hack/dependabot.sh
 	@# Use perl instead of sed due to https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux
 	@# We need to do this "sed replace" until controller-tools fixes this parameterized types issue: https://github.com/kubernetes-sigs/controller-tools/issues/756

--- a/hack/validation/resources.sh
+++ b/hack/validation/resources.sh
@@ -1,0 +1,2 @@
+# Adding validation for nodepool.spec.template.spec.resources 
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.resources.maxProperties = 0' -i pkg/apis/crds/karpenter.sh_nodepools.yaml 

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -314,6 +314,7 @@ spec:
                               description: Requests describes the minimum required resources for the NodeClaim to launch
                               type: object
                           type: object
+                          maxProperties: 0
                         startupTaints:
                           description: StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
                           items:

--- a/pkg/apis/v1beta1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_cel_test.go
@@ -771,4 +771,10 @@ var _ = Describe("CEL/Validation", func() {
 			}
 		})
 	})
+	Context("Resources", func() {
+		It("should not allow resources to be set", func() {
+			nodePool.Spec.Template.Spec.Resources = ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #955  <!-- issue number -->

**Description**
- The NodePool field `spec.template.spec.resources` was unintentionally allowed to be set by users on the NodePool. The correct validation is captured by the webhook validation, but was missed for OpenAPI validation. This PR adds the correct validation for the OpenAPI validation
-  Currently, the field is an undocumented and not utilized by the `NodePool` 

**How was this change tested?**
- Unit testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
