### PR TITLE
Revert "chore: Drop CloudProvider delete call from Node termination"

### DIFF
--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
 // PodEventHandler is a watcher on v1.Pods that maps Pods to NodeClaim based on the node names
@@ -187,6 +188,38 @@ func AllNodesForNodeClaim(ctx context.Context, c client.Client, nodeClaim *v1bet
 		return nil, fmt.Errorf("listing nodes, %w", err)
 	}
 	return lo.ToSlicePtr(nodeList.Items), nil
+}
+
+// NewFromNode converts a node into a pseudo-NodeClaim using known values from the node
+// Deprecated: This NodeClaim generator function can be removed when v1beta1 migration has completed.
+func NewFromNode(node *v1.Node) *v1beta1.NodeClaim {
+	nc := &v1beta1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        node.Name,
+			Annotations: node.Annotations,
+			Labels:      node.Labels,
+			Finalizers:  []string{v1beta1.TerminationFinalizer},
+		},
+		Spec: v1beta1.NodeClaimSpec{
+			Taints:       node.Spec.Taints,
+			Requirements: scheduling.NewLabelRequirements(node.Labels).NodeSelectorRequirements(),
+			Resources: v1beta1.ResourceRequirements{
+				Requests: node.Status.Allocatable,
+			},
+		},
+		Status: v1beta1.NodeClaimStatus{
+			NodeName:    node.Name,
+			ProviderID:  node.Spec.ProviderID,
+			Capacity:    node.Status.Capacity,
+			Allocatable: node.Status.Allocatable,
+		},
+	}
+	if _, ok := node.Labels[v1beta1.NodeInitializedLabelKey]; ok {
+		nc.StatusConditions().MarkTrue(v1beta1.Initialized)
+	}
+	nc.StatusConditions().MarkTrue(v1beta1.Launched)
+	nc.StatusConditions().MarkTrue(v1beta1.Registered)
+	return nc
 }
 
 func UpdateNodeOwnerReferences(nodeClaim *v1beta1.NodeClaim, node *v1.Node) *v1.Node {


### PR DESCRIPTION
Reverting https://github.com/kubernetes-sigs/karpenter/pull/1103

This change meant that the node could be deleted before the instance termination was completed. This doesn't have significant impact -- because we weren't waiting for EC2 to fully terminate the node before -- however, we are planning to wait for instance termination before the node gets deregistered and we will need this delete call to be in the finalization flow