### PR TITLE
fix: Changing the MaxInstanceTypes back to original value of 60 in order to…

### DIFF
--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -31,8 +31,6 @@ import (
 
 // MaxInstanceTypes is a constant that restricts the number of instance types to be sent for launch. Note that this
 // is intentionally changed to var just to help in testing the code.
-// Increasing this value needs caution as it also requires stress testing the cloud provider API to launch so many instances
-// with various other combinatorial parameters such as zones, tags etc. in the largest region.
 var MaxInstanceTypes = 60
 
 // NodeClaimTemplate encapsulates the fields required to create a node and mirrors

--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -31,7 +31,9 @@ import (
 
 // MaxInstanceTypes is a constant that restricts the number of instance types to be sent for launch. Note that this
 // is intentionally changed to var just to help in testing the code.
-var MaxInstanceTypes = 100
+// Increasing this value needs caution as it also requires stress testing the cloud provider API to launch so many instances
+// with various other combinatorial parameters such as zones, tags etc. in the largest region.
+var MaxInstanceTypes = 60
 
 // NodeClaimTemplate encapsulates the fields required to create a node and mirrors
 // the fields in NodePool. These structs are maintained separately in order


### PR DESCRIPTION
Fixes: https://github.com/aws/karpenter-provider-aws/issues/5776

**Description**
`MaxInstanceTypes` was changed from 60 to 100 in version `0.35.0` in order to send more instance types to launch API but that resulted in the request size to be too large for the cases where the requests are highly flexible with multiple zones in large regions leading to validation error from the launch API. This caused unscheduled pods in the cluster. So, we have reverted this particular value back to 60.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
