### PR TITLE
fix: Add capacity-type label to karpenter_nodeclaims_registered and karpen…

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -133,7 +133,8 @@ func (c *Controller) removeFinalizer(ctx context.Context, n *v1.Node) error {
 			return client.IgnoreNotFound(fmt.Errorf("patching node, %w", err))
 		}
 		metrics.NodesTerminatedCounter.With(prometheus.Labels{
-			metrics.NodePoolLabel: n.Labels[v1beta1.NodePoolLabelKey],
+			metrics.NodePoolLabel:     n.Labels[v1beta1.NodePoolLabelKey],
+			metrics.CapacityTypeLabel: n.Labels[v1beta1.CapacityTypeLabelKey],
 		}).Inc()
 		// We use stored.DeletionTimestamp since the api-server may give back a node after the patch without a deletionTimestamp
 		TerminationSummary.With(prometheus.Labels{

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -70,10 +70,12 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeCla
 	nodeClaim.Status.NodeName = node.Name
 
 	metrics.NodeClaimsRegisteredCounter.With(prometheus.Labels{
-		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
 	}).Inc()
 	metrics.NodesCreatedCounter.With(prometheus.Labels{
-		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
 	}).Inc()
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -350,9 +350,8 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 	})
 	logging.FromContext(ctx).With("nodeclaim", nodeClaim.Name, "requests", nodeClaim.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).Infof("created nodeclaim")
 	metrics.NodeClaimsCreatedCounter.With(prometheus.Labels{
-		metrics.ReasonLabel:       options.Reason,
-		metrics.NodePoolLabel:     nodeClaim.Labels[v1beta1.NodePoolLabelKey],
-		metrics.CapacityTypeLabel: nodeClaim.Labels[v1beta1.CapacityTypeLabelKey],
+		metrics.ReasonLabel:   options.Reason,
+		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 	}).Inc()
 	// Update the nodeclaim manually in state to avoid evenutal consistency delay races with our watcher.
 	// This is essential to avoiding races where disruption can create a replacement node, then immediately

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -37,7 +37,6 @@ var (
 		[]string{
 			ReasonLabel,
 			NodePoolLabel,
-			CapacityTypeLabel,
 		},
 	)
 	NodeClaimsTerminatedCounter = prometheus.NewCounterVec(
@@ -73,6 +72,7 @@ var (
 		},
 		[]string{
 			NodePoolLabel,
+			CapacityTypeLabel,
 		},
 	)
 	NodeClaimsInitializedCounter = prometheus.NewCounterVec(
@@ -119,6 +119,7 @@ var (
 		},
 		[]string{
 			NodePoolLabel,
+			CapacityTypeLabel,
 		},
 	)
 	NodesTerminatedCounter = prometheus.NewCounterVec(


### PR DESCRIPTION
…ter_nodes_created

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1210 

**Description**

Removed `capacity_type` from `karpenter_nodeclaims_created` as at that point it is not known, so it will always be empty.
Added it for `karpenter_nodeclaims_registered` and `karpenter_nodes_created` as its available during that time.

**How was this change tested?**

Tested in personal cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
