### PR TITLE
cherrypick: fix: Changing the MaxInstanceTypes back to original value of 60 in order to reduce the request size to be sent to launch APIs.order t

### DIFF
--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -31,7 +31,7 @@ import (
 
 // MaxInstanceTypes is a constant that restricts the number of instance types to be sent for launch. Note that this
 // is intentionally changed to var just to help in testing the code.
-var MaxInstanceTypes = 100
+var MaxInstanceTypes = 60
 
 // NodeClaimTemplate encapsulates the fields required to create a node and mirrors
 // the fields in NodePool. These structs are maintained separately in order


### PR DESCRIPTION
Fixes: https://github.com/aws/karpenter-provider-aws/issues/5776

**Description**
`MaxInstanceTypes` was changed from 60 to 100 in version `0.35.0` in order to send more instance types to launch API but that resulted in the request size to be too large for the cases where the requests are highly flexible with multiple zones in large regions leading to validation error from the launch API. This caused unscheduled pods in the cluster. So, we have reverted this particular value back to 60.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
