### PR TITLE
feat: add disruption event for a fully blocking budget

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -152,16 +152,9 @@ func (c *Controller) disrupt(ctx context.Context, disruption Method) (bool, erro
 	if len(candidates) == 0 {
 		return false, nil
 	}
-	disruptionBudgetMapping, err := BuildDisruptionBudgets(ctx, c.cluster, c.clock, c.kubeClient)
+	disruptionBudgetMapping, err := BuildDisruptionBudgets(ctx, c.cluster, c.clock, c.kubeClient, c.recorder)
 	if err != nil {
 		return false, fmt.Errorf("building disruption budgets, %w", err)
-	}
-
-	// Emit metrics before we disrupt for allowed disruptions for each loop.
-	for nodePoolName, budget := range disruptionBudgetMapping {
-		disruptionBudgetsAllowedDisruptionsGauge.With(map[string]string{
-			metrics.NodePoolLabel: nodePoolName,
-		}).Set(float64(budget))
 	}
 
 	// Determine the disruption action

--- a/pkg/controllers/disruption/emptynodeconsolidation.go
+++ b/pkg/controllers/disruption/emptynodeconsolidation.go
@@ -90,7 +90,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	// We do this so that we can re-validate that the candidates that were computed before we made the decision are the same
 	candidatesToDelete := mapCandidates(cmd.candidates, validationCandidates)
 
-	postValidationMapping, err := BuildDisruptionBudgets(ctx, c.cluster, c.clock, c.kubeClient)
+	postValidationMapping, err := BuildDisruptionBudgets(ctx, c.cluster, c.clock, c.kubeClient, c.recorder)
 	if err != nil {
 		return Command{}, fmt.Errorf("building disruption budgets, %w", err)
 	}

--- a/pkg/controllers/disruption/events/events.go
+++ b/pkg/controllers/disruption/events/events.go
@@ -120,3 +120,13 @@ func Blocked(node *v1.Node, nodeClaim *v1beta1.NodeClaim, reason string) []event
 		},
 	}
 }
+
+func NodePoolBlocked(nodePool *v1beta1.NodePool) events.Event {
+	return events.Event{
+		InvolvedObject: nodePool,
+		Type:           v1.EventTypeNormal,
+		Reason:         "DisruptionBlocked",
+		Message:        "No allowed disruptions due to blocking budget",
+		DedupeValues:   []string{string(nodePool.UID)},
+	}
+}

--- a/pkg/controllers/disruption/events/events.go
+++ b/pkg/controllers/disruption/events/events.go
@@ -128,5 +128,7 @@ func NodePoolBlocked(nodePool *v1beta1.NodePool) events.Event {
 		Reason:         "DisruptionBlocked",
 		Message:        "No allowed disruptions due to blocking budget",
 		DedupeValues:   []string{string(nodePool.UID)},
+		// Set a small timeout as a NodePool's disruption budget can change every minute.
+		DedupeTimeout: 1 * time.Minute,
 	}
 }

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -38,6 +38,7 @@ import (
 	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 )
@@ -192,7 +193,7 @@ func GetCandidates(ctx context.Context, cluster *state.Cluster, kubeClient clien
 }
 
 // BuildDisruptionBudgets will return a map for nodePoolName -> numAllowedDisruptions and an error
-func BuildDisruptionBudgets(ctx context.Context, cluster *state.Cluster, clk clock.Clock, kubeClient client.Client) (map[string]int, error) {
+func BuildDisruptionBudgets(ctx context.Context, cluster *state.Cluster, clk clock.Clock, kubeClient client.Client, recorder events.Recorder) (map[string]int, error) {
 	nodePoolList := &v1beta1.NodePoolList{}
 	if err := kubeClient.List(ctx, nodePoolList); err != nil {
 		return nil, fmt.Errorf("listing node pools, %w", err)
@@ -231,7 +232,15 @@ func BuildDisruptionBudgets(ctx context.Context, cluster *state.Cluster, clk clo
 		// Floor the value since the number of deleting nodes can exceed the number of allowed disruptions.
 		// Allowing this value to be negative breaks assumptions in the code used to calculate how
 		// many nodes can be disrupted.
-		disruptionBudgetMapping[nodePool.Name] = lo.Clamp(disruptions-deleting[nodePool.Name], 0, math.MaxInt32)
+		allowedDisruptions := lo.Clamp(disruptions-deleting[nodePool.Name], 0, math.MaxInt32)
+		disruptionBudgetMapping[nodePool.Name] = allowedDisruptions
+		// If the nodepool is fully blocked, emit an event
+		if allowedDisruptions == 0 {
+			recorder.Publish(disruptionevents.NodePoolBlocked(lo.ToPtr(nodePool)))
+		}
+		disruptionBudgetsAllowedDisruptionsGauge.With(map[string]string{
+			metrics.NodePoolLabel: nodePool.Name,
+		}).Set(float64(allowedDisruptions))
 	}
 	return disruptionBudgetMapping, nil
 }

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -335,7 +335,7 @@ var _ = Describe("BuildDisruptionBudgetMapping", func() {
 		unmanaged := test.Node()
 		ExpectApplied(ctx, env.Client, unmanaged)
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{unmanaged}, []*v1beta1.NodeClaim{})
-		budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client)
+		budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 		Expect(err).To(Succeed())
 		// This should not bring in the unmanaged node.
 		Expect(budgets[nodePool.Name]).To(Equal(10))
@@ -364,7 +364,7 @@ var _ = Describe("BuildDisruptionBudgetMapping", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 		ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nodeClaim))
 
-		budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client)
+		budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 		Expect(err).To(Succeed())
 		// This should not bring in the uninitialized node.
 		Expect(budgets[nodePool.Name]).To(Equal(10))
@@ -384,7 +384,7 @@ var _ = Describe("BuildDisruptionBudgetMapping", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(i))
 		}
 
-		budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client)
+		budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 		Expect(err).To(Succeed())
 		Expect(budgets[nodePool.Name]).To(Equal(0))
 	})
@@ -406,7 +406,7 @@ var _ = Describe("BuildDisruptionBudgetMapping", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(i))
 		}
 
-		budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client)
+		budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 		Expect(err).To(Succeed())
 		Expect(budgets[nodePool.Name]).To(Equal(8))
 	})

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -96,7 +96,7 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 		return false, nil
 	}
 	// Rebuild the disruption budget mapping to see if any budgets have changed since validation.
-	postValidationMapping, err := BuildDisruptionBudgets(ctx, v.cluster, v.clock, v.kubeClient)
+	postValidationMapping, err := BuildDisruptionBudgets(ctx, v.cluster, v.clock, v.kubeClient, v.recorder)
 	if err != nil {
 		return false, fmt.Errorf("building disruption budgets, %w", err)
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This adds an event that is emitted for a NodePool whenever there are currently 0 allowed disruptions. This is to allow users to monitor kube-events on their cluster to see if Karpenter thinks their budget is reached.

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
