### PR TITLE
feat: consider not ready nodes for budgets

### DIFF
--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	utilsnode "sigs.k8s.io/karpenter/pkg/utils/node"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
@@ -222,9 +223,7 @@ func BuildDisruptionBudgets(ctx context.Context, cluster *state.Cluster, clk clo
 		// If the node satisfies one of the following, we subtract it from the allowed disruptions.
 		// 1. Has a NotReady conditiion
 		// 2. Is marked as deleting
-		if _, found := lo.Find(node.Node.Status.Conditions, func(nc v1.NodeCondition) bool {
-			return nc.Type == v1.NodeReady && nc.Status != v1.ConditionTrue
-		}); found || node.MarkedForDeletion() {
+		if cond := utilsnode.GetCondition(node.Node, v1.NodeReady); cond.Status != v1.ConditionTrue || node.MarkedForDeletion() {
 			deleting[nodePool]++
 		}
 		numNodes[nodePool]++

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -372,6 +372,26 @@ func ExpectMakeNodesInitialized(ctx context.Context, c client.Client, nodes ...*
 	}
 }
 
+func ExpectMakeNodesNotReady(ctx context.Context, c client.Client, nodes ...*v1.Node) {
+	for i := range nodes {
+		nodes[i] = ExpectExists(ctx, c, nodes[i])
+		nodes[i].Status.Phase = v1.NodeRunning
+		nodes[i].Status.Conditions = []v1.NodeCondition{
+			{
+				Type:               v1.NodeReady,
+				Status:             v1.ConditionFalse,
+				LastHeartbeatTime:  metav1.Now(),
+				LastTransitionTime: metav1.Now(),
+				Reason:             "NotReady",
+			},
+		}
+		if nodes[i].Labels == nil {
+			nodes[i].Labels = map[string]string{}
+		}
+		ExpectApplied(ctx, c, nodes[i])
+	}
+}
+
 func ExpectMakeNodesReady(ctx context.Context, c client.Client, nodes ...*v1.Node) {
 	for i := range nodes {
 		nodes[i] = ExpectExists(ctx, c, nodes[i])


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Karpenter will now consider unhealthy nodes when consider budgets, decrementing the total allowed disruptions if the node is Not Ready.

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
