### PR TITLE
docs: Update documented stability level for spot-to-spot consolidation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ vulncheck: ## Verify code vulnerabilities
 licenses: download ## Verifies dependency licenses
 	! go-licenses csv ./... | grep -v -e 'MIT' -e 'Apache-2.0' -e 'BSD-3-Clause' -e 'BSD-2-Clause' -e 'ISC' -e 'MPL-2.0'
 
-verify: ## Verify code. Includes codegen, dependencies, linting, formatting, etc
+verify: ## Verify code. Includes codegen, docgen, dependencies, linting, formatting, etc
 	go mod tidy
 	go generate ./...
 	hack/validation/kubelet.sh
@@ -81,6 +81,7 @@ verify: ## Verify code. Includes codegen, dependencies, linting, formatting, etc
 	@perl -i -pe 's/sets.Set/sets.Set[string]/g' pkg/scheduling/zz_generated.deepcopy.go
 	hack/boilerplate.sh
 	go vet ./...
+	cd kwok/charts && helm-docs
 	golangci-lint run
 	@git diff --quiet ||\
 		{ echo "New file modification detected in the Git working tree. Please check in before commit."; git --no-pager diff --name-only | uniq | awk '{print "  - " $$0}'; \

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -13,6 +13,7 @@ tools() {
     go install github.com/google/go-licenses@latest
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     go install github.com/mikefarah/yq/v4@latest
+    go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
     go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/kwok/charts/Chart.yaml
+++ b/kwok/charts/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: karpenter
 description: A Helm chart for Karpenter's KwoK Provider, integrated with https://github.com/kubernetes-sigs/kwok.
 type: application
-version: 0.33.1
-appVersion: 0.33.1
+version: 0.35.0
+appVersion: 0.35.0
 keywords:
   - cluster
   - node

--- a/kwok/charts/README.md
+++ b/kwok/charts/README.md
@@ -1,6 +1,8 @@
-# karpenter-kwok
+# karpenter
 
-A Helm chart for Karpenter's kwok provider.
+A Helm chart for Karpenter's KwoK Provider, integrated with https://github.com/kubernetes-sigs/kwok.
+
+![Version: 0.35.0](https://img.shields.io/badge/Version-0.35.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.35.0](https://img.shields.io/badge/AppVersion-0.35.0-informational?style=flat-square)
 
 ## Documentation
 
@@ -18,9 +20,9 @@ For full Karpenter documentation please checkout [https://karpenter.sh](https://
 | controller.envFrom | list | `[]` |  |
 | controller.extraVolumeMounts | list | `[]` | Additional volumeMounts for the controller pod. |
 | controller.healthProbe.port | int | `8081` | The container port to use for http health probe. |
-| controller.image.digest | string | `"sha256:5e5f59f74d86ff7f13d7d80b89afff8c661cb4e3265f2fdda95b76dd9c838cc1"` | SHA256 digest of the controller image. |
-| controller.image.repository | string | `"public.ecr.aws/karpenter/controller"` | Repository path to the controller image. |
-| controller.image.tag | string | `"v0.33.0"` | Tag of the controller image. |
+| controller.image.digest | string | `""` | SHA256 digest of the controller image. |
+| controller.image.repository | string | `""` | Repository path to the controller image. |
+| controller.image.tag | string | `""` | Tag of the controller image. |
 | controller.metrics.port | int | `8000` | The container port to use for metrics. |
 | controller.resources | object | `{}` | Resources for the controller pod. |
 | controller.sidecarContainer | list | `[]` | Additional sidecarContainer config |
@@ -32,15 +34,6 @@ For full Karpenter documentation please checkout [https://karpenter.sh](https://
 | hostNetwork | bool | `false` | Bind the pod to the host network. This is required when using a custom CNI. |
 | imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Docker images. |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images. |
-| logConfig | object | `{"enabled":false,"errorOutputPaths":["stderr"],"logEncoding":"json","logLevel":{"controller":"info","global":"info","webhook":"error"},"outputPaths":["stdout"]}` | Log configuration (Deprecated: Logging configuration will be dropped by v1, use logLevel instead) |
-| logConfig.enabled | bool | `false` | Whether to enable provisioning and mounting the log ConfigMap |
-| logConfig.errorOutputPaths | list | `["stderr"]` | Log errorOutputPaths - defaults to stderr only |
-| logConfig.logEncoding | string | `"json"` | Log encoding - defaults to json - must be one of 'json', 'console' |
-| logConfig.logLevel | object | `{"controller":"info","global":"info","webhook":"error"}` | Component-based log configuration |
-| logConfig.logLevel.controller | string | `"info"` | Controller log level, defaults to 'info' |
-| logConfig.logLevel.global | string | `"info"` | Global log level, defaults to 'info' |
-| logConfig.logLevel.webhook | string | `"error"` | Error log level, defaults to 'error' |
-| logConfig.outputPaths | list | `["stdout"]` | Log outputPaths - defaults to stdout only |
 | logLevel | string | `"info"` | Global log level, defaults to 'info' |
 | nameOverride | string | `""` | Overrides the chart's name. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selectors to schedule the pod to nodes with labels. |
@@ -61,13 +54,11 @@ For full Karpenter documentation please checkout [https://karpenter.sh](https://
 | settings | object | `{"batchIdleDuration":"1s","batchMaxDuration":"10s","featureGates":{"drift":true,"spotToSpotConsolidation":false}}` | Global Settings to configure Karpenter |
 | settings.batchIdleDuration | string | `"1s"` | The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately. |
 | settings.batchMaxDuration | string | `"10s"` | The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes. |
-| settings.featureGates | object | `{"drift":true}` | Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features |
+| settings.featureGates | object | `{"drift":true,"spotToSpotConsolidation":false}` | Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features |
 | settings.featureGates.drift | bool | `true` | drift is in BETA and is enabled by default. Setting drift to false disables the drift disruption method to watch for drift between currently deployed nodes and the desired state of nodes set in nodepools and nodeclasses |
+| settings.featureGates.spotToSpotConsolidation | bool | `false` | spotToSpotConsolidation is ALPHA and is disabled by default. Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation. |
 | strategy | object | `{"rollingUpdate":{"maxUnavailable":1}}` | Strategy for updating the pod. |
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period for the pod. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Tolerations to allow the pod to be scheduled to nodes with taints. |
 | topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}]` | Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels. |
-| webhook.enabled | bool | `false` | Whether to enable the webhooks and webhook permissions. |
-| webhook.metrics.port | int | `8001` | The container port to use for webhook metrics. |
-| webhook.port | int | `8443` | The container port to use for the webhook. |
 

--- a/kwok/charts/README.md.gotmpl
+++ b/kwok/charts/README.md.gotmpl
@@ -1,0 +1,14 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+## Documentation
+
+For full Karpenter documentation please checkout [https://karpenter.sh](https://karpenter.sh/docs/).
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/kwok/charts/values.yaml
+++ b/kwok/charts/values.yaml
@@ -94,7 +94,7 @@ controller:
     tag: "" 
     # -- SHA256 digest of the controller image.
     digest: ""
-  # # -- Additional environment variables for the controller pod.
+  # -- Additional environment variables for the controller pod.
   env: []
   envFrom: []
   # -- Resources for the controller pod.
@@ -140,6 +140,6 @@ settings:
     # Setting drift to false disables the drift disruption method to watch for drift between currently deployed nodes
     # and the desired state of nodes set in nodepools and nodeclasses
     drift: true
-    # -- spotToSpotConsolidation is disabled by default.
+    # -- spotToSpotConsolidation is ALPHA and is disabled by default.
     # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
     spotToSpotConsolidation: false


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This updates the documented stability level for `SpotToSpotConsolidation` feature to be marked as ALPHA since it is disabled by default

This also adds `helm-docs` generation for the kwok cloudprovider chart that is shipped in this repo.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
