### PR TITLE
ci: Remove needs-triage auto-add

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,6 +1,6 @@
 name: Bug
 description: Report a bug
-labels: ['kind/bug', 'needs-triage']
+labels: ['kind/bug']
 body:
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,6 +1,6 @@
 name: Feature
 description: Suggest an idea for a new feature
-labels: ['kind/feature', 'needs-triage']
+labels: ['kind/feature']
 body:
 - type: textarea
   attributes:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #910

**Description**

The bot should now auto-add this label with: https://github.com/kubernetes/test-infra/blob/63c23493ceefcfdedc7571fa42504b0ba94d7a5b/config/prow/plugins.yaml#L831

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
