### PR TITLE
feat: Add options to configure consolidation timeouts

### DIFF
--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"time"
 
 	"github.com/samber/lo"
@@ -119,7 +120,7 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 	lastSavedCommand := Command{}
 	lastSavedResults := scheduling.Results{}
 	// Set a timeout
-	timeout := m.clock.Now().Add(MultiNodeConsolidationTimeoutDuration)
+	timeout := m.clock.Now().Add(options.FromContext(ctx).ConsolidationMultiTimeoutDuration)
 	// binary search to find the maximum number of NodeClaims we can terminate
 	for min <= max {
 		if m.clock.Now().After(timeout) {

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -19,6 +19,7 @@ package disruption
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"time"
 
 	"knative.dev/pkg/logging"
@@ -53,7 +54,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 	v := NewValidation(consolidationTTL, s.clock, s.cluster, s.kubeClient, s.provisioner, s.cloudProvider, s.recorder, s.queue)
 
 	// Set a timeout
-	timeout := s.clock.Now().Add(SingleNodeConsolidationTimeoutDuration)
+	timeout := s.clock.Now().Add(options.FromContext(ctx).ConsolidationSingleTimeoutDuration)
 	constrainedByBudgets := false
 	// binary search to find the maximum number of NodeClaims we can terminate
 	for i, candidate := range candidates {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -47,21 +47,23 @@ type FeatureGates struct {
 
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
 type Options struct {
-	ServiceName          string
-	DisableWebhook       bool
-	WebhookPort          int
-	MetricsPort          int
-	WebhookMetricsPort   int
-	HealthProbePort      int
-	KubeClientQPS        int
-	KubeClientBurst      int
-	EnableProfiling      bool
-	EnableLeaderElection bool
-	MemoryLimit          int64
-	LogLevel             string
-	BatchMaxDuration     time.Duration
-	BatchIdleDuration    time.Duration
-	FeatureGates         FeatureGates
+	ServiceName                        string
+	DisableWebhook                     bool
+	WebhookPort                        int
+	MetricsPort                        int
+	WebhookMetricsPort                 int
+	HealthProbePort                    int
+	KubeClientQPS                      int
+	KubeClientBurst                    int
+	EnableProfiling                    bool
+	EnableLeaderElection               bool
+	MemoryLimit                        int64
+	LogLevel                           string
+	BatchMaxDuration                   time.Duration
+	BatchIdleDuration                  time.Duration
+	FeatureGates                       FeatureGates
+	ConsolidationSingleTimeoutDuration time.Duration
+	ConsolidationMultiTimeoutDuration  time.Duration
 }
 
 type FlagSet struct {
@@ -97,6 +99,8 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "Drift=true,SpotToSpotConsolidation=false"), "Optional features can be enabled / disabled using feature gates. Current options are: Drift,SpotToSpotConsolidation")
+	fs.DurationVar(&o.ConsolidationSingleTimeoutDuration, "consolidation-single-timeout-duration", env.WithDefaultDuration("CONSOLIDATION_SINGLE_TIMEOUT_DURATION", 3*time.Minute), "The maximum amount of time to spend consolidating a single node, after this it times out and starts again.")
+	fs.DurationVar(&o.ConsolidationMultiTimeoutDuration, "consolidation-multi-timeout-duration", env.WithDefaultDuration("CONSOLIDATION_MULTI_TIMEOUT_DURATION", 1*time.Minute), "The maximum amount of time to spend consolidating multiple nodes, after this it times out and starts again.")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -28,21 +28,23 @@ import (
 
 type OptionsFields struct {
 	// Vendor Neutral
-	ServiceName          *string
-	DisableWebhook       *bool
-	WebhookPort          *int
-	MetricsPort          *int
-	WebhookMetricsPort   *int
-	HealthProbePort      *int
-	KubeClientQPS        *int
-	KubeClientBurst      *int
-	EnableProfiling      *bool
-	EnableLeaderElection *bool
-	MemoryLimit          *int64
-	LogLevel             *string
-	BatchMaxDuration     *time.Duration
-	BatchIdleDuration    *time.Duration
-	FeatureGates         FeatureGates
+	ServiceName                        *string
+	DisableWebhook                     *bool
+	WebhookPort                        *int
+	MetricsPort                        *int
+	WebhookMetricsPort                 *int
+	HealthProbePort                    *int
+	KubeClientQPS                      *int
+	KubeClientBurst                    *int
+	EnableProfiling                    *bool
+	EnableLeaderElection               *bool
+	MemoryLimit                        *int64
+	LogLevel                           *string
+	BatchMaxDuration                   *time.Duration
+	BatchIdleDuration                  *time.Duration
+	FeatureGates                       FeatureGates
+	ConsolidationSingleTimeoutDuration *time.Duration
+	ConsolidationMultiTimeoutDuration  *time.Duration
 }
 
 type FeatureGates struct {
@@ -77,5 +79,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 			Drift:                   lo.FromPtrOr(opts.FeatureGates.Drift, false),
 			SpotToSpotConsolidation: lo.FromPtrOr(opts.FeatureGates.SpotToSpotConsolidation, false),
 		},
+		ConsolidationSingleTimeoutDuration: lo.FromPtrOr(opts.ConsolidationSingleTimeoutDuration, 3*time.Minute),
+		ConsolidationMultiTimeoutDuration:  lo.FromPtrOr(opts.ConsolidationMultiTimeoutDuration, 1*time.Minute),
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/kubernetes-sigs/karpenter/issues/903

**Description**
Adds option values to configure the timeout for multi and single node consolidations. Depending on the size of a cluster and your various affinities/topology spreads this can take longer then these hard coded values. Allowing them to be configured means large complex clusters can have longer timeouts if wanted.


**How was this change tested?**
I added this version as the Karpenter version for the aws-provider repo, built and image and deployed it on a test cluster. Working with the value both set and not set (defaulting to existing values) things were fine.
ie.
```
replace sigs.k8s.io/karpenter => github.com/domgoodwin/karpenter v0.0.0-20240220105243-cf5336018872
```

The unit test changes also cover setting the value to a non-default and then timing out after that time.
