### PR TITLE
chore: Pin the release action for v0.32.x 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,13 +4,16 @@ on:
     tags: ['v*.*.*']
 jobs:
   release:
+    permissions:
+      contents: write # Needed for creating and editing releases
+      id-token: write # Needed for cosigning build attestation files with tejolote
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Create Github Release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- We are seeing failure for v0.32.x on creating a release, so we will be pinning the version to v1.2.1
- https://github.com/kubernetes-sigs/karpenter/actions/runs/8512485503
- https://github.com/kubernetes-sigs/karpenter/blob/3d493b30f2464833a6482b99c80117dc20a23a44/.github/workflows/release.yaml#L27

**How was this change tested?**
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
