### PR TITLE
chore: Remove validation as covered by OpenAPI validation

### DIFF
--- a/pkg/apis/v1beta1/nodepool_validation.go
+++ b/pkg/apis/v1beta1/nodepool_validation.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	"github.com/robfig/cron/v3"
 	"github.com/samber/lo"
@@ -121,12 +120,6 @@ func (in *Budget) validate() (errs *apis.FieldError) {
 	if in.Schedule != nil {
 		if _, err := cron.ParseStandard(lo.FromPtr(in.Schedule)); err != nil {
 			return apis.ErrInvalidValue(in.Schedule, "schedule", fmt.Sprintf("invalid schedule %s", err))
-		}
-	}
-	if in.Duration != nil {
-		goodDuration, err := regexp.Match("^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$", []byte(in.Duration.Duration.String()))
-		if err != nil || !goodDuration {
-			return apis.ErrInvalidValue(in.Schedule, "duration", fmt.Sprintf("invalid duration %s", err))
 		}
 	}
 	return errs


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Removing web hook validation as openAPI validation will be evaluated by the APIServer for all version of supposed k8s 
- https://github.com/kubernetes-sigs/karpenter/blob/066cc4cb70fc09031cee4c54f9acca5c557db0d7/pkg/apis/v1beta1/nodepool.go#L127

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
