### PR TITLE
fix: Add capacity-type label to karpenter_nodes_created and karpenter_node…

### DIFF
--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -270,8 +270,9 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) error {
 			multiErr = multierr.Append(multiErr, client.IgnoreNotFound(err))
 		} else {
 			metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
-				metrics.ReasonLabel:   cmd.method,
-				metrics.NodePoolLabel: cmd.candidates[i].NodeClaim.Labels[v1beta1.NodePoolLabelKey],
+				metrics.ReasonLabel:       cmd.method,
+				metrics.NodePoolLabel:     cmd.candidates[i].NodeClaim.Labels[v1beta1.NodePoolLabelKey],
+				metrics.CapacityTypeLabel: cmd.candidates[i].NodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
 			}).Inc()
 		}
 	}

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -91,8 +91,9 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			).
 			Debugf("garbage collecting nodeclaim with no cloudprovider representation")
 		metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
-			metrics.ReasonLabel:   "garbage_collected",
-			metrics.NodePoolLabel: nodeClaims[i].Labels[v1beta1.NodePoolLabelKey],
+			metrics.ReasonLabel:       "garbage_collected",
+			metrics.NodePoolLabel:     nodeClaims[i].Labels[v1beta1.NodePoolLabelKey],
+			metrics.CapacityTypeLabel: nodeClaims[i].Labels[v1beta1.CapacityTypeLabelKey],
 		}).Inc()
 	})
 	if err = multierr.Combine(errs...); err != nil {

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -88,8 +88,9 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 				return nil, client.IgnoreNotFound(err)
 			}
 			metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
-				metrics.ReasonLabel:   "insufficient_capacity",
-				metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+				metrics.ReasonLabel:       "insufficient_capacity",
+				metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+				metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
 			}).Inc()
 			return nil, nil
 		case cloudprovider.IsNodeClassNotReadyError(err):

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -57,8 +57,9 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) 
 	}
 	logging.FromContext(ctx).With("ttl", registrationTTL).Debugf("terminating due to registration ttl")
 	metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
-		metrics.ReasonLabel:   "liveness",
-		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.ReasonLabel:       "liveness",
+		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
 	}).Inc()
 
 	return reconcile.Result{}, nil

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -356,8 +356,9 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 	})
 	logging.FromContext(ctx).With("nodeclaim", nodeClaim.Name, "requests", nodeClaim.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).Infof("created nodeclaim")
 	metrics.NodeClaimsCreatedCounter.With(prometheus.Labels{
-		metrics.ReasonLabel:   options.Reason,
-		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.ReasonLabel:       options.Reason,
+		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
 	}).Inc()
 	// Update the nodeclaim manually in state to avoid evenutal consistency delay races with our watcher.
 	// This is essential to avoiding races where disruption can create a replacement node, then immediately

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -26,9 +26,10 @@ const (
 	// Common namespace for application metrics.
 	Namespace = "karpenter"
 
-	NodePoolLabel = "nodepool"
-	ReasonLabel   = "reason"
-	TypeLabel     = "type"
+	NodePoolLabel     = "nodepool"
+	ReasonLabel       = "reason"
+	TypeLabel         = "type"
+	CapacityTypeLabel = "capacity_type"
 
 	// Reasons for CREATE/DELETE shared metrics
 	ConsolidationReason = "consolidation"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -37,6 +37,7 @@ var (
 		[]string{
 			ReasonLabel,
 			NodePoolLabel,
+			CapacityTypeLabel,
 		},
 	)
 	NodeClaimsTerminatedCounter = prometheus.NewCounterVec(
@@ -49,6 +50,7 @@ var (
 		[]string{
 			ReasonLabel,
 			NodePoolLabel,
+			CapacityTypeLabel,
 		},
 	)
 	NodeClaimsLaunchedCounter = prometheus.NewCounterVec(


### PR DESCRIPTION
…s_terminated

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1072  <!-- issue number -->

**Description**

Add `capacity-type` label to `karpenter_nodes_created` and `karpenter_nodes_terminated`, in order to build a dashboard on this data comparing spot and on-demand nodes being created. Currently added as filter in Grafana dashboard Karpenter Capacity (https://github.com/aws/karpenter-provider-aws/blob/main/website/content/en/docs/getting-started/getting-started-with-karpenter/karpenter-capacity-dashboard.json) but not used in the panels.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
