### PR TITLE
kustomize patchesStrategicMerge is deprecated, use patches instead.

### DIFF
--- a/hack/install-kwok.sh
+++ b/hack/install-kwok.sh
@@ -49,8 +49,8 @@ cat <<EOF > "${BASE}/kustomization.yaml"
     newTag: "${KWOK_LATEST_RELEASE}"
   resources:
   - "https://github.com/${KWOK_REPO}/kustomize/kwok?ref=${KWOK_LATEST_RELEASE}"
-  patchesStrategicMerge:
-  - tolerate-all.yaml
+  patches:
+  - path: tolerate-all.yaml
 EOF
 
 # Define 10 different kwok controllers to handle large load


### PR DESCRIPTION
**Description**
kustomize `patchesStrategicMerge` is deprecated, use `patches` instead.

**How was this change tested?**
By running the hack/install-kwok.sh script locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
