### PR TITLE
chore: Add queue depth metrics for provisioning and termination

### DIFF
--- a/pkg/controllers/leasegarbagecollection/controller.go
+++ b/pkg/controllers/leasegarbagecollection/controller.go
@@ -57,7 +57,7 @@ func (c *Controller) Reconcile(ctx context.Context, l *v1.Lease) (reconcile.Resu
 	err := c.kubeClient.Delete(ctx, l)
 	if err == nil {
 		logging.FromContext(ctx).Debug("found and delete leaked lease")
-		NodeLeaseDeletedCounter.WithLabelValues().Inc()
+		NodeLeasesDeletedCounter.WithLabelValues().Inc()
 	}
 
 	return reconcile.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controllers/leasegarbagecollection/suite_test.go
+++ b/pkg/controllers/leasegarbagecollection/suite_test.go
@@ -99,7 +99,7 @@ var _ = Describe("GarbageCollection", func() {
 	})
 	AfterEach(func() {
 		// Reset the metrics collectors
-		leasegarbagecollection.NodeLeaseDeletedCounter.Reset()
+		leasegarbagecollection.NodeLeasesDeletedCounter.Reset()
 	})
 	Context("Metrics", func() {
 		It("should fire the leaseDeletedCounter metric when deleting leases", func() {

--- a/pkg/controllers/node/termination/metrics.go
+++ b/pkg/controllers/node/termination/metrics.go
@@ -23,11 +23,15 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
+func init() {
+	crmetrics.Registry.MustRegister(TerminationSummary)
+}
+
 var (
 	TerminationSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Namespace:  "karpenter",
-			Subsystem:  "nodes",
+			Namespace:  metrics.Namespace,
+			Subsystem:  metrics.NodeSubsystem,
 			Name:       "termination_time_seconds",
 			Help:       "The time taken between a node's deletion request and the removal of its finalizer",
 			Objectives: metrics.SummaryObjectives(),
@@ -35,7 +39,3 @@ var (
 		[]string{metrics.NodePoolLabel},
 	)
 )
-
-func init() {
-	crmetrics.Registry.MustRegister(TerminationSummary)
-}

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -125,6 +125,7 @@ func (q *Queue) Has(pod *v1.Pod) bool {
 }
 
 func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	EvictionQueueDepth.Set(float64(q.RateLimitingInterface.Len()))
 	// Check if the queue is empty. client-go recommends not using this function to gate the subsequent
 	// get call, but since we're popping items off the queue synchronously, there should be no synchonization
 	// issues.

--- a/pkg/controllers/node/termination/terminator/metrics.go
+++ b/pkg/controllers/node/termination/terminator/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package leasegarbagecollection
+package terminator
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,18 +23,17 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
+func init() {
+	crmetrics.Registry.MustRegister(EvictionQueueDepth)
+}
+
 var (
-	NodeLeasesDeletedCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	EvictionQueueDepth = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: metrics.NodeSubsystem,
-			Name:      "leases_deleted",
-			Help:      "Number of deleted leaked leases.",
+			Name:      "eviction_queue_depth",
+			Help:      "The number of pods currently waiting for a successful eviction in the eviction queue.",
 		},
-		[]string{},
 	)
 )
-
-func init() {
-	crmetrics.Registry.MustRegister(NodeLeasesDeletedCounter)
-}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -284,7 +284,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	if err != nil {
 		return nil, fmt.Errorf("getting daemon pods, %w", err)
 	}
-	return scheduler.NewScheduler(ctx, p.kubeClient, nodeClaimTemplates, nodePoolList.Items, p.cluster, stateNodes, topology, instanceTypes, daemonSetPods, p.recorder), nil
+	return scheduler.NewScheduler(p.kubeClient, nodeClaimTemplates, nodePoolList.Items, p.cluster, stateNodes, topology, instanceTypes, daemonSetPods, p.recorder), nil
 }
 
 func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {

--- a/pkg/controllers/provisioning/scheduling/metrics.go
+++ b/pkg/controllers/provisioning/scheduling/metrics.go
@@ -24,15 +24,37 @@ import (
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(schedulingSimulationDuration)
+	crmetrics.Registry.MustRegister(SimulationDurationSeconds, QueueDepth)
 }
 
-var schedulingSimulationDuration = prometheus.NewHistogram(
-	prometheus.HistogramOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: "provisioner",
-		Name:      "scheduling_simulation_duration_seconds",
-		Help:      "Duration of scheduling simulations used for deprovisioning and provisioning in seconds.",
-		Buckets:   metrics.DurationBuckets(),
-	},
+const (
+	controllerLabel   = "controller"
+	schedulingIDLabel = "scheduling_id"
+)
+
+var (
+	SimulationDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: "provisioner",
+			Name:      "scheduling_simulation_duration_seconds",
+			Help:      "Duration of scheduling simulations used for deprovisioning and provisioning in seconds.",
+			Buckets:   metrics.DurationBuckets(),
+		},
+		[]string{
+			controllerLabel,
+		},
+	)
+	QueueDepth = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: "provisioner",
+			Name:      "scheduling_queue_depth",
+			Help:      "The number of pods currently waiting to be scheduled.",
+		},
+		[]string{
+			controllerLabel,
+			schedulingIDLabel,
+		},
+	)
 )

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -174,7 +174,7 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 		b.Fatalf("creating topology, %s", err)
 	}
 
-	scheduler := scheduling.NewScheduler(ctx, client, []*scheduling.NodeClaimTemplate{scheduling.NewNodeClaimTemplate(nodePool)},
+	scheduler := scheduling.NewScheduler(client, []*scheduling.NodeClaimTemplate{scheduling.NewNodeClaimTemplate(nodePool)},
 		nil, cluster, nil, topology,
 		map[string][]*cloudprovider.InstanceType{nodePool.Name: instanceTypes}, nil,
 		events.NewRecorder(&record.FakeRecorder{}))

--- a/pkg/operator/controller/singleton.go
+++ b/pkg/operator/controller/singleton.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+
 	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
@@ -79,6 +81,7 @@ func (s *Singleton) initMetrics() {
 var singletonRequest = reconcile.Request{}
 
 func (s *Singleton) Start(ctx context.Context) error {
+	ctx = injection.WithControllerName(ctx, s.Name())
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named(s.Name()))
 	logging.FromContext(ctx).Infof("starting controller")
 	defer logging.FromContext(ctx).Infof("stopping controller")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This changes adds the `karpenter_nodes_eviction_queue_depth` and `karpenter_provisioner_scheduling_queue_depth` to give metrics on the number of items that are currently in these queues. This will allow us to get better insight into how quickly we are processing through items and also to know if we are making progress.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
