### PR TITLE
chore: Reject NodePools and NodeClaims if they don't have spec

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -430,6 +430,8 @@ spec:
                   description: ProviderID of the corresponding node object
                   type: string
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -520,6 +520,8 @@ spec:
                   description: Resources is the list of resources that have been provisioned.
                   type: object
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -176,7 +176,8 @@ type NodeClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   NodeClaimSpec   `json:"spec,omitempty"`
+	// +required
+	Spec   NodeClaimSpec   `json:"spec"`
 	Status NodeClaimStatus `json:"status,omitempty"`
 }
 

--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -185,7 +185,8 @@ type NodePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   NodePoolSpec   `json:"spec,omitempty"`
+	// +required
+	Spec   NodePoolSpec   `json:"spec"`
 	Status NodePoolStatus `json:"status,omitempty"`
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

We've seen some Karpenter users running into issues with NodePool or NodeClaim applies, specifically when the spec isn't present. If you apply the NodePool or NodeClaim without a spec, you can circumvent the other checking, we should just require the spec.

One example issue that we hit in the AWS provider repo is here: https://github.com/aws/karpenter-provider-aws/issues/5689

**How was this change tested?**

`make presubmit`
`kubectl apply -f pkg/apis/crds && kubectl apply -f nodepool.yaml` and validate failure with no `spec` specified

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
