### PR TITLE
cherrypick(v0.35): fix: Adjust duration validation to include format for `1h10m`

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -80,7 +80,7 @@ spec:
                               This is required if Schedule is set.
                               This regex has an optional 0s at the end since the duration.String() always adds
                               a 0s at the end.
-                            pattern: ^([0-9]+(m|h)+(0s)?)$
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
                             type: string
                           nodes:
                             default: 10%

--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -124,7 +124,7 @@ type Budget struct {
 	// This is required if Schedule is set.
 	// This regex has an optional 0s at the end since the duration.String() always adds
 	// a 0s at the end.
-	// +kubebuilder:validation:Pattern=`^([0-9]+(m|h)+(0s)?)$`
+	// +kubebuilder:validation:Pattern=`^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$`
 	// +kubebuilder:validation:Type="string"
 	// +optional
 	Duration *metav1.Duration `json:"duration,omitempty" hash:"ignore"`

--- a/pkg/apis/v1beta1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_cel_test.go
@@ -165,7 +165,7 @@ var _ = Describe("CEL/Validation", func() {
 		It("should fail when creating a budget with a duration but no cron", func() {
 			nodePool.Spec.Disruption.Budgets = []Budget{{
 				Nodes:    "10",
-				Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("-20m"))},
+				Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
 			}}
 			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
 		})
@@ -174,6 +174,14 @@ var _ = Describe("CEL/Validation", func() {
 				Nodes:    "10",
 				Schedule: ptr.String("* * * * *"),
 				Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
+			}}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+		})
+		It("should succeed when creating a budget with hours and minutes in duration", func() {
+			nodePool.Spec.Disruption.Budgets = []Budget{{
+				Nodes:    "10",
+				Schedule: ptr.String("* * * * *"),
+				Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("2h20m"))},
 			}}
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 		})

--- a/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Webhook/Validation", func() {
 		It("should fail to validate a budget with a duration but no cron", func() {
 			nodePool.Spec.Disruption.Budgets = []Budget{{
 				Nodes:    "10",
-				Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("-20m"))},
+				Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
 			}}
 			Expect(nodePool.Validate(ctx)).ToNot(Succeed())
 		})
@@ -128,6 +128,14 @@ var _ = Describe("Webhook/Validation", func() {
 				Nodes:    "10",
 				Schedule: ptr.String("@annually"),
 				Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("20m"))},
+			}}
+			Expect(nodePool.Validate(ctx)).To(Succeed())
+		})
+		It("should succeed when creating a budget with hours and minutes in duration", func() {
+			nodePool.Spec.Disruption.Budgets = []Budget{{
+				Nodes:    "10",
+				Schedule: ptr.String("* * * * *"),
+				Duration: &metav1.Duration{Duration: lo.Must(time.ParseDuration("2h20m"))},
 			}}
 			Expect(nodePool.Validate(ctx)).To(Succeed())
 		})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Add a cherry pick of https://github.com/kubernetes-sigs/karpenter/pull/1125

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
