### PR TITLE
chore: Remove Cloudprovider from Consistency controller

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -71,7 +71,7 @@ func NewControllers(
 		metricsnodepool.NewController(kubeClient),
 		metricsnode.NewController(cluster),
 		nodepoolcounter.NewController(kubeClient, cluster),
-		nodeclaimconsistency.NewController(clock, kubeClient, recorder, cloudProvider),
+		nodeclaimconsistency.NewController(clock, kubeClient, recorder),
 		nodeclaimlifecycle.NewController(clock, kubeClient, cloudProvider, recorder),
 		nodeclaimgarbagecollection.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimtermination.NewController(kubeClient, cloudProvider),

--- a/pkg/controllers/nodeclaim/consistency/controller.go
+++ b/pkg/controllers/nodeclaim/consistency/controller.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
 	operatorcontroller "sigs.k8s.io/karpenter/pkg/operator/controller"
 	nodeclaimutil "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
@@ -61,8 +60,7 @@ type Check interface {
 // scanPeriod is how often we inspect and report issues that are found.
 const scanPeriod = 10 * time.Minute
 
-func NewController(clk clock.Clock, kubeClient client.Client, recorder events.Recorder,
-	provider cloudprovider.CloudProvider) operatorcontroller.Controller {
+func NewController(clk clock.Clock, kubeClient client.Client, recorder events.Recorder) operatorcontroller.Controller {
 
 	return operatorcontroller.Typed[*v1beta1.NodeClaim](kubeClient, &Controller{
 		clock:       clk,
@@ -71,7 +69,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, recorder events.Re
 		lastScanned: cache.New(scanPeriod, 1*time.Minute),
 		checks: []Check{
 			NewTermination(clk, kubeClient),
-			NewNodeShape(provider),
+			NewNodeShape(),
 		},
 	})
 }

--- a/pkg/controllers/nodeclaim/consistency/nodeshape.go
+++ b/pkg/controllers/nodeclaim/consistency/nodeshape.go
@@ -23,18 +23,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 )
 
 // NodeShape detects nodes that have launched with 10% or less of any resource than was expected.
-type NodeShape struct {
-	provider cloudprovider.CloudProvider
-}
+type NodeShape struct{}
 
-func NewNodeShape(provider cloudprovider.CloudProvider) Check {
-	return &NodeShape{
-		provider: provider,
-	}
+func NewNodeShape() Check {
+	return &NodeShape{}
 }
 
 func (n *NodeShape) Check(_ context.Context, node *v1.Node, nodeClaim *v1beta1.NodeClaim) ([]Issue, error) {

--- a/pkg/controllers/nodeclaim/consistency/suite_test.go
+++ b/pkg/controllers/nodeclaim/consistency/suite_test.go
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	cp = &fake.CloudProvider{}
 	recorder = test.NewEventRecorder()
-	nodeClaimConsistencyController = consistency.NewController(fakeClock, env.Client, recorder, cp)
+	nodeClaimConsistencyController = consistency.NewController(fakeClock, env.Client, recorder)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Remove cloudprovider interface from NodeClaim Consistency controller , since it's not used in the provider

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
