### PR TITLE
ci: Drop `--ginkgo.timeout` and add `--ginkgo.randomize-all` CLI arg for Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ presubmit: verify test licenses vulncheck ## Run all steps required for code to 
 
 install-kwok: ## Install kwok provider
 	UNINSTALL_KWOK=false ./hack/install-kwok.sh
-uninstall-kwok: ## Install kwok provider
+
+uninstall-kwok: ## Uninstall kwok provider
 	UNINSTALL_KWOK=true ./hack/install-kwok.sh
 
 build: ## Build the Karpenter KWOK controller images using ko build
@@ -46,7 +47,7 @@ test: ## Run tests
 		-race \
 		-timeout 15m \
 		--ginkgo.focus="${FOCUS}" \
-		--ginkgo.timeout=15m \
+		--ginkgo.randomize-all \
 		--ginkgo.v \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
 
@@ -94,4 +95,4 @@ download: ## Recursively "go mod download" on all directories where go.mod exist
 toolchain: ## Install developer toolchain
 	./hack/toolchain.sh
 
-.PHONY: help presubmit dev test verify toolchain
+.PHONY: help presubmit install-kwok uninstall-kwok build apply delete test deflake vulncheck licenses verify download toolchain

--- a/pkg/controllers/leasegarbagecollection/controller.go
+++ b/pkg/controllers/leasegarbagecollection/controller.go
@@ -57,7 +57,7 @@ func (c *Controller) Reconcile(ctx context.Context, l *v1.Lease) (reconcile.Resu
 	err := c.kubeClient.Delete(ctx, l)
 	if err == nil {
 		logging.FromContext(ctx).Debug("found and delete leaked lease")
-		NodeLeaseDeletedCounter.Inc()
+		NodeLeaseDeletedCounter.WithLabelValues().Inc()
 	}
 
 	return reconcile.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controllers/leasegarbagecollection/metrics.go
+++ b/pkg/controllers/leasegarbagecollection/metrics.go
@@ -24,13 +24,14 @@ import (
 )
 
 var (
-	NodeLeaseDeletedCounter = prometheus.NewCounter(
+	NodeLeaseDeletedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "karpenter",
 			Subsystem: metrics.NodeSubsystem,
 			Name:      "leases_deleted",
 			Help:      "Number of deleted leaked leases.",
 		},
+		[]string{},
 	)
 )
 

--- a/pkg/controllers/leasegarbagecollection/suite_test.go
+++ b/pkg/controllers/leasegarbagecollection/suite_test.go
@@ -21,11 +21,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	coordinationsv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/samber/lo"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/controllers/leasegarbagecollection"
@@ -97,6 +96,10 @@ var _ = Describe("GarbageCollection", func() {
 				Labels:            map[string]string{test.DiscoveryLabel: "unspecified"},
 			},
 		}
+	})
+	AfterEach(func() {
+		// Reset the metrics collectors
+		leasegarbagecollection.NodeLeaseDeletedCounter.Reset()
 	})
 	Context("Metrics", func() {
 		It("should fire the leaseDeletedCounter metric when deleting leases", func() {

--- a/pkg/controllers/nodeclaim/disruption/suite_test.go
+++ b/pkg/controllers/nodeclaim/disruption/suite_test.go
@@ -76,10 +76,10 @@ var _ = AfterSuite(func() {
 
 var _ = BeforeEach(func() {
 	ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(true)}}))
+	fakeClock.SetTime(time.Now())
 })
 
 var _ = AfterEach(func() {
-	fakeClock.SetTime(time.Now())
 	cp.Reset()
 	cluster.Reset()
 	ExpectCleanedUp(ctx, env.Client)

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -43,7 +43,6 @@ func TestOptions(t *testing.T) {
 }
 
 var _ = Describe("Options", func() {
-	var envState map[string]string
 	var environmentVariables = []string{
 		"KARPENTER_SERVICE",
 		"DISABLE_WEBHOOK",
@@ -51,6 +50,7 @@ var _ = Describe("Options", func() {
 		"METRICS_PORT",
 		"WEBHOOK_METRICS_PORT",
 		"HEALTH_PROBE_PORT",
+		"KUBE_CLIENT_QPS",
 		"KUBE_CLIENT_BURST",
 		"ENABLE_PROFILING",
 		"LEADER_ELECT",
@@ -62,15 +62,6 @@ var _ = Describe("Options", func() {
 	}
 
 	BeforeEach(func() {
-		envState = map[string]string{}
-		for _, ev := range environmentVariables {
-			val, ok := os.LookupEnv(ev)
-			if ok {
-				envState[ev] = val
-			}
-			os.Unsetenv(ev)
-		}
-
 		fs = &options.FlagSet{
 			FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
 		}
@@ -80,10 +71,7 @@ var _ = Describe("Options", func() {
 
 	AfterEach(func() {
 		for _, ev := range environmentVariables {
-			os.Unsetenv(ev)
-		}
-		for ev, val := range envState {
-			os.Setenv(ev, val)
+			Expect(os.Unsetenv(ev)).To(Succeed())
 		}
 	})
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

From reviewing the code and testing, it isn't necessary to specify both of `--ginkgo.timeout` and `--timeout`. This drops the former to prefer the suite-based timeout with `go test`

This change also adds the `--ginkgo.randomize-all` CLI flag to ensure that we aren't missing any test flakiness due to implicit ordering in our testing.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
