### PR TITLE
perf: improve scheduling with large numbers of nodes using hostname topologies

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/utils/functional"
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -164,7 +165,7 @@ func (t *Topology) AddRequirements(podRequirements, nodeRequirements scheduling.
 		}
 		domains := topology.Get(p, podDomains, nodeDomains)
 		if domains.Len() == 0 {
-			return nil, fmt.Errorf("unsatisfiable topology constraint for %s, key=%s (counts = %v, podDomains = %v, nodeDomains = %v)", topology.Type, topology.Key, topology.domains, podDomains, nodeDomains)
+			return nil, fmt.Errorf("unsatisfiable topology constraint for %s, key=%s (counts = %s, podDomains = %v, nodeDomains = %v", topology.Type, topology.Key, pretty.Map(topology.domains, 5), podDomains, nodeDomains)
 		}
 		requirements.Add(domains)
 	}

--- a/pkg/utils/pretty/pretty.go
+++ b/pkg/utils/pretty/pretty.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pretty
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -44,4 +45,20 @@ func Slice[T any](s []T, maxItems int) string {
 		fmt.Fprint(&sb, elem)
 	}
 	return sb.String()
+}
+
+// Map truncates a map after a certain number of max items to ensure that the
+// description in a log doesn't get too long
+func Map[K comparable, V any](values map[K]V, maxItems int) string {
+	var buf bytes.Buffer
+	for k, v := range values {
+		fmt.Fprintf(&buf, "%v: %v ", k, v)
+		if buf.Len() > maxItems {
+			break
+		}
+	}
+	if maxItems < buf.Len() {
+		fmt.Fprintf(&buf, "and %d other(s)", buf.Len()-maxItems)
+	}
+	return buf.String()
 }


### PR DESCRIPTION

Fixes #N/A <!-- issue number -->

**Description**

This particularly helps with pod anti-affinities. I modified the benchmark to have 500 self anti-affinity pods and this improves the performance by 1000% at 500 pods/nodes. The more nodes, the better the improvement.

name              old pods/sec  new pods/sec  delta
Scheduling500-12     15.3 ±10%    171.3 ± 7%  +1022.36%  (p=0.008 n=5+5)

**How was this change tested?**

Benchmarking

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
