### PR TITLE
chore: Clarify failed scheduling error on all disruption methods

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -3161,7 +3161,7 @@ var _ = Describe("Consolidation", func() {
 			// and will not be recreated
 			ExpectNotFound(ctx, env.Client, nodeClaims[1], nodes[1])
 		})
-		It("won't delete node if it would require pods to schedule on an un-initialized node", func() {
+		It("won't delete node if it would require pods to schedule on an uninitialized node", func() {
 			// create our RS so we can link a pod to it
 			rs := test.ReplicaSet()
 			ExpectApplied(ctx, env.Client, rs)
@@ -3205,11 +3205,11 @@ var _ = Describe("Consolidation", func() {
 			})
 			Expect(ok).To(BeTrue())
 			_, ok = lo.Find(evts, func(e events.Event) bool {
-				return strings.Contains(e.Message, "would schedule against a non-initialized node")
+				return strings.Contains(e.Message, "would schedule against uninitialized nodeclaim")
 			})
 			Expect(ok).To(BeTrue())
 		})
-		It("should consider initialized nodes before un-initialized nodes", func() {
+		It("should consider initialized nodes before uninitialized nodes", func() {
 			defaultInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name: "default-instance-type",
 				Resources: v1.ResourceList{
@@ -3343,10 +3343,10 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, queue, types.NamespacedName{})
 
 			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, consolidatableNodeClaim)
-			// Expect no events that state that the pods would schedule against a non-initialized node
+			// Expect no events that state that the pods would schedule against a uninitialized node
 			evts := recorder.Events()
 			_, ok := lo.Find(evts, func(e events.Event) bool {
-				return strings.Contains(e.Message, "would schedule against a non-initialized node")
+				return strings.Contains(e.Message, "would schedule against uninitialized nodeclaim")
 			})
 			Expect(ok).To(BeFalse())
 

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -61,8 +61,6 @@ type Controller struct {
 // pollingPeriod that we inspect cluster to look for opportunities to disrupt
 const pollingPeriod = 10 * time.Second
 
-var errCandidateDeleting = fmt.Errorf("candidate is deleting")
-
 func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provisioning.Provisioner,
 	cp cloudprovider.CloudProvider, recorder events.Recorder, cluster *state.Cluster, queue *orchestration.Queue,
 ) *Controller {

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -107,7 +107,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[
 		}
 		// Emit an event that we couldn't reschedule the pods on the node.
 		if !results.AllNonPendingPodsScheduled() {
-			d.recorder.Publish(disruptionevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
+			d.recorder.Publish(disruptionevents.Blocked(candidate.Node, candidate.NodeClaim, results.NonPendingPodSchedulingErrors())...)
 			continue
 		}
 

--- a/pkg/controllers/disruption/expiration.go
+++ b/pkg/controllers/disruption/expiration.go
@@ -113,7 +113,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, disruptionBudgetMapping
 		}
 		// Emit an event that we couldn't reschedule the pods on the node.
 		if !results.AllNonPendingPodsScheduled() {
-			e.recorder.Publish(disruptionevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
+			e.recorder.Publish(disruptionevents.Blocked(candidate.Node, candidate.NodeClaim, results.NonPendingPodSchedulingErrors())...)
 			continue
 		}
 		logging.FromContext(ctx).With("ttl", candidates[0].nodePool.Spec.Disruption.ExpireAfter.String()).Infof("triggering termination for expired node after TTL")

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -165,7 +165,7 @@ func (v *Validation) ValidateCommand(ctx context.Context, cmd Command, candidate
 		return fmt.Errorf("simluating scheduling, %w", err)
 	}
 	if !results.AllNonPendingPodsScheduled() {
-		return NewValidationError(fmt.Errorf("all pending pods could not be scheduled"))
+		return NewValidationError(fmt.Errorf(results.NonPendingPodSchedulingErrors()))
 	}
 
 	// We want to ensure that the re-simulated scheduling using the current cluster state produces the same result.

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -329,7 +329,7 @@ func (s *Scheduler) calculateExistingNodeClaims(stateNodes []*state.StateNode, d
 	}
 	// Order the existing nodes for scheduling with initialized nodes first
 	// This is done specifically for consolidation where we want to make sure we schedule to initialized nodes
-	// before we attempt to schedule un-initialized ones
+	// before we attempt to schedule uninitialized ones
 	sort.SliceStable(s.existingNodes, func(i, j int) bool {
 		if s.existingNodes[i].Initialized() && !s.existingNodes[j].Initialized() {
 			return true

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2370,7 +2370,7 @@ var _ = Context("Scheduling", func() {
 			// shouldn't create a second node
 			Expect(nodes.Items).To(HaveLen(1))
 		})
-		It("should order initialized nodes for scheduling un-initialized nodes when all other nodes are inflight", func() {
+		It("should order initialized nodes for scheduling uninitialized nodes when all other nodes are inflight", func() {
 			ExpectApplied(ctx, env.Client, nodePool)
 
 			var nodeClaims []*v1beta1.NodeClaim
@@ -2468,7 +2468,7 @@ var _ = Context("Scheduling", func() {
 				Expect(node.Name).To(Equal(scheduledNode.Name))
 			}
 		})
-		It("should order initialized nodes for scheduling un-initialized nodes", func() {
+		It("should order initialized nodes for scheduling uninitialized nodes", func() {
 			ExpectApplied(ctx, env.Client, nodePool)
 
 			var nodeClaims []*v1beta1.NodeClaim


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the eventing to be more specific about why not all pods were able to schedule, similar to how Consolidation gives this information back through eventing right now.

#### Before PR

```
  Type    Reason             Age    From       Message
  ----    ------             ----   ----       -------
  Normal  DisruptionBlocked  2s     karpenter  Cannot disrupt NodeClaim: Scheduling simulation failed to schedule all pods
```

#### After PR

```
  Type    Reason             Age    From       Message
  ----    ------             ----   ----       -------
  Normal  Unconsolidatable            62s   karpenter  not all pods would schedule, default/inflate-6f56784d74-cqzdj => would schedule against uninitialized nodeclaim/default-lkv5s
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
