### PR TITLE
revert changes made in #1164, #1170 and #1172

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -268,33 +268,3 @@ func IgnoreNodeClassNotReadyError(err error) error {
 	}
 	return err
 }
-
-// RetryableError is an error type returned by CloudProviders when the action emitting the error has to be retried
-type RetryableError struct {
-	error
-}
-
-func NewRetryableError(err error) *RetryableError {
-	return &RetryableError{
-		error: err,
-	}
-}
-
-func (e *RetryableError) Error() string {
-	return fmt.Sprintf("retryable error, %s", e.error)
-}
-
-func IsRetryableError(err error) bool {
-	if err == nil {
-		return false
-	}
-	var retryableError *RetryableError
-	return errors.As(err, &retryableError)
-}
-
-func IgnoreRetryableError(err error) error {
-	if IsRetryableError(err) {
-		return nil
-	}
-	return err
-}

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -108,12 +108,6 @@ func (c *Controller) Finalize(ctx context.Context, node *v1.Node) (reconcile.Res
 	// This delete call is needed so that we ensure that we don't remove the node from the cluster
 	// until the full instance shutdown has taken place
 	if err := c.cloudProvider.Delete(ctx, nodeclaimutil.NewFromNode(node)); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil {
-		// We expect cloudProvider to emit a Retryable Error when the underlying instance is not terminated and if that
-		// happens, we want to re-enqueue reconciliation until we terminate the underlying instance before removing
-		// finalizer from the node.
-		if cloudprovider.IsRetryableError(err) {
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-		}
 		return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 	}
 	if err := c.removeFinalizer(ctx, node); err != nil {

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -18,15 +18,12 @@ package termination_test
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 
 	"github.com/samber/lo"
 	clock "k8s.io/utils/clock/testing"
@@ -717,27 +714,6 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{}) // Reconcile the queue so that we set the metric
 
 			ExpectMetricGaugeValue(terminator.EvictionQueueDepth, 5, map[string]string{})
-		})
-		It("should retry node deletion when cloudProvider returns retryable error", func() {
-			ExpectApplied(ctx, env.Client, node)
-			cloudProvider.NextDeleteErr = cloudprovider.NewRetryableError(fmt.Errorf("underlying instance not terminated"))
-
-			// Expect the node to stick around and requeue while it gets a retryable error
-			Expect(env.Client.Delete(ctx, node)).To(Succeed())
-			result := ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			Expect(result.RequeueAfter).To(Equal(time.Second * 10))
-
-			// Instance still exists
-			_, err := cloudProvider.Get(ctx, node.Spec.ProviderID)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Requeue again and we should no longer get an error and succeed to delete the instance
-			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node)) // re-enqueue reconciliation since we got retryable error previously
-			ExpectNotFound(ctx, env.Client, node)
-
-			// Expect the instance to be gone from the cloudprovider
-			_, err = cloudProvider.Get(ctx, node.Spec.ProviderID)
-			Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 		})
 	})
 })

--- a/pkg/controllers/nodeclaim/termination/controller.go
+++ b/pkg/controllers/nodeclaim/termination/controller.go
@@ -90,12 +90,6 @@ func (c *Controller) Finalize(ctx context.Context, nodeClaim *v1beta1.NodeClaim)
 	}
 	if nodeClaim.Status.ProviderID != "" {
 		if err = c.cloudProvider.Delete(ctx, nodeClaim); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil {
-			// We expect cloudProvider to emit a Retryable Error when the underlying instance is not terminated and if that
-			// happens, we want to re-enqueue reconciliation until we terminate the underlying instance before removing
-			// finalizer from the nodeClaim.
-			if cloudprovider.IsRetryableError(err) {
-				return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-			}
 			return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 		}
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR reverts the changes that were made in #1164, #1170 and #1172. We don't want to make use of retryable error to drive nodeClaim termination. When this approach was tested for AWS provider we found that some instances could take too long to delete. We do not want to use retryable error to trigger multiple `cloudProvider.Delete()` calls.

**How was this change tested?**
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
