### PR TITLE
chore: Report node allocatable capacity as part of log on register/initialize

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -83,7 +83,7 @@ func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeC
 			return reconcile.Result{}, err
 		}
 	}
-	logging.FromContext(ctx).Infof("initialized nodeclaim")
+	logging.FromContext(ctx).With("allocatable", node.Status.Allocatable).Infof("initialized nodeclaim")
 	nodeClaim.StatusConditions().MarkTrue(v1beta1.Initialized)
 	metrics.NodeClaimsInitializedCounter.With(prometheus.Labels{
 		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -65,7 +65,7 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeCla
 	if err = r.syncNode(ctx, nodeClaim, node); err != nil {
 		return reconcile.Result{}, fmt.Errorf("syncing node, %w", err)
 	}
-	logging.FromContext(ctx).Debugf("registered nodeclaim")
+	logging.FromContext(ctx).Infof("registered nodeclaim")
 	nodeClaim.StatusConditions().MarkTrue(v1beta1.Registered)
 	nodeClaim.Status.NodeName = node.Name
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Ensure that we report the actual node allocatable in our "initialized nodeclaim" call. This also bumps the "registered nodeclaim" call to the Info level since it's a critical point in the NodeClaim's lifecycle

This also makes it a bit clearer from looking at the log data on the difference between what Karpenter thinks is going to be the allocatable of the node after it launches and what it actually is

```
{"level":"INFO","time":"2024-02-16T23:28:55.484Z","logger":"controller.nodeclaim.lifecycle","message":"launched nodeclaim","commit":"ccbc1b0-dirty","nodeclaim":"default-gmsh2","provider-id":"aws:///us-west-2b/i-02ce789377dd5fe6f","instance-type":"m6a.2xlarge","zone":"us-west-2b","capacity-type":"on-demand","allocatable":{"cpu":"7910m","ephemeral-storage":"17Gi","memory":"31775Mi","pods":"58","vpc.amazonaws.com/pod-eni":"38"}}
{"level":"INFO","time":"2024-02-16T23:28:55.765Z","logger":"controller.node.termination","message":"deleted node","commit":"ccbc1b0-dirty","node":"ip-192-168-54-251.us-west-2.compute.internal"}
{"level":"INFO","time":"2024-02-16T23:28:56.101Z","logger":"controller.nodeclaim.termination","message":"deleted nodeclaim","commit":"ccbc1b0-dirty","nodeclaim":"default-8w97q","node":"ip-192-168-54-251.us-west-2.compute.internal","provider-id":"aws:///us-west-2a/i-0be91c44e900475dd"}
{"level":"INFO","time":"2024-02-16T23:29:18.921Z","logger":"controller.nodeclaim.lifecycle","message":"registered nodeclaim","commit":"ccbc1b0-dirty","nodeclaim":"default-gmsh2","provider-id":"aws:///us-west-2b/i-02ce789377dd5fe6f","node":"ip-192-168-185-49.us-west-2.compute.internal"}
{"level":"DEBUG","time":"2024-02-16T23:29:21.865Z","logger":"controller.nodeclaim.disruption","message":"discovered subnets","commit":"ccbc1b0-dirty","nodeclaim":"default-gmsh2","subnets":["subnet-006396cb4eae056f1 (us-west-2b)","subnet-0c31672d8f3da27ee (us-west-2b)","subnet-0e8ac99bc70aa8051 (us-west-2d)","subnet-068b2a87ec024682c (us-west-2d)","subnet-0f03dba293533e055 (us-west-2a)","subnet-0ff6eb107cd458d60 (us-west-2a)"]}
{"level":"INFO","time":"2024-02-16T23:29:28.723Z","logger":"controller.nodeclaim.lifecycle","message":"initialized nodeclaim","commit":"ccbc1b0-dirty","nodeclaim":"default-gmsh2","provider-id":"aws:///us-west-2b/i-02ce789377dd5fe6f","node":"ip-192-168-185-49.us-west-2.compute.internal","allocatable":{"cpu":"7910m","ephemeral-storage":"18242267924","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"31138276Ki","pods":"58"}}
```

This should also make it easier to debug issues like #1019 where there is a marked difference between the reported allocatable of the node and the simulated allocatable

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
