### PR TITLE
chore: Drop CloudProvider delete call from Node termination

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -42,7 +42,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	operatorcontroller "sigs.k8s.io/karpenter/pkg/operator/controller"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
-	nodeclaimutil "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
 var _ operatorcontroller.FinalizingTypedController[*v1.Node] = (*Controller)(nil)
@@ -103,9 +102,6 @@ func (c *Controller) Finalize(ctx context.Context, node *v1.Node) (reconcile.Res
 			}
 		}
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
-	}
-	if err := c.cloudProvider.Delete(ctx, nodeclaimutil.NewFromNode(node)); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil {
-		return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 	}
 	if err := c.removeFinalizer(ctx, node); err != nil {
 		return reconcile.Result{}, err

--- a/pkg/utils/nodeclaim/suite_test.go
+++ b/pkg/utils/nodeclaim/suite_test.go
@@ -34,7 +34,6 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/test"
 	nodeclaimutil "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
@@ -110,26 +109,6 @@ var _ = Describe("NodeClaimUtils", func() {
 				v1.ResourceEphemeralStorage: resource.MustParse("95Gi"),
 			},
 		})
-	})
-	It("should convert a Node to a NodeClaim", func() {
-		nodeClaim := nodeclaimutil.NewFromNode(node)
-		for k, v := range node.Annotations {
-			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(k, v))
-		}
-		for k, v := range node.Labels {
-			Expect(nodeClaim.Labels).To(HaveKeyWithValue(k, v))
-		}
-		Expect(lo.Contains(nodeClaim.Finalizers, v1beta1.TerminationFinalizer)).To(BeTrue())
-		Expect(nodeClaim.Spec.Taints).To(Equal(node.Spec.Taints))
-		Expect(nodeClaim.Spec.Requirements).To(ContainElements(scheduling.NewLabelRequirements(node.Labels).NodeSelectorRequirements()))
-		Expect(nodeClaim.Spec.Resources.Requests).To(Equal(node.Status.Allocatable))
-		Expect(nodeClaim.Status.NodeName).To(Equal(node.Name))
-		Expect(nodeClaim.Status.ProviderID).To(Equal(node.Spec.ProviderID))
-		Expect(nodeClaim.Status.Capacity).To(Equal(node.Status.Capacity))
-		Expect(nodeClaim.Status.Allocatable).To(Equal(node.Status.Allocatable))
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Launched).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Registered).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Initialized).IsTrue()).To(BeTrue())
 	})
 	It("should update the owner for a Node to a NodeClaim", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Removes the call to `cloudProvider.Delete()` from the node termination controller. This hands-off responsibility of deleting the instance solely to the NodeClaim termination controller. This delete call was only in there for legacy reasons during the machine migration that could have occurred prior to v0.32.0

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
