### PR TITLE
perf: Reduce delete calls by checking DeletionTimestamp

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -112,8 +112,11 @@ func (c *Controller) deleteAllNodeClaims(ctx context.Context, node *v1.Node) err
 		return err
 	}
 	for i := range nodeClaimList.Items {
-		if err := c.kubeClient.Delete(ctx, &nodeClaimList.Items[i]); err != nil {
-			return client.IgnoreNotFound(err)
+		// If we still get the NodeClaim, but it's already marked as terminating, we don't need to call Delete again
+		if nodeClaimList.Items[i].DeletionTimestamp.IsZero() {
+			if err := c.kubeClient.Delete(ctx, &nodeClaimList.Items[i]); err != nil {
+				return client.IgnoreNotFound(err)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Check DeletionTimestamp when calling `Delete()`. If the DeletionTimestamp is already set, we don't need to call `Delete()` again. I noticed that we were over-calling Delete() when I was looking at kube-apiserver audit logs for the termination flow.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
