### PR TITLE
cleanup: clean redundant condition checking

### DIFF
--- a/pkg/controllers/disruption/emptiness.go
+++ b/pkg/controllers/disruption/emptiness.go
@@ -75,15 +75,13 @@ func (e *Emptiness) ComputeCommand(_ context.Context, disruptionBudgetMapping ma
 
 	empty := make([]*Candidate, 0, len(emptyCandidates))
 	for _, candidate := range emptyCandidates {
-		if len(candidate.reschedulablePods) > 0 {
-			continue
-		}
 		// If there's disruptions allowed for the candidate's nodepool,
 		// add it to the list of candidates, and decrement the budget.
-		if disruptionBudgetMapping[candidate.nodePool.Name] > 0 {
-			empty = append(empty, candidate)
-			disruptionBudgetMapping[candidate.nodePool.Name]--
+		if disruptionBudgetMapping[candidate.nodePool.Name] == 0 {
+			continue
 		}
+		empty = append(empty, candidate)
+		disruptionBudgetMapping[candidate.nodePool.Name]--
 	}
 	return Command{
 		candidates: empty,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
```
func (e *Emptiness) ComputeCommand(_ context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, scheduling.Results, error) {
	// First check how many nodes are empty so that we can emit a metric on how many nodes are eligible
	emptyCandidates := lo.Filter(candidates, func(cn *Candidate, _ int) bool {
                // After this filtering, all the candidates have zero reschedulablePods
		return cn.NodeClaim.DeletionTimestamp.IsZero() && len(cn.reschedulablePods) == 0
	})

	EligibleNodesGauge.With(map[string]string{
		methodLabel:            e.Type(),
		consolidationTypeLabel: e.ConsolidationType(),
	}).Set(float64(len(candidates)))

	empty := make([]*Candidate, 0, len(emptyCandidates))
	for _, candidate := range emptyCandidates {
                // Here is redundant 
                if len(candidate.reschedulablePods) > 0 {
			continue
		}
		// If there's disruptions allowed for the candidate's nodepool,
		// add it to the list of candidates, and decrement the budget.
		if disruptionBudgetMapping[candidate.nodePool.Name] > 0 {
			empty = append(empty, candidate)
			disruptionBudgetMapping[candidate.nodePool.Name]--
		}
	}
	return Command{
		candidates: empty,
	}, scheduling.Results{}, nil
}

```

**How was this change tested?**

Code review

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
