### PR TITLE
fix: add hardcoded utc prefix to crontab

### DIFF
--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -293,9 +293,9 @@ func (in *Budget) IsActive(c clock.Clock) (bool, error) {
 		return false, fmt.Errorf("invariant violated, invalid cron %s", schedule)
 	}
 	// Walk back in time for the duration associated with the schedule
-	checkPoint := c.Now().Add(-lo.FromPtr(in.Duration).Duration)
+	checkPoint := c.Now().UTC().Add(-lo.FromPtr(in.Duration).Duration)
 	nextHit := schedule.Next(checkPoint)
-	return !nextHit.After(c.Now()), nil
+	return !nextHit.After(c.Now().UTC()), nil
 }
 
 func GetIntStrFromValue(str string) intstr.IntOrString {

--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -286,7 +286,7 @@ func (in *Budget) IsActive(c clock.Clock) (bool, error) {
 	if in.Schedule == nil && in.Duration == nil {
 		return true, nil
 	}
-	schedule, err := cron.ParseStandard(lo.FromPtr(in.Schedule))
+	schedule, err := cron.ParseStandard(fmt.Sprintf("TZ=UTC %s", lo.FromPtr(in.Schedule)))
 	if err != nil {
 		// Should only occur if there's a discrepancy
 		// with the validation regex and the cron package.

--- a/pkg/apis/v1beta1/nodepool_budgets_test.go
+++ b/pkg/apis/v1beta1/nodepool_budgets_test.go
@@ -128,6 +128,16 @@ var _ = Describe("Budgets", func() {
 		})
 	})
 	Context("IsActive", func() {
+		It("should always consider a schedule and time in UTC", func() {
+			// Set the time to start of June 2000 in a time zone 1 hour ahead of UTC
+			fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 0, 0, 0, 0, 0, time.FixedZone("fake-zone", 3600)))
+			budgets[0].Schedule = lo.ToPtr("@daily")
+			budgets[0].Duration = lo.ToPtr(metav1.Duration{Duration: lo.Must(time.ParseDuration("30m"))})
+			// IsActive should use UTC, not the location of the clock that's inputted.
+			active, err := budgets[0].IsActive(fakeClock)
+			Expect(err).To(Succeed())
+			Expect(active).To(BeFalse())
+		})
 		It("should return that a schedule is active when schedule and duration are nil", func() {
 			budgets[0].Schedule = nil
 			budgets[0].Duration = nil


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #943 

**Description**
Karpenter releases are built with UTC, but this adds a "TZ=UTC" prefix to valid schedules for budgets to ensure that the underlying cron library always parses the schedule in UTC time.

**How was this change tested?**
make apply with kwok and test different schedules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
