### PR TITLE
perf: track empty domains separately in topology

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -63,8 +63,9 @@ type TopologyGroup struct {
 	selector   *metav1.LabelSelector
 	nodeFilter TopologyNodeFilter
 	// Index
-	owners  map[types.UID]struct{} // Pods that have this topology as a scheduling rule
-	domains map[string]int32       // TODO(ellistarn) explore replacing with a minheap
+	owners       map[types.UID]struct{} // Pods that have this topology as a scheduling rule
+	domains      map[string]int32       // TODO(ellistarn) explore replacing with a minheap
+	emptyDomains sets.Set[string]       // domains for which we know that no pod exists
 }
 
 func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod, namespaces sets.Set[string], labelSelector *metav1.LabelSelector, maxSkew int32, minDomains *int32, domains sets.Set[string]) *TopologyGroup {
@@ -78,15 +79,16 @@ func NewTopologyGroup(topologyType TopologyType, topologyKey string, pod *v1.Pod
 		nodeSelector = MakeTopologyNodeFilter(pod)
 	}
 	return &TopologyGroup{
-		Type:       topologyType,
-		Key:        topologyKey,
-		namespaces: namespaces,
-		selector:   labelSelector,
-		nodeFilter: nodeSelector,
-		maxSkew:    maxSkew,
-		domains:    domainCounts,
-		owners:     map[types.UID]struct{}{},
-		minDomains: minDomains,
+		Type:         topologyType,
+		Key:          topologyKey,
+		namespaces:   namespaces,
+		selector:     labelSelector,
+		nodeFilter:   nodeSelector,
+		maxSkew:      maxSkew,
+		domains:      domainCounts,
+		emptyDomains: domains.Clone(),
+		owners:       map[types.UID]struct{}{},
+		minDomains:   minDomains,
 	}
 }
 
@@ -106,6 +108,7 @@ func (t *TopologyGroup) Get(pod *v1.Pod, podDomains, nodeDomains *scheduling.Req
 func (t *TopologyGroup) Record(domains ...string) {
 	for _, domain := range domains {
 		t.domains[domain]++
+		t.emptyDomains.Delete(domain)
 	}
 }
 
@@ -120,6 +123,7 @@ func (t *TopologyGroup) Register(domains ...string) {
 	for _, domain := range domains {
 		if _, ok := t.domains[domain]; !ok {
 			t.domains[domain] = 0
+			t.emptyDomains.Insert(domain)
 		}
 	}
 }
@@ -247,6 +251,14 @@ func (t *TopologyGroup) nextDomainAffinity(pod *v1.Pod, podDomains *scheduling.R
 
 func (t *TopologyGroup) nextDomainAntiAffinity(domains *scheduling.Requirement) *scheduling.Requirement {
 	options := scheduling.NewRequirement(domains.Key, v1.NodeSelectorOpDoesNotExist)
+	// pods with anti-affinity must schedule to a domain where there are currently none of those pods (an empty
+	// domain). If there are none of those domains, then the pod can't schedule and we don't need to walk this
+	// list of domains.  The use case where this optimization is really great is when we are launching nodes for
+	// a deployment of pods with self anti-affinity.  The domains map here continues to grow, and we continue to
+	// fully scan it each iteration.
+	if len(t.emptyDomains) == 0 {
+		return options
+	}
 	for domain := range t.domains {
 		if domains.Has(domain) && t.domains[domain] == 0 {
 			options.Insert(domain)


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->


**Description**

Tracking empty domains separately allows for more efficient anti-affinity checks when there are no empty domains.  This is a frequent operation when doing a large scale up of a deployment with self anti-affinity.

Using benchmarks with anti-affinity pods only, scheduling performance increases greatly:

```
name               old pods/sec  new pods/sec  delta
Scheduling1-12        71.4 ±62%    304.0 ±13%  +326.11%  (p=0.008 n=5+5)
Scheduling50-12       49.2 ±12%    295.2 ± 3%  +499.63%  (p=0.008 n=5+5)
Scheduling250-12       236 ± 4%      455 ± 3%   +92.83%  (p=0.008 n=5+5)
Scheduling500-12       226 ± 7%      364 ± 1%   +61.51%  (p=0.008 n=5+5)
Scheduling1000-12     74.4 ± 4%    349.6 ± 1%  +370.05%  (p=0.008 n=5+5)
Scheduling2000-12     21.7 ± 1%    186.8 ± 1%  +759.80%  (p=0.016 n=5+4)
```
**How was this change tested?**

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
