### PR TITLE
test: Fix flake in requeueAfter returned from expiration disruption

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/expiration_test.go
+++ b/pkg/controllers/nodeclaim/disruption/expiration_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Expiration", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 200)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 
-		fakeClock.Step(time.Second * 100)
+		fakeClock.SetTime(nodeClaim.CreationTimestamp.Time.Add(time.Second * 100))
 
 		result := ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(result.RequeueAfter).To(BeNumerically("~", time.Second*100, time.Second))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This fixes a flake in the `requeueAfter` returned from a test in the NodeClaim Disruption controller. This ensures that the expiry time is always 100 seconds away from the current time.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
