### PR TITLE
feat: Get the GVK of the supported NodeClasses as part of the CloudProvider interface

### DIFF
--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -116,6 +117,10 @@ func (c CloudProvider) IsDrifted(ctx context.Context, nodeClaim *v1beta1.NodeCla
 
 func (c CloudProvider) Name() string {
 	return "kwok"
+}
+
+func (c CloudProvider) GetSupportedNodeClasses() []schema.GroupVersionKind {
+	return []schema.GroupVersionKind{}
 }
 
 func (c CloudProvider) getInstanceType(instanceTypeName string) (*cloudprovider.InstanceType, error) {

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -51,8 +52,9 @@ type CloudProvider struct {
 	NextCreateErr      error
 	DeleteCalls        []*v1beta1.NodeClaim
 
-	CreatedNodeClaims map[string]*v1beta1.NodeClaim
-	Drifted           cloudprovider.DriftReason
+	CreatedNodeClaims         map[string]*v1beta1.NodeClaim
+	Drifted                   cloudprovider.DriftReason
+	NodeClassGroupVersionKind []schema.GroupVersionKind
 }
 
 func NewCloudProvider() *CloudProvider {
@@ -77,6 +79,13 @@ func (c *CloudProvider) Reset() {
 	c.NextCreateErr = nil
 	c.DeleteCalls = []*v1beta1.NodeClaim{}
 	c.Drifted = "drifted"
+	c.NodeClassGroupVersionKind = []schema.GroupVersionKind{
+		{
+			Group:   "",
+			Version: "",
+			Kind:    "",
+		},
+	}
 }
 
 func (c *CloudProvider) Create(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (*v1beta1.NodeClaim, error) {
@@ -236,4 +245,8 @@ func (c *CloudProvider) IsDrifted(context.Context, *v1beta1.NodeClaim) (cloudpro
 // Name returns the CloudProvider implementation name.
 func (c *CloudProvider) Name() string {
 	return "fake"
+}
+
+func (c *CloudProvider) GetSupportedNodeClasses() []schema.GroupVersionKind {
+	return c.NodeClassGroupVersionKind
 }

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
@@ -55,6 +56,8 @@ type CloudProvider interface {
 	IsDrifted(context.Context, *v1beta1.NodeClaim) (DriftReason, error)
 	// Name returns the CloudProvider implementation name.
 	Name() string
+	// GetSupportedNodeClass returns the group, version, and kind of the CloudProvider NodeClass
+	GetSupportedNodeClasses() []schema.GroupVersionKind
 }
 
 // InstanceType describes the properties of a potential node (either concrete attributes of an instance of this type


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- For Karpenter to be able to query the APIServer for NodeClass, we will need to know the Kind, Version and Group of the nodeclass supported by the cloudprovider. 
- Adding `GetSupportedNodeClasses` to get all the NodeClasses used by a cloudprovider

**How was this change tested?**
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
