### PR TITLE
ci: add go version to dep cache key

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -8,6 +8,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      id: setup-go
       with:
         go-version-file: go.mod
         check-latest: true
@@ -21,7 +22,9 @@ runs:
         path: |
           /usr/local/kubebuilder/bin
           ~/go/bin
-        key: ${{ runner.os }}-${{ inputs.k8sVersion }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
+        # Added go version to compensate for this issue with govulncheck: https://github.com/golang/go/issues/65590. Could re-evaluate if this is necessary once the
+        # upstream go issue is corrected and if this is causing too many cache misses.
+        key: ${{ runner.os }}-${{ inputs.k8sVersion }}-${{ steps.setup-go.outputs.go-version }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
       shell: bash
       run: K8S_VERSION=${{ inputs.k8sVersion }} make toolchain


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds the go version to the dependency cache key. This is to address an issue with govulncheck, where the same version of govulncheck built with 1.21 crashes when run against a 1.22 project: https://github.com/golang/go/issues/65590

**How was this change tested?**
- Run against github actions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
