### PR TITLE
chore: Add retryable error to cloud provider

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -198,8 +198,8 @@ func IsNodeClaimNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var mnfErr *NodeClaimNotFoundError
-	return errors.As(err, &mnfErr)
+	var ncnfErr *NodeClaimNotFoundError
+	return errors.As(err, &ncnfErr)
 }
 
 func IgnoreNodeClaimNotFoundError(err error) error {
@@ -267,4 +267,27 @@ func IgnoreNodeClassNotReadyError(err error) error {
 		return nil
 	}
 	return err
+}
+
+// RetryableError is an error type returned by CloudProviders when the action emitting the error has to be retried
+type RetryableError struct {
+	error
+}
+
+func NewRetryableError(err error) *RetryableError {
+	return &RetryableError{
+		error: err,
+	}
+}
+
+func (e *RetryableError) Error() string {
+	return fmt.Sprintf("retryable error, %s", e.error)
+}
+
+func IsRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var retryableError *RetryableError
+	return errors.As(err, &retryableError)
 }

--- a/pkg/controllers/nodeclaim/termination/controller.go
+++ b/pkg/controllers/nodeclaim/termination/controller.go
@@ -89,7 +89,7 @@ func (c *Controller) Finalize(ctx context.Context, nodeClaim *v1beta1.NodeClaim)
 		return reconcile.Result{}, nil
 	}
 	if nodeClaim.Status.ProviderID != "" {
-		if err = c.cloudProvider.Delete(ctx, nodeClaim); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil {
+		if err = c.cloudProvider.Delete(ctx, nodeClaim); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil || cloudprovider.IsRetryableError(err) {
 			return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 		}
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #947

**Description**
The termination controller calls `cloudProvider.Delete(nodeClaim)` which tries to terminate the underlying instance. It will remove the finalizer once the cloudProvider.Delete() call succeeds. However, the current implementation in AWS does not wait until the instance state is actually `terminated` and proceeds to remove the finalizer once the `ec2.TerminateInstance()` call has succeeded. 

The change in this PR adds a retryable error to cloudprovider which will allow Karpenter to parse instance state that has been successfully called terminate, but wasn't fully terminated. This effectively re-enqueues the node into the reconciliation loop of the termination controller.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
