### PR TITLE
chore: migrate knative logger to controller-runtime injected logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/awslabs/operatorpkg v0.0.0-20240514175841-edb8fe5824b4
 	github.com/docker/docker v26.1.2+incompatible
 	github.com/go-logr/logr v1.4.1
-	github.com/go-logr/zapr v1.3.0
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.17.3
@@ -35,8 +34,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.18.2
 )
 
-require github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
-
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0 // indirect
@@ -52,9 +49,11 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/go-logr/zapr v1.3.0
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gobuffalo/flect v0.2.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/kwok/main.go
+++ b/kwok/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kwok "sigs.k8s.io/karpenter/kwok/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -41,7 +41,7 @@ func main() {
 	ctx, op := operator.NewOperator()
 	instanceTypes, err := kwok.ConstructInstanceTypes()
 	if err != nil {
-		logging.FromContext(ctx).Fatalf("failed to construct instance types: %s", err)
+		log.FromContext(ctx).Error(err, "failed constructing instance types")
 	}
 
 	cloudProvider := kwok.NewCloudProvider(ctx, op.GetClient(), instanceTypes)

--- a/pkg/apis/v1beta1/suite_test.go
+++ b/pkg/apis/v1beta1/suite_test.go
@@ -24,7 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -284,7 +284,7 @@ func (c *Controller) logAbnormalRuns(ctx context.Context) {
 func (c *Controller) logInvalidBudgets(ctx context.Context) {
 	nodePoolList := &v1beta1.NodePoolList{}
 	if err := c.kubeClient.List(ctx, nodePoolList); err != nil {
-		log.FromContext(ctx).Error(fmt.Errorf("listing nodepools, %w", err), "Disruption error")
+		log.FromContext(ctx).Error(fmt.Errorf("listing nodepools, %w", err), "disruption error")
 		return
 	}
 	var buf bytes.Buffer
@@ -295,6 +295,6 @@ func (c *Controller) logInvalidBudgets(ctx context.Context) {
 		}
 	}
 	if buf.Len() > 0 {
-		log.FromContext(ctx).Error(fmt.Errorf("detected disruption budget errors, %w", errors.New(buf.String())), "Disruption error")
+		log.FromContext(ctx).Error(fmt.Errorf("detected disruption budget errors, %w", errors.New(buf.String())), "disruption error")
 	}
 }

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -185,7 +185,7 @@ func (c *Controller) disrupt(ctx context.Context, disruption Method) (bool, erro
 // 3. Add Command to orchestration.Queue to wait to delete the candiates.
 func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command, schedulingResults scheduling.Results) error {
 	commandID := uuid.NewUUID()
-	log.FromContext(ctx).WithValues("command-id", commandID).Info("disrupting via %s %s", m.Type(), cmd)
+	log.FromContext(ctx).WithValues("command-id", commandID).Info(fmt.Sprintf("disrupting via %s %s", m.Type(), cmd))
 
 	stateNodes := lo.Map(cmd.candidates, func(c *Candidate, _ int) *state.StateNode {
 		return c.StateNode
@@ -275,7 +275,7 @@ func (c *Controller) logAbnormalRuns(ctx context.Context) {
 	defer c.mu.Unlock()
 	for name, runTime := range c.lastRun {
 		if timeSince := c.clock.Since(runTime); timeSince > AbnormalTimeLimit {
-			log.FromContext(ctx).V(1).Info("abnormal time between runs of %s = %s", name, timeSince)
+			log.FromContext(ctx).V(1).Info(fmt.Sprintf("abnormal time between runs of %s = %s", name, timeSince))
 		}
 	}
 }

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -284,7 +284,7 @@ func (c *Controller) logAbnormalRuns(ctx context.Context) {
 func (c *Controller) logInvalidBudgets(ctx context.Context) {
 	nodePoolList := &v1beta1.NodePoolList{}
 	if err := c.kubeClient.List(ctx, nodePoolList); err != nil {
-		log.FromContext(ctx).Error(fmt.Errorf("listing nodepools, %w", err), "disruption error")
+		log.FromContext(ctx).Error(err, "failed listing nodepools")
 		return
 	}
 	var buf bytes.Buffer
@@ -295,6 +295,6 @@ func (c *Controller) logInvalidBudgets(ctx context.Context) {
 		}
 	}
 	if buf.Len() > 0 {
-		log.FromContext(ctx).Error(fmt.Errorf("detected disruption budget errors, %w", errors.New(buf.String())), "disruption error")
+		log.FromContext(ctx).Error(errors.New(buf.String()), "detected disruption budget errors")
 	}
 }

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -19,6 +19,7 @@ package disruption
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -27,12 +28,10 @@ import (
 	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	operatorlogging "sigs.k8s.io/karpenter/pkg/operator/logging"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -43,6 +42,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/controller"
+	operatorlogging "sigs.k8s.io/karpenter/pkg/operator/logging"
 )
 
 type Controller struct {
@@ -110,7 +110,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !c.cluster.Synced(ctx) {
-		logging.FromContext(ctx).Debugf("waiting on cluster sync")
+		log.FromContext(ctx).V(1).Info("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 
@@ -185,7 +185,7 @@ func (c *Controller) disrupt(ctx context.Context, disruption Method) (bool, erro
 // 3. Add Command to orchestration.Queue to wait to delete the candiates.
 func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command, schedulingResults scheduling.Results) error {
 	commandID := uuid.NewUUID()
-	logging.FromContext(ctx).With("command-id", commandID).Infof("disrupting via %s %s", m.Type(), cmd)
+	log.FromContext(ctx).WithValues("command-id", commandID).Info("disrupting via %s %s", m.Type(), cmd)
 
 	stateNodes := lo.Map(cmd.candidates, func(c *Candidate, _ int) *state.StateNode {
 		return c.StateNode
@@ -214,7 +214,7 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command, 
 	// tainted with the Karpenter taint, the provisioning controller will continue
 	// to do scheduling simulations and nominate the pods on the candidate nodes until
 	// the node is cleaned up.
-	schedulingResults.Record(logging.WithLogger(ctx, operatorlogging.NopLogger), c.recorder, c.cluster)
+	schedulingResults.Record(log.IntoContext(ctx, operatorlogging.NopLogger), c.recorder, c.cluster)
 
 	providerIDs := lo.Map(cmd.candidates, func(c *Candidate, _ int) string { return c.ProviderID() })
 	// We have the new NodeClaims created at the API server so mark the old NodeClaims for deletion
@@ -275,7 +275,7 @@ func (c *Controller) logAbnormalRuns(ctx context.Context) {
 	defer c.mu.Unlock()
 	for name, runTime := range c.lastRun {
 		if timeSince := c.clock.Since(runTime); timeSince > AbnormalTimeLimit {
-			logging.FromContext(ctx).Debugf("abnormal time between runs of %s = %s", name, timeSince)
+			log.FromContext(ctx).V(1).Info("abnormal time between runs of %s = %s", name, timeSince)
 		}
 	}
 }
@@ -284,7 +284,7 @@ func (c *Controller) logAbnormalRuns(ctx context.Context) {
 func (c *Controller) logInvalidBudgets(ctx context.Context) {
 	nodePoolList := &v1beta1.NodePoolList{}
 	if err := c.kubeClient.List(ctx, nodePoolList); err != nil {
-		logging.FromContext(ctx).Errorf("listing nodepools, %s", err)
+		log.FromContext(ctx).Error(err, "listing nodepools")
 		return
 	}
 	var buf bytes.Buffer
@@ -295,6 +295,6 @@ func (c *Controller) logInvalidBudgets(ctx context.Context) {
 		}
 	}
 	if buf.Len() > 0 {
-		logging.FromContext(ctx).Errorf("detected disruption budget errors: %s", buf.String())
+		log.FromContext(ctx).Error(errors.New(buf.String()), "detected disruption budget errors")
 	}
 }

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -284,7 +284,7 @@ func (c *Controller) logAbnormalRuns(ctx context.Context) {
 func (c *Controller) logInvalidBudgets(ctx context.Context) {
 	nodePoolList := &v1beta1.NodePoolList{}
 	if err := c.kubeClient.List(ctx, nodePoolList); err != nil {
-		log.FromContext(ctx).Error(err, "listing nodepools")
+		log.FromContext(ctx).Error(fmt.Errorf("listing nodepools, %w", err), "Disruption error")
 		return
 	}
 	var buf bytes.Buffer
@@ -295,6 +295,6 @@ func (c *Controller) logInvalidBudgets(ctx context.Context) {
 		}
 	}
 	if buf.Len() > 0 {
-		log.FromContext(ctx).Error(errors.New(buf.String()), "detected disruption budget errors")
+		log.FromContext(ctx).Error(fmt.Errorf("detected disruption budget errors, %w", errors.New(buf.String())), "Disruption error")
 	}
 }

--- a/pkg/controllers/disruption/emptynodeconsolidation.go
+++ b/pkg/controllers/disruption/emptynodeconsolidation.go
@@ -19,6 +19,7 @@ package disruption
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -89,7 +90,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	validatedCandidates, err := v.ValidateCandidates(ctx, cmd.candidates...)
 	if err != nil {
 		if IsValidationError(err) {
-			log.FromContext(ctx).V(1).Info("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+			log.FromContext(ctx).V(1).Info(fmt.Sprintf("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd))
 			return Command{}, scheduling.Results{}, nil
 		}
 		return Command{}, scheduling.Results{}, err
@@ -99,7 +100,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	if lo.ContainsBy(validatedCandidates, func(c *Candidate) bool {
 		return len(c.reschedulablePods) != 0
 	}) {
-		log.FromContext(ctx).V(1).Info("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+		log.FromContext(ctx).V(1).Info(fmt.Sprintf("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd))
 		return Command{}, scheduling.Results{}, nil
 	}
 

--- a/pkg/controllers/disruption/emptynodeconsolidation.go
+++ b/pkg/controllers/disruption/emptynodeconsolidation.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 
 	"github.com/samber/lo"
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/metrics"
@@ -89,7 +89,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	validatedCandidates, err := v.ValidateCandidates(ctx, cmd.candidates...)
 	if err != nil {
 		if IsValidationError(err) {
-			logging.FromContext(ctx).Debugf("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+			log.FromContext(ctx).V(1).Info("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
 			return Command{}, scheduling.Results{}, nil
 		}
 		return Command{}, scheduling.Results{}, err
@@ -99,7 +99,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	if lo.ContainsBy(validatedCandidates, func(c *Candidate) bool {
 		return len(c.reschedulablePods) != 0
 	}) {
-		logging.FromContext(ctx).Debugf("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+		log.FromContext(ctx).V(1).Info("abandoning empty node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
 		return Command{}, scheduling.Results{}, nil
 	}
 

--- a/pkg/controllers/disruption/expiration.go
+++ b/pkg/controllers/disruption/expiration.go
@@ -23,8 +23,8 @@ import (
 
 	"k8s.io/utils/clock"
 
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
@@ -112,7 +112,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, disruptionBudgetMapping
 			e.recorder.Publish(disruptionevents.Blocked(candidate.Node, candidate.NodeClaim, results.NonPendingPodSchedulingErrors())...)
 			continue
 		}
-		logging.FromContext(ctx).With("ttl", candidates[0].nodePool.Spec.Disruption.ExpireAfter.String()).Infof("triggering termination for expired node after TTL")
+		log.FromContext(ctx).WithValues("ttl", candidates[0].nodePool.Spec.Disruption.ExpireAfter.String()).Info("triggering termination for expired node after TTL")
 		return Command{
 			candidates:   []*Candidate{candidate},
 			replacements: results.NewNodeClaims,

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -150,8 +150,7 @@ func GetPodEvictionCost(ctx context.Context, p *v1.Pod) float64 {
 	if ok {
 		podDeletionCost, err := strconv.ParseFloat(podDeletionCostStr, 64)
 		if err != nil {
-			log.FromContext(ctx).Error(fmt.Errorf("parsing %s=%s from pod %s, %w",
-				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p), err), "disruption error")
+			log.FromContext(ctx).Error(err, fmt.Sprintf("failed parsing %s=%s from pod %s", v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p)))
 		} else {
 			// the pod deletion disruptionCost is in [-2147483647, 2147483647]
 			// the min pod disruptionCost makes one pod ~ -15 pods, and the max pod disruptionCost to ~ 17 pods.
@@ -288,7 +287,7 @@ func BuildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 		if err != nil {
 			// don't error out on building the node pool, we just won't be able to handle any nodes that
 			// were created by it
-			log.FromContext(ctx).Error(fmt.Errorf("listing instance types for %s, %w", np.Name, err), "disruption error")
+			log.FromContext(ctx).Error(err, fmt.Sprintf("failed listing instance types for %s", np.Name))
 			continue
 		}
 		if len(nodePoolInstanceTypes) == 0 {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -150,8 +150,8 @@ func GetPodEvictionCost(ctx context.Context, p *v1.Pod) float64 {
 	if ok {
 		podDeletionCost, err := strconv.ParseFloat(podDeletionCostStr, 64)
 		if err != nil {
-			log.FromContext(ctx).Error(err, fmt.Sprintf("parsing %s=%s from pod %s",
-				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p)))
+			log.FromContext(ctx).Error(fmt.Errorf("parsing %s=%s from pod %s, %w",
+				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p), err), "Disruption error")
 		} else {
 			// the pod deletion disruptionCost is in [-2147483647, 2147483647]
 			// the min pod disruptionCost makes one pod ~ -15 pods, and the max pod disruptionCost to ~ 17 pods.
@@ -288,7 +288,7 @@ func BuildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 		if err != nil {
 			// don't error out on building the node pool, we just won't be able to handle any nodes that
 			// were created by it
-			log.FromContext(ctx).Error(err, fmt.Sprintf("listing instance types for %s", np.Name))
+			log.FromContext(ctx).Error(fmt.Errorf("listing instance types for %s, %w", np.Name, err), "Disruption error")
 			continue
 		}
 		if len(nodePoolInstanceTypes) == 0 {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -151,7 +151,7 @@ func GetPodEvictionCost(ctx context.Context, p *v1.Pod) float64 {
 		podDeletionCost, err := strconv.ParseFloat(podDeletionCostStr, 64)
 		if err != nil {
 			log.FromContext(ctx).Error(fmt.Errorf("parsing %s=%s from pod %s, %w",
-				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p), err), "Disruption error")
+				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p), err), "disruption error")
 		} else {
 			// the pod deletion disruptionCost is in [-2147483647, 2147483647]
 			// the min pod disruptionCost makes one pod ~ -15 pods, and the max pod disruptionCost to ~ 17 pods.
@@ -288,7 +288,7 @@ func BuildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 		if err != nil {
 			// don't error out on building the node pool, we just won't be able to handle any nodes that
 			// were created by it
-			log.FromContext(ctx).Error(fmt.Errorf("listing instance types for %s, %w", np.Name, err), "Disruption error")
+			log.FromContext(ctx).Error(fmt.Errorf("listing instance types for %s, %w", np.Name, err), "disruption error")
 			continue
 		}
 		if len(nodePoolInstanceTypes) == 0 {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -150,8 +150,8 @@ func GetPodEvictionCost(ctx context.Context, p *v1.Pod) float64 {
 	if ok {
 		podDeletionCost, err := strconv.ParseFloat(podDeletionCostStr, 64)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "parsing %s=%s from pod %s, %s",
-				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p))
+			log.FromContext(ctx).Error(err, fmt.Sprintf("parsing %s=%s from pod %s",
+				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p)))
 		} else {
 			// the pod deletion disruptionCost is in [-2147483647, 2147483647]
 			// the min pod disruptionCost makes one pod ~ -15 pods, and the max pod disruptionCost to ~ 17 pods.
@@ -288,7 +288,7 @@ func BuildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 		if err != nil {
 			// don't error out on building the node pool, we just won't be able to handle any nodes that
 			// were created by it
-			log.FromContext(ctx).Error(err, "listing instance types for %s, %s", np.Name)
+			log.FromContext(ctx).Error(err, fmt.Sprintf("listing instance types for %s", np.Name))
 			continue
 		}
 		if len(nodePoolInstanceTypes) == 0 {

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -90,7 +90,7 @@ func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 
 	if err := NewValidation(m.clock, m.cluster, m.kubeClient, m.provisioner, m.cloudProvider, m.recorder, m.queue).IsValid(ctx, cmd, consolidationTTL); err != nil {
 		if IsValidationError(err) {
-			log.FromContext(ctx).V(1).Info("abandoning multi-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+			log.FromContext(ctx).V(1).Info(fmt.Sprintf("abandoning multi-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd))
 			return Command{}, scheduling.Results{}, nil
 		}
 		return Command{}, scheduling.Results{}, fmt.Errorf("validating consolidation, %w", err)
@@ -119,9 +119,9 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 		if m.clock.Now().After(timeout) {
 			ConsolidationTimeoutTotalCounter.WithLabelValues(m.ConsolidationType()).Inc()
 			if lastSavedCommand.candidates == nil {
-				log.FromContext(ctx).V(1).Info("failed to find a multi-node consolidation after timeout, last considered batch had %d", (min+max)/2)
+				log.FromContext(ctx).V(1).Info(fmt.Sprintf("failed to find a multi-node consolidation after timeout, last considered batch had %d", (min+max)/2))
 			} else {
-				log.FromContext(ctx).V(1).Info("stopping multi-node consolidation after timeout, returning last valid command %s", lastSavedCommand)
+				log.FromContext(ctx).V(1).Info(fmt.Sprintf("stopping multi-node consolidation after timeout, returning last valid command %s", lastSavedCommand))
 			}
 			return lastSavedCommand, lastSavedResults, nil
 		}

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -24,7 +24,8 @@ import (
 
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"knative.dev/pkg/logging"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
@@ -89,7 +90,7 @@ func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 
 	if err := NewValidation(m.clock, m.cluster, m.kubeClient, m.provisioner, m.cloudProvider, m.recorder, m.queue).IsValid(ctx, cmd, consolidationTTL); err != nil {
 		if IsValidationError(err) {
-			logging.FromContext(ctx).Debugf("abandoning multi-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+			log.FromContext(ctx).V(1).Info("abandoning multi-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
 			return Command{}, scheduling.Results{}, nil
 		}
 		return Command{}, scheduling.Results{}, fmt.Errorf("validating consolidation, %w", err)
@@ -118,9 +119,9 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 		if m.clock.Now().After(timeout) {
 			ConsolidationTimeoutTotalCounter.WithLabelValues(m.ConsolidationType()).Inc()
 			if lastSavedCommand.candidates == nil {
-				logging.FromContext(ctx).Debugf("failed to find a multi-node consolidation after timeout, last considered batch had %d", (min+max)/2)
+				log.FromContext(ctx).V(1).Info("failed to find a multi-node consolidation after timeout, last considered batch had %d", (min+max)/2)
 			} else {
-				logging.FromContext(ctx).Debugf("stopping multi-node consolidation after timeout, returning last valid command %s", lastSavedCommand)
+				log.FromContext(ctx).V(1).Info("stopping multi-node consolidation after timeout, returning last valid command %s", lastSavedCommand)
 			}
 			return lastSavedCommand, lastSavedResults, nil
 		}

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -205,7 +205,7 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 		// Log the error
 		log.FromContext(ctx).WithValues("nodes", strings.Join(lo.Map(cmd.candidates, func(s *state.StateNode, _ int) string {
 			return s.Name()
-		}), ",")).Error(multiErr, "Disruption error")
+		}), ",")).Error(multiErr, "failed terminating nodes while executing a disruption command")
 	}
 	// If command is complete, remove command from queue.
 	q.Remove(cmd)

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -205,7 +205,7 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 		// Log the error
 		log.FromContext(ctx).WithValues("nodes", strings.Join(lo.Map(cmd.candidates, func(s *state.StateNode, _ int) string {
 			return s.Name()
-		}), ",")).Error(multiErr, "failed to disrupt nodes")
+		}), ",")).Error(multiErr, "Disruption error")
 	}
 	// If command is complete, remove command from queue.
 	q.Remove(cmd)

--- a/pkg/controllers/disruption/orchestration/suite_test.go
+++ b/pkg/controllers/disruption/orchestration/suite_test.go
@@ -27,8 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -68,7 +68,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 		// compute a possible consolidation option
 		cmd, results, err := s.computeConsolidation(ctx, candidate)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "computing consolidation")
+			log.FromContext(ctx).Error(fmt.Errorf("computing consolidation, %w", err), "Disruption error")
 			continue
 		}
 		if cmd.Action() == NoOpAction {

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/metrics"
@@ -62,13 +62,13 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 		}
 		if s.clock.Now().After(timeout) {
 			ConsolidationTimeoutTotalCounter.WithLabelValues(s.ConsolidationType()).Inc()
-			logging.FromContext(ctx).Debugf("abandoning single-node consolidation due to timeout after evaluating %d candidates", i)
+			log.FromContext(ctx).V(1).Info("abandoning single-node consolidation due to timeout after evaluating %d candidates", i)
 			return Command{}, scheduling.Results{}, nil
 		}
 		// compute a possible consolidation option
 		cmd, results, err := s.computeConsolidation(ctx, candidate)
 		if err != nil {
-			logging.FromContext(ctx).Errorf("computing consolidation %s", err)
+			log.FromContext(ctx).Error(err, "computing consolidation")
 			continue
 		}
 		if cmd.Action() == NoOpAction {
@@ -76,7 +76,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 		}
 		if err := v.IsValid(ctx, cmd, consolidationTTL); err != nil {
 			if IsValidationError(err) {
-				logging.FromContext(ctx).Debugf("abandoning single-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+				log.FromContext(ctx).V(1).Info("abandoning single-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
 				return Command{}, scheduling.Results{}, nil
 			}
 			return Command{}, scheduling.Results{}, fmt.Errorf("validating consolidation, %w", err)

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -68,7 +68,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 		// compute a possible consolidation option
 		cmd, results, err := s.computeConsolidation(ctx, candidate)
 		if err != nil {
-			log.FromContext(ctx).Error(fmt.Errorf("computing consolidation, %w", err), "disruption error")
+			log.FromContext(ctx).Error(err, "failed computing consolidation")
 			continue
 		}
 		if cmd.Action() == NoOpAction {

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -62,7 +62,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 		}
 		if s.clock.Now().After(timeout) {
 			ConsolidationTimeoutTotalCounter.WithLabelValues(s.ConsolidationType()).Inc()
-			log.FromContext(ctx).V(1).Info("abandoning single-node consolidation due to timeout after evaluating %d candidates", i)
+			log.FromContext(ctx).V(1).Info(fmt.Sprintf("abandoning single-node consolidation due to timeout after evaluating %d candidates", i))
 			return Command{}, scheduling.Results{}, nil
 		}
 		// compute a possible consolidation option
@@ -76,7 +76,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 		}
 		if err := v.IsValid(ctx, cmd, consolidationTTL); err != nil {
 			if IsValidationError(err) {
-				log.FromContext(ctx).V(1).Info("abandoning single-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+				log.FromContext(ctx).V(1).Info(fmt.Sprintf("abandoning single-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd))
 				return Command{}, scheduling.Results{}, nil
 			}
 			return Command{}, scheduling.Results{}, fmt.Errorf("validating consolidation, %w", err)

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -68,7 +68,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 		// compute a possible consolidation option
 		cmd, results, err := s.computeConsolidation(ctx, candidate)
 		if err != nil {
-			log.FromContext(ctx).Error(fmt.Errorf("computing consolidation, %w", err), "Disruption error")
+			log.FromContext(ctx).Error(fmt.Errorf("computing consolidation, %w", err), "disruption error")
 			continue
 		}
 		if cmd.Action() == NoOpAction {

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -34,9 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	coreapis "sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -116,7 +116,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	}
 	pods, err := node.Pods(ctx, kubeClient)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "determining node pods")
+		log.FromContext(ctx).Error(fmt.Errorf("determining node pods, %w", err), "Disruption error")
 		return nil, fmt.Errorf("getting pods from state node, %w", err)
 	}
 	for _, po := range pods {

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -116,7 +116,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	}
 	pods, err := node.Pods(ctx, kubeClient)
 	if err != nil {
-		log.FromContext(ctx).Error(fmt.Errorf("determining node pods, %w", err), "Disruption error")
+		log.FromContext(ctx).Error(fmt.Errorf("determining node pods, %w", err), "disruption error")
 		return nil, fmt.Errorf("getting pods from state node, %w", err)
 	}
 	for _, po := range pods {

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -24,8 +24,8 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 
@@ -116,7 +116,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	}
 	pods, err := node.Pods(ctx, kubeClient)
 	if err != nil {
-		logging.FromContext(ctx).Errorf("determining node pods, %s", err)
+		log.FromContext(ctx).Error(err, "determining node pods, %s")
 		return nil, fmt.Errorf("getting pods from state node, %w", err)
 	}
 	for _, po := range pods {

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -116,7 +116,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	}
 	pods, err := node.Pods(ctx, kubeClient)
 	if err != nil {
-		log.FromContext(ctx).Error(fmt.Errorf("determining node pods, %w", err), "disruption error")
+		log.FromContext(ctx).Error(err, "failed resolving node pods")
 		return nil, fmt.Errorf("getting pods from state node, %w", err)
 	}
 	for _, po := range pods {

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -116,7 +116,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	}
 	pods, err := node.Pods(ctx, kubeClient)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "determining node pods, %s")
+		log.FromContext(ctx).Error(err, "determining node pods")
 		return nil, fmt.Errorf("getting pods from state node, %w", err)
 	}
 	for _, po := range pods {

--- a/pkg/controllers/leasegarbagecollection/suite_test.go
+++ b/pkg/controllers/leasegarbagecollection/suite_test.go
@@ -33,7 +33,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )

--- a/pkg/controllers/metrics/node/suite_test.go
+++ b/pkg/controllers/metrics/node/suite_test.go
@@ -40,7 +40,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )

--- a/pkg/controllers/metrics/nodepool/controller.go
+++ b/pkg/controllers/metrics/nodepool/controller.go
@@ -21,15 +21,16 @@ import (
 	"strings"
 	"time"
 
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"knative.dev/pkg/logging"
 
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -91,7 +92,7 @@ func NewController(kubeClient client.Client) *Controller {
 
 // Reconcile executes a termination control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("metrics.nodepool").With("nodepool", req.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("metrics.nodepool").WithValues("nodepool", req.Name))
 	ctx = injection.WithControllerName(ctx, "metrics.nodepool")
 
 	nodePool := &v1beta1.NodePool{}

--- a/pkg/controllers/metrics/nodepool/suite_test.go
+++ b/pkg/controllers/metrics/nodepool/suite_test.go
@@ -25,8 +25,9 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -119,7 +119,7 @@ func (c *Controller) Name() string {
 
 // Reconcile executes a termination control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("metrics.pod").With("pod", req.String()))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("metrics.pod").WithValues("pod", req.String()))
 	ctx = injection.WithControllerName(ctx, "metrics.pod")
 
 	pod := &v1.Pod{}

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -23,8 +23,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/controllers/metrics/pod"
 	"sigs.k8s.io/karpenter/pkg/operator/scheme"

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -26,11 +26,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/util/workqueue"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -65,7 +65,7 @@ func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudPr
 }
 
 func (c *Controller) Reconcile(ctx context.Context, n *v1.Node) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("node.termination").With("node", n.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("node.termination").WithValues("node", n.Name))
 	ctx = injection.WithControllerName(ctx, "node.termination")
 
 	if !n.GetDeletionTimestamp().IsZero() {
@@ -147,7 +147,7 @@ func (c *Controller) removeFinalizer(ctx context.Context, n *v1.Node) error {
 		TerminationSummary.With(prometheus.Labels{
 			metrics.NodePoolLabel: n.Labels[v1beta1.NodePoolLabelKey],
 		}).Observe(time.Since(stored.DeletionTimestamp.Time).Seconds())
-		logging.FromContext(ctx).Infof("deleted node")
+		log.FromContext(ctx).Info("deleted node")
 	}
 	return nil
 }

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/ptr"
 
-	. "knative.dev/pkg/logging/testing"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -178,7 +178,7 @@ func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
 			}}, fmt.Errorf("evicting pod %s/%s violates a PDB", key.Namespace, key.Name)))
 			return false
 		}
-		log.FromContext(ctx).Error(err, "evicting pod, %s")
+		log.FromContext(ctx).Error(err, "evicting pod")
 		return false
 	}
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}))

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -152,7 +152,7 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 
 // Evict returns true if successful eviction call, and false if not an eviction-related error
 func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("pod", key.NamespacedName))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("pod", key.NamespacedName))
 	if err := q.kubeClient.SubResource("eviction").Create(ctx,
 		&v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}},
 		&policyv1.Eviction{
@@ -178,7 +178,7 @@ func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
 			}}, fmt.Errorf("evicting pod %s/%s violates a PDB", key.Namespace, key.Name)))
 			return false
 		}
-		logging.FromContext(ctx).Errorf("evicting pod, %s", err)
+		log.FromContext(ctx).Error(err, "evicting pod, %s")
 		return false
 	}
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}))

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -178,7 +178,7 @@ func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
 			}}, fmt.Errorf("evicting pod %s/%s violates a PDB", key.Namespace, key.Name)))
 			return false
 		}
-		log.FromContext(ctx).Error(err, "Eviction error")
+		log.FromContext(ctx).Error(err, "eviction error")
 		return false
 	}
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}))

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -178,7 +178,7 @@ func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
 			}}, fmt.Errorf("evicting pod %s/%s violates a PDB", key.Namespace, key.Name)))
 			return false
 		}
-		log.FromContext(ctx).Error(err, "eviction error")
+		log.FromContext(ctx).Error(err, "failed evicting pod")
 		return false
 	}
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}))

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -178,7 +178,7 @@ func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
 			}}, fmt.Errorf("evicting pod %s/%s violates a PDB", key.Namespace, key.Name)))
 			return false
 		}
-		log.FromContext(ctx).Error(err, "evicting pod")
+		log.FromContext(ctx).Error(err, "Eviction error")
 		return false
 	}
 	q.recorder.Publish(terminatorevents.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}))

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -29,8 +29,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator"
 

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -24,8 +24,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	nodeutil "sigs.k8s.io/karpenter/pkg/utils/node"
 
@@ -72,7 +72,7 @@ func (t *Terminator) Taint(ctx context.Context, node *v1.Node) error {
 		if err := t.kubeClient.Patch(ctx, node, client.StrategicMergeFrom(stored)); err != nil {
 			return err
 		}
-		logging.FromContext(ctx).Infof("tainted node")
+		log.FromContext(ctx).Info("tainted node")
 	}
 	return nil
 }

--- a/pkg/controllers/nodeclaim/consistency/controller.go
+++ b/pkg/controllers/nodeclaim/consistency/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim
 			return reconcile.Result{}, fmt.Errorf("checking node with %T, %w", check, err)
 		}
 		for _, issue := range issues {
-			log.FromContext(ctx).Error(err, "check failed")
+			log.FromContext(ctx).Error(err, "Consistency error")
 			consistencyErrors.With(prometheus.Labels{checkLabel: reflect.TypeOf(check).Elem().Name()}).Inc()
 			c.recorder.Publish(FailedConsistencyCheckEvent(nodeClaim, string(issue)))
 		}

--- a/pkg/controllers/nodeclaim/consistency/controller.go
+++ b/pkg/controllers/nodeclaim/consistency/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim
 			return reconcile.Result{}, fmt.Errorf("checking node with %T, %w", check, err)
 		}
 		for _, issue := range issues {
-			log.FromContext(ctx).Error(err, "Consistency error")
+			log.FromContext(ctx).Error(err, "consistency error")
 			consistencyErrors.With(prometheus.Labels{checkLabel: reflect.TypeOf(check).Elem().Name()}).Inc()
 			c.recorder.Publish(FailedConsistencyCheckEvent(nodeClaim, string(issue)))
 		}

--- a/pkg/controllers/nodeclaim/consistency/controller.go
+++ b/pkg/controllers/nodeclaim/consistency/controller.go
@@ -26,10 +26,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -73,7 +73,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, recorder events.Re
 }
 
 func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("nodeclaim.consistency").With("nodeclaim", nodeClaim.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodeclaim.consistency").WithValues("nodeclaim", nodeClaim.Name))
 	ctx = injection.WithControllerName(ctx, "nodeclaim.consistency")
 
 	if nodeClaim.Status.ProviderID == "" {
@@ -102,7 +102,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim
 			return reconcile.Result{}, fmt.Errorf("checking node with %T, %w", check, err)
 		}
 		for _, issue := range issues {
-			logging.FromContext(ctx).Errorf("check failed, %s", issue)
+			log.FromContext(ctx).Error(err, "check failed")
 			consistencyErrors.With(prometheus.Labels{checkLabel: reflect.TypeOf(check).Elem().Name()}).Inc()
 			c.recorder.Publish(FailedConsistencyCheckEvent(nodeClaim, string(issue)))
 		}

--- a/pkg/controllers/nodeclaim/consistency/suite_test.go
+++ b/pkg/controllers/nodeclaim/consistency/suite_test.go
@@ -29,9 +29,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/consistency"

--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -26,10 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -70,7 +70,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, cluster *state.Clu
 
 // Reconcile executes a control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("nodeclaim.disruption").With("nodeclaim", nodeClaim.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodeclaim.disruption").WithValues("nodeclaim", nodeClaim.Name))
 	ctx = injection.WithControllerName(ctx, "nodeclaim.disruption")
 
 	if !nodeClaim.DeletionTimestamp.IsZero() {

--- a/pkg/controllers/nodeclaim/disruption/suite_test.go
+++ b/pkg/controllers/nodeclaim/disruption/suite_test.go
@@ -27,9 +27,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -96,13 +96,11 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			errs[i] = client.IgnoreNotFound(err)
 			return
 		}
-		logging.FromContext(ctx).
-			With(
-				"nodeclaim", nodeClaims[i].Name,
-				"provider-id", nodeClaims[i].Status.ProviderID,
-				"nodepool", nodeClaims[i].Labels[v1beta1.NodePoolLabelKey],
-			).
-			Debugf("garbage collecting nodeclaim with no cloudprovider representation")
+		log.FromContext(ctx).WithValues(
+			"nodeclaim", nodeClaims[i].Name,
+			"provider-id", nodeClaims[i].Status.ProviderID,
+			"nodepool", nodeClaims[i].Labels[v1beta1.NodePoolLabelKey],
+		).V(1).Info("garbage collecting nodeclaim with no cloudprovider representation")
 		metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
 			metrics.ReasonLabel:       "garbage_collected",
 			metrics.NodePoolLabel:     nodeClaims[i].Labels[v1beta1.NodePoolLabelKey],

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -32,7 +32,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -27,10 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
@@ -77,7 +77,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider clou
 }
 
 func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("nodeclaim.lifecycle").With("nodeclaim", nodeClaim.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodeclaim.lifecycle").WithValues("nodeclaim", nodeClaim.Name))
 	ctx = injection.WithControllerName(ctx, "nodeclaim.lifecycle")
 
 	if !nodeClaim.DeletionTimestamp.IsZero() {

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -83,7 +83,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 		switch {
 		case cloudprovider.IsInsufficientCapacityError(err):
 			l.recorder.Publish(InsufficientCapacityErrorEvent(nodeClaim, err))
-			log.FromContext(ctx).Error(fmt.Errorf("failed to launch nodeClaim, %w", err), "NodeClaim lifecycle error")
+			log.FromContext(ctx).Error(fmt.Errorf("launching nodeclaim, %w", err), "NodeClaim lifecycle error")
 
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 				return nil, client.IgnoreNotFound(err)

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -83,7 +83,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 		switch {
 		case cloudprovider.IsInsufficientCapacityError(err):
 			l.recorder.Publish(InsufficientCapacityErrorEvent(nodeClaim, err))
-			log.FromContext(ctx).Error(fmt.Errorf("launching nodeclaim, %w", err), "nodeClaim lifecycle error")
+			log.FromContext(ctx).Error(err, "failed launching nodeclaim")
 
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 				return nil, client.IgnoreNotFound(err)

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -83,7 +83,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 		switch {
 		case cloudprovider.IsInsufficientCapacityError(err):
 			l.recorder.Publish(InsufficientCapacityErrorEvent(nodeClaim, err))
-			log.FromContext(ctx).Error(fmt.Errorf("launching nodeclaim, %w", err), "NodeClaim lifecycle error")
+			log.FromContext(ctx).Error(fmt.Errorf("launching nodeclaim, %w", err), "nodeClaim lifecycle error")
 
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 				return nil, client.IgnoreNotFound(err)

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -83,7 +83,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 		switch {
 		case cloudprovider.IsInsufficientCapacityError(err):
 			l.recorder.Publish(InsufficientCapacityErrorEvent(nodeClaim, err))
-			log.FromContext(ctx).Error(err, "falied to launch nodeClaim")
+			log.FromContext(ctx).Error(fmt.Errorf("failed to launch nodeClaim, %w", err), "NodeClaim lifecycle error")
 
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 				return nil, client.IgnoreNotFound(err)

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -24,8 +24,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -83,7 +83,8 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 		switch {
 		case cloudprovider.IsInsufficientCapacityError(err):
 			l.recorder.Publish(InsufficientCapacityErrorEvent(nodeClaim, err))
-			logging.FromContext(ctx).Error(err)
+			log.FromContext(ctx).Error(err, "falied to launch nodeClaim")
+
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -102,12 +103,12 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 			return nil, fmt.Errorf("launching nodeclaim, %w", err)
 		}
 	}
-	logging.FromContext(ctx).With(
+	log.FromContext(ctx).WithValues(
 		"provider-id", created.Status.ProviderID,
 		"instance-type", created.Labels[v1.LabelInstanceTypeStable],
 		"zone", created.Labels[v1.LabelTopologyZone],
 		"capacity-type", created.Labels[v1beta1.CapacityTypeLabelKey],
-		"allocatable", created.Status.Allocatable).Infof("launched nodeclaim")
+		"allocatable", created.Status.Allocatable).Info("launched nodeclaim")
 	return created, nil
 }
 

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -55,7 +55,7 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) 
 	if err := l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	logging.FromContext(ctx).With("ttl", registrationTTL).Infof("terminating due to registration ttl")
+	log.FromContext(ctx).V(1).WithValues("ttl", registrationTTL).Info("terminating due to registration ttl")
 	metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
 		metrics.ReasonLabel:       "liveness",
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -28,9 +28,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/nodeclaim/termination/controller.go
+++ b/pkg/controllers/nodeclaim/termination/controller.go
@@ -26,13 +26,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/workqueue"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -60,7 +60,7 @@ func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudPr
 }
 
 func (c *Controller) Reconcile(ctx context.Context, n *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("nodeclaim.termination").With("nodeclaim", n.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodeclaim.termination").WithValues("nodeclaim", n.Name))
 	ctx = injection.WithControllerName(ctx, "nodeclaim.termination")
 
 	if !n.GetDeletionTimestamp().IsZero() {
@@ -71,7 +71,7 @@ func (c *Controller) Reconcile(ctx context.Context, n *v1beta1.NodeClaim) (recon
 
 //nolint:gocyclo
 func (c *Controller) finalize(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", nodeClaim.Status.NodeName, "provider-id", nodeClaim.Status.ProviderID))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("node", nodeClaim.Status.NodeName, "provider-id", nodeClaim.Status.ProviderID))
 	stored := nodeClaim.DeepCopy()
 	if !controllerutil.ContainsFinalizer(nodeClaim, v1beta1.TerminationFinalizer) {
 		return reconcile.Result{}, nil
@@ -109,7 +109,7 @@ func (c *Controller) finalize(ctx context.Context, nodeClaim *v1beta1.NodeClaim)
 			}
 			return reconcile.Result{}, client.IgnoreNotFound(fmt.Errorf("removing termination finalizer, %w", err))
 		}
-		logging.FromContext(ctx).Infof("deleted nodeclaim")
+		log.FromContext(ctx).Info("deleted nodeclaim")
 	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclaim/termination/suite_test.go
+++ b/pkg/controllers/nodeclaim/termination/suite_test.go
@@ -29,9 +29,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	nodeclaimtermination "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/termination"
 

--- a/pkg/controllers/nodepool/counter/controller.go
+++ b/pkg/controllers/nodepool/counter/controller.go
@@ -23,8 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/logging"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
@@ -33,7 +34,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/utils/functional"
 
 	v1 "k8s.io/api/core/v1"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -58,7 +58,7 @@ func NewController(kubeClient client.Client, cluster *state.Cluster) *Controller
 
 // Reconcile a control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("nodepool.counter").With("nodepool", nodePool.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodepool.counter").WithValues("nodepool", nodePool.Name))
 	ctx = injection.WithControllerName(ctx, "nodepool.counter")
 
 	// We need to ensure that our internal cluster state mechanism is synced before we proceed

--- a/pkg/controllers/nodepool/counter/suite_test.go
+++ b/pkg/controllers/nodepool/counter/suite_test.go
@@ -27,8 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 

--- a/pkg/controllers/nodepool/hash/controller.go
+++ b/pkg/controllers/nodepool/hash/controller.go
@@ -22,10 +22,10 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -48,7 +48,7 @@ func NewController(kubeClient client.Client) *Controller {
 
 // Reconcile the resource
 func (c *Controller) Reconcile(ctx context.Context, np *v1beta1.NodePool) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("nodepool.hash").With("nodepool", np.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodepool.hash").WithValues("nodepool", np.Name))
 	ctx = injection.WithControllerName(ctx, "nodepool.hash")
 
 	stored := np.DeepCopy()

--- a/pkg/controllers/nodepool/hash/suite_test.go
+++ b/pkg/controllers/nodepool/hash/suite_test.go
@@ -27,11 +27,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 
-	"sigs.k8s.io/karpenter/pkg/apis"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/controllers/nodepool/hash"

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -54,8 +54,8 @@ func NewPodController(kubeClient client.Client, provisioner *Provisioner, record
 
 // Reconcile the resource
 func (c *PodController) Reconcile(ctx context.Context, p *v1.Pod) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("provisioner.trigger.pod").With("pod", client.ObjectKeyFromObject(p).String())) //nolint:ineffassign,staticcheck
-	ctx = injection.WithControllerName(ctx, "provisioner.trigger.pod")                                                                           //nolint:ineffassign,staticcheck
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("provisioner.trigger.pod").WithValues("pod", client.ObjectKeyFromObject(p).String())) //nolint:ineffassign,staticcheck
+	ctx = injection.WithControllerName(ctx, "provisioner.trigger.pod")                                                                             //nolint:ineffassign,staticcheck
 
 	if !pod.IsProvisionable(p) {
 		return reconcile.Result{}, nil
@@ -95,8 +95,8 @@ func NewNodeController(kubeClient client.Client, provisioner *Provisioner, recor
 // Reconcile the resource
 func (c *NodeController) Reconcile(ctx context.Context, n *v1.Node) (reconcile.Result, error) {
 	//nolint:ineffassign
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("provisioner.trigger.node").With("node", n.Name)) //nolint:ineffassign,staticcheck
-	ctx = injection.WithControllerName(ctx, "provisioner.trigger.node")                                            //nolint:ineffassign,staticcheck
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("provisioner.trigger.node").WithValues("node", n.Name)) //nolint:ineffassign,staticcheck
+	ctx = injection.WithControllerName(ctx, "provisioner.trigger.node")                                              //nolint:ineffassign,staticcheck
 
 	// If the disruption taint doesn't exist or the deletion timestamp isn't set, it's not being disrupted.
 	// We don't check the deletion timestamp here, as we expect the termination controller to eventually set

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -159,7 +159,7 @@ func (p *Provisioner) GetPendingPods(ctx context.Context) ([]*v1.Pod, error) {
 	}
 	return lo.Reject(pods, func(po *v1.Pod, _ int) bool {
 		if err := p.Validate(ctx, po); err != nil {
-			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(po)).V(1).Info("ignoring pod, %s", err)
+			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(po)).V(1).Info(fmt.Sprintf("ignoring pod, %s", err))
 			return true
 		}
 		p.consolidationWarnings(ctx, po)
@@ -199,7 +199,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	}
 	nodePoolList.Items = lo.Filter(nodePoolList.Items, func(n v1beta1.NodePool, _ int) bool {
 		if err := n.RuntimeValidate(); err != nil {
-			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(err, "nodepool failed validation, %s")
+			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(err, "nodepool failed validation")
 			return false
 		}
 		return n.DeletionTimestamp.IsZero()
@@ -221,7 +221,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 		if err != nil {
 			// we just log an error and skip the provisioner to prevent a single mis-configured provisioner from stopping
 			// all scheduling
-			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(err, "skipping, unable to resolve instance types, %s")
+			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(err, "skipping, unable to resolve instance types")
 			continue
 		}
 		if len(instanceTypeOptions) == 0 {
@@ -437,7 +437,7 @@ func (p *Provisioner) injectVolumeTopologyRequirements(ctx context.Context, pods
 	var schedulablePods []*v1.Pod
 	for _, pod := range pods {
 		if err := p.volumeTopology.Inject(ctx, pod); err != nil {
-			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(err, "getting volume topology requirements, %s")
+			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(err, "getting volume topology requirements")
 		} else {
 			schedulablePods = append(schedulablePods, pod)
 		}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -31,12 +31,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nodeutil "sigs.k8s.io/karpenter/pkg/utils/node"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/operator/controller"
@@ -116,7 +117,7 @@ func (p *Provisioner) Reconcile(ctx context.Context, _ reconcile.Request) (resul
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !p.cluster.Synced(ctx) {
-		logging.FromContext(ctx).Debugf("waiting on cluster sync")
+		log.FromContext(ctx).V(1).Info("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 
@@ -158,7 +159,7 @@ func (p *Provisioner) GetPendingPods(ctx context.Context) ([]*v1.Pod, error) {
 	}
 	return lo.Reject(pods, func(po *v1.Pod, _ int) bool {
 		if err := p.Validate(ctx, po); err != nil {
-			logging.FromContext(ctx).With("pod", client.ObjectKeyFromObject(po)).Debugf("ignoring pod, %s", err)
+			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(po)).V(1).Info("ignoring pod, %s", err)
 			return true
 		}
 		p.consolidationWarnings(ctx, po)
@@ -174,14 +175,14 @@ func (p *Provisioner) consolidationWarnings(ctx context.Context, po *v1.Pod) {
 	if po.Spec.Affinity != nil && po.Spec.Affinity.PodAntiAffinity != nil {
 		if len(po.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0 {
 			if p.cm.HasChanged(string(po.UID), "pod-antiaffinity") {
-				logging.FromContext(ctx).Infof("pod %q has a preferred Anti-Affinity which can prevent consolidation", client.ObjectKeyFromObject(po))
+				log.FromContext(ctx).Info(fmt.Sprintf("pod %s has a preferred Anti-Affinity which can prevent consolidation", client.ObjectKeyFromObject(po)))
 			}
 		}
 	}
 	for _, tsc := range po.Spec.TopologySpreadConstraints {
 		if tsc.WhenUnsatisfiable == v1.ScheduleAnyway {
 			if p.cm.HasChanged(string(po.UID), "pod-topology-spread") {
-				logging.FromContext(ctx).Infof("pod %q has a preferred TopologySpreadConstraint which can prevent consolidation", client.ObjectKeyFromObject(po))
+				log.FromContext(ctx).Info(fmt.Sprintf("pod %s has a preferred TopologySpreadConstraint which can prevent consolidation", client.ObjectKeyFromObject(po)))
 			}
 		}
 	}
@@ -198,7 +199,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	}
 	nodePoolList.Items = lo.Filter(nodePoolList.Items, func(n v1beta1.NodePool, _ int) bool {
 		if err := n.RuntimeValidate(); err != nil {
-			logging.FromContext(ctx).With("nodepool", n.Name).Errorf("nodepool failed validation, %s", err)
+			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(err, "nodepool failed validation, %s")
 			return false
 		}
 		return n.DeletionTimestamp.IsZero()
@@ -220,11 +221,12 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 		if err != nil {
 			// we just log an error and skip the provisioner to prevent a single mis-configured provisioner from stopping
 			// all scheduling
-			logging.FromContext(ctx).With("nodepool", nodePool.Name).Errorf("skipping, unable to resolve instance types, %s", err)
+			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(err, "skipping, unable to resolve instance types, %s")
 			continue
 		}
 		if len(instanceTypeOptions) == 0 {
-			logging.FromContext(ctx).With("nodepool", nodePool.Name).Info("skipping, no resolved instance types found")
+			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Info("skipping, no resolved instance types found")
+
 			continue
 		}
 		instanceTypes[nodePool.Name] = append(instanceTypes[nodePool.Name], instanceTypeOptions...)
@@ -315,23 +317,21 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	s, err := p.NewScheduler(ctx, pods, nodes.Active())
 	if err != nil {
 		if errors.Is(err, ErrNodePoolsNotFound) {
-			logging.FromContext(ctx).Info(ErrNodePoolsNotFound)
+			log.FromContext(ctx).Info(ErrNodePoolsNotFound.Error())
 			return scheduler.Results{}, nil
 		}
 		return scheduler.Results{}, fmt.Errorf("creating scheduler, %w", err)
 	}
 	results := s.Solve(ctx, pods).TruncateInstanceTypes(scheduler.MaxInstanceTypes)
 	if len(results.NewNodeClaims) > 0 {
-		logging.FromContext(ctx).With("pods", pretty.Slice(lo.Map(pods, func(p *v1.Pod, _ int) string { return client.ObjectKeyFromObject(p).String() }), 5)).
-			With("duration", time.Since(start)).
-			Infof("found provisionable pod(s)")
+		log.FromContext(ctx).WithValues("pods", pretty.Slice(lo.Map(pods, func(p *v1.Pod, _ int) string { return client.ObjectKeyFromObject(p).String() }), 5), "duration", time.Since(start)).Info("found provisionable pod(s)")
 	}
 	results.Record(ctx, p.recorder, p.cluster)
 	return results, nil
 }
 
 func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts ...functional.Option[LaunchOptions]) (string, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("nodepool", n.NodePoolName))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("nodepool", n.NodePoolName))
 	options := functional.ResolveOptions(opts...)
 	latest := &v1beta1.NodePool{}
 	if err := p.kubeClient.Get(ctx, types.NamespacedName{Name: n.NodePoolName}, latest); err != nil {
@@ -348,7 +348,9 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 	instanceTypeRequirement, _ := lo.Find(nodeClaim.Spec.Requirements, func(req v1beta1.NodeSelectorRequirementWithMinValues) bool {
 		return req.Key == v1.LabelInstanceTypeStable
 	})
-	logging.FromContext(ctx).With("nodeclaim", nodeClaim.Name, "requests", nodeClaim.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).Infof("created nodeclaim")
+
+	log.FromContext(ctx).WithValues("nodeclaim", nodeClaim.Name, "requests", nodeClaim.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).
+		Info("created nodeclaim")
 	metrics.NodeClaimsCreatedCounter.With(prometheus.Labels{
 		metrics.ReasonLabel:       options.Reason,
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
@@ -435,7 +437,7 @@ func (p *Provisioner) injectVolumeTopologyRequirements(ctx context.Context, pods
 	var schedulablePods []*v1.Pod
 	for _, pod := range pods {
 		if err := p.volumeTopology.Inject(ctx, pod); err != nil {
-			logging.FromContext(ctx).With("pod", client.ObjectKeyFromObject(pod)).Errorf("getting volume topology requirements, %s", err)
+			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(err, "getting volume topology requirements, %s")
 		} else {
 			schedulablePods = append(schedulablePods, pod)
 		}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -199,7 +199,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	}
 	nodePoolList.Items = lo.Filter(nodePoolList.Items, func(n v1beta1.NodePool, _ int) bool {
 		if err := n.RuntimeValidate(); err != nil {
-			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(fmt.Errorf("nodepool failed validation, %w", err), "Provisioner error")
+			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(fmt.Errorf("nodepool failed validation, %w", err), "provisioner error")
 			return false
 		}
 		return n.DeletionTimestamp.IsZero()
@@ -221,7 +221,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 		if err != nil {
 			// we just log an error and skip the provisioner to prevent a single mis-configured provisioner from stopping
 			// all scheduling
-			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(fmt.Errorf("skipping, unable to resolve instance types %w", err), "Provisioner error")
+			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(fmt.Errorf("skipping, unable to resolve instance types %w", err), "provisioner error")
 			continue
 		}
 		if len(instanceTypeOptions) == 0 {
@@ -317,7 +317,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	s, err := p.NewScheduler(ctx, pods, nodes.Active())
 	if err != nil {
 		if errors.Is(err, ErrNodePoolsNotFound) {
-			log.FromContext(ctx).Info(ErrNodePoolsNotFound.Error())
+			log.FromContext(ctx).Error(ErrNodePoolsNotFound, "nodepool not found")
 			return scheduler.Results{}, nil
 		}
 		return scheduler.Results{}, fmt.Errorf("creating scheduler, %w", err)
@@ -437,7 +437,7 @@ func (p *Provisioner) injectVolumeTopologyRequirements(ctx context.Context, pods
 	var schedulablePods []*v1.Pod
 	for _, pod := range pods {
 		if err := p.volumeTopology.Inject(ctx, pod); err != nil {
-			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(fmt.Errorf("getting volume topology requirements, %w", err), "Provisioner error")
+			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(fmt.Errorf("getting volume topology requirements, %w", err), "provisioner error")
 		} else {
 			schedulablePods = append(schedulablePods, pod)
 		}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -199,7 +199,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	}
 	nodePoolList.Items = lo.Filter(nodePoolList.Items, func(n v1beta1.NodePool, _ int) bool {
 		if err := n.RuntimeValidate(); err != nil {
-			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(err, "nodepool failed validation")
+			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(fmt.Errorf("nodepool failed validation, %w", err), "Provisioner error")
 			return false
 		}
 		return n.DeletionTimestamp.IsZero()
@@ -221,7 +221,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 		if err != nil {
 			// we just log an error and skip the provisioner to prevent a single mis-configured provisioner from stopping
 			// all scheduling
-			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(err, "skipping, unable to resolve instance types")
+			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(fmt.Errorf("skipping, unable to resolve instance types %w", err), "Provisioner error")
 			continue
 		}
 		if len(instanceTypeOptions) == 0 {
@@ -437,7 +437,7 @@ func (p *Provisioner) injectVolumeTopologyRequirements(ctx context.Context, pods
 	var schedulablePods []*v1.Pod
 	for _, pod := range pods {
 		if err := p.volumeTopology.Inject(ctx, pod); err != nil {
-			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(err, "getting volume topology requirements")
+			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(fmt.Errorf("getting volume topology requirements, %w", err), "Provisioner error")
 		} else {
 			schedulablePods = append(schedulablePods, pod)
 		}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -199,7 +199,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	}
 	nodePoolList.Items = lo.Filter(nodePoolList.Items, func(n v1beta1.NodePool, _ int) bool {
 		if err := n.RuntimeValidate(); err != nil {
-			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(fmt.Errorf("nodepool failed validation, %w", err), "provisioner error")
+			log.FromContext(ctx).WithValues("nodepool", n.Name).Error(err, "nodepool failed validation")
 			return false
 		}
 		return n.DeletionTimestamp.IsZero()
@@ -221,7 +221,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 		if err != nil {
 			// we just log an error and skip the provisioner to prevent a single mis-configured provisioner from stopping
 			// all scheduling
-			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(fmt.Errorf("skipping, unable to resolve instance types %w", err), "provisioner error")
+			log.FromContext(ctx).WithValues("nodepool", nodePool.Name).Error(err, "skipping, unable to resolve instance types")
 			continue
 		}
 		if len(instanceTypeOptions) == 0 {
@@ -317,7 +317,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	s, err := p.NewScheduler(ctx, pods, nodes.Active())
 	if err != nil {
 		if errors.Is(err, ErrNodePoolsNotFound) {
-			log.FromContext(ctx).Error(ErrNodePoolsNotFound, "nodepool not found")
+			log.FromContext(ctx).Info("no nodepools found")
 			return scheduler.Results{}, nil
 		}
 		return scheduler.Results{}, fmt.Errorf("creating scheduler, %w", err)
@@ -437,7 +437,7 @@ func (p *Provisioner) injectVolumeTopologyRequirements(ctx context.Context, pods
 	var schedulablePods []*v1.Pod
 	for _, pod := range pods {
 		if err := p.volumeTopology.Inject(ctx, pod); err != nil {
-			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(fmt.Errorf("getting volume topology requirements, %w", err), "provisioner error")
+			log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)).Error(err, "failed getting volume topology requirements")
 		} else {
 			schedulablePods = append(schedulablePods, pod)
 		}

--- a/pkg/controllers/provisioning/scheduling/preferences.go
+++ b/pkg/controllers/provisioning/scheduling/preferences.go
@@ -51,7 +51,7 @@ func (p *Preferences) Relax(ctx context.Context, pod *v1.Pod) bool {
 
 	for _, relaxFunc := range relaxations {
 		if reason := relaxFunc(pod); reason != nil {
-			log.FromContext(ctx).V(1).Info("relaxing soft constraints for pod since it previously failed to schedule, %s", ptr.StringValue(reason))
+			log.FromContext(ctx).V(1).Info(fmt.Sprintf("relaxing soft constraints for pod since it previously failed to schedule, %s", ptr.StringValue(reason)))
 			return true
 		}
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -28,8 +28,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
@@ -104,7 +104,7 @@ type Results struct {
 func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *state.Cluster) {
 	// Report failures and nominations
 	for p, err := range r.PodErrors {
-		logging.FromContext(ctx).With("pod", client.ObjectKeyFromObject(p)).Errorf("Could not schedule pod, %s", err)
+		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(err, "Could not schedule pod, %s")
 		recorder.Publish(PodFailedToScheduleEvent(p, err))
 	}
 	for _, existing := range r.ExistingNodes {
@@ -123,7 +123,7 @@ func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *
 	if newCount == 0 {
 		return
 	}
-	logging.FromContext(ctx).With("nodeclaims", len(r.NewNodeClaims), "pods", newCount).Infof("computed new nodeclaim(s) to fit pod(s)")
+	log.FromContext(ctx).WithValues("nodeclaims", len(r.NewNodeClaims), "pods", newCount).Info("computed new nodeclaim(s) to fit pod(s)")
 	// Report in flight newNodes, or exit to avoid log spam
 	inflightCount := 0
 	existingCount := 0
@@ -134,7 +134,7 @@ func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *
 	if existingCount == 0 {
 		return
 	}
-	logging.FromContext(ctx).Infof("computed %d unready node(s) will fit %d pod(s)", inflightCount, existingCount)
+	log.FromContext(ctx).Info("computed %d unready node(s) will fit %d pod(s)", inflightCount, existingCount)
 }
 
 // AllNonPendingPodsScheduled returns true if all pods scheduled.
@@ -223,7 +223,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*v1.Pod) Results {
 		q.Push(pod, relaxed)
 		if relaxed {
 			if err := s.topology.Update(ctx, pod); err != nil {
-				logging.FromContext(ctx).Errorf("updating topology, %s", err)
+				log.FromContext(ctx).Error(err, "updating topology, %s")
 			}
 		}
 	}
@@ -273,7 +273,8 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 				errs = multierr.Append(errs, fmt.Errorf("all available instance types exceed limits for nodepool: %q", nodeClaimTemplate.NodePoolName))
 				continue
 			} else if len(s.instanceTypes[nodeClaimTemplate.NodePoolName]) != len(instanceTypes) {
-				logging.FromContext(ctx).With("nodepool", nodeClaimTemplate.NodePoolName).Debugf("%d out of %d instance types were excluded because they would breach limits",
+
+				log.FromContext(ctx).V(1).WithValues("nodepool", nodeClaimTemplate.NodePoolName).Info("%d out of %d instance types were excluded because they would breach limits",
 					len(s.instanceTypes[nodeClaimTemplate.NodePoolName])-len(instanceTypes), len(s.instanceTypes[nodeClaimTemplate.NodePoolName]))
 			}
 		}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -104,7 +104,7 @@ type Results struct {
 func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *state.Cluster) {
 	// Report failures and nominations
 	for p, err := range r.PodErrors {
-		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(fmt.Errorf("could not schedule pod, %w", err), "scheduler error")
+		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(err, "could not schedule pod")
 		recorder.Publish(PodFailedToScheduleEvent(p, err))
 	}
 	for _, existing := range r.ExistingNodes {
@@ -223,7 +223,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*v1.Pod) Results {
 		q.Push(pod, relaxed)
 		if relaxed {
 			if err := s.topology.Update(ctx, pod); err != nil {
-				log.FromContext(ctx).Error(fmt.Errorf("updating topology, %w", err), "scheduler error")
+				log.FromContext(ctx).Error(err, "failed updating topology")
 			}
 		}
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -104,7 +104,7 @@ type Results struct {
 func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *state.Cluster) {
 	// Report failures and nominations
 	for p, err := range r.PodErrors {
-		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(err, "could not schedule pod")
+		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(fmt.Errorf("could not schedule pod, %w", err), "Scheduler error")
 		recorder.Publish(PodFailedToScheduleEvent(p, err))
 	}
 	for _, existing := range r.ExistingNodes {
@@ -223,7 +223,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*v1.Pod) Results {
 		q.Push(pod, relaxed)
 		if relaxed {
 			if err := s.topology.Update(ctx, pod); err != nil {
-				log.FromContext(ctx).Error(err, "updating topology")
+				log.FromContext(ctx).Error(fmt.Errorf("updating topology, %w", err), "Scheduler error")
 			}
 		}
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -104,7 +104,7 @@ type Results struct {
 func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *state.Cluster) {
 	// Report failures and nominations
 	for p, err := range r.PodErrors {
-		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(fmt.Errorf("could not schedule pod, %w", err), "Scheduler error")
+		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(fmt.Errorf("could not schedule pod, %w", err), "scheduler error")
 		recorder.Publish(PodFailedToScheduleEvent(p, err))
 	}
 	for _, existing := range r.ExistingNodes {
@@ -223,7 +223,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*v1.Pod) Results {
 		q.Push(pod, relaxed)
 		if relaxed {
 			if err := s.topology.Update(ctx, pod); err != nil {
-				log.FromContext(ctx).Error(fmt.Errorf("updating topology, %w", err), "Scheduler error")
+				log.FromContext(ctx).Error(fmt.Errorf("updating topology, %w", err), "scheduler error")
 			}
 		}
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -104,7 +104,7 @@ type Results struct {
 func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *state.Cluster) {
 	// Report failures and nominations
 	for p, err := range r.PodErrors {
-		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(err, "Could not schedule pod, %s")
+		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(err, "could not schedule pod")
 		recorder.Publish(PodFailedToScheduleEvent(p, err))
 	}
 	for _, existing := range r.ExistingNodes {
@@ -134,7 +134,7 @@ func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *
 	if existingCount == 0 {
 		return
 	}
-	log.FromContext(ctx).Info("computed %d unready node(s) will fit %d pod(s)", inflightCount, existingCount)
+	log.FromContext(ctx).Info(fmt.Sprintf("computed %d unready node(s) will fit %d pod(s)", inflightCount, existingCount))
 }
 
 // AllNonPendingPodsScheduled returns true if all pods scheduled.
@@ -223,7 +223,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*v1.Pod) Results {
 		q.Push(pod, relaxed)
 		if relaxed {
 			if err := s.topology.Update(ctx, pod); err != nil {
-				log.FromContext(ctx).Error(err, "updating topology, %s")
+				log.FromContext(ctx).Error(err, "updating topology")
 			}
 		}
 	}
@@ -274,8 +274,8 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 				continue
 			} else if len(s.instanceTypes[nodeClaimTemplate.NodePoolName]) != len(instanceTypes) {
 
-				log.FromContext(ctx).V(1).WithValues("nodepool", nodeClaimTemplate.NodePoolName).Info("%d out of %d instance types were excluded because they would breach limits",
-					len(s.instanceTypes[nodeClaimTemplate.NodePoolName])-len(instanceTypes), len(s.instanceTypes[nodeClaimTemplate.NodePoolName]))
+				log.FromContext(ctx).V(1).WithValues("nodepool", nodeClaimTemplate.NodePoolName).Info(fmt.Sprintf("%d out of %d instance types were excluded because they would breach limits",
+					len(s.instanceTypes[nodeClaimTemplate.NodePoolName])-len(instanceTypes), len(s.instanceTypes[nodeClaimTemplate.NodePoolName])))
 			}
 		}
 		nodeClaim := NewNodeClaim(nodeClaimTemplate, s.topology, s.daemonOverhead[nodeClaimTemplate], instanceTypes)

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -36,10 +36,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
 	fakecr "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/logging"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -47,6 +46,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
+	operatorlogging "sigs.k8s.io/karpenter/pkg/operator/logging"
 	"sigs.k8s.io/karpenter/pkg/test"
 
 	v1 "k8s.io/api/core/v1"
@@ -141,7 +141,7 @@ func TestSchedulingProfile(t *testing.T) {
 
 func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 	// disable logging
-	ctx = logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+	ctx = ctrl.IntoContext(context.Background(), operatorlogging.NopLogger)
 	nodePoolWithMinValues := test.NodePool(v1beta1.NodePool{
 		Spec: v1beta1.NodePoolSpec{
 			Template: v1beta1.NodeClaimTemplate{

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -58,8 +58,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )

--- a/pkg/controllers/provisioning/scheduling/volumetopology.go
+++ b/pkg/controllers/provisioning/scheduling/volumetopology.go
@@ -72,7 +72,7 @@ func (v *VolumeTopology) Inject(ctx context.Context, pod *v1.Pod) error {
 
 	log.FromContext(ctx).
 		WithValues("pod", client.ObjectKeyFromObject(pod)).
-		V(1).Info("adding requirements derived from pod volumes, %s", requirements)
+		V(1).Info(fmt.Sprintf("adding requirements derived from pod volumes, %s", requirements))
 	return nil
 }
 

--- a/pkg/controllers/provisioning/scheduling/volumetopology.go
+++ b/pkg/controllers/provisioning/scheduling/volumetopology.go
@@ -24,8 +24,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	volumeutil "sigs.k8s.io/karpenter/pkg/utils/volume"
 )
@@ -70,9 +70,9 @@ func (v *VolumeTopology) Inject(ctx context.Context, pod *v1.Pod) error {
 			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions, requirements...)
 	}
 
-	logging.FromContext(ctx).
-		With("pod", client.ObjectKeyFromObject(pod)).
-		Debugf("adding requirements derived from pod volumes, %s", requirements)
+	log.FromContext(ctx).
+		WithValues("pod", client.ObjectKeyFromObject(pod)).
+		V(1).Info("adding requirements derived from pod volumes, %s", requirements)
 	return nil
 }
 

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -32,9 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -34,9 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -93,12 +94,12 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	}()
 	nodeClaimList := &v1beta1.NodeClaimList{}
 	if err := c.kubeClient.List(ctx, nodeClaimList); err != nil {
-		logging.FromContext(ctx).Errorf("checking cluster state sync, %v", err)
+		log.FromContext(ctx).Error(err, "checking cluster state sync, %v")
 		return false
 	}
 	nodeList := &v1.NodeList{}
 	if err := c.kubeClient.List(ctx, nodeList); err != nil {
-		logging.FromContext(ctx).Errorf("checking cluster state sync, %v", err)
+		log.FromContext(ctx).Error(err, "checking cluster state sync, %v")
 		return false
 	}
 	c.mu.RLock()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -94,12 +94,12 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	}()
 	nodeClaimList := &v1beta1.NodeClaimList{}
 	if err := c.kubeClient.List(ctx, nodeClaimList); err != nil {
-		log.FromContext(ctx).Error(fmt.Errorf("checking cluster state sync, %w", err), "cluster state error")
+		log.FromContext(ctx).Error(err, "failed checking cluster state sync")
 		return false
 	}
 	nodeList := &v1.NodeList{}
 	if err := c.kubeClient.List(ctx, nodeList); err != nil {
-		log.FromContext(ctx).Error(fmt.Errorf("checking cluster state sync, %w", err), "cluster state error")
+		log.FromContext(ctx).Error(err, "failed checking cluster state sync")
 		return false
 	}
 	c.mu.RLock()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -94,12 +94,12 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	}()
 	nodeClaimList := &v1beta1.NodeClaimList{}
 	if err := c.kubeClient.List(ctx, nodeClaimList); err != nil {
-		log.FromContext(ctx).Error(err, "checking cluster state sync")
+		log.FromContext(ctx).Error(fmt.Errorf("checking cluster state sync, %w", err), "Cluster state error")
 		return false
 	}
 	nodeList := &v1.NodeList{}
 	if err := c.kubeClient.List(ctx, nodeList); err != nil {
-		log.FromContext(ctx).Error(err, "checking cluster state sync")
+		log.FromContext(ctx).Error(fmt.Errorf("checking cluster state sync, %w", err), "Cluster state error")
 		return false
 	}
 	c.mu.RLock()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -94,12 +94,12 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	}()
 	nodeClaimList := &v1beta1.NodeClaimList{}
 	if err := c.kubeClient.List(ctx, nodeClaimList); err != nil {
-		log.FromContext(ctx).Error(fmt.Errorf("checking cluster state sync, %w", err), "Cluster state error")
+		log.FromContext(ctx).Error(fmt.Errorf("checking cluster state sync, %w", err), "cluster state error")
 		return false
 	}
 	nodeList := &v1.NodeList{}
 	if err := c.kubeClient.List(ctx, nodeList); err != nil {
-		log.FromContext(ctx).Error(fmt.Errorf("checking cluster state sync, %w", err), "Cluster state error")
+		log.FromContext(ctx).Error(fmt.Errorf("checking cluster state sync, %w", err), "cluster state error")
 		return false
 	}
 	c.mu.RLock()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -94,12 +94,12 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	}()
 	nodeClaimList := &v1beta1.NodeClaimList{}
 	if err := c.kubeClient.List(ctx, nodeClaimList); err != nil {
-		log.FromContext(ctx).Error(err, "checking cluster state sync, %v")
+		log.FromContext(ctx).Error(err, "checking cluster state sync")
 		return false
 	}
 	nodeList := &v1.NodeList{}
 	if err := c.kubeClient.List(ctx, nodeList); err != nil {
-		log.FromContext(ctx).Error(err, "checking cluster state sync, %v")
+		log.FromContext(ctx).Error(err, "checking cluster state sync")
 		return false
 	}
 	c.mu.RLock()

--- a/pkg/controllers/state/informer/daemonset.go
+++ b/pkg/controllers/state/informer/daemonset.go
@@ -22,10 +22,10 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -47,7 +47,7 @@ func NewDaemonSetController(kubeClient client.Client, cluster *state.Cluster) *D
 }
 
 func (c *DaemonSetController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("state.daemonset").With("daemonset", req.String()))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.daemonset").WithValues("daemonset", req.String()))
 	ctx = injection.WithControllerName(ctx, "state.daemonset")
 
 	daemonSet := appsv1.DaemonSet{}

--- a/pkg/controllers/state/informer/node.go
+++ b/pkg/controllers/state/informer/node.go
@@ -21,10 +21,11 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"knative.dev/pkg/logging"
+
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -48,7 +49,7 @@ func NewNodeController(kubeClient client.Client, cluster *state.Cluster) *NodeCo
 }
 
 func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("state.node").With("node", req.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.node").WithValues("node", req.Name))
 	ctx = injection.WithControllerName(ctx, "state.node")
 
 	node := &v1.Node{}

--- a/pkg/controllers/state/informer/nodeclaim.go
+++ b/pkg/controllers/state/informer/nodeclaim.go
@@ -20,10 +20,10 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -48,7 +48,7 @@ func NewNodeClaimController(kubeClient client.Client, cluster *state.Cluster) *N
 }
 
 func (c *NodeClaimController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("state.nodeclaim").With("nodeclaim", req.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.nodeclaim").WithValues("nodeclaim", req.Name))
 	ctx = injection.WithControllerName(ctx, "state.nodeclaim")
 
 	nodeClaim := &v1beta1.NodeClaim{}

--- a/pkg/controllers/state/informer/nodepool.go
+++ b/pkg/controllers/state/informer/nodepool.go
@@ -19,11 +19,11 @@ package informer
 import (
 	"context"
 
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -49,8 +49,8 @@ func NewNodePoolController(kubeClient client.Client, cluster *state.Cluster) *No
 
 func (c *NodePoolController) Reconcile(ctx context.Context, np *v1beta1.NodePool) (reconcile.Result, error) {
 	//nolint:ineffassign
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("state.nodepool").With("nodepool", np.Name)) //nolint:ineffassign,staticcheck
-	ctx = injection.WithControllerName(ctx, "state.nodepool")                                                 //nolint:ineffassign,staticcheck
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.nodepool").WithValues("nodepool", np.Name)) //nolint:ineffassign,staticcheck
+	ctx = injection.WithControllerName(ctx, "state.nodepool")                                                   //nolint:ineffassign,staticcheck
 
 	// Something changed in the NodePool so we should re-consider consolidation
 	c.cluster.MarkUnconsolidated()

--- a/pkg/controllers/state/informer/pod.go
+++ b/pkg/controllers/state/informer/pod.go
@@ -22,10 +22,10 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -50,7 +50,7 @@ func NewPodController(kubeClient client.Client, cluster *state.Cluster) *PodCont
 }
 
 func (c *PodController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("state.pod").With("pod", req.String()))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.pod").WithValues("pod", req.String()))
 	ctx = injection.WithControllerName(ctx, "state.pod")
 
 	pod := &v1.Pod{}

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -48,7 +48,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -119,7 +119,7 @@ func (s *Singleton) reconcile(ctx context.Context) time.Duration {
 	case err != nil:
 		reconcileErrors.WithLabelValues(s.name).Inc()
 		reconcileTotal.WithLabelValues(s.name, labelError).Inc()
-		log.FromContext(ctx).Error(err, "Reconciler error")
+		log.FromContext(ctx).Error(err, "reconciler error")
 		return s.rateLimiter.When(singletonRequest)
 	case res.Requeue:
 		reconcileTotal.WithLabelValues(s.name, labelRequeue).Inc()

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/util/workqueue"
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
@@ -94,9 +94,9 @@ var singletonRequest = reconcile.Request{}
 
 func (s *Singleton) Start(ctx context.Context) error {
 	ctx = injection.WithControllerName(ctx, s.name)
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named(s.name))
-	logging.FromContext(ctx).Infof("starting controller")
-	defer logging.FromContext(ctx).Infof("stopping controller")
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName(s.name))
+	log.FromContext(ctx).Info("starting controller")
+	defer log.FromContext(ctx).Info("stopping controller")
 
 	for {
 		select {
@@ -119,7 +119,7 @@ func (s *Singleton) reconcile(ctx context.Context) time.Duration {
 	case err != nil:
 		reconcileErrors.WithLabelValues(s.name).Inc()
 		reconcileTotal.WithLabelValues(s.name, labelError).Inc()
-		logging.FromContext(ctx).Error(err)
+		log.FromContext(ctx).Error(err, "Reconciler error")
 		return s.rateLimiter.When(singletonRequest)
 	case res.Requeue:
 		reconcileTotal.WithLabelValues(s.name, labelRequeue).Inc()

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -95,8 +95,8 @@ var singletonRequest = reconcile.Request{}
 func (s *Singleton) Start(ctx context.Context) error {
 	ctx = injection.WithControllerName(ctx, s.name)
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName(s.name))
-	log.FromContext(ctx).Info("starting controller")
-	defer log.FromContext(ctx).Info("stopping controller")
+	log.FromContext(ctx).Info("Starting controller")
+	defer log.FromContext(ctx).Info("Stopping controller")
 
 	for {
 		select {
@@ -119,7 +119,7 @@ func (s *Singleton) reconcile(ctx context.Context) time.Duration {
 	case err != nil:
 		reconcileErrors.WithLabelValues(s.name).Inc()
 		reconcileTotal.WithLabelValues(s.name, labelError).Inc()
-		log.FromContext(ctx).Error(err, "reconciler error")
+		log.FromContext(ctx).Error(err, "Reconciler error")
 		return s.rateLimiter.When(singletonRequest)
 	case res.Requeue:
 		reconcileTotal.WithLabelValues(s.name, labelRequeue).Inc()

--- a/pkg/operator/logging/logging.go
+++ b/pkg/operator/logging/logging.go
@@ -81,15 +81,15 @@ func DefaultZapConfig(ctx context.Context, component string) zap.Config {
 }
 
 // NewLogger returns a configured *zap.SugaredLogger
-func NewLogger(ctx context.Context, component string) *zap.SugaredLogger {
+func NewLogger(ctx context.Context, component string) *zap.Logger {
 	if logger := loggerFromFile(ctx, component); logger != nil {
-		logger.Debugf("loaded log configuration from file %q", loggerCfgFilePath)
+		logger.Debug(fmt.Sprintf("loaded log configuration from file %q", loggerCfgFilePath))
 		return logger
 	}
 	return defaultLogger(ctx, component)
 }
 
-func WithCommit(logger *zap.SugaredLogger) *zap.SugaredLogger {
+func WithCommit(logger *zap.Logger) *zap.Logger {
 	revision := changeset.Get()
 	if revision == changeset.Unknown {
 		logger.Info("Unable to read vcs.revision from binary")
@@ -99,11 +99,11 @@ func WithCommit(logger *zap.SugaredLogger) *zap.SugaredLogger {
 	return logger.With(zap.String(logkey.Commit, revision))
 }
 
-func defaultLogger(ctx context.Context, component string) *zap.SugaredLogger {
-	return WithCommit(lo.Must(DefaultZapConfig(ctx, component).Build()).Sugar()).Named(component)
+func defaultLogger(ctx context.Context, component string) *zap.Logger {
+	return WithCommit(lo.Must(DefaultZapConfig(ctx, component).Build())).Named(component)
 }
 
-func loggerFromFile(ctx context.Context, component string) *zap.SugaredLogger {
+func loggerFromFile(ctx context.Context, component string) *zap.Logger {
 	raw, err := os.ReadFile(loggerCfgFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -121,7 +121,7 @@ func loggerFromFile(ctx context.Context, component string) *zap.SugaredLogger {
 	if raw != nil {
 		cfg.Level = lo.Must(zap.ParseAtomicLevel(string(raw)))
 	}
-	return WithCommit(lo.Must(cfg.Build()).Sugar()).Named(component)
+	return WithCommit(lo.Must(cfg.Build())).Named(component)
 }
 
 type ignoreDebugEventsSink struct {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -55,7 +55,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	zapr "sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"github.com/go-logr/zapr"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/events"
@@ -135,7 +135,7 @@ func NewOperator() (context.Context, *Operator) {
 	kubernetesInterface := kubernetes.NewForConfigOrDie(config)
 
 	// Logging
-	logger := zapr.New().WithName(component)
+	logger := zapr.NewLogger(logging.NewLogger(ctx, component))
 	log.SetLogger(logger)
 	klog.SetLogger(logger)
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -28,14 +28,16 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/klog/v2"
 	"knative.dev/pkg/changeset"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/karpenter/pkg/operator/controller"
 
 	"sigs.k8s.io/karpenter/pkg/metrics"
 
-	"github.com/go-logr/zapr"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -44,16 +46,16 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/utils/clock"
 	knativeinjection "knative.dev/pkg/injection"
-	knativelogging "knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	zapr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/events"
@@ -69,13 +71,16 @@ const (
 	component = "controller"
 )
 
-var BuildInfo = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Namespace: metrics.Namespace,
-		Name:      "build_info",
-		Help:      "A metric with a constant '1' value labeled by version from which karpenter was built.",
-	},
-	[]string{"version", "goversion", "goarch", "commit"},
+var (
+	BuildInfo = prometheus.NewGaugeVec(
+
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Name:      "build_info",
+			Help:      "A metric with a constant '1' value labeled by version from which karpenter was built.",
+		},
+		[]string{"version", "goversion", "goarch", "commit"},
+	)
 )
 
 // Version is the karpenter app version injected during compilation
@@ -122,7 +127,7 @@ func NewOperator() (context.Context, *Operator) {
 	})
 
 	// Client Config
-	config := controllerruntime.GetConfigOrDie()
+	config := ctrl.GetConfigOrDie()
 	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(float32(options.FromContext(ctx).KubeClientQPS), options.FromContext(ctx).KubeClientBurst)
 	config.UserAgent = fmt.Sprintf("%s/%s", appName, Version)
 
@@ -130,15 +135,15 @@ func NewOperator() (context.Context, *Operator) {
 	kubernetesInterface := kubernetes.NewForConfigOrDie(config)
 
 	// Logging
-	logger := logging.NewLogger(ctx, component)
-	ctx = knativelogging.WithLogger(ctx, logger)
-	logging.ConfigureGlobalLoggers(ctx)
+	logger := zapr.New().WithName(component)
+	log.SetLogger(logger)
+	klog.SetLogger(logger)
 
-	knativelogging.FromContext(ctx).With("version", Version).Debugf("discovered karpenter version")
+	log.FromContext(ctx).WithValues("version", Version).V(1).Info("discovered karpenter version")
 
 	// Manager
-	mgrOpts := controllerruntime.Options{
-		Logger:                        logging.IgnoreDebugEvents(zapr.NewLogger(logger.Desugar())),
+	mgrOpts := ctrl.Options{
+		Logger:                        logging.IgnoreDebugEvents(logger),
 		LeaderElection:                options.FromContext(ctx).EnableLeaderElection,
 		LeaderElectionID:              "karpenter-leader-election",
 		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
@@ -150,8 +155,7 @@ func NewOperator() (context.Context, *Operator) {
 		},
 		HealthProbeBindAddress: fmt.Sprintf(":%d", options.FromContext(ctx).HealthProbePort),
 		BaseContext: func() context.Context {
-			ctx := context.Background()
-			ctx = knativelogging.WithLogger(ctx, logger)
+			ctx := log.IntoContext(context.Background(), logger)
 			ctx = injection.WithOptionsOrDie(ctx, options.Injectables...)
 			return ctx
 		},
@@ -180,7 +184,7 @@ func NewOperator() (context.Context, *Operator) {
 			"/debug/pprof/threadcreate": pprof.Handler("threadcreate"),
 		})
 	}
-	mgr, err := controllerruntime.NewManager(config, mgrOpts)
+	mgr, err := ctrl.NewManager(config, mgrOpts)
 	mgr = lo.Must(mgr, err, "failed to setup manager")
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.Pod{}, "spec.nodeName", func(o client.Object) []string {
 		return []string{o.(*v1.Pod).Spec.NodeName}
@@ -239,7 +243,7 @@ func (o *Operator) Start(ctx context.Context) {
 		lo.Must0(o.Manager.Start(ctx))
 	}()
 	if options.FromContext(ctx).DisableWebhook {
-		knativelogging.FromContext(ctx).Infof("webhook disabled")
+		log.FromContext(ctx).Info("webhook disabled")
 	} else {
 		wg.Add(1)
 		go func() {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -73,7 +73,6 @@ const (
 
 var (
 	BuildInfo = prometheus.NewGaugeVec(
-
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Name:      "build_info",

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -26,7 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/test"

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -88,7 +88,7 @@ func GetVolumes(ctx context.Context, kubeClient client.Client, pod *v1.Pod) (Vol
 		// computing limits, otherwise Karpenter may never be able to update its cluster state.
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(fmt.Errorf("failed tracking CSI volume limits for volume, %w", err), "volume usage tracking error")
+				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(err, "failed tracking CSI volume limits for volume")
 				continue
 			}
 			return nil, fmt.Errorf("failed updating volume limits, %w", err)

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -88,7 +88,7 @@ func GetVolumes(ctx context.Context, kubeClient client.Client, pod *v1.Pod) (Vol
 		// computing limits, otherwise Karpenter may never be able to update its cluster state.
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(fmt.Errorf("failed tracking CSI volume limits for volume, %w", err), "Volume usage tracking error")
+				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(fmt.Errorf("failed tracking CSI volume limits for volume, %w", err), "volume usage tracking error")
 				continue
 			}
 			return nil, fmt.Errorf("failed updating volume limits, %w", err)

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -28,8 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	csitranslation "k8s.io/csi-translation-lib"
 	"k8s.io/csi-translation-lib/plugins"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	volumeutil "sigs.k8s.io/karpenter/pkg/utils/volume"
 )
@@ -87,7 +88,7 @@ func GetVolumes(ctx context.Context, kubeClient client.Client, pod *v1.Pod) (Vol
 		// computing limits, otherwise Karpenter may never be able to update its cluster state.
 		if err != nil {
 			if errors.IsNotFound(err) {
-				logging.FromContext(ctx).With("pod", pod.Name, "volume", volume.Name).Errorf("failed tracking CSI volume limits for volume, %w", err)
+				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(err, "failed tracking CSI volume limits for volume, %w")
 				continue
 			}
 			return nil, fmt.Errorf("failed updating volume limits, %w", err)
@@ -133,7 +134,7 @@ func resolveDriver(ctx context.Context, kubeClient client.Client, pod *v1.Pod, v
 	// In either of these cases, a PV must have been previously bound to the PVC and has since been removed. We can
 	// ignore this PVC while computing limits and continue.
 	if storageClassName == "" {
-		logging.FromContext(ctx).With("pod", pod.Name, "volume", volumeName, "pvc", pvc.Name).Debugf("failed tracking CSI volume limits for volume with unbound PVC, no storage class specified")
+		log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volumeName, "pvc", pvc.Name).V(1).Info("failed tracking CSI volume limits for volume with unbound PVC, no storage class specified")
 		return "", nil
 	}
 
@@ -144,7 +145,7 @@ func resolveDriver(ctx context.Context, kubeClient client.Client, pod *v1.Pod, v
 		//  2. The StorageClass never existed and was used to bind the PVC to an existing PV, but that PV was removed
 		// In either of these cases, we should ignore the PVC while computing limits and continue.
 		if errors.IsNotFound(err) {
-			logging.FromContext(ctx).With("pod", pod.Name, "volume", volumeName, "pvc", pvc.Name, "storageclass", storageClassName).Debugf("failed tracking CSI volume limits for volume with unbound PVC, %w", err)
+			log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volumeName, "pvc", pvc.Name, "storageclass", storageClassName).V(1).Info("failed tracking CSI volume limits for volume with unbound PVC, %w")
 			return "", nil
 		}
 		return "", err

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -88,7 +88,7 @@ func GetVolumes(ctx context.Context, kubeClient client.Client, pod *v1.Pod) (Vol
 		// computing limits, otherwise Karpenter may never be able to update its cluster state.
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(err, "failed tracking CSI volume limits for volume, %w")
+				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(err, "failed tracking CSI volume limits for volume")
 				continue
 			}
 			return nil, fmt.Errorf("failed updating volume limits, %w", err)
@@ -145,7 +145,7 @@ func resolveDriver(ctx context.Context, kubeClient client.Client, pod *v1.Pod, v
 		//  2. The StorageClass never existed and was used to bind the PVC to an existing PV, but that PV was removed
 		// In either of these cases, we should ignore the PVC while computing limits and continue.
 		if errors.IsNotFound(err) {
-			log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volumeName, "pvc", pvc.Name, "storageclass", storageClassName).V(1).Info("failed tracking CSI volume limits for volume with unbound PVC, %w")
+			log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volumeName, "pvc", pvc.Name, "storageclass", storageClassName).V(1).Info(fmt.Sprintf("failed tracking CSI volume limits for volume with unbound PVC, %s", err))
 			return "", nil
 		}
 		return "", err

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -88,7 +88,7 @@ func GetVolumes(ctx context.Context, kubeClient client.Client, pod *v1.Pod) (Vol
 		// computing limits, otherwise Karpenter may never be able to update its cluster state.
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(err, "failed tracking CSI volume limits for volume")
+				log.FromContext(ctx).WithValues("pod", pod.Name, "volume", volume.Name).Error(fmt.Errorf("failed tracking CSI volume limits for volume, %w", err), "Volume usage tracking error")
 				continue
 			}
 			return nil, fmt.Errorf("failed updating volume limits, %w", err)

--- a/pkg/utils/nodeclaim/suite_test.go
+++ b/pkg/utils/nodeclaim/suite_test.go
@@ -26,12 +26,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/operator/scheme"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/scheduling"

--- a/pkg/utils/testing/util.go
+++ b/pkg/utils/testing/util.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"knative.dev/pkg/logging"
+)
+
+// TestLogger gets a logger to use in unit and end to end tests
+func TestLogger(t zaptest.TestingT) *zap.SugaredLogger {
+	opts := zaptest.WrapOptions(
+		zap.AddCaller(),
+		zap.Development(),
+	)
+
+	return zaptest.NewLogger(t, opts).Sugar()
+}
+
+// TestContextWithLogger returns a context with a logger to be used in tests
+func TestContextWithLogger(t zaptest.TestingT) context.Context {
+	return logging.WithLogger(context.Background(), TestLogger(t))
+}

--- a/pkg/utils/testing/util.go
+++ b/pkg/utils/testing/util.go
@@ -19,23 +19,17 @@ package testing
 import (
 	"context"
 
+	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// TestLogger gets a logger to use in unit and end to end tests
-func TestLogger(t zaptest.TestingT) *zap.SugaredLogger {
+// TestContextWithLogger returns a context with a logger to be used in tests
+func TestContextWithLogger(t zaptest.TestingT) context.Context {
 	opts := zaptest.WrapOptions(
 		zap.AddCaller(),
 		zap.Development(),
 	)
-
-	return zaptest.NewLogger(t, opts).Sugar()
-}
-
-// TestContextWithLogger returns a context with a logger to be used in tests
-func TestContextWithLogger(t zaptest.TestingT) context.Context {
-	return logging.WithLogger(context.Background(), TestLogger(t))
+	return log.IntoContext(context.Background(), zapr.NewLogger(zaptest.NewLogger(t, opts)))
 }

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -90,7 +90,7 @@ func NewConfigValidationWebhook(ctx context.Context, _ configmap.Watcher) *contr
 // https://github.com/knative/pkg/blob/0f52db700d63/injection/sharedmain/main.go#L227
 func Start(ctx context.Context, cfg *rest.Config, ctors ...knativeinjection.ControllerConstructor) {
 	ctx, startInformers := knativeinjection.EnableInjectionOrDie(ctx, cfg)
-	logger := logging.NewLogger(ctx, component)
+	logger := logging.NewLogger(ctx, component).Sugar()
 	ctx = knativelogging.WithLogger(ctx, logger)
 	cmw := sharedmain.SetupConfigMapWatchOrDie(ctx, knativelogging.FromContext(ctx))
 	controllers, webhooks := sharedmain.ControllersAndWebhooksFromCtors(ctx, cmw, ctors...)
@@ -118,7 +118,7 @@ func Start(ctx context.Context, cfg *rest.Config, ctors ...knativeinjection.Cont
 			ConfigMap:      lo.Must(metrics.NewObservabilityConfigFromConfigMap(nil)).GetConfigMap().Data,
 			Secrets:        sharedmain.SecretFetcher(ctx),
 			PrometheusPort: options.FromContext(ctx).WebhookMetricsPort,
-		}, logging.NewLogger(ctx, component)))
+		}, logger))
 		// Register webhook metrics
 		webhook.RegisterMetrics()
 

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -87,9 +87,10 @@ func NewConfigValidationWebhook(ctx context.Context, _ configmap.Watcher) *contr
 // Start copies the relevant portions for starting the webhooks from sharedmain.MainWithConfig
 // https://github.com/knative/pkg/blob/0f52db700d63/injection/sharedmain/main.go#L227
 func Start(ctx context.Context, cfg *rest.Config, ctors ...knativeinjection.ControllerConstructor) {
-	ctx, startInformers := knativeinjection.EnableInjectionOrDie(ctx, cfg)
 	logger := logging.NewLogger(ctx, component).Sugar()
 	ctx = knativelogging.WithLogger(ctx, logger)
+
+	ctx, startInformers := knativeinjection.EnableInjectionOrDie(ctx, cfg)
 	cmw := sharedmain.SetupConfigMapWatchOrDie(ctx, logger)
 	controllers, webhooks := sharedmain.ControllersAndWebhooksFromCtors(ctx, cmw, ctors...)
 


### PR DESCRIPTION
Fixes:  https://github.com/kubernetes-sigs/karpenter/issues/922

**Description**
Migrate knative logger to controller-runtime injected logger

After this change the logging messages look like below

```
{"level":"info","ts":"2024-03-14T10:13:26Z","logger":"controller","msg":"discovered karpenter version","version":"unspecified"}
{"level":"info","ts":"2024-03-14T10:13:26Z","logger":"controller","msg":"webhook disabled"}
{"level":"info","ts":"2024-03-14T10:13:26Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-03-14T10:13:26Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8000","secure":false}
{"level":"info","ts":"2024-03-14T10:13:26Z","logger":"controller","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":1710411206.3906345,"logger":"fallback","caller":"leaderelection/leaderelection.go:250","msg":"attempting to acquire leader lease kube-system/karpenter-leader-election..."}
{"level":"info","ts":1710411221.86726,"logger":"fallback","caller":"leaderelection/leaderelection.go:260","msg":"successfully acquired lease kube-system/karpenter-leader-election"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller.provisioner","msg":"starting controller"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller.disruption.queue","msg":"starting controller"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller.eviction-queue","msg":"starting controller"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"provisioner.trigger.pod","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"provisioner.trigger.pod","controllerGroup":"","controllerKind":"Pod"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"provisioner.trigger.pod","controllerGroup":"","controllerKind":"Pod","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller.disruption","msg":"starting controller"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodepool.hash","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1beta1.NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"nodepool.hash","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"provisioner.trigger.node","controllerGroup":"","controllerKind":"Node","source":"kind source: *v1.Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"provisioner.trigger.node","controllerGroup":"","controllerKind":"Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"state.node","controllerGroup":"","controllerKind":"Node","source":"kind source: *v1.Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"state.node","controllerGroup":"","controllerKind":"Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"state.daemonset","controllerGroup":"apps","controllerKind":"DaemonSet","source":"kind source: *v1.DaemonSet"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"state.daemonset","controllerGroup":"apps","controllerKind":"DaemonSet"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"state.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1beta1.NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"state.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"state.pod","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"state.pod","controllerGroup":"","controllerKind":"Pod"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"node.termination","controllerGroup":"","controllerKind":"Node","source":"kind source: *v1.Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"node.termination","controllerGroup":"","controllerKind":"Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"state.nodeclaim","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1beta1.NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"state.nodeclaim","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"metrics.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1beta1.NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"metrics.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"metrics.pod","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"metrics.pod","controllerGroup":"","controllerKind":"Pod"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1beta1.NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1beta1.NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller.metrics.node","msg":"starting controller"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1beta1.NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.consistency","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1beta1.NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.consistency","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"nodeclaim.consistency","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.termination","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1beta1.NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.termination","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.Node"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"nodeclaim.termination","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller.nodeclaim.garbagecollection","msg":"starting controller"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"lease.garbagecollection","controllerGroup":"coordination.k8s.io","controllerKind":"Lease","source":"kind source: *v1.Lease"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"lease.garbagecollection","controllerGroup":"coordination.k8s.io","controllerKind":"Lease"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1beta1.NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1beta1.NodePool"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting EventSource","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.Pod"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting Controller","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller.disruption","msg":"waiting on cluster sync"}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"nodepool.hash","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"provisioner.trigger.node","controllerGroup":"","controllerKind":"Node","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"state.node","controllerGroup":"","controllerKind":"Node","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"state.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"state.pod","controllerGroup":"","controllerKind":"Pod","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"node.termination","controllerGroup":"","controllerKind":"Node","worker count":100}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"state.nodeclaim","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"metrics.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":1}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"metrics.pod","controllerGroup":"","controllerKind":"Pod","worker count":1}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":1000}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"nodeclaim.consistency","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"nodeclaim.termination","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":100}
{"level":"info","ts":"2024-03-14T10:13:41Z","logger":"controller","msg":"Starting workers","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:42Z","logger":"controller","msg":"Starting workers","controller":"lease.garbagecollection","controllerGroup":"coordination.k8s.io","controllerKind":"Lease","worker count":10}
{"level":"info","ts":"2024-03-14T10:13:42Z","logger":"controller","msg":"Starting workers","controller":"state.daemonset","controllerGroup":"apps","controllerKind":"DaemonSet","worker count":10}
```

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
