### PR TITLE
fix: Fix budget validation through CEL

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -109,7 +109,7 @@ spec:
                       type: array
                       x-kubernetes-validations:
                         - message: '''schedule'' must be set with ''duration'''
-                          rule: '!self.all(x, (has(x.schedule) && !has(x.duration)) || (!has(x.schedule) && has(x.duration)))'
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
                     consolidateAfter:
                       description: |-
                         ConsolidateAfter is the duration the controller will wait

--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -91,7 +91,7 @@ type Disruption struct {
 	// If there are multiple active budgets, Karpenter uses
 	// the most restrictive value. If left undefined,
 	// this will default to one budget with a value to 10%.
-	// +kubebuilder:validation:XValidation:message="'schedule' must be set with 'duration'",rule="!self.all(x, (has(x.schedule) && !has(x.duration)) || (!has(x.schedule) && has(x.duration)))"
+	// +kubebuilder:validation:XValidation:message="'schedule' must be set with 'duration'",rule="self.all(x, has(x.schedule) == has(x.duration))"
 	// +kubebuilder:default:={{nodes: "10%"}}
 	// +kubebuilder:validation:MaxItems=50
 	// +optional

--- a/pkg/apis/v1beta1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_cel_test.go
@@ -188,7 +188,7 @@ var _ = Describe("CEL/Validation", func() {
 			}}
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 		})
-		It("should fail when creating two budgets where one is invalid", func() {
+		It("should fail when creating two budgets where one has an invalid crontab", func() {
 			nodePool.Spec.Disruption.Budgets = []Budget{
 				{
 					Nodes:    "10",
@@ -200,6 +200,23 @@ var _ = Describe("CEL/Validation", func() {
 					Schedule: ptr.String("*"),
 					Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
 				}}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should fail when creating multiple budgets where one doesn't have both schedule and duration", func() {
+			nodePool.Spec.Disruption.Budgets = []Budget{
+				{
+					Nodes:    "10",
+					Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
+				},
+				{
+					Nodes:    "10",
+					Schedule: ptr.String("* * * * *"),
+					Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
+				},
+				{
+					Nodes: "10",
+				},
+			}
 			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
 		})
 	})

--- a/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Webhook/Validation", func() {
 			}}
 			Expect(nodePool.Validate(ctx)).To(Succeed())
 		})
-		It("should fail to validate two budgets where one is invalid", func() {
+		It("should fail when creating two budgets where one has an invalid crontab", func() {
 			nodePool.Spec.Disruption.Budgets = []Budget{
 				{
 					Nodes:    "10",
@@ -143,6 +143,23 @@ var _ = Describe("Webhook/Validation", func() {
 					Schedule: ptr.String("*"),
 					Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
 				}}
+			Expect(nodePool.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail when creating multiple budgets where one doesn't have both schedule and duration", func() {
+			nodePool.Spec.Disruption.Budgets = []Budget{
+				{
+					Nodes:    "10",
+					Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
+				},
+				{
+					Nodes:    "10",
+					Schedule: ptr.String("* * * * *"),
+					Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
+				},
+				{
+					Nodes: "10",
+				},
+			}
 			Expect(nodePool.Validate(ctx)).ToNot(Succeed())
 		})
 	})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1003

**Description**

Budget validation for CEL wasn't properly catching the case where one budget had properly set the schedule and duration together but another hadn't. This change ensures that _every_ budget has set a valid combination of schedule and duration

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
