### PR TITLE
test: Ensure that MaxInstanceTypes is reset at the beginning of each test

### DIFF
--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -75,7 +75,6 @@ var _ = Describe("Instance Type Selection", func() {
 		cloudProvider.InstanceTypes = fake.InstanceTypesAssorted()
 		instanceTypeMap = getInstanceTypeMap(cloudProvider.InstanceTypes)
 		minPrice = getMinPrice(cloudProvider.InstanceTypes)
-		scheduling.MaxInstanceTypes = 100
 		// add some randomness to instance type ordering to ensure we sort everywhere we need to
 		rand.Shuffle(len(cloudProvider.InstanceTypes), func(i, j int) {
 			cloudProvider.InstanceTypes[i], cloudProvider.InstanceTypes[j] = cloudProvider.InstanceTypes[j], cloudProvider.InstanceTypes[i]

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -104,6 +104,7 @@ var _ = BeforeEach(func() {
 	cloudProvider.InstanceTypes, _ = newCP.GetInstanceTypes(ctx, nil)
 	cloudProvider.CreateCalls = nil
 	pscheduling.ResetDefaultStorageClass()
+	scheduling.MaxInstanceTypes = 100
 })
 
 var _ = AfterEach(func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the scheduler testing to ensure that `maxInstanceTypes` is reset at the beginning of each test so that changing this value throughout a single test doesn't affect subsequent tests.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
