### PR TITLE
feat: add uid for orchestration queue for logs

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -186,7 +186,7 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command) 
 		consolidationTypeLabel: m.ConsolidationType(),
 	}).Inc()
 	uid := uuid.NewUUID()
-	logging.FromContext(ctx).With("uid", uid).Infof("disrupting via %s %s", m.Type(), cmd)
+	logging.FromContext(ctx).With("command-uid", uid).Infof("disrupting via %s %s", m.Type(), cmd)
 
 	stateNodes := lo.Map(cmd.candidates, func(c *Candidate, _ int) *state.StateNode {
 		return c.StateNode

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -204,11 +204,11 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 		// Log the error
 		logging.FromContext(ctx).With("nodes", strings.Join(lo.Map(cmd.candidates, func(s *state.StateNode, _ int) string {
 			return s.Name()
-		}), ","), "uid", cmd.uid).Errorf("failed to disrupt nodes, %s", multiErr)
+		}), ","), "command-uid", cmd.uid).Errorf("failed to disrupt nodes, %s", multiErr)
 	}
 	// If command is complete, remove command from queue.
 	q.Remove(cmd)
-	logging.FromContext(ctx).With("uid", cmd.uid).Infof("command succeeded")
+	logging.FromContext(ctx).With("command-uid", cmd.uid).Infof("command succeeded")
 	return reconcile.Result{RequeueAfter: controller.Immediately}, nil
 }
 

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -179,7 +179,7 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 		panic("unexpected failure, disruption queue has shut down")
 	}
 	cmd := item.(*Command)
-	ctx = context.WithValue(ctx, "command-id", cmd.id)
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("command-id", string(cmd.id)))
 	if err := q.waitOrTerminate(ctx, cmd); err != nil {
 		// If recoverable, re-queue and try again.
 		if !IsUnrecoverableError(err) {

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -57,7 +57,7 @@ type Command struct {
 	Replacements      []Replacement
 	candidates        []*state.StateNode
 	timeAdded         time.Time // timeAdded is used to track timeouts
-	uid               types.UID // used for log tracking
+	id                types.UID // used for log tracking
 	method            string    // used for metrics
 	consolidationType string    // used for metrics
 	lastError         error
@@ -140,7 +140,7 @@ func NewTestingQueue(kubeClient client.Client, recorder events.Recorder, cluster
 }
 
 // NewCommand creates a command key and adds in initial data for the orchestration queue.
-func NewCommand(replacements []string, candidates []*state.StateNode, uid types.UID, method, consolidationType string) *Command {
+func NewCommand(replacements []string, candidates []*state.StateNode, id types.UID, method, consolidationType string) *Command {
 	return &Command{
 		Replacements: lo.Map(replacements, func(name string, _ int) Replacement {
 			return Replacement{name: name}
@@ -148,7 +148,7 @@ func NewCommand(replacements []string, candidates []*state.StateNode, uid types.
 		candidates:        candidates,
 		method:            method,
 		consolidationType: consolidationType,
-		uid:               uid,
+		id:                id,
 	}
 }
 
@@ -204,11 +204,11 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 		// Log the error
 		logging.FromContext(ctx).With("nodes", strings.Join(lo.Map(cmd.candidates, func(s *state.StateNode, _ int) string {
 			return s.Name()
-		}), ","), "command-uid", cmd.uid).Errorf("failed to disrupt nodes, %s", multiErr)
+		}), ","), "command-id", cmd.id).Errorf("failed to disrupt nodes, %s", multiErr)
 	}
 	// If command is complete, remove command from queue.
 	q.Remove(cmd)
-	logging.FromContext(ctx).With("command-uid", cmd.uid).Infof("command succeeded")
+	logging.FromContext(ctx).With("command-id", cmd.id).Infof("command succeeded")
 	return reconcile.Result{RequeueAfter: controller.Immediately}, nil
 }
 

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -57,6 +57,7 @@ type Command struct {
 	Replacements      []Replacement
 	candidates        []*state.StateNode
 	timeAdded         time.Time // timeAdded is used to track timeouts
+	uid               types.UID // used for log tracking
 	method            string    // used for metrics
 	consolidationType string    // used for metrics
 	lastError         error
@@ -139,7 +140,7 @@ func NewTestingQueue(kubeClient client.Client, recorder events.Recorder, cluster
 }
 
 // NewCommand creates a command key and adds in initial data for the orchestration queue.
-func NewCommand(replacements []string, candidates []*state.StateNode, method string, consolidationType string) *Command {
+func NewCommand(replacements []string, candidates []*state.StateNode, uid types.UID, method, consolidationType string) *Command {
 	return &Command{
 		Replacements: lo.Map(replacements, func(name string, _ int) Replacement {
 			return Replacement{name: name}
@@ -147,6 +148,7 @@ func NewCommand(replacements []string, candidates []*state.StateNode, method str
 		candidates:        candidates,
 		method:            method,
 		consolidationType: consolidationType,
+		uid:               uid,
 	}
 }
 
@@ -202,10 +204,11 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 		// Log the error
 		logging.FromContext(ctx).With("nodes", strings.Join(lo.Map(cmd.candidates, func(s *state.StateNode, _ int) string {
 			return s.Name()
-		}), ",")).Errorf("failed to disrupt nodes, %s", multiErr)
+		}), ","), "uid", cmd.uid).Errorf("failed to disrupt nodes, %s", multiErr)
 	}
 	// If command is complete, remove command from queue.
 	q.Remove(cmd)
+	logging.FromContext(ctx).With("uid", cmd.uid).Infof("command succeeded")
 	return reconcile.Result{RequeueAfter: controller.Immediately}, nil
 }
 

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -179,6 +179,7 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 		panic("unexpected failure, disruption queue has shut down")
 	}
 	cmd := item.(*Command)
+	ctx = context.WithValue(ctx, "command-id", cmd.id)
 	if err := q.waitOrTerminate(ctx, cmd); err != nil {
 		// If recoverable, re-queue and try again.
 		if !IsUnrecoverableError(err) {
@@ -204,11 +205,11 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 		// Log the error
 		logging.FromContext(ctx).With("nodes", strings.Join(lo.Map(cmd.candidates, func(s *state.StateNode, _ int) string {
 			return s.Name()
-		}), ","), "command-id", cmd.id).Errorf("failed to disrupt nodes, %s", multiErr)
+		}), ",")).Errorf("failed to disrupt nodes, %s", multiErr)
 	}
 	// If command is complete, remove command from queue.
 	q.Remove(cmd)
-	logging.FromContext(ctx).With("command-id", cmd.id).Infof("command succeeded")
+	logging.FromContext(ctx).Infof("command succeeded")
 	return reconcile.Result{RequeueAfter: controller.Immediately}, nil
 }
 

--- a/pkg/controllers/disruption/orchestration/suite_test.go
+++ b/pkg/controllers/disruption/orchestration/suite_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Queue", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
 
 			stateNode := ExpectStateNodeExists(cluster, node1)
-			Expect(queue.Add(orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "test-method", "fake-type"))).To(BeNil())
+			Expect(queue.Add(orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "", "test-method", "fake-type"))).To(BeNil())
 
 			node1 = ExpectNodeExists(ctx, env.Client, node1.Name)
 			Expect(node1.Spec.Taints).To(ContainElement(v1beta1.DisruptionNoScheduleTaint))
@@ -186,7 +186,7 @@ var _ = Describe("Queue", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
 			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
 
-			Expect(queue.Add(orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "test-method", "fake-type"))).To(BeNil())
+			Expect(queue.Add(orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "", "test-method", "fake-type"))).To(BeNil())
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 		})
 		It("should untaint nodes when a command times out", func() {
@@ -194,7 +194,7 @@ var _ = Describe("Queue", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
 			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
 
-			Expect(queue.Add(orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "test-method", "fake-type"))).To(BeNil())
+			Expect(queue.Add(orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "", "test-method", "fake-type"))).To(BeNil())
 
 			// Step the clock to trigger the timeout.
 			fakeClock.Step(11 * time.Minute)
@@ -208,7 +208,7 @@ var _ = Describe("Queue", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
 			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
 
-			cmd := orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "test-method", "fake-type")
+			cmd := orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "", "test-method", "fake-type")
 			Expect(queue.Add(cmd)).To(BeNil())
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 
@@ -245,7 +245,7 @@ var _ = Describe("Queue", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
 			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
 
-			cmd := orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "test-method", "fake-type")
+			cmd := orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "", "test-method", "fake-type")
 			Expect(queue.Add(cmd)).To(BeNil())
 
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
@@ -274,7 +274,7 @@ var _ = Describe("Queue", func() {
 			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool)
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
 			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
-			cmd := orchestration.NewCommand([]string{}, []*state.StateNode{stateNode}, "test-method", "fake-type")
+			cmd := orchestration.NewCommand([]string{}, []*state.StateNode{stateNode}, "", "test-method", "fake-type")
 			Expect(queue.Add(cmd)).To(BeNil())
 
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
@@ -301,9 +301,9 @@ var _ = Describe("Queue", func() {
 			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
 			stateNode2 := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim2)
 
-			cmd := orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "test-method", "fake-type")
+			cmd := orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "", "test-method", "fake-type")
 			Expect(queue.Add(cmd)).To(BeNil())
-			cmd2 := orchestration.NewCommand(replacements2, []*state.StateNode{stateNode2}, "test-method", "fake-type")
+			cmd2 := orchestration.NewCommand(replacements2, []*state.StateNode{stateNode2}, "", "test-method", "fake-type")
 			Expect(queue.Add(cmd2)).To(BeNil())
 
 			// Reconcile the first command and expect nothing to be initialized


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a types.UID that's attached to a command in memory. This allows us to log this uid on command creation, and track it when the command eventually fails or succeeds.

**How was this change tested?**
make apply

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
