### PR TITLE
chore: Changes to run e2e for private cluster

### DIFF
--- a/pkg/test/deployment.go
+++ b/pkg/test/deployment.go
@@ -44,7 +44,7 @@ func Deployment(overrides ...DeploymentOptions) *appsv1.Deployment {
 	objectMeta := NamespacedObjectMeta(options.ObjectMeta)
 
 	if options.PodOptions.Image == "" {
-		options.PodOptions.Image = "public.ecr.aws/eks-distro/kubernetes/pause:3.2"
+		options.PodOptions.Image = DefaultImage
 	}
 	if options.PodOptions.Labels == nil {
 		options.PodOptions.Labels = map[string]string{

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -71,7 +71,7 @@ type EphemeralVolumeTemplateOptions struct {
 	StorageClassName *string
 }
 
-const (
+var (
 	DefaultImage = "public.ecr.aws/eks-distro/kubernetes/pause:3.2"
 )
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
When running E2E tests on private cluster, we can't pull the pod image from the internet. But currently the default pod image is a constant. Changing it to variable so that the value can be configured in case the tests are running on private cluster.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
