### PR TITLE
fix: Change type to hash on KubeReserved and SystemReserved 

### DIFF
--- a/hack/validation/kubelet.sh
+++ b/hack/validation/kubelet.sh
@@ -1,11 +1,22 @@
 # Kubelet Validation 
 
-# The regular expression will be adding a check for if kublet.evictionHard and kubelet.evictionSoft are percentage or a quantity value
-# Adding validation for nodeclaim 
+# The regular expression adds validation for kubelet.kubeReserved and kubelet.systemReserved values of the map are resource.Quantity
+# Quantity: https://github.com/kubernetes/apimachinery/blob/d82afe1e363acae0e8c0953b1bc230d65fdb50e2/pkg/api/resource/quantity.go#L100
+# NodeClaim Validation:
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.kubelet.properties.kubeReserved.additionalProperties.pattern = "^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.kubelet.properties.systemReserved.additionalProperties.pattern = "^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml 
+
+# NodePool Vaildation:
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.kubelet.properties.kubeReserved.additionalProperties.pattern = "^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$"' -i pkg/apis/crds/karpenter.sh_nodepools.yaml 
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.kubelet.properties.systemReserved.additionalProperties.pattern = "^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$"' -i pkg/apis/crds/karpenter.sh_nodepools.yaml 
+
+
+# The regular expression is a validation for kublet.evictionHard and kubelet.evictionSoft are percentage or a quantity value
+# NodeClaim Validation:
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.kubelet.properties.evictionHard.additionalProperties.pattern = "^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml 
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.kubelet.properties.evictionSoft.additionalProperties.pattern = "^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml 
 
-# The regular expression will be adding a check for if kublet.evictionHard and kubelet.evictionSoft are percentage or a quantity value
-# Adding validation for nodepool
+# NodePool Validation: 
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.kubelet.properties.evictionHard.additionalProperties.pattern = "^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$"' -i pkg/apis/crds/karpenter.sh_nodepools.yaml 
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.kubelet.properties.evictionSoft.additionalProperties.pattern = "^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$"' -i pkg/apis/crds/karpenter.sh_nodepools.yaml 
+

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -140,11 +140,8 @@ spec:
                       type: integer
                     kubeReserved:
                       additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
+                        type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
                       description: KubeReserved contains resources reserved for Kubernetes system components.
                       type: object
                       x-kubernetes-validations:
@@ -169,11 +166,8 @@ spec:
                       type: integer
                     systemReserved:
                       additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
+                        type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
                       description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
                       type: object
                       x-kubernetes-validations:

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -264,11 +264,8 @@ spec:
                               type: integer
                             kubeReserved:
                               additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
+                                type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
                               description: KubeReserved contains resources reserved for Kubernetes system components.
                               type: object
                               x-kubernetes-validations:
@@ -293,11 +290,8 @@ spec:
                               type: integer
                             systemReserved:
                               additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
+                                type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
                               description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
                               type: object
                               x-kubernetes-validations:

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -100,12 +100,12 @@ type KubeletConfiguration struct {
 	// +kubebuilder:validation:XValidation:message="valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']",rule="self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')"
 	// +kubebuilder:validation:XValidation:message="systemReserved value cannot be a negative resource quantity",rule="self.all(x, !self[x].startsWith('-'))"
 	// +optional
-	SystemReserved v1.ResourceList `json:"systemReserved,omitempty"`
+	SystemReserved map[string]string `json:"systemReserved,omitempty"`
 	// KubeReserved contains resources reserved for Kubernetes system components.
 	// +kubebuilder:validation:XValidation:message="valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']",rule="self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')"
 	// +kubebuilder:validation:XValidation:message="kubeReserved value cannot be a negative resource quantity",rule="self.all(x, !self[x].startsWith('-'))"
 	// +optional
-	KubeReserved v1.ResourceList `json:"kubeReserved,omitempty"`
+	KubeReserved map[string]string `json:"kubeReserved,omitempty"`
 	// EvictionHard is the map of signal names to quantities that define hard eviction thresholds
 	// +kubebuilder:validation:XValidation:message="valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']",rule="self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])"
 	// +optional

--- a/pkg/apis/v1beta1/nodeclaim_validation_cel_test.go
+++ b/pkg/apis/v1beta1/nodeclaim_validation_cel_test.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/Pallinder/go-randomdata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -220,16 +218,16 @@ var _ = Describe("Validation", func() {
 	Context("Kubelet", func() {
 		It("should fail on kubeReserved with invalid keys", func() {
 			nodeClaim.Spec.Kubelet = &KubeletConfiguration{
-				KubeReserved: v1.ResourceList{
-					v1.ResourcePods: resource.MustParse("2"),
+				KubeReserved: map[string]string{
+					string(v1.ResourcePods): "2",
 				},
 			}
 			Expect(env.Client.Create(ctx, nodeClaim)).ToNot(Succeed())
 		})
 		It("should fail on systemReserved with invalid keys", func() {
 			nodeClaim.Spec.Kubelet = &KubeletConfiguration{
-				SystemReserved: v1.ResourceList{
-					v1.ResourcePods: resource.MustParse("2"),
+				SystemReserved: map[string]string{
+					string(v1.ResourcePods): "2",
 				},
 			}
 			Expect(env.Client.Create(ctx, nodeClaim)).ToNot(Succeed())

--- a/pkg/apis/v1beta1/nodeclaim_validation_webhook_test.go
+++ b/pkg/apis/v1beta1/nodeclaim_validation_webhook_test.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/Pallinder/go-randomdata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -179,16 +177,16 @@ var _ = Describe("Validation", func() {
 	Context("Kubelet", func() {
 		It("should fail on kubeReserved with invalid keys", func() {
 			nodeClaim.Spec.Kubelet = &KubeletConfiguration{
-				KubeReserved: v1.ResourceList{
-					v1.ResourcePods: resource.MustParse("2"),
+				KubeReserved: map[string]string{
+					string(v1.ResourcePods): "2",
 				},
 			}
 			Expect(nodeClaim.Validate(ctx)).ToNot(Succeed())
 		})
 		It("should fail on systemReserved with invalid keys", func() {
 			nodeClaim.Spec.Kubelet = &KubeletConfiguration{
-				SystemReserved: v1.ResourceList{
-					v1.ResourcePods: resource.MustParse("2"),
+				SystemReserved: map[string]string{
+					string(v1.ResourcePods): "2",
 				},
 			}
 			Expect(nodeClaim.Validate(ctx)).ToNot(Succeed())

--- a/pkg/apis/v1beta1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_cel_test.go
@@ -232,34 +232,34 @@ var _ = Describe("CEL/Validation", func() {
 		})
 	})
 	Context("KubeletConfiguration", func() {
-		It("should succeed on kubeReserved with invalid keys", func() {
+		It("should succeed on kubeReserved with valid keys", func() {
 			nodePool.Spec.Template.Spec.Kubelet = &KubeletConfiguration{
-				KubeReserved: v1.ResourceList{
-					v1.ResourceCPU: resource.MustParse("2"),
+				KubeReserved: map[string]string{
+					string(v1.ResourceCPU): "2",
 				},
 			}
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 		})
-		It("should succeed on systemReserved with invalid keys", func() {
+		It("should succeed on systemReserved with valid keys", func() {
 			nodePool.Spec.Template.Spec.Kubelet = &KubeletConfiguration{
-				SystemReserved: v1.ResourceList{
-					v1.ResourceCPU: resource.MustParse("2"),
+				SystemReserved: map[string]string{
+					string(v1.ResourceCPU): "2",
 				},
 			}
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 		})
 		It("should fail on kubeReserved with invalid keys", func() {
 			nodePool.Spec.Template.Spec.Kubelet = &KubeletConfiguration{
-				KubeReserved: v1.ResourceList{
-					v1.ResourcePods: resource.MustParse("2"),
+				KubeReserved: map[string]string{
+					string(v1.ResourcePods): "2",
 				},
 			}
 			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
 		})
 		It("should fail on systemReserved with invalid keys", func() {
 			nodePool.Spec.Template.Spec.Kubelet = &KubeletConfiguration{
-				SystemReserved: v1.ResourceList{
-					v1.ResourcePods: resource.MustParse("2"),
+				SystemReserved: map[string]string{
+					string(v1.ResourcePods): "2",
 				},
 			}
 			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())

--- a/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
@@ -392,16 +392,16 @@ var _ = Describe("Webhook/Validation", func() {
 		Context("KubeletConfiguration", func() {
 			It("should fail on kubeReserved with invalid keys", func() {
 				nodePool.Spec.Template.Spec.Kubelet = &KubeletConfiguration{
-					KubeReserved: v1.ResourceList{
-						v1.ResourcePods: resource.MustParse("2"),
+					KubeReserved: map[string]string{
+						string(v1.ResourcePods): "2",
 					},
 				}
 				Expect(nodePool.Validate(ctx)).ToNot(Succeed())
 			})
 			It("should fail on systemReserved with invalid keys", func() {
 				nodePool.Spec.Template.Spec.Kubelet = &KubeletConfiguration{
-					SystemReserved: v1.ResourceList{
-						v1.ResourcePods: resource.MustParse("2"),
+					SystemReserved: map[string]string{
+						string(v1.ResourcePods): "2",
 					},
 				}
 				Expect(nodePool.Validate(ctx)).ToNot(Succeed())

--- a/pkg/apis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1beta1/zz_generated.deepcopy.go
@@ -101,16 +101,16 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	}
 	if in.SystemReserved != nil {
 		in, out := &in.SystemReserved, &out.SystemReserved
-		*out = make(v1.ResourceList, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val.DeepCopy()
+			(*out)[key] = val
 		}
 	}
 	if in.KubeReserved != nil {
 		in, out := &in.KubeReserved, &out.KubeReserved
-		*out = make(v1.ResourceList, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val.DeepCopy()
+			(*out)[key] = val
 		}
 	}
 	if in.EvictionHard != nil {

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -466,11 +466,15 @@ var _ = Describe("Drift", func() {
 								},
 							},
 							Kubelet: &v1beta1.KubeletConfiguration{
-								ClusterDNS:     []string{"fakeDNS"},
-								MaxPods:        ptr.Int32(0),
-								PodsPerCore:    ptr.Int32(0),
-								SystemReserved: v1.ResourceList{},
-								KubeReserved:   v1.ResourceList{},
+								ClusterDNS:  []string{"fakeDNS"},
+								MaxPods:     ptr.Int32(0),
+								PodsPerCore: ptr.Int32(0),
+								SystemReserved: map[string]string{
+									"cpu": "2",
+								},
+								KubeReserved: map[string]string{
+									"memory": "10Gi",
+								},
 								EvictionHard: map[string]string{
 									"memory.available": "20Gi",
 								},
@@ -520,11 +524,8 @@ var _ = Describe("Drift", func() {
 			Entry("kubeletConfiguration ClusterDNS", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{ClusterDNS: []string{"testDNS"}}}}}}),
 			Entry("KubeletConfiguration MaxPods", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{MaxPods: ptr.Int32(5)}}}}}),
 			Entry("KubeletConfiguration PodsPerCore", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{PodsPerCore: ptr.Int32(5)}}}}}),
-			// Karpenter currently have a bug with systemReserved and kubeReserved will cause NodeClaims to not be drifted, when the field is updated
-			// TODO: Enable systemReserved and kubeReserved once they can be used for static drift
-			// For more information: https://github.com/kubernetes-sigs/karpenter/issues/1080
-			// Entry("KubeletConfiguration SystemReserved", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{SystemReserved: v1.ResourceList{}}}}}}),
-			// Entry("KubeletConfiguration KubeReserved", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{KubeReserved: v1.ResourceList{}}}}}}),
+			Entry("KubeletConfiguration SystemReserved", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{SystemReserved: map[string]string{"memory": "30Gi"}}}}}}),
+			Entry("KubeletConfiguration KubeReserved", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{KubeReserved: map[string]string{"cpu": "10"}}}}}}),
 			Entry("KubeletConfiguration EvictionHard", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{EvictionHard: map[string]string{"memory.available": "30Gi"}}}}}}),
 			Entry("KubeletConfiguration EvictionSoft", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{EvictionSoft: map[string]string{"nodefs.available": "30Gi"}}}}}}),
 			Entry("KubeletConfiguration EvictionSoftGracePeriod", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{Spec: v1beta1.NodeClaimSpec{Kubelet: &v1beta1.KubeletConfiguration{EvictionSoftGracePeriod: map[string]metav1.Duration{"nodefs.available": {Duration: time.Minute}}}}}}}),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1080 

**Description**
- To allow drift to happen on the on KubeReserved and SystemReserved, we need to update the type to be a map[string]string so that we can hash on the values 

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
