### PR TITLE
chore: Add retryable error handling to node termination

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -104,7 +104,16 @@ func (c *Controller) Finalize(ctx context.Context, node *v1.Node) (reconcile.Res
 		}
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
+	// Be careful when removing this delete call in the Node termination flow
+	// This delete call is needed so that we ensure that we don't remove the node from the cluster
+	// until the full instance shutdown has taken place
 	if err := c.cloudProvider.Delete(ctx, nodeclaimutil.NewFromNode(node)); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil {
+		// We expect cloudProvider to emit a Retryable Error when the underlying instance is not terminated and if that
+		// happens, we want to re-enqueue reconciliation until we terminate the underlying instance before removing
+		// finalizer from the node.
+		if cloudprovider.IsRetryableError(err) {
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		}
 		return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 	}
 	if err := c.removeFinalizer(ctx, node); err != nil {

--- a/pkg/controllers/nodeclaim/termination/suite_test.go
+++ b/pkg/controllers/nodeclaim/termination/suite_test.go
@@ -238,6 +238,10 @@ var _ = Describe("Termination", func() {
 		result := ExpectReconcileSucceeded(ctx, nodeClaimTerminationController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(result.RequeueAfter).To(Equal(time.Second * 10))
 
+		// Instance still exists
+		_, err = cloudProvider.Get(ctx, node.Spec.ProviderID)
+		Expect(err).ToNot(HaveOccurred())
+
 		ExpectReconcileSucceeded(ctx, nodeClaimTerminationController, client.ObjectKeyFromObject(nodeClaim)) //re-enqueue reconciliation since we got retryable error previously
 		ExpectNotFound(ctx, env.Client, nodeClaim, node)
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add retryable error handling during the node termination handling

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
