### PR TITLE
chore: bump registration ttl log

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -55,7 +55,7 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) 
 	if err := l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	logging.FromContext(ctx).With("ttl", registrationTTL).Debugf("terminating due to registration ttl")
+	logging.FromContext(ctx).With("ttl", registrationTTL).Infof("terminating due to registration ttl")
 	metrics.NodeClaimsTerminatedCounter.With(prometheus.Labels{
 		metrics.ReasonLabel:       "liveness",
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
We have a system that allow us to raise alerts based on logs. Liveness probe is a useful signal for greater node registration problems on the cluster.

We log at the Info level verbosity. Registration TTL should be more than just debug. I can figure out the nodeclaim is being deleted at 15 minutes but not why. Having this explicit log would be useful for alerting on logs. 
**How was this change tested?**
- it wasn't
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
