### PR TITLE
fix: don't mark cluster consolidated if constrained by budgets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ delete: ## Delete the controller from your ~/.kube/config cluster
 test: ## Run tests
 	go test ./... \
 		-race \
-		-timeout 10m \
+		-timeout 15m \
 		--ginkgo.focus="${FOCUS}" \
-		--ginkgo.timeout=10m \
+		--ginkgo.timeout=15m \
 		--ginkgo.v \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
 

--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -88,8 +88,8 @@ func (c *consolidation) sortAndFilterCandidates(ctx context.Context, candidates 
 	return candidates, nil
 }
 
-// isConsolidated returns true if nothing has changed since markConsolidated was called.
-func (c *consolidation) isConsolidated() bool {
+// IsConsolidated returns true if nothing has changed since markConsolidated was called.
+func (c *consolidation) IsConsolidated() bool {
 	return c.lastConsolidationState.Equal(c.cluster.ConsolidationState())
 }
 

--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -61,7 +61,7 @@ type consolidation struct {
 	lastConsolidationState time.Time
 }
 
-func makeConsolidation(clock clock.Clock, cluster *state.Cluster, kubeClient client.Client, provisioner *provisioning.Provisioner,
+func MakeConsolidation(clock clock.Clock, cluster *state.Cluster, kubeClient client.Client, provisioner *provisioning.Provisioner,
 	cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, queue *orchestration.Queue) consolidation {
 	return consolidation{
 		queue:         queue,

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -211,9 +211,96 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(0))
 		})
+		FIt("should not mark empty node consolidated if candidates can't be disrupted due to budgets", func() {
+			nodePool.Spec.Disruption.Budgets = []v1beta1.Budget{{Nodes: "0%"}}
+
+			ExpectApplied(ctx, env.Client, nodePool)
+			for i := 0; i < numNodes; i++ {
+				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
+			}
+			// inform cluster state about nodes and nodeclaims
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+
+			emptyConsolidation := disruption.NewEmptyNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client)
+			Expect(err).To(Succeed())
+
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, emptyConsolidation.ShouldDisrupt, queue)
+			Expect(err).To(Succeed())
+
+			var wg sync.WaitGroup
+			ExpectTriggerVerifyAction(&wg)
+			cmd, err := emptyConsolidation.ComputeCommand(ctx, budgets, candidates...)
+			Expect(err).To(Succeed())
+			Expect(cmd)
+			wg.Wait()
+
+			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
+		})
+		FIt("should not mark empty node consolidated if all nodepools are blocked by budgets", func() {
+			// Create 10 nodepools
+			nps := test.NodePools(10, v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Disruption: v1beta1.Disruption{
+						ConsolidationPolicy: v1beta1.ConsolidationPolicyWhenUnderutilized,
+						Budgets: []v1beta1.Budget{{
+							Nodes: "0%",
+						}},
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodePool)
+			for i := 0; i < len(nps); i++ {
+				ExpectApplied(ctx, env.Client, nps[i])
+			}
+			nodeClaims = make([]*v1beta1.NodeClaim, 0, 30)
+			nodes = make([]*v1.Node, 0, 30)
+			// Create 3 nodes for each nodePool
+			for _, np := range nps {
+				ncs, ns := test.NodeClaimsAndNodes(3, v1beta1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							v1beta1.NodePoolLabelKey:     np.Name,
+							v1.LabelInstanceTypeStable:   mostExpensiveInstance.Name,
+							v1beta1.CapacityTypeLabelKey: mostExpensiveOffering.CapacityType,
+							v1.LabelTopologyZone:         mostExpensiveOffering.Zone,
+						},
+					},
+					Status: v1beta1.NodeClaimStatus{
+						Allocatable: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU:  resource.MustParse("32"),
+							v1.ResourcePods: resource.MustParse("100"),
+						},
+					},
+				})
+				nodeClaims = append(nodeClaims, ncs...)
+				nodes = append(nodes, ns...)
+			}
+			ExpectApplied(ctx, env.Client, nodePool)
+			for i := 0; i < len(nodeClaims); i++ {
+				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
+			}
+
+			// inform cluster state about nodes and nodeclaims
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+
+			emptyConsolidation := disruption.NewEmptyNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client)
+			Expect(err).To(Succeed())
+
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, emptyConsolidation.ShouldDisrupt, queue)
+			Expect(err).To(Succeed())
+
+			var wg sync.WaitGroup
+			ExpectTriggerVerifyAction(&wg)
+			cmd, err := emptyConsolidation.ComputeCommand(ctx, budgets, candidates...)
+			Expect(err).To(Succeed())
+			Expect(cmd)
+			wg.Wait()
+
+			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
+		})
 		It("should allow no empty nodes to be disrupted", func() {
-			// temporarily get the state of the cluster
-			state := cluster.ConsolidationState()
 			nodePool.Spec.Disruption.Budgets = []v1beta1.Budget{{Nodes: "0%"}}
 
 			ExpectApplied(ctx, env.Client, nodePool)
@@ -229,9 +316,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
-			// Expect the cluster consolidated state to not change.
-			Expect(disruptionController.Methods[3].(*disruption.EmptyNodeConsolidation).IsConsolidated()).To(BeFalse())
-
 			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
@@ -241,8 +325,6 @@ var _ = Describe("Consolidation", func() {
 			// Execute command, thus deleting all nodes
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(numNodes))
-			// Expect the cluster consolidated state to not change.
-			Expect(cluster.ConsolidationState()).To(Equal(state))
 		})
 		It("should only allow 3 nodes to be deleted in multi node consolidation delete", func() {
 			nodePool.Spec.Disruption.Budgets = []v1beta1.Budget{{Nodes: "30%"}}
@@ -519,9 +601,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
-
-			// Expect the cluster consolidated state to not change.
-			Expect(disruptionController.Methods[3].(*disruption.EmptyNodeConsolidation).IsConsolidated()).To(BeFalse())
 
 			for _, np := range nps {
 				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -525,7 +525,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(30))
 		})
-		It("should not mark empty node consolidated if candidates can't be disrupted due to budgets", func() {
+		It("should not mark empty node consolidated if the candidates can't be disrupted due to budgets with one nodepool", func() {
 			nodePool.Spec.Disruption.Budgets = []v1beta1.Budget{{Nodes: "0%"}}
 
 			ExpectApplied(ctx, env.Client, nodePool)
@@ -551,7 +551,7 @@ var _ = Describe("Consolidation", func() {
 
 			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
 		})
-		It("should not mark empty node consolidated if all nodepools are blocked by budgets", func() {
+		It("should not mark empty node consolidated if all candidates can't be disrupted due to budgets with many nodepools", func() {
 			// Create 10 nodepools
 			nps := test.NodePools(10, v1beta1.NodePool{
 				Spec: v1beta1.NodePoolSpec{

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -614,7 +614,7 @@ var _ = Describe("Consolidation", func() {
 
 			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
 		})
-		It("should not mark multi node consolidated if candidates can't be disrupted due to budgets", func() {
+		It("should not mark multi node consolidated if the candidates can't be disrupted due to budgets with one nodepool", func() {
 			nodePool.Spec.Disruption.Budgets = []v1beta1.Budget{{Nodes: "0%"}}
 
 			ExpectApplied(ctx, env.Client, nodePool)
@@ -640,7 +640,7 @@ var _ = Describe("Consolidation", func() {
 
 			Expect(multiConsolidation.IsConsolidated()).To(BeFalse())
 		})
-		It("should not mark multi node consolidated if all nodepools are blocked by budgets", func() {
+		It("should not mark multi node consolidated if all candidates can't be disrupted due to budgets with many nodepools", func() {
 			// Create 10 nodepools
 			nps := test.NodePools(10, v1beta1.NodePool{
 				Spec: v1beta1.NodePoolSpec{
@@ -703,7 +703,7 @@ var _ = Describe("Consolidation", func() {
 
 			Expect(multiConsolidation.IsConsolidated()).To(BeFalse())
 		})
-		It("should not mark single node consolidated if candidates can't be disrupted due to budgets", func() {
+		It("should not mark single node consolidated if the candidates can't be disrupted due to budgets with one nodepool", func() {
 			nodePool.Spec.Disruption.Budgets = []v1beta1.Budget{{Nodes: "0%"}}
 
 			ExpectApplied(ctx, env.Client, nodePool)
@@ -729,7 +729,7 @@ var _ = Describe("Consolidation", func() {
 
 			Expect(singleConsolidation.IsConsolidated()).To(BeFalse())
 		})
-		It("should not mark single node consolidated if all nodepools are blocked by budgets", func() {
+		It("should not mark single node consolidated if all candidates can't be disrupted due to budgets with many nodepools", func() {
 			// Create 10 nodepools
 			nps := test.NodePools(10, v1beta1.NodePool{
 				Spec: v1beta1.NodePoolSpec{

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -49,7 +49,7 @@ type Controller struct {
 	recorder      events.Recorder
 	clock         clock.Clock
 	cloudProvider cloudprovider.CloudProvider
-	Methods       []Method
+	methods       []Method
 	mu            sync.Mutex
 	lastRun       map[string]time.Time
 }
@@ -72,7 +72,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provi
 		recorder:      recorder,
 		cloudProvider: cp,
 		lastRun:       map[string]time.Time{},
-		Methods: []Method{
+		methods: []Method{
 			// Expire any NodeClaims that must be deleted, allowing their pods to potentially land on currently
 			NewExpiration(clk, kubeClient, cluster, provisioner, recorder),
 			// Terminate any NodeClaims that have drifted from provisioning specifications, allowing the pods to reschedule.
@@ -124,7 +124,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 
 	// Attempt different disruption methods. We'll only let one method perform an action
-	for _, m := range c.Methods {
+	for _, m := range c.methods {
 		c.recordRun(fmt.Sprintf("%T", m))
 		success, err := c.disrupt(ctx, m)
 		if err != nil {

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -49,7 +49,7 @@ type Controller struct {
 	recorder      events.Recorder
 	clock         clock.Clock
 	cloudProvider cloudprovider.CloudProvider
-	methods       []Method
+	Methods       []Method
 	mu            sync.Mutex
 	lastRun       map[string]time.Time
 }
@@ -72,7 +72,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provi
 		recorder:      recorder,
 		cloudProvider: cp,
 		lastRun:       map[string]time.Time{},
-		methods: []Method{
+		Methods: []Method{
 			// Expire any NodeClaims that must be deleted, allowing their pods to potentially land on currently
 			NewExpiration(clk, kubeClient, cluster, provisioner, recorder),
 			// Terminate any NodeClaims that have drifted from provisioning specifications, allowing the pods to reschedule.
@@ -124,7 +124,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 
 	// Attempt different disruption methods. We'll only let one method perform an action
-	for _, m := range c.methods {
+	for _, m := range c.Methods {
 		c.recordRun(fmt.Sprintf("%T", m))
 		success, err := c.disrupt(ctx, m)
 		if err != nil {

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -62,7 +62,7 @@ var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provisioning.Provisioner,
 	cp cloudprovider.CloudProvider, recorder events.Recorder, cluster *state.Cluster, queue *orchestration.Queue,
 ) *Controller {
-	c := makeConsolidation(clk, cluster, kubeClient, provisioner, cp, recorder, queue)
+	c := MakeConsolidation(clk, cluster, kubeClient, provisioner, cp, recorder, queue)
 	return &Controller{
 		queue:         queue,
 		clock:         clk,

--- a/pkg/controllers/disruption/emptynodeconsolidation.go
+++ b/pkg/controllers/disruption/emptynodeconsolidation.go
@@ -39,7 +39,7 @@ func NewEmptyNodeConsolidation(consolidation consolidation) *EmptyNodeConsolidat
 //
 //nolint:gocyclo
 func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, error) {
-	if c.isConsolidated() {
+	if c.IsConsolidated() {
 		return Command{}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -42,7 +42,7 @@ func NewMultiNodeConsolidation(consolidation consolidation) *MultiNodeConsolidat
 }
 
 func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, error) {
-	if m.isConsolidated() {
+	if m.IsConsolidated() {
 		return Command{}, nil
 	}
 	candidates, err := m.sortAndFilterCandidates(ctx, candidates)

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -67,10 +67,10 @@ func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 		// If there's disruptions allowed for the candidate's nodepool,
 		// add it to the list of candidates, and decrement the budget.
 		if disruptionBudgetMapping[candidate.nodePool.Name] == 0 {
+			constrainedByBudgets = true
 			continue
 		}
 		// set constrainedByBudgets to true if any node was a candidate but was constrained by a budget
-		constrainedByBudgets = true
 		disruptableCandidates = append(disruptableCandidates, candidate)
 		disruptionBudgetMapping[candidate.nodePool.Name]--
 	}

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -40,7 +40,7 @@ func NewSingleNodeConsolidation(consolidation consolidation) *SingleNodeConsolid
 // ComputeCommand generates a disruption command given candidates
 // nolint:gocyclo
 func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, error) {
-	if s.isConsolidated() {
+	if s.IsConsolidated() {
 		return Command{}, nil
 	}
 	candidates, err := s.sortAndFilterCandidates(ctx, candidates)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes a bug where we would mark the cluster as consolidated if budgets caused Consolidation to not occur. We only want to mark a cluster as consolidated if budgets aren't restricting the candidate set. 

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
