### PR TITLE
chore: Re-enqueue nodeclaim termination after 10s in case of retryable error

### DIFF
--- a/pkg/controllers/nodeclaim/termination/controller.go
+++ b/pkg/controllers/nodeclaim/termination/controller.go
@@ -89,7 +89,13 @@ func (c *Controller) Finalize(ctx context.Context, nodeClaim *v1beta1.NodeClaim)
 		return reconcile.Result{}, nil
 	}
 	if nodeClaim.Status.ProviderID != "" {
-		if err = c.cloudProvider.Delete(ctx, nodeClaim); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil || cloudprovider.IsRetryableError(err) {
+		if err = c.cloudProvider.Delete(ctx, nodeClaim); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil {
+			// We expect cloudProvider to emit a Retryable Error when the underlying instance is not terminated and if that
+			// happens, we want to re-enqueue reconciliation until we terminate the underlying instance before removing
+			// finalizer from the nodeClaim.
+			if cloudprovider.IsRetryableError(err) {
+				return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+			}
 			return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 		}
 	}

--- a/pkg/controllers/nodeclaim/termination/suite_test.go
+++ b/pkg/controllers/nodeclaim/termination/suite_test.go
@@ -18,6 +18,7 @@ package termination_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -215,5 +216,33 @@ var _ = Describe("Termination", func() {
 		for _, node := range nodes {
 			ExpectExists(ctx, env.Client, node)
 		}
+	})
+	It("should retry nodeClaim deletion when cloudProvider returns retryable error", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectReconcileSucceeded(ctx, nodeClaimLifecycleController, client.ObjectKeyFromObject(nodeClaim))
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		_, err := cloudProvider.Get(ctx, nodeClaim.Status.ProviderID)
+		Expect(err).ToNot(HaveOccurred())
+
+		node := test.NodeClaimLinkedNode(nodeClaim)
+		ExpectApplied(ctx, env.Client, node)
+
+		// Expect the node and the nodeClaim to both be gone
+		Expect(env.Client.Delete(ctx, nodeClaim)).To(Succeed())
+		ExpectReconcileSucceeded(ctx, nodeClaimTerminationController, client.ObjectKeyFromObject(nodeClaim)) // triggers the node deletion
+		ExpectFinalizersRemoved(ctx, env.Client, node)
+		ExpectNotFound(ctx, env.Client, node)
+
+		cloudProvider.NextDeleteErr = cloudprovider.NewRetryableError(fmt.Errorf("underlying instance not terminated"))
+		result := ExpectReconcileSucceeded(ctx, nodeClaimTerminationController, client.ObjectKeyFromObject(nodeClaim))
+		Expect(result.RequeueAfter).To(Equal(time.Second * 10))
+
+		ExpectReconcileSucceeded(ctx, nodeClaimTerminationController, client.ObjectKeyFromObject(nodeClaim)) //re-enqueue reconciliation since we got retryable error previously
+		ExpectNotFound(ctx, env.Client, nodeClaim, node)
+
+		// Expect the nodeClaim to be gone from the cloudprovider
+		_, err = cloudProvider.Get(ctx, nodeClaim.Status.ProviderID)
+		Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
1. Re-enqueue nodeClaim termination after 10s when we see an error. 
2. Added test for retryable error.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
