### PR TITLE
perf: increase scheduler performance

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -56,10 +56,22 @@ const PrintStats = false
 //nolint:gosec
 var r = rand.New(rand.NewSource(42))
 
+// To run the benchmarks use:
+// `go test -tags=test_performance -run=XXX -bench=.`
+//
+// to get something statistically significant for comparison we need to run them several times and then
+// compare the results between the old performance and the new performance.
+// ```sh
+//
+//	go test -tags=test_performance -run=XXX -bench=. -count=10 | tee /tmp/old
+//	# make your changes to the code
+//	go test -tags=test_performance -run=XXX -bench=. -count=10 | tee /tmp/new
+//	benchstat /tmp/old /tmp/new
+//
+// ```
 func BenchmarkScheduling1(b *testing.B) {
 	benchmarkScheduler(b, 400, 1)
 }
-
 func BenchmarkScheduling50(b *testing.B) {
 	benchmarkScheduler(b, 400, 50)
 }
@@ -102,7 +114,7 @@ func TestSchedulingProfile(t *testing.T) {
 	totalNodes := 0
 	var totalTime time.Duration
 	for _, instanceCount := range []int{400} {
-		for _, podCount := range []int{10, 100, 500, 1000, 1500, 2000, 2500} {
+		for _, podCount := range []int{10, 100, 500, 1000, 1500, 2000, 5000} {
 			start := time.Now()
 			res := testing.Benchmark(func(b *testing.B) { benchmarkScheduler(b, instanceCount, podCount) })
 			totalTime += time.Since(start) / time.Duration(res.N)

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -256,10 +256,7 @@ func (t *TopologyGroup) nextDomainAntiAffinity(domains *scheduling.Requirement) 
 	// list of domains.  The use case where this optimization is really great is when we are launching nodes for
 	// a deployment of pods with self anti-affinity.  The domains map here continues to grow, and we continue to
 	// fully scan it each iteration.
-	if len(t.emptyDomains) == 0 {
-		return options
-	}
-	for domain := range t.domains {
+	for domain := range t.emptyDomains {
 		if domains.Has(domain) && t.domains[domain] == 0 {
 			options.Insert(domain)
 		}

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -162,7 +162,7 @@ func Cmp(lhs resource.Quantity, rhs resource.Quantity) int {
 func Fits(candidate, total v1.ResourceList) bool {
 	// If any of the total resource values are negative then the resource will never fit
 	for _, quantity := range total {
-		if Cmp(resource.MustParse("0"), quantity) > 0 {
+		if Cmp(*resource.NewScaledQuantity(0, resource.Kilo), quantity) > 0 {
 			return false
 		}
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

A few changes that overall increase performance 10-60% depending on the number of pods/nodes. Its around a ~34% overall improvement:
```
name               old pods/sec  new pods/sec  delta
Scheduling1-12       3.89k ± 2%    4.36k ± 4%  +12.10%  (p=0.000 n=10+9)
Scheduling50-12      1.44k ±11%    1.70k ± 5%  +18.29%  (p=0.000 n=9+9)
Scheduling100-12     1.30k ±10%    2.09k ± 3%  +60.63%  (p=0.000 n=9+9)
Scheduling500-12     1.47k ± 3%    2.06k ± 1%  +40.65%  (p=0.000 n=8+9)
Scheduling1000-12    1.42k ± 5%    1.99k ± 1%  +39.32%  (p=0.000 n=10+10)
Scheduling2000-12    1.43k ± 1%    1.83k ± 2%  +28.36%  (p=0.000 n=9+9)
Scheduling5000-12    1.09k ± 6%    1.67k ± 2%  +53.75%  (p=0.000 n=9+10)
```

**How was this change tested?**

Benchmarking and unit testing/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
