### PR TITLE
fix: add shebang line in install-kwok.sh to execute commands with bash

### DIFF
--- a/hack/install-kwok.sh
+++ b/hack/install-kwok.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This script uses kustomize to generate the manifests of the latest 
 # version of kwok, and will then either apply/delete the resources 
 # depending on the UNINSTALL_KWOK environment variable. Set this to 


### PR DESCRIPTION
Fixes #N/A

**Description**
Ensure successful execution of `install-kwok` target in Makefile by adding shebang line to `install-kwok.sh` script.
Otherwise, you get the following error when running the target:

```command
$ make install-kwok 
UNINSTALL_KWOK=false ./hack/install-kwok.sh
./hack/install-kwok.sh: 9: set: Illegal option -o pipefail
make: *** [Makefile:17: install-kwok] Error 2
```


**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
