### PR TITLE
fix: allow disruption when considering past disruption commands

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -117,7 +117,7 @@ func (c *consolidation) sortCandidates(candidates []*Candidate) []*Candidate {
 // nolint:gocyclo
 func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	// Run scheduling simulation to compute consolidation option
-	results, err := simulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, candidates...)
+	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, candidates...)
 	if err != nil {
 		// if a candidate node is now deleting, just retry
 		if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -96,7 +96,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[
 			continue
 		}
 		// Check if we need to create any NodeClaims.
-		results, err := simulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, candidate)
+		results, err := SimulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, candidate)
 		if err != nil {
 			// if a candidate is now deleting, just retry
 			if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/expiration.go
+++ b/pkg/controllers/disruption/expiration.go
@@ -101,7 +101,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, disruptionBudgetMapping
 			continue
 		}
 		// Check if we need to create any NodeClaims.
-		results, err := simulateScheduling(ctx, e.kubeClient, e.cluster, e.provisioner, candidate)
+		results, err := SimulateScheduling(ctx, e.kubeClient, e.cluster, e.provisioner, candidate)
 		if err != nil {
 			// if a candidate node is now deleting, just retry
 			if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -277,14 +277,17 @@ var _ = Describe("Simulate Scheduling", func() {
 		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 		wg.Wait()
 
+		// Expect a replace action
 		ExpectTaintedNodeCount(ctx, env.Client, 1)
 		ncs := ExpectNodeClaims(ctx, env.Client)
+		// which would create one more node claim
 		Expect(len(ncs)).To(Equal(11))
 		nc, new := lo.Find(ncs, func(nc *v1beta1.NodeClaim) bool {
 			_, ok := nodeClaimNames[nc.Name]
 			return !ok
 		})
 		Expect(new).To(BeTrue())
+		// which needs to be deployed
 		ExpectNodeClaimDeployed(ctx, env.Client, cluster, cloudProvider, nc)
 		nodeClaimNames[nc.Name] = struct{}{}
 
@@ -292,6 +295,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 		wg.Wait()
 
+		// Another replacement disruption action
 		ncs = ExpectNodeClaims(ctx, env.Client)
 		Expect(len(ncs)).To(Equal(12))
 		nc, new = lo.Find(ncs, func(nc *v1beta1.NodeClaim) bool {
@@ -306,6 +310,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 		wg.Wait()
 
+		// One more replacement disruption action
 		ncs = ExpectNodeClaims(ctx, env.Client)
 		Expect(len(ncs)).To(Equal(13))
 		nc, new = lo.Find(ncs, func(nc *v1beta1.NodeClaim) bool {
@@ -316,6 +321,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		ExpectNodeClaimDeployed(ctx, env.Client, cluster, cloudProvider, nc)
 		nodeClaimNames[nc.Name] = struct{}{}
 
+		// Try one more time, but fail since the budgets only allow 3 disruptions.
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 		wg.Wait()

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -216,9 +216,12 @@ var _ = Describe("Simulate Scheduling", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
 		}
 
+		pdbs, err := disruption.NewPDBLimits(ctx, fakeClock, env.Client)
+		Expect(err).To(Succeed())
+
 		// Generate a candidate
 		stateNode := ExpectStateNodeExists(cluster, nodes[0])
-		candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, stateNode, nodePoolMap, nodePoolToInstanceTypesMap, queue)
+		candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, stateNode, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue)
 		Expect(err).To(Succeed())
 
 		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, candidate)

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -128,7 +128,7 @@ func (v *Validation) ValidateCommand(ctx context.Context, cmd Command, candidate
 	if len(candidates) == 0 {
 		return false, nil
 	}
-	results, err := simulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, candidates...)
+	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, candidates...)
 	if err != nil {
 		return false, fmt.Errorf("simluating scheduling, %w", err)
 	}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -361,6 +361,16 @@ func ExpectMakeNodeClaimsInitialized(ctx context.Context, c client.Client, nodeC
 	}
 }
 
+func ExpectMakeNodeClaimsLaunchedAndStateUpdated(ctx context.Context, c client.Client, nodeClaimStateController controller.Controller, nodeClaims ...*v1beta1.NodeClaim) {
+	GinkgoHelper()
+	for i := range nodeClaims {
+		nodeClaims[i] = ExpectExists(ctx, c, nodeClaims[i])
+		nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Launched)
+		ExpectApplied(ctx, c, nodeClaims[i])
+		ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nodeClaims[i]))
+	}
+}
+
 func ExpectMakeNodesInitialized(ctx context.Context, c client.Client, nodes ...*v1.Node) {
 	GinkgoHelper()
 	ExpectMakeNodesReady(ctx, c, nodes...)

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -361,16 +361,6 @@ func ExpectMakeNodeClaimsInitialized(ctx context.Context, c client.Client, nodeC
 	}
 }
 
-func ExpectMakeNodeClaimsLaunchedAndStateUpdated(ctx context.Context, c client.Client, nodeClaimStateController controller.Controller, nodeClaims ...*v1beta1.NodeClaim) {
-	GinkgoHelper()
-	for i := range nodeClaims {
-		nodeClaims[i] = ExpectExists(ctx, c, nodeClaims[i])
-		nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Launched)
-		ExpectApplied(ctx, c, nodeClaims[i])
-		ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nodeClaims[i]))
-	}
-}
-
 func ExpectMakeNodesInitialized(ctx context.Context, c client.Client, nodes ...*v1.Node) {
 	GinkgoHelper()
 	ExpectMakeNodesReady(ctx, c, nodes...)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
When considering deleting pods for scheduling simulations, we won't fail to disrupt if the pods that scheduled to uninitialized nodes were from an already deleting node. This is because they'll either be a node from a previous disruption command or a manually deleted node, either one of which we should assume is being disrupted and getting a replacement node as needed from the disruption or provisioning controller.

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
