### PR TITLE
chore: Display CPU and Memory on nodepools, with -o wide you also get limits!

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -20,6 +20,20 @@ spec:
         - jsonPath: .spec.template.spec.nodeClassRef.name
           name: NodeClass
           type: string
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          type: string
+        - jsonPath: .spec.limits.cpu
+          name: CPU_Limit
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          type: string
+        - jsonPath: .spec.limits.memory
+          name: MEM_Limit
+          priority: 1
+          type: string
         - jsonPath: .spec.weight
           name: Weight
           priority: 1


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1054  <!-- issue number -->

**Description**: Added information already available so it's visible in the kubectl get

Output : 
```
[karpenter]$ k get nodepools.karpenter.sh
NAME            NODECLASS       CPU   MEMORY
default         default         10    19846992Ki
karpenter-pub   karpenter-pub
karpenter-wl1   karpenter-wl1

[karpenter]$ k get nodepools.karpenter.sh -o wide
NAME            NODECLASS       CPU   CPU_LIMIT   MEMORY       MEM_LIMIT   WEIGHT
default         default         10    500         19846992Ki   20Ti
karpenter-pub   karpenter-pub         1k
karpenter-wl1   karpenter-wl1         400
```

**How was this change tested?**: make build && make test && kubectl apply -f karpenter.sh_nodepools.yaml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
