### PR TITLE
chore: Use strategic merge patching for Core APIs

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -123,7 +123,7 @@ func (c *Controller) removeFinalizer(ctx context.Context, n *v1.Node) error {
 	stored := n.DeepCopy()
 	controllerutil.RemoveFinalizer(n, v1beta1.TerminationFinalizer)
 	if !equality.Semantic.DeepEqual(stored, n) {
-		if err := c.kubeClient.Patch(ctx, n, client.MergeFrom(stored)); err != nil {
+		if err := c.kubeClient.Patch(ctx, n, client.StrategicMergeFrom(stored)); err != nil {
 			return client.IgnoreNotFound(fmt.Errorf("patching node, %w", err))
 		}
 		metrics.NodesTerminatedCounter.With(prometheus.Labels{

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -69,7 +69,7 @@ func (t *Terminator) Taint(ctx context.Context, node *v1.Node) error {
 		v1.LabelNodeExcludeBalancers: "karpenter",
 	})
 	if !equality.Semantic.DeepEqual(node, stored) {
-		if err := t.kubeClient.Patch(ctx, node, client.MergeFrom(stored)); err != nil {
+		if err := t.kubeClient.Patch(ctx, node, client.StrategicMergeFrom(stored)); err != nil {
 			return err
 		}
 		logging.FromContext(ctx).Infof("tainted node")

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -79,7 +79,7 @@ func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeC
 	stored := node.DeepCopy()
 	node.Labels = lo.Assign(node.Labels, map[string]string{v1beta1.NodeInitializedLabelKey: "true"})
 	if !equality.Semantic.DeepEqual(stored, node) {
-		if err = i.kubeClient.Patch(ctx, node, client.MergeFrom(stored)); err != nil {
+		if err = i.kubeClient.Patch(ctx, node, client.StrategicMergeFrom(stored)); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -92,7 +92,7 @@ func (r *Registration) syncNode(ctx context.Context, nodeClaim *v1beta1.NodeClai
 		v1beta1.NodeRegisteredLabelKey: "true",
 	})
 	if !equality.Semantic.DeepEqual(stored, node) {
-		if err := r.kubeClient.Patch(ctx, node, client.MergeFrom(stored)); err != nil {
+		if err := r.kubeClient.Patch(ctx, node, client.StrategicMergeFrom(stored)); err != nil {
 			return fmt.Errorf("syncing node labels, %w", err)
 		}
 	}

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -411,7 +411,7 @@ func RequireNoScheduleTaint(ctx context.Context, kubeClient client.Client, addTa
 			node.Spec.Taints = append(node.Spec.Taints, v1beta1.DisruptionNoScheduleTaint)
 		}
 		if !equality.Semantic.DeepEqual(stored, node) {
-			if err := kubeClient.Patch(ctx, node, client.MergeFrom(stored)); err != nil {
+			if err := kubeClient.Patch(ctx, node, client.StrategicMergeFrom(stored)); err != nil {
 				multiErr = multierr.Append(multiErr, fmt.Errorf("patching node %s, %w", node.Name, err))
 			}
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Core APIs support [strategic merge patching](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/). This provides a more advanced way to patch together lists from standard merge patching, where lists can be merged if they have a `strategic-merge-patch-key` to denote them. For instance, this is true for the status conditions API.

[CRDs do not support strategic merge patching out of the box](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#advanced-features-and-flexibility:~:text=Yes-,strategic%2Dmerge%2Dpatch,-The%20new%20endpoints) so we cannot get rid of standard merge patching for them. This will resolve some errors in AWS E2E testing, where we are seeing errors like `patching node, Node \"ip-192-168-49-61.us-east-2.compute.internal\" is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{\"foregroundDeletion\"}"}`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
