### PR TITLE
fix: Add locking/unlocking to set `Add()`, `Delete()`, and `Reset()`

### DIFF
--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -23,14 +23,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	v1 "k8s.io/api/core/v1"
 
 	"sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator"
 
@@ -126,6 +125,27 @@ var _ = Describe("Eviction/Queue", func() {
 			})
 			ExpectApplied(ctx, env.Client, pdb, pdb2, pod)
 			Expect(queue.Evict(ctx, terminator.NewQueueKey(pod))).To(BeFalse())
+		})
+		It("should ensure that calling Evict() is valid while making Add() calls", func() {
+			cancelCtx, cancel := context.WithCancel(ctx)
+			DeferCleanup(func() {
+				cancel()
+			})
+
+			// Keep calling Reconcile() for the entirety of this test
+			go func() {
+				for {
+					ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
+					if cancelCtx.Err() != nil {
+						return
+					}
+				}
+			}()
+
+			// Ensure that we add enough pods to the queue while we are pulling items off of the queue (enough to trigger a DATA RACE)
+			for i := 0; i < 10000; i++ {
+				queue.Add(test.Pod())
+			}
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

`Add()`, `Delete()`, and `Reset()` weren't gated by a mutex after we changed the package that we were using for sets to align with our other set packages

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
