### PR TITLE
chore: Wait for instance termination before deleting nodeclaim

### DIFF
--- a/pkg/apis/v1beta1/nodeclaim_status.go
+++ b/pkg/apis/v1beta1/nodeclaim_status.go
@@ -28,6 +28,7 @@ const (
 	ConditionTypeEmpty       = "Empty"
 	ConditionTypeDrifted     = "Drifted"
 	ConditionTypeExpired     = "Expired"
+	ConditionTypeTerminating = "Terminating"
 )
 
 // NodeClaimStatus defines the observed state of NodeClaim

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -111,6 +111,7 @@ var _ = Describe("Termination", func() {
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
 			ExpectExists(ctx, env.Client, nodeClaim)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
 			ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
 			ExpectNotFound(ctx, env.Client, node, nodeClaim)
 		})

--- a/pkg/controllers/nodeclaim/termination/metrics.go
+++ b/pkg/controllers/nodeclaim/termination/metrics.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/karpenter/pkg/metrics"
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(InstanceTerminationDuration, NodeClaimTerminationDuration)
+}
+
+var InstanceTerminationDuration = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Namespace: metrics.Namespace,
+		Subsystem: metrics.NodeClaimSubsystem,
+		Name:      "instance_termination_duration_seconds",
+		Help:      "Duration of CloudProvider Instance termination in seconds.",
+		Buckets:   prometheus.ExponentialBuckets(1, 2, 11), //The threshold values generated here are 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024
+	},
+	[]string{metrics.NodePoolLabel},
+)
+
+var NodeClaimTerminationDuration = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Namespace: metrics.Namespace,
+		Subsystem: metrics.NodeClaimSubsystem,
+		Name:      "termination_duration_seconds",
+		Help:      "Duration of NodeClaim termination in seconds.",
+		Buckets:   prometheus.ExponentialBuckets(1, 2, 12)}, //The threshold values generated here are 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024. 2048
+	[]string{metrics.NodePoolLabel},
+)

--- a/pkg/controllers/nodeclaim/termination/suite_test.go
+++ b/pkg/controllers/nodeclaim/termination/suite_test.go
@@ -18,6 +18,7 @@ package termination_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -111,6 +112,8 @@ var _ = Describe("Termination", func() {
 				},
 			},
 		})
+		nodeclaimtermination.InstanceTerminationDuration.Reset()
+
 	})
 	It("should delete the node and the CloudProvider NodeClaim when NodeClaim deletion is triggered", func() {
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
@@ -129,12 +132,54 @@ var _ = Describe("Termination", func() {
 		ExpectFinalizersRemoved(ctx, env.Client, node)
 		ExpectNotFound(ctx, env.Client, node)
 
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // now all nodes are gone so nodeClaim deletion continues
+		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // now all the nodes are gone so nodeClaim deletion continues
+		Expect(result.RequeueAfter).To(BeEquivalentTo(5 * time.Second))
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
+
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // this will call cloudProvider Get to check if the instance is still around
+
+		ExpectMetricHistogramSampleCountValue("karpenter_nodeclaims_instance_termination_duration_seconds", 1, map[string]string{"nodepool": nodePool.Name})
+		ExpectMetricHistogramSampleCountValue("karpenter_nodeclaims_termination_duration_seconds", 1, map[string]string{"nodepool": nodePool.Name})
 		ExpectNotFound(ctx, env.Client, nodeClaim, node)
 
 		// Expect the nodeClaim to be gone from the cloudprovider
 		_, err = cloudProvider.Get(ctx, nodeClaim.Status.ProviderID)
 		Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
+	})
+	It("should requeue reconciliation if cloudProvider Get returns an error other than NodeClaimNotFoundError", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimLifecycleController, nodeClaim)
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		_, err := cloudProvider.Get(ctx, nodeClaim.Status.ProviderID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(env.Client.Delete(ctx, nodeClaim)).To(Succeed())
+		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // trigger nodeClaim Deletion that will set the nodeClaim status as terminating
+		Expect(result.RequeueAfter).To(BeEquivalentTo(5 * time.Second))
+		cloudProvider.NextGetErr = errors.New("fake error")
+		// trigger nodeClaim Deletion that will make cloudProvider Get and fail due to error
+		Expect(ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimTerminationController, nodeClaim)).To(HaveOccurred())
+		result = ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // trigger nodeClaim Deletion that will succeed
+		Expect(result.Requeue).To(BeFalse())
+		ExpectNotFound(ctx, env.Client, nodeClaim)
+	})
+	It("should not remove the finalizer and terminate the NodeClaim if the cloudProvider instance is still around", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimLifecycleController, nodeClaim)
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		_, err := cloudProvider.Get(ctx, nodeClaim.Status.ProviderID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(env.Client.Delete(ctx, nodeClaim)).To(Succeed())
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim)
+		// The delete call that happened first will remove the cloudProvider instance from cloudProvider.CreatedNodeClaims[].
+		// To model the behavior of having cloudProvider instance not terminated, we add it back here.
+		cloudProvider.CreatedNodeClaims[nodeClaim.Status.ProviderID] = nodeClaim
+		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // this will ensure that we call cloudProvider Get to check if the instance is still around
+		Expect(result.RequeueAfter).To(BeEquivalentTo(5 * time.Second))
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
 	})
 	It("should delete multiple Nodes if multiple Nodes map to the NodeClaim", func() {
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
@@ -155,7 +200,12 @@ var _ = Describe("Termination", func() {
 		ExpectFinalizersRemoved(ctx, env.Client, node1, node2, node3)
 		ExpectNotFound(ctx, env.Client, node1, node2, node3)
 
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // now all nodes are gone so nodeClaim deletion continues
+		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // now all nodes are gone so nodeClaim deletion continues
+		Expect(result.RequeueAfter).To(BeEquivalentTo(5 * time.Second))
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // this will call cloudProvider Get to check if the instance is still around
+
+		ExpectMetricHistogramSampleCountValue("karpenter_nodeclaims_instance_termination_duration_seconds", 1, map[string]string{"nodepool": nodePool.Name})
+		ExpectMetricHistogramSampleCountValue("karpenter_nodeclaims_termination_duration_seconds", 1, map[string]string{"nodepool": nodePool.Name})
 		ExpectNotFound(ctx, env.Client, nodeClaim, node1, node2, node3)
 
 		// Expect the nodeClaim to be gone from the cloudprovider
@@ -175,14 +225,14 @@ var _ = Describe("Termination", func() {
 
 		Expect(env.Client.Delete(ctx, nodeClaim)).To(Succeed())
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // triggers the node deletion
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // the node still hasn't been deleted, so the nodeClaim should remain
-
-		ExpectExists(ctx, env.Client, nodeClaim)
+		ExpectExists(ctx, env.Client, nodeClaim)                                           // the node still hasn't been deleted, so the nodeClaim should remain
 		ExpectExists(ctx, env.Client, node)
-
 		ExpectFinalizersRemoved(ctx, env.Client, node)
 		ExpectNotFound(ctx, env.Client, node)
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // now the nodeClaim should be gone
+
+		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // now the nodeClaim should be gone
+		Expect(result.RequeueAfter).To(BeEquivalentTo(5 * time.Second))
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // this will call cloudProvider Get to check if the instance is still around
 
 		ExpectNotFound(ctx, env.Client, nodeClaim)
 	})
@@ -211,6 +261,8 @@ var _ = Describe("Termination", func() {
 		Expect(env.Client.Delete(ctx, nodeClaim)).To(Succeed())
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim)
 
+		ExpectMetricHistogramSampleCountValue("karpenter_nodeclaims_instance_termination_duration_seconds", 1, map[string]string{"nodepool": nodePool.Name})
+		ExpectMetricHistogramSampleCountValue("karpenter_nodeclaims_termination_duration_seconds", 1, map[string]string{"nodepool": nodePool.Name})
 		ExpectNotFound(ctx, env.Client, nodeClaim)
 		for _, node := range nodes {
 			ExpectExists(ctx, env.Client, node)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,14 +23,14 @@ import (
 
 const (
 	NodeSubsystem      = "nodes"
-	nodeClaimSubsystem = "nodeclaims"
+	NodeClaimSubsystem = "nodeclaims"
 )
 
 var (
 	NodeClaimsCreatedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeClaimSubsystem,
+			Subsystem: NodeClaimSubsystem,
 			Name:      "created",
 			Help:      "Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created and the owning nodepool.",
 		},
@@ -43,7 +43,7 @@ var (
 	NodeClaimsTerminatedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeClaimSubsystem,
+			Subsystem: NodeClaimSubsystem,
 			Name:      "terminated",
 			Help:      "Number of nodeclaims terminated in total by Karpenter. Labeled by reason the nodeclaim was terminated and the owning nodepool.",
 		},
@@ -56,7 +56,7 @@ var (
 	NodeClaimsLaunchedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeClaimSubsystem,
+			Subsystem: NodeClaimSubsystem,
 			Name:      "launched",
 			Help:      "Number of nodeclaims launched in total by Karpenter. Labeled by the owning nodepool.",
 		},
@@ -67,7 +67,7 @@ var (
 	NodeClaimsRegisteredCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeClaimSubsystem,
+			Subsystem: NodeClaimSubsystem,
 			Name:      "registered",
 			Help:      "Number of nodeclaims registered in total by Karpenter. Labeled by the owning nodepool.",
 		},
@@ -78,7 +78,7 @@ var (
 	NodeClaimsInitializedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeClaimSubsystem,
+			Subsystem: NodeClaimSubsystem,
 			Name:      "initialized",
 			Help:      "Number of nodeclaims initialized in total by Karpenter. Labeled by the owning nodepool.",
 		},
@@ -89,7 +89,7 @@ var (
 	NodeClaimsDisruptedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeClaimSubsystem,
+			Subsystem: NodeClaimSubsystem,
 			Name:      "disrupted",
 			Help:      "Number of nodeclaims disrupted in total by Karpenter. Labeled by disruption type of the nodeclaim and the owning nodepool.",
 		},
@@ -101,7 +101,7 @@ var (
 	NodeClaimsDriftedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeClaimSubsystem,
+			Subsystem: NodeClaimSubsystem,
 			Name:      "drifted",
 			Help:      "Number of nodeclaims drifted reasons in total by Karpenter. Labeled by drift type of the nodeclaim and the owning nodepool.",
 		},

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -562,6 +562,13 @@ func ExpectMetricCounterValue(collector prometheus.Collector, expectedValue floa
 	Expect(lo.FromPtr(metric.Counter.Value)).To(Equal(expectedValue), "Metric "+metricName+" should have the expected value")
 }
 
+func ExpectMetricHistogramSampleCountValue(metricName string, expectedValue uint64, labels map[string]string) {
+	GinkgoHelper()
+	metric, ok := FindMetricWithLabelValues(metricName, labels)
+	Expect(ok).To(BeTrue(), "Metric "+metricName+" should be available")
+	Expect(lo.FromPtr(metric.Histogram.SampleCount)).To(Equal(expectedValue), "Metric "+metricName+" should have the expected value")
+}
+
 func ExpectManualBinding(ctx context.Context, c client.Client, pod *v1.Pod, node *v1.Node) {
 	GinkgoHelper()
 	Expect(c.Create(ctx, &v1.Binding{

--- a/pkg/utils/node/suite_test.go
+++ b/pkg/utils/node/suite_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node_test
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/karpenter/pkg/utils/node"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	. "knative.dev/pkg/logging/testing"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	"sigs.k8s.io/karpenter/pkg/operator/scheme"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+	"sigs.k8s.io/karpenter/pkg/test"
+)
+
+var (
+	ctx context.Context
+	env *test.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeUtils")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...), test.WithFieldIndexers(test.NodeClaimFieldIndexer(ctx)))
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("NodeUtils", func() {
+	var testNode *v1.Node
+	var nodeClaim *v1beta1.NodeClaim
+	BeforeEach(func() {
+		nodeClaim = test.NodeClaim(v1beta1.NodeClaim{
+			Spec: v1beta1.NodeClaimSpec{
+				NodeClassRef: &v1beta1.NodeClassReference{
+					Kind:       "NodeClassRef",
+					APIVersion: "test.cloudprovider/v1",
+					Name:       "default",
+				},
+			},
+		})
+	})
+	It("should return nodeClaim for node which has the same provider ID", func() {
+		testNode = test.NodeClaimLinkedNode(nodeClaim)
+		ExpectApplied(ctx, env.Client, testNode, nodeClaim)
+
+		nodeClaims, err := node.GetNodeClaims(ctx, testNode, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeClaims).To(HaveLen(1))
+		for _, nc := range nodeClaims {
+			Expect(nc.Status.ProviderID).To(BeEquivalentTo(testNode.Spec.ProviderID))
+		}
+	})
+	It("should not return nodeClaim for node since the node supplied here has different provider ID", func() {
+		testNode = test.Node(test.NodeOptions{
+			ProviderID: "testID",
+		})
+		ExpectApplied(ctx, env.Client, testNode, nodeClaim)
+
+		nodeClaims, err := node.GetNodeClaims(ctx, testNode, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeClaims).To(HaveLen(0))
+	})
+})

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
 // PodEventHandler is a watcher on v1.Pods that maps Pods to NodeClaim based on the node names
@@ -187,38 +186,6 @@ func AllNodesForNodeClaim(ctx context.Context, c client.Client, nodeClaim *v1bet
 		return nil, fmt.Errorf("listing nodes, %w", err)
 	}
 	return lo.ToSlicePtr(nodeList.Items), nil
-}
-
-// NewFromNode converts a node into a pseudo-NodeClaim using known values from the node
-// Deprecated: This NodeClaim generator function can be removed when v1beta1 migration has completed.
-func NewFromNode(node *v1.Node) *v1beta1.NodeClaim {
-	nc := &v1beta1.NodeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        node.Name,
-			Annotations: node.Annotations,
-			Labels:      node.Labels,
-			Finalizers:  []string{v1beta1.TerminationFinalizer},
-		},
-		Spec: v1beta1.NodeClaimSpec{
-			Taints:       node.Spec.Taints,
-			Requirements: scheduling.NewLabelRequirements(node.Labels).NodeSelectorRequirements(),
-			Resources: v1beta1.ResourceRequirements{
-				Requests: node.Status.Allocatable,
-			},
-		},
-		Status: v1beta1.NodeClaimStatus{
-			NodeName:    node.Name,
-			ProviderID:  node.Spec.ProviderID,
-			Capacity:    node.Status.Capacity,
-			Allocatable: node.Status.Allocatable,
-		},
-	}
-	if _, ok := node.Labels[v1beta1.NodeInitializedLabelKey]; ok {
-		nc.StatusConditions().SetTrue(v1beta1.ConditionTypeInitialized)
-	}
-	nc.StatusConditions().SetTrue(v1beta1.ConditionTypeLaunched)
-	nc.StatusConditions().SetTrue(v1beta1.ConditionTypeRegistered)
-	return nc
 }
 
 func UpdateNodeOwnerReferences(nodeClaim *v1beta1.NodeClaim, node *v1.Node) *v1.Node {

--- a/pkg/utils/nodeclaim/suite_test.go
+++ b/pkg/utils/nodeclaim/suite_test.go
@@ -34,7 +34,6 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/test"
 	nodeclaimutil "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
@@ -110,26 +109,6 @@ var _ = Describe("NodeClaimUtils", func() {
 				v1.ResourceEphemeralStorage: resource.MustParse("95Gi"),
 			},
 		})
-	})
-	It("should convert a Node to a NodeClaim", func() {
-		nodeClaim := nodeclaimutil.NewFromNode(node)
-		for k, v := range node.Annotations {
-			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(k, v))
-		}
-		for k, v := range node.Labels {
-			Expect(nodeClaim.Labels).To(HaveKeyWithValue(k, v))
-		}
-		Expect(lo.Contains(nodeClaim.Finalizers, v1beta1.TerminationFinalizer)).To(BeTrue())
-		Expect(nodeClaim.Spec.Taints).To(Equal(node.Spec.Taints))
-		Expect(nodeClaim.Spec.Requirements).To(ContainElements(scheduling.NewLabelRequirements(node.Labels).NodeSelectorRequirements()))
-		Expect(nodeClaim.Spec.Resources.Requests).To(Equal(node.Status.Allocatable))
-		Expect(nodeClaim.Status.NodeName).To(Equal(node.Name))
-		Expect(nodeClaim.Status.ProviderID).To(Equal(node.Spec.ProviderID))
-		Expect(nodeClaim.Status.Capacity).To(Equal(node.Status.Capacity))
-		Expect(nodeClaim.Status.Allocatable).To(Equal(node.Status.Allocatable))
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeLaunched).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeRegistered).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
 	})
 	It("should update the owner for a Node to a NodeClaim", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{

--- a/pkg/utils/termination/suite_test.go
+++ b/pkg/utils/termination/suite_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "knative.dev/pkg/logging/testing"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	"sigs.k8s.io/karpenter/pkg/operator/scheme"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+	"sigs.k8s.io/karpenter/pkg/test"
+)
+
+var (
+	ctx           context.Context
+	env           *test.Environment
+	cloudProvider *fake.CloudProvider
+)
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TerminationUtils")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
+	cloudProvider = fake.NewCloudProvider()
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = AfterEach(func() {
+	cloudProvider.Reset()
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("TerminationUtils", func() {
+	var nodeClaim *v1beta1.NodeClaim
+	BeforeEach(func() {
+		nodeClaim = test.NodeClaim()
+		cloudProvider.CreatedNodeClaims[nodeClaim.Status.ProviderID] = nodeClaim
+	})
+	It("should not call cloudProvider Delete if the status condition is already Terminating", func() {
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeTerminating)
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		instanceTerminated, err := EnsureTerminated(ctx, env.Client, nodeClaim, cloudProvider)
+		Expect(len(cloudProvider.DeleteCalls)).To(BeEquivalentTo(0))
+		Expect(len(cloudProvider.GetCalls)).To(BeEquivalentTo(1))
+		Expect(instanceTerminated).To(BeFalse())
+		Expect(err).NotTo(HaveOccurred())
+	})
+	It("should call cloudProvider Delete followed by Get and return true when the cloudProvider instance is terminated", func() {
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		// This will call cloudProvider.Delete()
+		instanceTerminated, err := EnsureTerminated(ctx, env.Client, nodeClaim, cloudProvider)
+		Expect(len(cloudProvider.DeleteCalls)).To(BeEquivalentTo(1))
+		Expect(instanceTerminated).To(BeFalse())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
+
+		//This will call cloudProvider.Get(). Instance is terminated at this point
+		instanceTerminated, err = EnsureTerminated(ctx, env.Client, nodeClaim, cloudProvider)
+		Expect(len(cloudProvider.GetCalls)).To(BeEquivalentTo(1))
+
+		Expect(instanceTerminated).To(BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+	})
+	It("should call cloudProvider Delete followed by Get and return false when the cloudProvider instance is not terminated", func() {
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		// This will call cloudProvider.Delete()
+		instanceTerminated, err := EnsureTerminated(ctx, env.Client, nodeClaim, cloudProvider)
+		Expect(len(cloudProvider.DeleteCalls)).To(BeEquivalentTo(1))
+		Expect(instanceTerminated).To(BeFalse())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
+
+		// The delete call that happened first will remove the cloudProvider instance from cloudProvider.CreatedNodeClaims[].
+		// To model the behavior of having cloudProvider instance not terminated, we add it back here.
+		cloudProvider.CreatedNodeClaims[nodeClaim.Status.ProviderID] = nodeClaim
+		//This will call cloudProvider.Get(). Instance is not terminated at this point
+		instanceTerminated, err = EnsureTerminated(ctx, env.Client, nodeClaim, cloudProvider)
+		Expect(len(cloudProvider.GetCalls)).To(BeEquivalentTo(1))
+
+		Expect(instanceTerminated).To(BeFalse())
+		Expect(err).NotTo(HaveOccurred())
+	})
+	It("should call cloudProvider Delete and return true if cloudProvider instance is not found", func() {
+		ExpectApplied(ctx, env.Client, nodeClaim)
+
+		cloudProvider.NextDeleteErr = cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("no nodeclaim exists"))
+		instanceTerminated, err := EnsureTerminated(ctx, env.Client, nodeClaim, cloudProvider)
+		Expect(len(cloudProvider.GetCalls)).To(BeEquivalentTo(0))
+
+		Expect(instanceTerminated).To(BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/utils/termination/termination.go
+++ b/pkg/utils/termination/termination.go
@@ -1,0 +1,69 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+)
+
+// EnsureTerminated is a helper function that takes a v1beta1.NodeClaim and calls cloudProvider.Delete() if status condition
+// on nodeClaim is not terminating. If it is terminating then it will call cloudProvider.Get() to check if the instance
+// is terminated or not. It will return an error and a boolean that indicates if the instance is terminated or not. We simply return
+// conflict or a NotFound error if we encounter it while updating the status on nodeClaim.
+func EnsureTerminated(ctx context.Context, c client.Client, nodeClaim *v1beta1.NodeClaim, cloudProvider cloudprovider.CloudProvider) (terminated bool, err error) {
+	// Check if the status condition on nodeClaim is Terminating
+	if !nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeTerminating).IsTrue() {
+		// If not then call Delete on cloudProvider to trigger termination and always requeue reconciliation
+		if err := cloudProvider.Delete(ctx, nodeClaim); err != nil {
+			if cloudprovider.IsNodeClaimNotFoundError(err) {
+				nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeTerminating)
+				// We call Update() here rather than Patch() because patching a list with a JSON merge patch
+				// can cause races due to the fact that it fully replaces the list on a change
+				// https://github.com/kubernetes/kubernetes/issues/111643#issuecomment-2016489732
+				if err = c.Status().Update(ctx, nodeClaim); err != nil {
+					return false, err
+				}
+				// Instance is terminated
+				return true, nil
+			}
+			return false, fmt.Errorf("terminating cloudprovider instance, %w", err)
+		}
+
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeTerminating)
+		// We call Update() here rather than Patch() because patching a list with a JSON merge patch
+		// can cause races due to the fact that it fully replaces the list on a change
+		// https://github.com/kubernetes/kubernetes/issues/111643#issuecomment-2016489732
+		if err := c.Status().Update(ctx, nodeClaim); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	// Call Get on cloudProvider to check if the instance is terminated
+	if _, err := cloudProvider.Get(ctx, nodeClaim.Status.ProviderID); err != nil {
+		if cloudprovider.IsNodeClaimNotFoundError(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("getting cloudprovider instance, %w", err)
+	}
+	return false, nil
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Finalizers on nodeClaim and node should not be removed until the underlying instance is deleted to avoid leaking any resources. The current approach relies on retryable error being emitted by cloudProvider.Delete() and continues reconciliation until this error is received. However, that is not an ideal approach. When this approach was tested for AWS provider we found that some instances could take too long to delete.Hence in this PR, instead a status condition `terminating` is added on nodeclaim and if the status exists then we call cloudProvider.Get() to check if the instance is terminated. If it is terminated, then we can remove finalizer from the nodeClaim.

**How was this change tested?**
Tested on my local cluster and ran unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
