### PR TITLE
test: Fix data race while calling `Reset()` in CI testing

### DIFF
--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -18,6 +18,7 @@ package terminator_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -128,12 +129,17 @@ var _ = Describe("Eviction/Queue", func() {
 		})
 		It("should ensure that calling Evict() is valid while making Add() calls", func() {
 			cancelCtx, cancel := context.WithCancel(ctx)
+			wg := sync.WaitGroup{}
 			DeferCleanup(func() {
 				cancel()
+				wg.Wait() // Ensure that we wait for reconcile loop to finish so that we don't get a RACE
 			})
 
 			// Keep calling Reconcile() for the entirety of this test
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
+
 				for {
 					ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 					if cancelCtx.Err() != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Because we were running an async flow to try to force a DATA RACE if the locking/unlocking wasn't working properly for the set, we were now causing a Reconcile() to happen while we were calling `Reset()` since we weren't waiting for the goroutine to finish 

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
