### PR TITLE
chore: Only Log when NodePool limits are reached and not on empty InstanceTypes  

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -279,6 +279,10 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 		instanceTypes := s.instanceTypes[nodeClaimTemplate.NodePoolName]
 		// if limits have been applied to the nodepool, ensure we filter instance types to avoid violating those limits
 		if remaining, ok := s.remainingResources[nodeClaimTemplate.NodePoolName]; ok {
+			// If we have zero instancetypes before filtering, we should skip logging about about limits
+			if len(s.instanceTypes[nodeClaimTemplate.NodePoolName]) == 0 {
+				continue
+			}
 			instanceTypes = filterByRemainingResources(s.instanceTypes[nodeClaimTemplate.NodePoolName], remaining)
 			if len(instanceTypes) == 0 {
 				errs = multierr.Append(errs, fmt.Errorf("all available instance types exceed limits for nodepool: %q", nodeClaimTemplate.NodePoolName))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #https://github.com/aws/karpenter-provider-aws/issues/5937

**Description**
- When the GetInstanceTypes returns empty, Karpenter logs errors that the NodePool limits are reached, even if the NodePool had available allocatable resources.

**How was this change tested?**
- N/A 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
