### PR TITLE
cherrypick(v0.32): feat: Add Versioned for NodePool Hash to Prevent Drift on NodePool CRD Upgrade

### DIFF
--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -44,6 +44,7 @@ const (
 	ProviderCompatabilityAnnotationKey = CompatabilityGroup + "/provider"
 	ManagedByAnnotationKey             = Group + "/managed-by"
 	NodePoolHashAnnotationKey          = Group + "/nodepool-hash"
+	NodePoolHashVersionAnnotationKey   = Group + "/nodepool-hash-version"
 )
 
 // Karpenter specific finalizers

--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -144,6 +144,12 @@ type NodePool struct {
 	IsProvisioner bool `json:"-"`
 }
 
+// We need to bump the NodePoolHashVersion when we make an update to the NodePool CRD under these conditions:
+// 1. A field changes its default value for an existing field that is already hashed
+// 2. A field is added to the hash calculation with an already-set value
+// 3. A field is removed from the hash calculations
+const NodePoolHashVersion = "v1"
+
 func (in *NodePool) Hash() string {
 	return fmt.Sprint(lo.Must(hashstructure.Hash(in.Spec.Template, hashstructure.FormatV2, &hashstructure.HashOptions{
 		SlicesAsSets:    true,

--- a/pkg/controllers/nodepool/hash/nodepool_test.go
+++ b/pkg/controllers/nodepool/hash/nodepool_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("NodePool Static Drift Hash", func() {
@@ -104,5 +106,108 @@ var _ = Describe("NodePool Static Drift Hash", func() {
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 
 		Expect(nodePool.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashAnnotationKey, expectedHash))
+	})
+	It("should update nodepool hash version when the nodepool hash version is out of sync with the controller hash version", func() {
+		nodePool.Annotations = map[string]string{
+			v1beta1.NodePoolHashAnnotationKey:        "abceduefed",
+			v1beta1.NodePoolHashVersionAnnotationKey: "test",
+		}
+		ExpectApplied(ctx, env.Client, nodePool)
+
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+
+		expectedHash := nodePool.Hash()
+		Expect(nodePool.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashAnnotationKey, expectedHash))
+		Expect(nodePool.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashVersionAnnotationKey, v1beta1.NodePoolHashVersion))
+	})
+	It("should update nodepool hash versions on all nodeclaims when the hash versions don't match the controller hash version", func() {
+		nodePool.Annotations = map[string]string{
+			v1beta1.NodePoolHashAnnotationKey:        "abceduefed",
+			v1beta1.NodePoolHashVersionAnnotationKey: "test",
+		}
+		nodeClaimOne := test.NodeClaim(v1beta1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1beta1.NodePoolLabelKey: nodePool.Name},
+				Annotations: map[string]string{
+					v1beta1.NodePoolHashAnnotationKey:        "123456",
+					v1beta1.NodePoolHashVersionAnnotationKey: "test",
+				},
+			},
+		})
+		nodeClaimTwo := test.NodeClaim(v1beta1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1beta1.NodePoolLabelKey: nodePool.Name},
+				Annotations: map[string]string{
+					v1beta1.NodePoolHashAnnotationKey:        "123456",
+					v1beta1.NodePoolHashVersionAnnotationKey: "test",
+				},
+			},
+		})
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaimOne, nodeClaimTwo)
+
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+		nodeClaimOne = ExpectExists(ctx, env.Client, nodeClaimOne)
+		nodeClaimTwo = ExpectExists(ctx, env.Client, nodeClaimTwo)
+
+		expectedHash := nodePool.Hash()
+		Expect(nodeClaimOne.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashAnnotationKey, expectedHash))
+		Expect(nodeClaimOne.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashVersionAnnotationKey, v1beta1.NodePoolHashVersion))
+		Expect(nodeClaimTwo.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashAnnotationKey, expectedHash))
+		Expect(nodeClaimTwo.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashVersionAnnotationKey, v1beta1.NodePoolHashVersion))
+	})
+	It("should not update nodepool hash on all nodeclaims when the hash versions match the controller hash version", func() {
+		nodePool.Annotations = map[string]string{
+			v1beta1.NodePoolHashAnnotationKey:        "abceduefed",
+			v1beta1.NodePoolHashVersionAnnotationKey: "test-version",
+		}
+		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1beta1.NodePoolLabelKey: nodePool.Name},
+				Annotations: map[string]string{
+					v1beta1.NodePoolHashAnnotationKey:        "1234564654",
+					v1beta1.NodePoolHashVersionAnnotationKey: v1beta1.NodePoolHashVersion,
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+
+		expectedHash := nodePool.Hash()
+
+		// Expect NodeClaims to have been updated to the original hash
+		Expect(nodePool.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashAnnotationKey, expectedHash))
+		Expect(nodePool.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashVersionAnnotationKey, v1beta1.NodePoolHashVersion))
+		Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashAnnotationKey, "1234564654"))
+		Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashVersionAnnotationKey, v1beta1.NodePoolHashVersion))
+	})
+	It("should not update nodepool hash on the nodeclaim if it's drifted", func() {
+		nodePool.Annotations = map[string]string{
+			v1beta1.NodePoolHashAnnotationKey:        "abceduefed",
+			v1beta1.NodePoolHashVersionAnnotationKey: "test",
+		}
+		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1beta1.NodePoolLabelKey: nodePool.Name},
+				Annotations: map[string]string{
+					v1beta1.NodePoolHashAnnotationKey:        "123456",
+					v1beta1.NodePoolHashVersionAnnotationKey: "test",
+				},
+			},
+		})
+		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+
+		// Expect NodeClaims hash to not have been updated
+		Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashAnnotationKey, "123456"))
+		Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1beta1.NodePoolHashVersionAnnotationKey, v1beta1.NodePoolHashVersion))
 	})
 })

--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -70,8 +70,11 @@ func (i *NodeClaimTemplate) ToNodeClaim(nodePool *v1beta1.NodePool) *v1beta1.Nod
 	nc := &v1beta1.NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", i.OwnerKey.Name),
-			Annotations:  lo.Assign(i.Annotations, map[string]string{v1beta1.NodePoolHashAnnotationKey: nodePool.Hash()}),
-			Labels:       i.Labels,
+			Annotations: lo.Assign(i.Annotations, map[string]string{
+				v1beta1.NodePoolHashAnnotationKey:        nodePool.Hash(),
+				v1beta1.NodePoolHashVersionAnnotationKey: v1beta1.NodePoolHashVersion,
+			}),
+			Labels: i.Labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         v1beta1.SchemeGroupVersion.String(),

--- a/pkg/utils/nodepool/nodepool.go
+++ b/pkg/utils/nodepool/nodepool.go
@@ -159,5 +159,8 @@ func HashAnnotation(nodePool *v1beta1.NodePool) map[string]string {
 		provisioner := provisionerutil.New(nodePool)
 		return map[string]string{v1alpha5.ProvisionerHashAnnotationKey: provisioner.Hash()}
 	}
-	return map[string]string{v1beta1.NodePoolHashAnnotationKey: nodePool.Hash()}
+	return map[string]string{
+		v1beta1.NodePoolHashAnnotationKey:        nodePool.Hash(),
+		v1beta1.NodePoolHashVersionAnnotationKey: v1beta1.NodePoolHashVersion,
+	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Add a cherry pick of feat: Add Versioned for NodePool Hash to Prevent Drift on NodePool CRD Upgrade  #1016

**How was this change tested?**
- make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
