### PR TITLE
chore: adding log for when cluster state has been out of sync for 15 seconds

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -115,7 +115,6 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		if time.Since(c.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration {
 			logging.FromContext(ctx).Infof("detected abnormal duration since cluster was last synced %v", c.cluster.LastSyncTime())
 		}
-		logging.FromContext(ctx).Debugf("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -112,6 +112,9 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !c.cluster.Synced(ctx) {
+		if time.Since(c.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration { 
+			logging.FromContext(ctx).Infof("cluster state has not been in sync since %v, waiting for sync", c.cluster.LastSyncTime()) 
+		}
 		logging.FromContext(ctx).Debugf("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -113,7 +113,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !c.cluster.Synced(ctx) {
 		if time.Since(c.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration {
-			logging.FromContext(ctx).Infof("cluster state has not been in sync since %v, waiting for sync", c.cluster.LastSyncTime())
+			logging.FromContext(ctx).Infof("detected abnormal duration since cluster was last synced %v", c.cluster.LastSyncTime())
 		}
 		logging.FromContext(ctx).Debugf("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -112,8 +112,8 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !c.cluster.Synced(ctx) {
-		if time.Since(c.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration { 
-			logging.FromContext(ctx).Infof("cluster state has not been in sync since %v, waiting for sync", c.cluster.LastSyncTime()) 
+		if time.Since(c.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration {
+			logging.FromContext(ctx).Infof("cluster state has not been in sync since %v, waiting for sync", c.cluster.LastSyncTime())
 		}
 		logging.FromContext(ctx).Debugf("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -112,9 +112,6 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !c.cluster.Synced(ctx) {
-		if time.Since(c.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration {
-			logging.FromContext(ctx).Infof("detected abnormal duration since cluster was last synced %v", c.cluster.LastSyncTime())
-		}
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -70,6 +70,7 @@ func WithReason(reason string) func(LaunchOptions) LaunchOptions {
 		return o
 	}
 }
+
 // Provisioner waits for enqueued pods, batches them, creates capacity and binds the pods to the capacity.
 type Provisioner struct {
 	cloudProvider  cloudprovider.CloudProvider
@@ -80,7 +81,6 @@ type Provisioner struct {
 	recorder       events.Recorder
 	cm             *pretty.ChangeMonitor
 }
-
 
 func NewProvisioner(kubeClient client.Client, recorder events.Recorder,
 	cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster,
@@ -118,8 +118,8 @@ func (p *Provisioner) Reconcile(ctx context.Context, _ reconcile.Request) (resul
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !p.cluster.Synced(ctx) {
-		if time.Since(p.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration { 
-			logging.FromContext(ctx).Infof("cluster state has not been in sync since %v, waiting for sync", p.cluster.LastSyncTime()) 
+		if time.Since(p.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration {
+			logging.FromContext(ctx).Infof("cluster state has not been in sync since %v, waiting for sync", p.cluster.LastSyncTime())
 		}
 		logging.FromContext(ctx).Debugf("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -118,9 +118,6 @@ func (p *Provisioner) Reconcile(ctx context.Context, _ reconcile.Request) (resul
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !p.cluster.Synced(ctx) {
-		if time.Since(p.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration {
-			logging.FromContext(ctx).Infof("detected abnormal duration since cluster was last synced %v", p.cluster.LastSyncTime())
-		}
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -70,7 +70,6 @@ func WithReason(reason string) func(LaunchOptions) LaunchOptions {
 		return o
 	}
 }
-
 // Provisioner waits for enqueued pods, batches them, creates capacity and binds the pods to the capacity.
 type Provisioner struct {
 	cloudProvider  cloudprovider.CloudProvider
@@ -81,6 +80,7 @@ type Provisioner struct {
 	recorder       events.Recorder
 	cm             *pretty.ChangeMonitor
 }
+
 
 func NewProvisioner(kubeClient client.Client, recorder events.Recorder,
 	cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster,
@@ -118,6 +118,9 @@ func (p *Provisioner) Reconcile(ctx context.Context, _ reconcile.Request) (resul
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !p.cluster.Synced(ctx) {
+		if time.Since(p.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration { 
+			logging.FromContext(ctx).Infof("cluster state has not been in sync since %v, waiting for sync", p.cluster.LastSyncTime()) 
+		}
 		logging.FromContext(ctx).Debugf("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -119,9 +119,8 @@ func (p *Provisioner) Reconcile(ctx context.Context, _ reconcile.Request) (resul
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !p.cluster.Synced(ctx) {
 		if time.Since(p.cluster.LastSyncTime()) > state.AbnormalClusterSyncDuration {
-			logging.FromContext(ctx).Infof("cluster state has not been in sync since %v, waiting for sync", p.cluster.LastSyncTime())
+			logging.FromContext(ctx).Infof("detected abnormal duration since cluster was last synced %v", p.cluster.LastSyncTime())
 		}
-		logging.FromContext(ctx).Debugf("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -75,7 +75,7 @@ const (
 	// AbnormalClusterSyncDuration is the duration after which the cluster state is considered to be out of sync for a long enough time to alarm the customer
 	AbnormalClusterSyncDuration = 15 * time.Second
 	// AbnormalClusterSyncLoggingInterval is the interval at which we will log about the cluster being out of sync if it is out of sync
-	AbnormalClusterSyncLoggingInterval = 5 * time.Minute
+	AbnormalClusterSyncLoggingInterval = 1 * time.Minute
 )
 
 func NewCluster(clk clock.Clock, client client.Client, cp cloudprovider.CloudProvider) *Cluster {
@@ -105,11 +105,11 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	defer func() {
 		ClusterStateSynced.Set(lo.Ternary[float64](synced, 1, 0))
 		if synced {
-			c.lastSynced = c.clock.Now()
+			c.lastSynced = time.Now() 
 		}
 		// If we have been out of sync for a while, and we haven't logged about it recently, log it
 		if time.Since(c.lastSynced) > AbnormalClusterSyncDuration && c.cm.HasChanged("ClusterSynced", synced) {
-			logging.FromContext(ctx).Warnf("cluster state is out of sync since %v", time.Since(c.lastSynced))
+			logging.FromContext(ctx).Infof("cluster state is out of sync for %v", time.Since(c.lastSynced))
 		}
 
 	}()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -85,6 +85,7 @@ func NewCluster(clk clock.Clock, client client.Client, cp cloudprovider.CloudPro
 		clock:                     clk,
 		kubeClient:                client,
 		cloudProvider:             cp,
+		lastSynced:                time.Now(),
 		cm:                        cm,
 		nodes:                     map[string]*StateNode{},
 		bindings:                  map[types.NamespacedName]string{},

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -212,7 +212,7 @@ func (c *Cluster) NominateNodeForPod(ctx context.Context, providerID string) {
 	}
 }
 
-// TODO remove this when v1alpha5 APIs are eprecated. With v1beta1 APIs Karpenter relies on the existence
+// TODO remove this when v1alpha5 APIs are deprecated. With v1beta1 APIs Karpenter relies on the existence
 // of the karpenter.sh/disruption taint to know when a node is marked for deletion.
 // UnmarkForDeletion removes the marking on the node as a node the controller intends to delete
 func (c *Cluster) UnmarkForDeletion(providerIDs ...string) {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -72,7 +72,7 @@ type Cluster struct {
 }
 
 const (
-	// AbnormalClusterSyncDuration is the duration after which the cluster state is considered to be out of sync for a long enough time to alarm the customer
+	// AbnormalClusterSyncDuration is the duration after which the cluster state is considered to be out of sync for a long enough time to log
 	AbnormalClusterSyncDuration = 15 * time.Second
 	// AbnormalClusterSyncLoggingInterval is the interval at which we will log about the cluster being out of sync if it is out of sync
 	AbnormalClusterSyncLoggingInterval = 1 * time.Minute
@@ -105,7 +105,7 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	defer func() {
 		ClusterStateSynced.Set(lo.Ternary[float64](synced, 1, 0))
 		if synced {
-			c.lastSynced = time.Now() 
+			c.lastSynced = time.Now()
 		}
 		// If we have been out of sync for a while, and we haven't logged about it recently, log it
 		if time.Since(c.lastSynced) > AbnormalClusterSyncDuration && c.cm.HasChanged("ClusterSynced", synced) {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -56,8 +56,8 @@ type Cluster struct {
 	nodeNameToProviderID      map[string]string               // node name -> provider id
 	nodeClaimNameToProviderID map[string]string               // node claim name -> provider id
 	daemonSetPods             sync.Map                        // daemonSet -> existing pod
-	
-	// Last Sync time when the cluster state was synced  with the apiserver 
+
+	// Last Sync time when the cluster state was synced  with the apiserver
 	lastSyncTime time.Time
 
 	clusterStateMu sync.RWMutex // Separate mutex as this is called in some places that mu is held
@@ -69,7 +69,6 @@ type Cluster struct {
 	clusterState     time.Time
 	antiAffinityPods sync.Map // pod namespaced name -> *v1.Pod of pods that have required anti affinities
 }
-
 
 // AbormalClusterSyncDuration is the duration after which the cluster state is considered to be out of sync for a long enough time to alarm the customer
 const AbnormalClusterSyncDuration = 15 * time.Second
@@ -97,7 +96,7 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	// Set the metric to whatever the result of the Synced() call is
 	defer func() {
 		ClusterStateSynced.Set(lo.Ternary[float64](synced, 1, 0))
-		if synced { 
+		if synced {
 			c.lastSyncTime = c.clock.Now()
 		}
 	}()
@@ -139,7 +138,6 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	// representation for every node/nodeClaim that exists on the apiserver
 	return stateNodeClaimNames.IsSuperset(nodeClaimNames) && stateNodeNames.IsSuperset(nodeNames)
 }
-
 
 func (c *Cluster) LastSyncTime() time.Time {
 	return c.lastSyncTime

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -101,7 +101,7 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 	defer func() {
 		ClusterStateSynced.Set(lo.Ternary[float64](synced, 1, 0))
 		if c.em.Alarm(synced) {
-			logging.FromContext(ctx).Infof("cluster state is out of sync for %v", time.Since(c.em.LastResolved()))
+			logging.FromContext(ctx).Infof("cluster state is out of sync for the last %v", time.Since(c.em.LastResolved()))
 		}
 
 	}()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -85,7 +85,7 @@ func NewCluster(clk clock.Clock, client client.Client, cp cloudprovider.CloudPro
 		clock:                     clk,
 		kubeClient:                client,
 		cloudProvider:             cp,
-		cm: 					  cm,
+		cm:                        cm,
 		nodes:                     map[string]*StateNode{},
 		bindings:                  map[types.NamespacedName]string{},
 		daemonSetPods:             sync.Map{},

--- a/pkg/utils/pretty/changemonitor.go
+++ b/pkg/utils/pretty/changemonitor.go
@@ -42,7 +42,7 @@ func (c *ChangeMonitor) Reconfigure(expiration time.Duration) {
 	c.lastSeen = cache.New(expiration, expiration/2)
 }
 
-// HasChanged takes a key and value and returns true if the hash of the value has changed since the last tine the
+// HasChanged takes a key and value and returns true if the hash of the value has changed since the last time the
 // change monitor was called.
 func (c *ChangeMonitor) HasChanged(key string, value any) bool {
 	hv, _ := hashstructure.Hash(value, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})

--- a/pkg/utils/pretty/errorstatemonitor.go
+++ b/pkg/utils/pretty/errorstatemonitor.go
@@ -1,0 +1,74 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pretty
+
+import (
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// Error state monitor encapsulates the logic for checking state eventually reaches its target by error Threshold and logs an error every interval we don't see the error.
+type ErrorStateMonitor struct {
+	goal           interface{}
+	errorThreshold time.Duration // amount of time we tolerate errorStateMonitor not reaching goal state
+	interval       time.Duration // frequency we want error state monitor to log
+	clk            clock.Clock
+
+	lastResolved time.Time // Last time we reached goal state
+	lastAlarmed  time.Time
+}
+
+func NewErrorStateMonitor(goal interface{}, errorThreshold, interval time.Duration, clk clock.Clock) *ErrorStateMonitor {
+	now := clk.Now()
+	return &ErrorStateMonitor{
+		goal:           goal,
+		errorThreshold: errorThreshold,
+		interval:       interval,
+		clk:            clk,
+		lastResolved:   now,
+		lastAlarmed:    now,
+	}
+}
+
+// Alarm returns a boolean value on if we need to alarm based on  if our actual state has been out of sync with our goal state for longer than the allowed errorThreshold
+func (e *ErrorStateMonitor) Alarm(actual any) bool {
+	now := e.clk.Now()
+
+	if actual == e.goal {
+		e.lastResolved = now
+		return false
+	}
+
+	if now.Sub(e.lastResolved) >= e.errorThreshold {
+		if now.Sub(e.lastAlarmed) > e.interval {
+			e.lastAlarmed = now
+			return true
+		}
+	}
+	return false
+}
+
+// LastResolved exposes a read only value of the last time our state passed in met our goal state
+func (e *ErrorStateMonitor) LastResolved() time.Time {
+	return e.lastResolved
+}
+
+// LastAlarmed exposes a read only value of the last time we alarmed based on not matching our goal state
+func (e *ErrorStateMonitor) LastAlarmed() time.Time {
+	return e.lastAlarmed
+}

--- a/pkg/utils/pretty/suite_test.go
+++ b/pkg/utils/pretty/suite_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pretty_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	clocktest "k8s.io/utils/clock/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/pretty"
+)
+
+func TestPretty(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pretty Suite")
+}
+
+var _ = Describe("ErrorStateMonitor", func() {
+	var (
+		mockClock *clocktest.FakeClock
+		monitor   *ErrorStateMonitor
+	)
+
+	BeforeEach(func() {
+		mockClock = clocktest.NewFakeClock(time.Now())
+		monitor = NewErrorStateMonitor("synced", 1*time.Minute, 5*time.Minute, mockClock)
+	})
+
+	Describe("Alarm", func() {
+		Context("when the actual state matches the goal state", func() {
+			It("should reset the lastResolved time and not alarm", func() {
+				Expect(monitor.Alarm("synced")).To(BeFalse())
+				Expect(monitor.LastResolved()).To(Equal(mockClock.Now()))
+			})
+		})
+
+		Context("when the actual state does not match the goal state", func() {
+			It("should alarm after threshold and interval have passed", func() {
+				mockClock.SetTime(mockClock.Now().Add(61 * time.Second))
+				Expect(monitor.Alarm("unsynced")).To(BeFalse())
+				currentTime := mockClock.Now()
+				mockClock.SetTime(currentTime.Add(5 * time.Minute))
+				Expect(monitor.Alarm("unsynced")).To(BeTrue())
+				Expect(monitor.LastAlarmed()).To(Equal(mockClock.Now()))
+			})
+		})
+	})
+
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1163 

**Description**
Adding a LastSyncTime to cluster state, along with a log to tell us when cluster state has been out of sync for 15 or more seconds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
