### PR TITLE
test: Add minValues to the NodePool requirements for benchmark testing.

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -96,10 +96,10 @@ func BenchmarkScheduling5000(b *testing.B) {
 	benchmarkScheduler(b, 400, 5000)
 }
 
-var includeMinValues *bool
+var includeMinValues bool
 
 func init() {
-	includeMinValues = flag.Bool("minValues", false, "include minValues in NodePool requirement")
+	flag.BoolVar(&includeMinValues, "minValues", false, "include minValues in NodePool requirement")
 }
 
 // TestSchedulingProfile is used to gather profiling metrics, benchmarking is primarily done with standard
@@ -135,7 +135,7 @@ func TestSchedulingProfile(t *testing.T) {
 			totalNodes += int(nodeCount)
 		}
 	}
-	fmt.Println("scheduled", totalPods, "against", totalNodes, "nodes in total in", totalTime, "with minValues included", *includeMinValues, float64(totalPods)/totalTime.Seconds(), "pods/sec")
+	fmt.Println("scheduled", totalPods, "against", totalNodes, "nodes in total in", totalTime, "with minValues included", includeMinValues, float64(totalPods)/totalTime.Seconds(), "pods/sec")
 	tw.Flush()
 }
 
@@ -160,7 +160,7 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 		},
 	})
 	nodePoolWithoutMinValues := test.NodePool()
-	nodePool := lo.Ternary(*includeMinValues, nodePoolWithMinValues, nodePoolWithoutMinValues)
+	nodePool := lo.Ternary(includeMinValues, nodePoolWithMinValues, nodePoolWithoutMinValues)
 	instanceTypes := fake.InstanceTypes(instanceCount)
 	cloudProvider = fake.NewCloudProvider()
 	cloudProvider.InstanceTypes = instanceTypes

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -154,13 +154,6 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 							},
 							MinValues: lo.ToPtr(50),
 						},
-						{
-							NodeSelectorRequirement: v1.NodeSelectorRequirement{
-								Key:      v1.LabelArchStable,
-								Operator: v1.NodeSelectorOpExists,
-							},
-							MinValues: lo.ToPtr(1),
-						},
 					},
 				},
 			},

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -152,7 +152,7 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 								Key:      v1.LabelInstanceTypeStable,
 								Operator: v1.NodeSelectorOpExists,
 							},
-							MinValues: lo.ToPtr(50),
+							MinValues: lo.ToPtr(50), // Adding highest possible minValues and safest way to add it would be to instanceType requirement.
 						},
 					},
 				},


### PR DESCRIPTION
**Description**
This PR adds minValues to the NodePool requirements for benchmark testing. This is added conditionally through a flag. So, to add minValues to the scheduling benchmark tests, you will have to run the below command:
```
go test -tags=test_performance -run=SchedulingProfile -minValues=true
```

By default, this is false since this is an optional field provided by the customer and is currently an ALPHA field.

**How was this change tested?**

`make presumbit`

Ran default command:
```
go test -tags=test_performance -run=SchedulingProfile
scheduled 10110 against 1690 nodes in total in 9.76606419s with minValues included false 1035.2174431079588 pods/sec
400 instances 10 pods    2 nodes    3.057932ms per scheduling    305.793µs per pod
400 instances 100 pods   17 nodes   37.709693ms per scheduling   377.096µs per pod
400 instances 500 pods   83 nodes   196.165732ms per scheduling  392.331µs per pod
400 instances 1000 pods  167 nodes  380.358472ms per scheduling  380.358µs per pod
400 instances 1500 pods  253 nodes  4.6531495s per scheduling    3.102099ms per pod
400 instances 2000 pods  334 nodes  831.605166ms per scheduling  415.802µs per pod
400 instances 5000 pods  834 nodes  2.256804542s per scheduling  451.36µs per pod
PASS
ok  	sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling	22.687s
```

Ran the command with minValues=true:
```
go test -tags=test_performance -run=SchedulingProfile -minValues=true
scheduled 10110 against 1690 nodes in total in 7.063416504s with minValues included true 1431.3186818694219 pods/sec
400 instances 10 pods    2 nodes    4.231954ms per scheduling    423.195µs per pod
400 instances 100 pods   17 nodes   48.402656ms per scheduling   484.026µs per pod
400 instances 500 pods   83 nodes   252.061958ms per scheduling  504.123µs per pod
400 instances 1000 pods  167 nodes  503.843396ms per scheduling  503.843µs per pod
400 instances 1500 pods  253 nodes  1.214069416s per scheduling  809.379µs per pod
400 instances 2000 pods  334 nodes  1.11161677s per scheduling   555.808µs per pod
400 instances 5000 pods  834 nodes  2.920281208s per scheduling  584.056µs per pod
PASS
ok  	sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling	14.023s
```
