### PR TITLE
fix: Check node readiness before force terminating

### DIFF
--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -319,7 +319,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		})
 		Expect(new).To(BeTrue())
 		// which needs to be deployed
-		ExpectNodeClaimDeployed(ctx, env.Client, cluster, cloudProvider, nc)
+		ExpectNodeClaimDeployedAndStateUpdated(ctx, env.Client, cluster, cloudProvider, nc)
 		nodeClaimNames[nc.Name] = struct{}{}
 
 		ExpectTriggerVerifyAction(&wg)
@@ -334,7 +334,7 @@ var _ = Describe("Simulate Scheduling", func() {
 			return !ok
 		})
 		Expect(new).To(BeTrue())
-		ExpectNodeClaimDeployed(ctx, env.Client, cluster, cloudProvider, nc)
+		ExpectNodeClaimDeployedAndStateUpdated(ctx, env.Client, cluster, cloudProvider, nc)
 		nodeClaimNames[nc.Name] = struct{}{}
 
 		ExpectTriggerVerifyAction(&wg)
@@ -349,7 +349,7 @@ var _ = Describe("Simulate Scheduling", func() {
 			return !ok
 		})
 		Expect(new).To(BeTrue())
-		ExpectNodeClaimDeployed(ctx, env.Client, cluster, cloudProvider, nc)
+		ExpectNodeClaimDeployedAndStateUpdated(ctx, env.Client, cluster, cloudProvider, nc)
 		nodeClaimNames[nc.Name] = struct{}{}
 
 		// Try one more time, but fail since the budgets only allow 3 disruptions.
@@ -1976,7 +1976,7 @@ func ExpectMakeNewNodeClaimsReady(ctx context.Context, c client.Client, wg *sync
 					if existingNodeClaimNames.Has(nc.Name) {
 						continue
 					}
-					nc, n := ExpectNodeClaimDeployed(ctx, c, cluster, cloudProvider, nc)
+					nc, n := ExpectNodeClaimDeployedAndStateUpdated(ctx, c, cluster, cloudProvider, nc)
 					ExpectMakeNodeClaimsInitialized(ctx, c, nc)
 					ExpectMakeNodesInitialized(ctx, c, n)
 

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	operatorcontroller "sigs.k8s.io/karpenter/pkg/operator/controller"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutil "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
@@ -88,12 +89,18 @@ func (c *Controller) Finalize(ctx context.Context, node *v1.Node) (reconcile.Res
 			return reconcile.Result{}, fmt.Errorf("draining node, %w", err)
 		}
 		c.recorder.Publish(terminatorevents.NodeFailedToDrain(node, err))
-		// If the underlying nodeclaim no longer exists.
-		if _, err := c.cloudProvider.Get(ctx, node.Spec.ProviderID); err != nil {
-			if cloudprovider.IsNodeClaimNotFoundError(err) {
-				return reconcile.Result{}, c.removeFinalizer(ctx, node)
+		// If the underlying NodeClaim no longer exists, we want to delete to avoid trying to gracefully draining
+		// on nodes that are no longer alive. We do a check on the Ready condition of the node since, even
+		// though the CloudProvider says the instance is not around, we know that the kubelet process is still running
+		// if the Node Ready condition is true
+		// Similar logic to: https://github.com/kubernetes/kubernetes/blob/3a75a8c8d9e6a1ebd98d8572132e675d4980f184/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go#L144
+		if nodeutils.GetCondition(node, v1.NodeReady).Status != v1.ConditionTrue {
+			if _, err := c.cloudProvider.Get(ctx, node.Spec.ProviderID); err != nil {
+				if cloudprovider.IsNodeClaimNotFoundError(err) {
+					return reconcile.Result{}, c.removeFinalizer(ctx, node)
+				}
+				return reconcile.Result{}, fmt.Errorf("getting nodeclaim, %w", err)
 			}
-			return reconcile.Result{}, fmt.Errorf("getting nodeclaim, %w", err)
 		}
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2387,10 +2387,11 @@ var _ = Context("Scheduling", func() {
 				})
 				ExpectApplied(ctx, env.Client, nc)
 				if i == elem {
-					nc, node = ExpectNodeClaimDeployed(ctx, env.Client, cluster, cloudProvider, nc)
+					nc, node = ExpectNodeClaimDeployedAndStateUpdated(ctx, env.Client, cluster, cloudProvider, nc)
 				} else {
 					var err error
-					nc, err = ExpectNodeClaimDeployedNoNode(ctx, env.Client, cluster, cloudProvider, nc)
+					nc, err = ExpectNodeClaimDeployedNoNode(ctx, env.Client, cloudProvider, nc)
+					cluster.UpdateNodeClaim(nc)
 					Expect(err).ToNot(HaveOccurred())
 				}
 				nodeClaims = append(nodeClaims, nc)
@@ -2481,7 +2482,7 @@ var _ = Context("Scheduling", func() {
 					},
 				})
 				ExpectApplied(ctx, env.Client, nc)
-				nc, n := ExpectNodeClaimDeployed(ctx, env.Client, cluster, cloudProvider, nc)
+				nc, n := ExpectNodeClaimDeployedAndStateUpdated(ctx, env.Client, cluster, cloudProvider, nc)
 				nodeClaims = append(nodeClaims, nc)
 				nodes = append(nodes, n)
 			}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1100

**Description**

This change gates deletion of the NodeClaim and the force deletion of the Node based on the readiness of the Node. Today, we blindly delete the NodeClaim and Node if we get NotExists from the CloudProvider; however, we should also gate this based on the Node readiness and kubelet heartbeat to deal with potential inconsistency issues on the List() CloudProvider call.

This also lets the Registration liveness controller cleanup any NodeClaims that don't register in time, but allows the full 15m timeout to occur before terminating a NodeClaim that doesn't exist being returned from the CloudProvider List() call.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
