### PR TITLE
feat: Add labels zone, arch, instance_type to karpenter node created/termin…

### DIFF
--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -272,7 +273,10 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) error {
 			metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
 				metrics.ReasonLabel:       cmd.method,
 				metrics.NodePoolLabel:     cmd.candidates[i].NodeClaim.Labels[v1beta1.NodePoolLabelKey],
+				metrics.ZoneLabel:         cmd.candidates[i].NodeClaim.Labels[v1.LabelTopologyZone],
+				metrics.ArchLabel:         cmd.candidates[i].NodeClaim.Labels[v1.LabelArchStable],
 				metrics.CapacityTypeLabel: cmd.candidates[i].NodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
+				metrics.InstanceTypeLabel: cmd.candidates[i].NodeClaim.Labels[v1.LabelInstanceTypeStable],
 			}).Inc()
 		}
 	}

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
@@ -93,7 +94,10 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
 			metrics.ReasonLabel:       "garbage_collected",
 			metrics.NodePoolLabel:     nodeClaims[i].Labels[v1beta1.NodePoolLabelKey],
+			metrics.ZoneLabel:         nodeClaims[i].Labels[v1.LabelTopologyZone],
+			metrics.ArchLabel:         nodeClaims[i].Labels[v1.LabelArchStable],
 			metrics.CapacityTypeLabel: nodeClaims[i].Labels[v1beta1.CapacityTypeLabelKey],
+			metrics.InstanceTypeLabel: nodeClaims[i].Labels[v1.LabelInstanceTypeStable],
 		}).Inc()
 	})
 	if err = multierr.Combine(errs...); err != nil {

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -90,7 +90,10 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 			metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
 				metrics.ReasonLabel:       "insufficient_capacity",
 				metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+				metrics.ZoneLabel:         nodeClaim.Labels[v1.LabelTopologyZone],
+				metrics.ArchLabel:         nodeClaim.Labels[v1.LabelArchStable],
 				metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
+				metrics.InstanceTypeLabel: nodeClaim.Labels[v1.LabelInstanceTypeStable],
 			}).Inc()
 			return nil, nil
 		case cloudprovider.IsNodeClassNotReadyError(err):

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,7 +60,10 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) 
 	metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
 		metrics.ReasonLabel:       "liveness",
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.ZoneLabel:         nodeClaim.Labels[v1.LabelTopologyZone],
+		metrics.ArchLabel:         nodeClaim.Labels[v1.LabelArchStable],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
+		metrics.InstanceTypeLabel: nodeClaim.Labels[v1.LabelInstanceTypeStable],
 	}).Inc()
 
 	return reconcile.Result{}, nil

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -352,7 +352,10 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 	metrics.NodeClaimsCreatedCounter.With(prometheus.Labels{
 		metrics.ReasonLabel:       options.Reason,
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.ZoneLabel:         nodeClaim.Labels[v1.LabelTopologyZone],
+		metrics.ArchLabel:         nodeClaim.Labels[v1.LabelArchStable],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
+		metrics.InstanceTypeLabel: nodeClaim.Labels[v1.LabelInstanceTypeStable],
 	}).Inc()
 	// Update the nodeclaim manually in state to avoid evenutal consistency delay races with our watcher.
 	// This is essential to avoiding races where disruption can create a replacement node, then immediately

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -29,7 +29,10 @@ const (
 	NodePoolLabel     = "nodepool"
 	ReasonLabel       = "reason"
 	TypeLabel         = "type"
+	ZoneLabel         = "zone"
+	ArchLabel         = "arch"
 	CapacityTypeLabel = "capacity_type"
+	InstanceTypeLabel = "instance_type"
 
 	// Reasons for CREATE/DELETE shared metrics
 	ConsolidationReason = "consolidation"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -37,7 +37,10 @@ var (
 		[]string{
 			ReasonLabel,
 			NodePoolLabel,
+			ZoneLabel,
+			ArchLabel,
 			CapacityTypeLabel,
+			InstanceTypeLabel,
 		},
 	)
 	NodeClaimsTerminatedCounter = prometheus.NewCounterVec(
@@ -50,7 +53,10 @@ var (
 		[]string{
 			ReasonLabel,
 			NodePoolLabel,
+			ZoneLabel,
+			ArchLabel,
 			CapacityTypeLabel,
+			InstanceTypeLabel,
 		},
 	)
 	NodeClaimsLaunchedCounter = prometheus.NewCounterVec(


### PR DESCRIPTION
…ated metrics used in karpenter capacity dashboard

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1097 <!-- issue number -->

**Description**

Adding labels for `zone`, `arch` and `instance_type` will make it possible to use them in the `karpenter capacity` dashboard. They are already added as filtered, but are not used in the panels.

(Improvement on https://github.com/kubernetes-sigs/karpenter/pull/1073)

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.