### PR TITLE
feat: add ignore resource requests arg

### DIFF
--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -55,7 +55,7 @@ const (
 
 var (
 	// RestrictedLabelDomains are either prohibited by the kubelet or reserved by karpenter
-	RestrictedLabelDomains = sets.New(
+	RestrictedLabelDomains = sets.New[string](
 		"kubernetes.io",
 		"k8s.io",
 		Group,
@@ -63,7 +63,7 @@ var (
 
 	// LabelDomainExceptions are sub-domains of the RestrictedLabelDomains but allowed because
 	// they are not used in a context where they may be passed as argument to kubelet.
-	LabelDomainExceptions = sets.New(
+	LabelDomainExceptions = sets.New[string](
 		"kops.k8s.io",
 		v1.LabelNamespaceSuffixNode,
 		v1.LabelNamespaceNodeRestriction,
@@ -72,7 +72,7 @@ var (
 	// WellKnownLabels are labels that belong to the RestrictedLabelDomains but allowed.
 	// Karpenter is aware of these labels, and they can be used to further narrow down
 	// the range of the corresponding values by either nodepool or pods.
-	WellKnownLabels = sets.New(
+	WellKnownLabels = sets.New[string](
 		NodePoolLabelKey,
 		v1.LabelTopologyZone,
 		v1.LabelTopologyRegion,

--- a/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"strings"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/ptr"
 
 	. "sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sort"
 	"sync"
 
@@ -98,7 +99,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *v1beta1.NodeClaim
 	instanceTypes := lo.Filter(lo.Must(c.GetInstanceTypes(ctx, np)), func(i *cloudprovider.InstanceType, _ int) bool {
 		return reqs.Compatible(i.Requirements, scheduling.AllowUndefinedWellKnownLabels) == nil &&
 			len(i.Offerings.Compatible(reqs).Available()) > 0 &&
-			resources.Fits(nodeClaim.Spec.Resources.Requests, i.Allocatable())
+			resources.Fits(nodeClaim.Spec.Resources.Requests, i.Allocatable(), options.FromContext(ctx).IgnoredResourceRequests.Keys)
 	})
 	// Order instance types so that we get the cheapest instance types of the available offerings
 	sort.Slice(instanceTypes, func(i, j int) bool {

--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -19,6 +19,7 @@ package scheduling
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -84,7 +85,7 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 	// node, which at this point can't be increased in size
 	requests := resources.Merge(n.requests, resources.RequestsForPods(pod))
 
-	if !resources.Fits(requests, n.Available()) {
+	if !resources.Fits(requests, n.Available(), options.FromContext(ctx).IgnoredResourceRequests.Keys) {
 		return fmt.Errorf("exceeds node resources")
 	}
 

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -17,7 +17,9 @@ limitations under the License.
 package scheduling
 
 import (
+	"context"
 	"fmt"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"strings"
 	"sync/atomic"
 
@@ -64,7 +66,7 @@ func NewNodeClaim(nodeClaimTemplate *NodeClaimTemplate, topology *Topology, daem
 	}
 }
 
-func (n *NodeClaim) Add(pod *v1.Pod) error {
+func (n *NodeClaim) Add(ctx context.Context, pod *v1.Pod) error {
 	// Check Taints
 	if err := scheduling.Taints(n.Spec.Taints).Tolerates(pod); err != nil {
 		return err
@@ -103,7 +105,7 @@ func (n *NodeClaim) Add(pod *v1.Pod) error {
 	// Check instance type combinations
 	requests := resources.Merge(n.Spec.Resources.Requests, resources.RequestsForPods(pod))
 
-	filtered := filterInstanceTypesByRequirements(n.InstanceTypeOptions, nodeClaimRequirements, requests)
+	filtered := filterInstanceTypesByRequirements(n.InstanceTypeOptions, nodeClaimRequirements, requests, options.FromContext(ctx).IgnoredResourceRequests.Keys)
 
 	if len(filtered.remaining) == 0 {
 		// log the total resources being requested (daemonset + the pod)
@@ -230,7 +232,7 @@ func (r filterResults) FailureReason() string {
 }
 
 //nolint:gocyclo
-func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceType, requirements scheduling.Requirements, requests v1.ResourceList) filterResults {
+func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceType, requirements scheduling.Requirements, requests, ignored v1.ResourceList) filterResults {
 	results := filterResults{
 		requests:        requests,
 		requirementsMet: false,
@@ -246,7 +248,7 @@ func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceTy
 		// the tradeoff to not short circuiting on the filtering is that we can report much better error messages
 		// about why scheduling failed
 		itCompat := compatible(it, requirements)
-		itFits := fits(it, requests)
+		itFits := fits(it, requests, ignored)
 		itHasOffering := hasOffering(it, requirements)
 
 		// track if any single instance type met a single criteria
@@ -278,8 +280,8 @@ func compatible(instanceType *cloudprovider.InstanceType, requirements schedulin
 	return instanceType.Requirements.Intersects(requirements) == nil
 }
 
-func fits(instanceType *cloudprovider.InstanceType, requests v1.ResourceList) bool {
-	return resources.Fits(requests, instanceType.Allocatable())
+func fits(instanceType *cloudprovider.InstanceType, requests, ignored v1.ResourceList) bool {
+	return resources.Fits(requests, instanceType.Allocatable(), ignored)
 }
 
 func hasOffering(instanceType *cloudprovider.InstanceType, requirements scheduling.Requirements) bool {

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -259,7 +259,7 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 
 	// Pick existing node that we are about to create
 	for _, nodeClaim := range s.newNodeClaims {
-		if err := nodeClaim.Add(pod); err == nil {
+		if err := nodeClaim.Add(ctx, pod); err == nil {
 			return nil
 		}
 	}
@@ -280,7 +280,7 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 			}
 		}
 		nodeClaim := NewNodeClaim(nodeClaimTemplate, s.topology, s.daemonOverhead[nodeClaimTemplate], instanceTypes)
-		if err := nodeClaim.Add(pod); err != nil {
+		if err := nodeClaim.Add(ctx, pod); err != nil {
 			errs = multierr.Append(errs, fmt.Errorf("incompatible with nodepool %q, daemonset overhead=%s, %w",
 				nodeClaimTemplate.NodePoolName,
 				resources.String(s.daemonOverhead[nodeClaimTemplate]),

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -21,7 +21,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -45,23 +48,29 @@ type FeatureGates struct {
 	SpotToSpotConsolidation bool
 }
 
+type IgnoredResourceRequests struct {
+	Keys     v1.ResourceList
+	inputStr string
+}
+
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
 type Options struct {
-	ServiceName          string
-	DisableWebhook       bool
-	WebhookPort          int
-	MetricsPort          int
-	WebhookMetricsPort   int
-	HealthProbePort      int
-	KubeClientQPS        int
-	KubeClientBurst      int
-	EnableProfiling      bool
-	EnableLeaderElection bool
-	MemoryLimit          int64
-	LogLevel             string
-	BatchMaxDuration     time.Duration
-	BatchIdleDuration    time.Duration
-	FeatureGates         FeatureGates
+	ServiceName             string
+	DisableWebhook          bool
+	WebhookPort             int
+	MetricsPort             int
+	WebhookMetricsPort      int
+	HealthProbePort         int
+	KubeClientQPS           int
+	KubeClientBurst         int
+	EnableProfiling         bool
+	EnableLeaderElection    bool
+	MemoryLimit             int64
+	LogLevel                string
+	BatchMaxDuration        time.Duration
+	BatchIdleDuration       time.Duration
+	FeatureGates            FeatureGates
+	IgnoredResourceRequests IgnoredResourceRequests
 }
 
 type FlagSet struct {
@@ -97,6 +106,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "Drift=true,SpotToSpotConsolidation=false"), "Optional features can be enabled / disabled using feature gates. Current options are: Drift,SpotToSpotConsolidation")
+	fs.StringVar(&o.IgnoredResourceRequests.inputStr, "ignored-resource-requests", env.WithDefaultString("IGNORED_RESOURCE_REQUESTS", ""), "List of resource requests ignored when electing a resource. Items are comma-separated.")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {
@@ -115,6 +125,9 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 		return fmt.Errorf("parsing feature gates, %w", err)
 	}
 	o.FeatureGates = gates
+
+	o.IgnoredResourceRequests = ParseIgnoredResourceRequests(o.IgnoredResourceRequests.inputStr)
+
 	return nil
 }
 
@@ -139,6 +152,22 @@ func ParseFeatureGates(gateStr string) (FeatureGates, error) {
 	}
 
 	return gates, nil
+}
+
+func ParseIgnoredResourceRequests(inputStr string) IgnoredResourceRequests {
+	ignoredResourceRequests := strings.Split(inputStr, ",")
+	keys := make(v1.ResourceList)
+
+	// NOTE: Dummy value as quantity, resource request filtering is happening only against the key we want to ignore.
+	q, _ := resource.ParseQuantity("1")
+	for _, v := range ignoredResourceRequests {
+		keys[v1.ResourceName(v)] = q
+	}
+
+	return IgnoredResourceRequests{
+		Keys:     keys,
+		inputStr: inputStr,
+	}
 }
 
 func ToContext(ctx context.Context, opts *Options) context.Context {

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -19,6 +19,8 @@ package options_test
 import (
 	"context"
 	"flag"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"testing"
 	"time"
@@ -59,6 +61,7 @@ var _ = Describe("Options", func() {
 		"BATCH_MAX_DURATION",
 		"BATCH_IDLE_DURATION",
 		"FEATURE_GATES",
+		"IGNORED_RESOURCE_REQUESTS",
 	}
 
 	BeforeEach(func() {
@@ -112,6 +115,9 @@ var _ = Describe("Options", func() {
 				FeatureGates: test.FeatureGates{
 					Drift: lo.ToPtr(true),
 				},
+				IgnoredResourceRequests: &options.IgnoredResourceRequests{
+					Keys: make(v1.ResourceList),
+				},
 			}))
 		})
 
@@ -133,6 +139,7 @@ var _ = Describe("Options", func() {
 				"--batch-max-duration", "5s",
 				"--batch-idle-duration", "5s",
 				"--feature-gates", "Drift=true",
+				"--ignored-resource-requests", "devices.kubevirt.io/tun,devices.kubevirt.io/kvm",
 			)
 			Expect(err).To(BeNil())
 			expectOptionsMatch(opts, test.Options(test.OptionsFields{
@@ -153,6 +160,10 @@ var _ = Describe("Options", func() {
 				FeatureGates: test.FeatureGates{
 					Drift: lo.ToPtr(true),
 				},
+				IgnoredResourceRequests: &options.IgnoredResourceRequests{Keys: v1.ResourceList{
+					"devices.kubevirt.io/tun": resource.MustParse("1"),
+					"devices.kubevirt.io/kvm": resource.MustParse("1"),
+				}},
 			}))
 		})
 
@@ -172,6 +183,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("BATCH_MAX_DURATION", "5s")
 			os.Setenv("BATCH_IDLE_DURATION", "5s")
 			os.Setenv("FEATURE_GATES", "Drift=true")
+			os.Setenv("IGNORED_RESOURCE_REQUESTS", "devices.kubevirt.io/tun")
 			fs = &options.FlagSet{
 				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
 			}
@@ -196,6 +208,7 @@ var _ = Describe("Options", func() {
 				FeatureGates: test.FeatureGates{
 					Drift: lo.ToPtr(true),
 				},
+				IgnoredResourceRequests: &options.IgnoredResourceRequests{Keys: v1.ResourceList{}},
 			}))
 		})
 
@@ -240,6 +253,9 @@ var _ = Describe("Options", func() {
 				BatchIdleDuration:    lo.ToPtr(5 * time.Second),
 				FeatureGates: test.FeatureGates{
 					Drift: lo.ToPtr(true),
+				},
+				IgnoredResourceRequests: &options.IgnoredResourceRequests{
+					Keys: make(v1.ResourceList),
 				},
 			}))
 		})

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"time"
 
 	"github.com/imdario/mergo"
@@ -28,21 +29,22 @@ import (
 
 type OptionsFields struct {
 	// Vendor Neutral
-	ServiceName          *string
-	DisableWebhook       *bool
-	WebhookPort          *int
-	MetricsPort          *int
-	WebhookMetricsPort   *int
-	HealthProbePort      *int
-	KubeClientQPS        *int
-	KubeClientBurst      *int
-	EnableProfiling      *bool
-	EnableLeaderElection *bool
-	MemoryLimit          *int64
-	LogLevel             *string
-	BatchMaxDuration     *time.Duration
-	BatchIdleDuration    *time.Duration
-	FeatureGates         FeatureGates
+	ServiceName             *string
+	DisableWebhook          *bool
+	WebhookPort             *int
+	MetricsPort             *int
+	WebhookMetricsPort      *int
+	HealthProbePort         *int
+	KubeClientQPS           *int
+	KubeClientBurst         *int
+	EnableProfiling         *bool
+	EnableLeaderElection    *bool
+	MemoryLimit             *int64
+	LogLevel                *string
+	BatchMaxDuration        *time.Duration
+	BatchIdleDuration       *time.Duration
+	IgnoredResourceRequests *options.IgnoredResourceRequests
+	FeatureGates            FeatureGates
 }
 
 type FeatureGates struct {
@@ -73,6 +75,9 @@ func Options(overrides ...OptionsFields) *options.Options {
 		LogLevel:             lo.FromPtrOr(opts.LogLevel, ""),
 		BatchMaxDuration:     lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
 		BatchIdleDuration:    lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
+		IgnoredResourceRequests: lo.FromPtrOr(opts.IgnoredResourceRequests, options.IgnoredResourceRequests{
+			Keys: make(v1.ResourceList),
+		}),
 		FeatureGates: options.FeatureGates{
 			Drift:                   lo.FromPtrOr(opts.FeatureGates.Drift, false),
 			SpotToSpotConsolidation: lo.FromPtrOr(opts.FeatureGates.SpotToSpotConsolidation, false),

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -218,7 +218,7 @@ func Cmp(lhs resource.Quantity, rhs resource.Quantity) int {
 }
 
 // Fits returns true if the candidate set of resources is less than or equal to the total set of resources.
-func Fits(candidate, total v1.ResourceList) bool {
+func Fits(candidate, total, ignored v1.ResourceList) bool {
 	// If any of the total resource values are negative then the resource will never fit
 	for _, quantity := range total {
 		if Cmp(*resource.NewScaledQuantity(0, resource.Kilo), quantity) > 0 {
@@ -226,6 +226,9 @@ func Fits(candidate, total v1.ResourceList) bool {
 		}
 	}
 	for resourceName, quantity := range candidate {
+		if _, match := ignored[resourceName]; match {
+			continue
+		}
 		if Cmp(quantity, total[resourceName]) > 0 {
 			return false
 		}


### PR DESCRIPTION
### Description


This PR is inspired by #603 and a follow-up regarding mega issue #751 opened a bit less than 2 years ago, its goal is to unblock many Karpenter users interested in the short term to still provision new nodes despite an unknown custom resource being requested by a pending pod.


### Impact
- Function `resources.Fits()` has a new arg to accept the list of resource requests to ignore, being a method signature change it requires a tiny change in the provider stack (aws/azure) to pass this new option resolved through the application context: `options.FromContext(ctx).IgnoredResourceRequests.Keys`

### How was this change tested?
- Unit tests around options updated
- Karpenter controller deployed on 3 different EKS clusters using KubeVirt, it's provisioning as expected new nodes for virtual machines requiring resource requests mentioned in the _new_ environment variable below:
```
# Option 'IgnoredResourceRequests'
IGNORED_RESOURCE_REQUESTS:   devices.kubevirt.io/kvm,devices.kubevirt.io/tun,devices.kubevirt.io/vhost-net
```



### Fixes
- #751
- #603 
- https://github.com/aws/karpenter-provider-aws/pull/2161

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
