### PR TITLE
BREAKING: Convert knative status conditions to operatorpkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.3
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
+	github.com/awslabs/operatorpkg v0.0.0-20240509171849-455f977cee10
 	github.com/docker/docker v26.1.1+incompatible
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
@@ -46,7 +47,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
@@ -62,7 +63,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -74,7 +75,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/common v0.48.0 // indirect
+	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1
@@ -85,7 +86,7 @@ require (
 	go.uber.org/automaxprocs v1.4.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.24.0 // indirect
-	golang.org/x/oauth2 v0.16.0 // indirect
+	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
+github.com/awslabs/operatorpkg v0.0.0-20240509171849-455f977cee10 h1:l9aKssdP1CaqzB/kRyMjYBgZxXnZlqYl0EhYT9iPBFY=
+github.com/awslabs/operatorpkg v0.0.0-20240509171849-455f977cee10/go.mod h1:G4QVeP+gdcP8JtDDxelh58IlFbpKNJcS8/isVDMW2KY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -79,8 +81,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
-github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
@@ -181,8 +183,8 @@ github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 h1:k7nVchz72niMH6YLQN
 github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
@@ -268,8 +270,8 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.28.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
-github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSzKKE=
-github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
+github.com/prometheus/common v0.53.0 h1:U2pL9w9nmJwJDa4qqLQ3ZaePJ6ZTwt7cMD3AG3+aLCE=
+github.com/prometheus/common v0.53.0/go.mod h1:BrxBKv3FWBIGXw89Mg1AeBq7FSyRzXWI3l3e7W3RN5U=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
@@ -413,8 +415,8 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.16.0 h1:aDkGMBSYxElaoP81NpoUoz2oo2R2wHdZpGToUxfyQrQ=
-golang.org/x/oauth2 v0.16.0/go.mod h1:hqZ+0LWXsiVoZpeld6jVt06P3adbS2Uu911W1SsJv2o=
+golang.org/x/oauth2 v0.18.0 h1:09qnuIAgzdx1XplqJvW6CQqMCtGZykZWcXzPMPUusvI=
+golang.org/x/oauth2 v0.18.0/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -383,34 +383,60 @@ spec:
                 conditions:
                   description: Conditions contains signals for health and readiness
                   items:
-                    description: |-
-                      Condition defines a readiness condition for a Knative resource.
-                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    description: Condition aliases the upstream type and adds additional helper methods
                     properties:
                       lastTransitionTime:
                         description: |-
-                          LastTransitionTime is the last time the condition transitioned from one status to another.
-                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
-                          differences (all other things held constant).
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
                         type: string
                       message:
-                        description: A human readable message indicating details about the transition.
-                        type: string
-                      reason:
-                        description: The reason for the condition's last transition.
-                        type: string
-                      severity:
                         description: |-
-                          Severity with which to treat failures of this type of condition.
-                          When this is not specified, it defaults to Error.
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                         type: string
                       status:
-                        description: Status of the condition, one of True, False, Unknown.
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
                         type: string
                       type:
-                        description: Type of condition.
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
+                      - lastTransitionTime
+                      - message
+                      - reason
                       - status
                       - type
                     type: object

--- a/pkg/apis/v1beta1/nodeclaim_status.go
+++ b/pkg/apis/v1beta1/nodeclaim_status.go
@@ -17,8 +17,17 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/awslabs/operatorpkg/status"
 	v1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/apis"
+)
+
+const (
+	Launched    = "Launched"
+	Registered  = "Registered"
+	Initialized = "Initialized"
+	Empty       = "Empty"
+	Drifted     = "Drifted"
+	Expired     = "Expired"
 )
 
 // NodeClaimStatus defines the observed state of NodeClaim
@@ -40,36 +49,21 @@ type NodeClaimStatus struct {
 	Allocatable v1.ResourceList `json:"allocatable,omitempty"`
 	// Conditions contains signals for health and readiness
 	// +optional
-	Conditions apis.Conditions `json:"conditions,omitempty"`
+	Conditions []status.Condition `json:"conditions,omitempty"`
 }
 
-func (in *NodeClaim) StatusConditions() apis.ConditionManager {
-	return apis.NewLivingConditionSet(
+func (in *NodeClaim) StatusConditions() status.ConditionSet {
+	return status.NewReadyConditions(
 		Launched,
 		Registered,
 		Initialized,
-	).Manage(in)
+	).For(in)
 }
 
-var LivingConditions = []apis.ConditionType{
-	Launched,
-	Registered,
-	Initialized,
-}
-
-var (
-	Launched    apis.ConditionType = "Launched"
-	Registered  apis.ConditionType = "Registered"
-	Initialized apis.ConditionType = "Initialized"
-	Empty       apis.ConditionType = "Empty"
-	Drifted     apis.ConditionType = "Drifted"
-	Expired     apis.ConditionType = "Expired"
-)
-
-func (in *NodeClaim) GetConditions() apis.Conditions {
+func (in *NodeClaim) GetConditions() []status.Condition {
 	return in.Status.Conditions
 }
 
-func (in *NodeClaim) SetConditions(conditions apis.Conditions) {
+func (in *NodeClaim) SetConditions(conditions []status.Condition) {
 	in.Status.Conditions = conditions
 }

--- a/pkg/apis/v1beta1/nodeclaim_status.go
+++ b/pkg/apis/v1beta1/nodeclaim_status.go
@@ -22,12 +22,12 @@ import (
 )
 
 const (
-	Launched    = "Launched"
-	Registered  = "Registered"
-	Initialized = "Initialized"
-	Empty       = "Empty"
-	Drifted     = "Drifted"
-	Expired     = "Expired"
+	ConditionTypeLaunched    = "Launched"
+	ConditionTypeRegistered  = "Registered"
+	ConditionTypeInitialized = "Initialized"
+	ConditionTypeEmpty       = "Empty"
+	ConditionTypeDrifted     = "Drifted"
+	ConditionTypeExpired     = "Expired"
 )
 
 // NodeClaimStatus defines the observed state of NodeClaim
@@ -54,9 +54,9 @@ type NodeClaimStatus struct {
 
 func (in *NodeClaim) StatusConditions() status.ConditionSet {
 	return status.NewReadyConditions(
-		Launched,
-		Registered,
-		Initialized,
+		ConditionTypeLaunched,
+		ConditionTypeRegistered,
+		ConditionTypeInitialized,
 	).For(in)
 }
 

--- a/pkg/apis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1beta1/zz_generated.deepcopy.go
@@ -21,10 +21,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/awslabs/operatorpkg/status"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"knative.dev/pkg/apis"
 	timex "time"
 )
 
@@ -332,7 +332,7 @@ func (in *NodeClaimStatus) DeepCopyInto(out *NodeClaimStatus) {
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make(apis.Conditions, len(*in))
+		*out = make([]status.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -53,14 +53,14 @@ func NewDrift(kubeClient client.Client, cluster *state.Cluster, provisioner *pro
 // ShouldDisrupt is a predicate used to filter candidates
 func (d *Drift) ShouldDisrupt(ctx context.Context, c *Candidate) bool {
 	return options.FromContext(ctx).FeatureGates.Drift &&
-		c.NodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()
+		c.NodeClaim.StatusConditions().Get(v1beta1.ConditionTypeDrifted).IsTrue()
 }
 
 // ComputeCommand generates a disruption command given candidates
 func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, scheduling.Results, error) {
 	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].NodeClaim.StatusConditions().Get(v1beta1.Drifted).LastTransitionTime.Time.Before(
-			candidates[j].NodeClaim.StatusConditions().Get(v1beta1.Drifted).LastTransitionTime.Time)
+		return candidates[i].NodeClaim.StatusConditions().Get(v1beta1.ConditionTypeDrifted).LastTransitionTime.Time.Before(
+			candidates[j].NodeClaim.StatusConditions().Get(v1beta1.ConditionTypeDrifted).LastTransitionTime.Time)
 	})
 
 	// Do a quick check through the candidates to see if they're empty.

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -53,14 +53,14 @@ func NewDrift(kubeClient client.Client, cluster *state.Cluster, provisioner *pro
 // ShouldDisrupt is a predicate used to filter candidates
 func (d *Drift) ShouldDisrupt(ctx context.Context, c *Candidate) bool {
 	return options.FromContext(ctx).FeatureGates.Drift &&
-		c.NodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()
+		c.NodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()
 }
 
 // ComputeCommand generates a disruption command given candidates
 func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, scheduling.Results, error) {
 	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].NodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).LastTransitionTime.Inner.Time.Before(
-			candidates[j].NodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).LastTransitionTime.Inner.Time)
+		return candidates[i].NodeClaim.StatusConditions().Get(v1beta1.Drifted).LastTransitionTime.Time.Before(
+			candidates[j].NodeClaim.StatusConditions().Get(v1beta1.Drifted).LastTransitionTime.Time)
 	})
 
 	// Do a quick check through the candidates to see if they're empty.

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Drift", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 	})
 	Context("Metrics", func() {
 		var eligibleNodesLabels = map[string]string{
@@ -155,7 +155,7 @@ var _ = Describe("Drift", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 			// inform cluster state about nodes and nodeclaims
@@ -198,7 +198,7 @@ var _ = Describe("Drift", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 			// inform cluster state about nodes and nodeclaims
@@ -241,7 +241,7 @@ var _ = Describe("Drift", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 			// inform cluster state about nodes and nodeclaims
@@ -285,7 +285,7 @@ var _ = Describe("Drift", func() {
 
 			// Mark the first five as drifted
 			for i := range lo.Range(5) {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 			}
 
 			for i := 0; i < numNodes; i++ {
@@ -380,7 +380,7 @@ var _ = Describe("Drift", func() {
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -446,7 +446,7 @@ var _ = Describe("Drift", func() {
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -529,7 +529,7 @@ var _ = Describe("Drift", func() {
 					},
 				},
 			})
-			nodeClaim2.StatusConditions().SetTrue(v1beta1.Drifted)
+			nodeClaim2.StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 			ExpectApplied(ctx, env.Client, nodeClaim2, node2, podToExpire)
 			ExpectManualBinding(ctx, env.Client, podToExpire, node2)
 
@@ -553,7 +553,7 @@ var _ = Describe("Drift", func() {
 			ExpectNotFound(ctx, env.Client, nodeClaim2)
 		})
 		It("should ignore nodes without the drifted status condition", func() {
-			_ = nodeClaim.StatusConditions().Clear(v1beta1.Drifted)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.ConditionTypeDrifted)
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -624,7 +624,7 @@ var _ = Describe("Drift", func() {
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
 		It("should ignore nodes with the drifted status condition set to false", func() {
-			nodeClaim.StatusConditions().SetFalse(v1beta1.Drifted, "NotDrifted", "NotDrifted")
+			nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeDrifted, "NotDrifted", "NotDrifted")
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -679,7 +679,7 @@ var _ = Describe("Drift", func() {
 				},
 			})
 			for _, m := range nodeClaims {
-				m.StatusConditions().SetTrue(v1beta1.Drifted)
+				m.StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 				ExpectApplied(ctx, env.Client, m)
 			}
 			for _, n := range nodes {
@@ -942,10 +942,10 @@ var _ = Describe("Drift", func() {
 				},
 			})
 			nodeClaim2.Status.Conditions = append(nodeClaim2.Status.Conditions, status.Condition{
-				Type:               v1beta1.Drifted,
+				Type:               v1beta1.ConditionTypeDrifted,
 				Status:             metav1.ConditionTrue,
-				Reason:             v1beta1.Drifted,
-				Message:            v1beta1.Drifted,
+				Reason:             v1beta1.ConditionTypeDrifted,
+				Message:            v1beta1.ConditionTypeDrifted,
 				LastTransitionTime: metav1.Time{Time: time.Now().Add(-time.Hour)},
 			})
 

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/awslabs/operatorpkg/status"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -28,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -77,7 +77,7 @@ var _ = Describe("Drift", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
 	})
 	Context("Metrics", func() {
 		var eligibleNodesLabels = map[string]string{
@@ -155,7 +155,7 @@ var _ = Describe("Drift", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 			// inform cluster state about nodes and nodeclaims
@@ -198,7 +198,7 @@ var _ = Describe("Drift", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 			// inform cluster state about nodes and nodeclaims
@@ -241,7 +241,7 @@ var _ = Describe("Drift", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 			// inform cluster state about nodes and nodeclaims
@@ -285,7 +285,7 @@ var _ = Describe("Drift", func() {
 
 			// Mark the first five as drifted
 			for i := range lo.Range(5) {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
 			}
 
 			for i := 0; i < numNodes; i++ {
@@ -380,7 +380,7 @@ var _ = Describe("Drift", func() {
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -446,7 +446,7 @@ var _ = Describe("Drift", func() {
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Drifted)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Drifted)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -529,7 +529,7 @@ var _ = Describe("Drift", func() {
 					},
 				},
 			})
-			nodeClaim2.StatusConditions().MarkTrue(v1beta1.Drifted)
+			nodeClaim2.StatusConditions().SetTrue(v1beta1.Drifted)
 			ExpectApplied(ctx, env.Client, nodeClaim2, node2, podToExpire)
 			ExpectManualBinding(ctx, env.Client, podToExpire, node2)
 
@@ -553,7 +553,7 @@ var _ = Describe("Drift", func() {
 			ExpectNotFound(ctx, env.Client, nodeClaim2)
 		})
 		It("should ignore nodes without the drifted status condition", func() {
-			_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Drifted)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.Drifted)
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -624,7 +624,7 @@ var _ = Describe("Drift", func() {
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
 		It("should ignore nodes with the drifted status condition set to false", func() {
-			nodeClaim.StatusConditions().MarkFalse(v1beta1.Drifted, "", "")
+			nodeClaim.StatusConditions().SetFalse(v1beta1.Drifted, "NotDrifted", "NotDrifted")
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -679,7 +679,7 @@ var _ = Describe("Drift", func() {
 				},
 			})
 			for _, m := range nodeClaims {
-				m.StatusConditions().MarkTrue(v1beta1.Drifted)
+				m.StatusConditions().SetTrue(v1beta1.Drifted)
 				ExpectApplied(ctx, env.Client, m)
 			}
 			for _, n := range nodes {
@@ -941,10 +941,12 @@ var _ = Describe("Drift", func() {
 					Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("32")},
 				},
 			})
-			nodeClaim2.Status.Conditions = append(nodeClaim2.Status.Conditions, apis.Condition{
+			nodeClaim2.Status.Conditions = append(nodeClaim2.Status.Conditions, status.Condition{
 				Type:               v1beta1.Drifted,
-				Status:             v1.ConditionTrue,
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(-time.Hour)}},
+				Status:             metav1.ConditionTrue,
+				Reason:             v1beta1.Drifted,
+				Message:            v1beta1.Drifted,
+				LastTransitionTime: metav1.Time{Time: time.Now().Add(-time.Hour)},
 			})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], nodeClaim, node, nodeClaim2, node2, nodePool)

--- a/pkg/controllers/disruption/emptiness.go
+++ b/pkg/controllers/disruption/emptiness.go
@@ -60,8 +60,8 @@ func (e *Emptiness) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 	if len(c.reschedulablePods) != 0 {
 		return false
 	}
-	return c.NodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue() &&
-		!e.clock.Now().Before(c.NodeClaim.StatusConditions().GetCondition(v1beta1.Empty).LastTransitionTime.Inner.Add(*c.nodePool.Spec.Disruption.ConsolidateAfter.Duration))
+	return c.NodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue() &&
+		!e.clock.Now().Before(c.NodeClaim.StatusConditions().Get(v1beta1.Empty).LastTransitionTime.Add(*c.nodePool.Spec.Disruption.ConsolidateAfter.Duration))
 }
 
 // ComputeCommand generates a disruption command given candidates

--- a/pkg/controllers/disruption/emptiness.go
+++ b/pkg/controllers/disruption/emptiness.go
@@ -60,8 +60,8 @@ func (e *Emptiness) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 	if len(c.reschedulablePods) != 0 {
 		return false
 	}
-	return c.NodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue() &&
-		!e.clock.Now().Before(c.NodeClaim.StatusConditions().Get(v1beta1.Empty).LastTransitionTime.Add(*c.nodePool.Spec.Disruption.ConsolidateAfter.Duration))
+	return c.NodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty).IsTrue() &&
+		!e.clock.Now().Before(c.NodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty).LastTransitionTime.Add(*c.nodePool.Spec.Disruption.ConsolidateAfter.Duration))
 }
 
 // ComputeCommand generates a disruption command given candidates

--- a/pkg/controllers/disruption/emptiness_test.go
+++ b/pkg/controllers/disruption/emptiness_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Emptiness", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 	})
 	Context("Events", func() {
 		It("should not fire an event for ConsolidationDisabled when the NodePool has consolidation set to WhenUnderutilized", func() {
@@ -164,7 +164,7 @@ var _ = Describe("Emptiness", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -210,7 +210,7 @@ var _ = Describe("Emptiness", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -256,7 +256,7 @@ var _ = Describe("Emptiness", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -325,7 +325,7 @@ var _ = Describe("Emptiness", func() {
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -395,7 +395,7 @@ var _ = Describe("Emptiness", func() {
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -446,7 +446,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectNotFound(ctx, env.Client, nodeClaim, node)
 		})
 		It("should ignore nodes without the empty status condition", func() {
-			_ = nodeClaim.StatusConditions().Clear(v1beta1.Empty)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.ConditionTypeEmpty)
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -516,7 +516,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
 		It("should ignore nodes with the empty status condition set to false", func() {
-			nodeClaim.StatusConditions().SetFalse(v1beta1.Empty, "NotEmpty", "NotEmpty")
+			nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeEmpty, "NotEmpty", "NotEmpty")
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims

--- a/pkg/controllers/disruption/emptiness_test.go
+++ b/pkg/controllers/disruption/emptiness_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Emptiness", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
 	})
 	Context("Events", func() {
 		It("should not fire an event for ConsolidationDisabled when the NodePool has consolidation set to WhenUnderutilized", func() {
@@ -164,7 +164,7 @@ var _ = Describe("Emptiness", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -210,7 +210,7 @@ var _ = Describe("Emptiness", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -256,7 +256,7 @@ var _ = Describe("Emptiness", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -325,7 +325,7 @@ var _ = Describe("Emptiness", func() {
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -395,7 +395,7 @@ var _ = Describe("Emptiness", func() {
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Empty)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Empty)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -446,7 +446,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectNotFound(ctx, env.Client, nodeClaim, node)
 		})
 		It("should ignore nodes without the empty status condition", func() {
-			_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Empty)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.Empty)
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -516,7 +516,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
 		It("should ignore nodes with the empty status condition set to false", func() {
-			nodeClaim.StatusConditions().MarkFalse(v1beta1.Empty, "", "")
+			nodeClaim.StatusConditions().SetFalse(v1beta1.Empty, "NotEmpty", "NotEmpty")
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims

--- a/pkg/controllers/disruption/expiration.go
+++ b/pkg/controllers/disruption/expiration.go
@@ -58,14 +58,14 @@ func NewExpiration(clk clock.Clock, kubeClient client.Client, cluster *state.Clu
 // ShouldDisrupt is a predicate used to filter candidates
 func (e *Expiration) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 	return c.nodePool.Spec.Disruption.ExpireAfter.Duration != nil &&
-		c.NodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()
+		c.NodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired).IsTrue()
 }
 
 // ComputeCommand generates a disruption command given candidates
 func (e *Expiration) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, scheduling.Results, error) {
 	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].NodeClaim.StatusConditions().Get(v1beta1.Expired).LastTransitionTime.Time.Before(
-			candidates[j].NodeClaim.StatusConditions().Get(v1beta1.Expired).LastTransitionTime.Time)
+		return candidates[i].NodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired).LastTransitionTime.Time.Before(
+			candidates[j].NodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired).LastTransitionTime.Time)
 	})
 
 	// Do a quick check through the candidates to see if they're empty.

--- a/pkg/controllers/disruption/expiration.go
+++ b/pkg/controllers/disruption/expiration.go
@@ -58,14 +58,14 @@ func NewExpiration(clk clock.Clock, kubeClient client.Client, cluster *state.Clu
 // ShouldDisrupt is a predicate used to filter candidates
 func (e *Expiration) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 	return c.nodePool.Spec.Disruption.ExpireAfter.Duration != nil &&
-		c.NodeClaim.StatusConditions().GetCondition(v1beta1.Expired).IsTrue()
+		c.NodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()
 }
 
 // ComputeCommand generates a disruption command given candidates
 func (e *Expiration) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, scheduling.Results, error) {
 	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].NodeClaim.StatusConditions().GetCondition(v1beta1.Expired).LastTransitionTime.Inner.Time.Before(
-			candidates[j].NodeClaim.StatusConditions().GetCondition(v1beta1.Expired).LastTransitionTime.Inner.Time)
+		return candidates[i].NodeClaim.StatusConditions().Get(v1beta1.Expired).LastTransitionTime.Time.Before(
+			candidates[j].NodeClaim.StatusConditions().Get(v1beta1.Expired).LastTransitionTime.Time)
 	})
 
 	// Do a quick check through the candidates to see if they're empty.

--- a/pkg/controllers/disruption/expiration_test.go
+++ b/pkg/controllers/disruption/expiration_test.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/awslabs/operatorpkg/status"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -28,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -75,7 +75,7 @@ var _ = Describe("Expiration", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Expired)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
 	})
 	Context("Metrics", func() {
 		var eligibleNodesLabels = map[string]string{
@@ -152,7 +152,7 @@ var _ = Describe("Expiration", func() {
 			})
 
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -199,7 +199,7 @@ var _ = Describe("Expiration", func() {
 			})
 
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -246,7 +246,7 @@ var _ = Describe("Expiration", func() {
 			})
 
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -294,7 +294,7 @@ var _ = Describe("Expiration", func() {
 
 			// Mark the first five as drifted
 			for i := range lo.Range(5) {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
 			}
 
 			for i := 0; i < numNodes; i++ {
@@ -388,7 +388,7 @@ var _ = Describe("Expiration", func() {
 			}
 
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -453,7 +453,7 @@ var _ = Describe("Expiration", func() {
 			}
 
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().MarkTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -481,7 +481,7 @@ var _ = Describe("Expiration", func() {
 	})
 	Context("Expiration", func() {
 		It("should ignore nodes without the expired status condition", func() {
-			_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Expired)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.Expired)
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -588,7 +588,7 @@ var _ = Describe("Expiration", func() {
 					},
 				},
 			})
-			nodeClaim2.StatusConditions().MarkTrue(v1beta1.Expired)
+			nodeClaim2.StatusConditions().SetTrue(v1beta1.Expired)
 			ExpectApplied(ctx, env.Client, nodeClaim2, node2, podToExpire)
 			ExpectManualBinding(ctx, env.Client, podToExpire, node2)
 
@@ -612,7 +612,7 @@ var _ = Describe("Expiration", func() {
 			ExpectNotFound(ctx, env.Client, nodeClaim2)
 		})
 		It("should ignore nodes with the expired status condition set to false", func() {
-			nodeClaim.StatusConditions().MarkFalse(v1beta1.Expired, "", "")
+			nodeClaim.StatusConditions().SetFalse(v1beta1.Expired, "NotExpired", "NotExpired")
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -665,7 +665,7 @@ var _ = Describe("Expiration", func() {
 				},
 			})
 			for _, m := range nodeClaims {
-				m.StatusConditions().MarkTrue(v1beta1.Expired)
+				m.StatusConditions().SetTrue(v1beta1.Expired)
 				ExpectApplied(ctx, env.Client, m)
 			}
 			for _, n := range nodes {
@@ -730,10 +730,12 @@ var _ = Describe("Expiration", func() {
 					Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("32")},
 				},
 			})
-			nodeClaim2.Status.Conditions = append(nodeClaim2.Status.Conditions, apis.Condition{
+			nodeClaim2.Status.Conditions = append(nodeClaim2.Status.Conditions, status.Condition{
 				Type:               v1beta1.Expired,
-				Status:             v1.ConditionTrue,
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(-time.Hour)}},
+				Status:             metav1.ConditionTrue,
+				Reason:             v1beta1.Expired,
+				Message:            v1beta1.Expired,
+				LastTransitionTime: metav1.Time{Time: time.Now().Add(-time.Hour)},
 			})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], nodeClaim, nodeClaim2, node, node2, nodePool)

--- a/pkg/controllers/disruption/expiration_test.go
+++ b/pkg/controllers/disruption/expiration_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Expiration", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 	})
 	Context("Metrics", func() {
 		var eligibleNodesLabels = map[string]string{
@@ -152,7 +152,7 @@ var _ = Describe("Expiration", func() {
 			})
 
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -199,7 +199,7 @@ var _ = Describe("Expiration", func() {
 			})
 
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -246,7 +246,7 @@ var _ = Describe("Expiration", func() {
 			})
 
 			for i := 0; i < numNodes; i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -294,7 +294,7 @@ var _ = Describe("Expiration", func() {
 
 			// Mark the first five as drifted
 			for i := range lo.Range(5) {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 			}
 
 			for i := 0; i < numNodes; i++ {
@@ -388,7 +388,7 @@ var _ = Describe("Expiration", func() {
 			}
 
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -453,7 +453,7 @@ var _ = Describe("Expiration", func() {
 			}
 
 			for i := 0; i < len(nodeClaims); i++ {
-				nodeClaims[i].StatusConditions().SetTrue(v1beta1.Expired)
+				nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
 			}
 
@@ -481,7 +481,7 @@ var _ = Describe("Expiration", func() {
 	})
 	Context("Expiration", func() {
 		It("should ignore nodes without the expired status condition", func() {
-			_ = nodeClaim.StatusConditions().Clear(v1beta1.Expired)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.ConditionTypeExpired)
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -588,7 +588,7 @@ var _ = Describe("Expiration", func() {
 					},
 				},
 			})
-			nodeClaim2.StatusConditions().SetTrue(v1beta1.Expired)
+			nodeClaim2.StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 			ExpectApplied(ctx, env.Client, nodeClaim2, node2, podToExpire)
 			ExpectManualBinding(ctx, env.Client, podToExpire, node2)
 
@@ -612,7 +612,7 @@ var _ = Describe("Expiration", func() {
 			ExpectNotFound(ctx, env.Client, nodeClaim2)
 		})
 		It("should ignore nodes with the expired status condition set to false", func() {
-			nodeClaim.StatusConditions().SetFalse(v1beta1.Expired, "NotExpired", "NotExpired")
+			nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeExpired, "NotExpired", "NotExpired")
 			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 			// inform cluster state about nodes and nodeclaims
@@ -665,7 +665,7 @@ var _ = Describe("Expiration", func() {
 				},
 			})
 			for _, m := range nodeClaims {
-				m.StatusConditions().SetTrue(v1beta1.Expired)
+				m.StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 				ExpectApplied(ctx, env.Client, m)
 			}
 			for _, n := range nodes {
@@ -731,10 +731,10 @@ var _ = Describe("Expiration", func() {
 				},
 			})
 			nodeClaim2.Status.Conditions = append(nodeClaim2.Status.Conditions, status.Condition{
-				Type:               v1beta1.Expired,
+				Type:               v1beta1.ConditionTypeExpired,
 				Status:             metav1.ConditionTrue,
-				Reason:             v1beta1.Expired,
-				Message:            v1beta1.Expired,
+				Reason:             v1beta1.ConditionTypeExpired,
+				Message:            v1beta1.ConditionTypeExpired,
 				LastTransitionTime: metav1.Time{Time: time.Now().Add(-time.Hour)},
 			})
 

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -229,9 +229,9 @@ func BuildDisruptionBudgets(ctx context.Context, cluster *state.Cluster, clk clo
 	deleting := map[string]int{}
 	disruptionBudgetMapping := map[string]int{}
 	// We need to get all the nodes in the cluster
-	// Get each current active number of nodes per nodePool
-	// Get the max disruptions for each nodePool
-	// Get the number of deleting nodes for each of those nodePools
+	// GetCondition each current active number of nodes per nodePool
+	// GetCondition the max disruptions for each nodePool
+	// GetCondition the number of deleting nodes for each of those nodePools
 	// Find the difference to know how much left we can disrupt
 	nodes := cluster.Nodes()
 	for _, node := range nodes {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -229,9 +229,9 @@ func BuildDisruptionBudgets(ctx context.Context, cluster *state.Cluster, clk clo
 	deleting := map[string]int{}
 	disruptionBudgetMapping := map[string]int{}
 	// We need to get all the nodes in the cluster
-	// GetCondition each current active number of nodes per nodePool
-	// GetCondition the max disruptions for each nodePool
-	// GetCondition the number of deleting nodes for each of those nodePools
+	// Get each current active number of nodes per nodePool
+	// Get the max disruptions for each nodePool
+	// Get the number of deleting nodes for each of those nodePools
 	// Find the difference to know how much left we can disrupt
 	nodes := cluster.Nodes()
 	for _, node := range nodes {

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -243,7 +243,7 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) error {
 		// We emitted this event when disruption was blocked on launching/termination.
 		// This does not block other forms of deprovisioning, but we should still emit this.
 		q.recorder.Publish(disruptionevents.Launching(nodeClaim, cmd.Reason()))
-		initializedStatus := nodeClaim.StatusConditions().Get(v1beta1.Initialized)
+		initializedStatus := nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeInitialized)
 		if !initializedStatus.IsTrue() {
 			q.recorder.Publish(disruptionevents.WaitingOnReadiness(nodeClaim))
 			waitErrs[i] = fmt.Errorf("nodeclaim %s not initialized", nodeClaim.Name)

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -243,7 +243,7 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) error {
 		// We emitted this event when disruption was blocked on launching/termination.
 		// This does not block other forms of deprovisioning, but we should still emit this.
 		q.recorder.Publish(disruptionevents.Launching(nodeClaim, cmd.Reason()))
-		initializedStatus := nodeClaim.StatusConditions().GetCondition(v1beta1.Initialized)
+		initializedStatus := nodeClaim.StatusConditions().Get(v1beta1.Initialized)
 		if !initializedStatus.IsTrue() {
 			q.recorder.Publish(disruptionevents.WaitingOnReadiness(nodeClaim))
 			waitErrs[i] = fmt.Errorf("nodeclaim %s not initialized", nodeClaim.Name)
@@ -251,7 +251,7 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) error {
 		}
 		cmd.Replacements[i].Initialized = true
 		// Subtract the last initialization time from the time the command was added to get initialization duration.
-		initLength := initializedStatus.LastTransitionTime.Inner.Time.Sub(nodeClaim.CreationTimestamp.Time).Seconds()
+		initLength := initializedStatus.LastTransitionTime.Time.Sub(nodeClaim.CreationTimestamp.Time).Seconds()
 		disruptionReplacementNodeClaimInitializedHistogram.Observe(initLength)
 	}
 	// If we have any errors, don't continue

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Simulate Scheduling", func() {
 
 		// Mark all nodeclaims as expired
 		for _, nc := range nodeClaims {
-			nc.StatusConditions().SetTrue(v1beta1.Expired)
+			nc.StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 			ExpectApplied(ctx, env.Client, nc)
 			ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nc))
 		}
@@ -1523,7 +1523,7 @@ var _ = Describe("Metrics", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 		// inform cluster state about nodes and nodeclaims
@@ -1570,7 +1570,7 @@ var _ = Describe("Metrics", func() {
 		})
 		pods := test.Pods(4, test.PodOptions{})
 
-		nodeClaims[0].StatusConditions().SetTrue(v1beta1.Drifted)
+		nodeClaims[0].StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 
 		ExpectApplied(ctx, env.Client, pods[0], pods[1], pods[2], pods[3], nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodePool)
 
@@ -1624,7 +1624,7 @@ var _ = Describe("Metrics", func() {
 			},
 		})
 		pods := test.Pods(4, test.PodOptions{})
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 
 		ExpectApplied(ctx, env.Client, pods[0], pods[1], pods[2], pods[3], nodeClaim, node, nodePool)
 

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Simulate Scheduling", func() {
 
 		// Mark all nodeclaims as expired
 		for _, nc := range nodeClaims {
-			nc.StatusConditions().MarkTrue(v1beta1.Expired)
+			nc.StatusConditions().SetTrue(v1beta1.Expired)
 			ExpectApplied(ctx, env.Client, nc)
 			ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nc))
 		}
@@ -1523,7 +1523,7 @@ var _ = Describe("Metrics", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
 		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 		// inform cluster state about nodes and nodeclaims
@@ -1570,7 +1570,7 @@ var _ = Describe("Metrics", func() {
 		})
 		pods := test.Pods(4, test.PodOptions{})
 
-		nodeClaims[0].StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaims[0].StatusConditions().SetTrue(v1beta1.Drifted)
 
 		ExpectApplied(ctx, env.Client, pods[0], pods[1], pods[2], pods[3], nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodePool)
 
@@ -1624,7 +1624,7 @@ var _ = Describe("Metrics", func() {
 			},
 		})
 		pods := test.Pods(4, test.PodOptions{})
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
 
 		ExpectApplied(ctx, env.Client, pods[0], pods[1], pods[2], pods[3], nodeClaim, node, nodePool)
 

--- a/pkg/controllers/nodeclaim/consistency/nodeshape.go
+++ b/pkg/controllers/nodeclaim/consistency/nodeshape.go
@@ -38,7 +38,7 @@ func (n *NodeShape) Check(_ context.Context, node *v1.Node, nodeClaim *v1beta1.N
 		return nil, nil
 	}
 	// and NodeClaims that haven't initialized yet
-	if !nodeClaim.StatusConditions().GetCondition(v1beta1.Initialized).IsTrue() {
+	if !nodeClaim.StatusConditions().Get(v1beta1.Initialized).IsTrue() {
 		return nil, nil
 	}
 	var issues []Issue

--- a/pkg/controllers/nodeclaim/consistency/nodeshape.go
+++ b/pkg/controllers/nodeclaim/consistency/nodeshape.go
@@ -38,7 +38,7 @@ func (n *NodeShape) Check(_ context.Context, node *v1.Node, nodeClaim *v1beta1.N
 		return nil, nil
 	}
 	// and NodeClaims that haven't initialized yet
-	if !nodeClaim.StatusConditions().Get(v1beta1.Initialized).IsTrue() {
+	if !nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeInitialized).IsTrue() {
 		return nil, nil
 	}
 	var issues []Issue

--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -47,20 +45,20 @@ type Drift struct {
 }
 
 func (d *Drift) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	hasDriftedCondition := nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted) != nil
+	hasDriftedCondition := nodeClaim.StatusConditions().Get(v1beta1.Drifted) != nil
 
 	// From here there are three scenarios to handle:
 	// 1. If drift is not enabled but the NodeClaim is drifted, remove the status condition
 	if !options.FromContext(ctx).FeatureGates.Drift {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Drifted)
+		_ = nodeClaim.StatusConditions().Clear(v1beta1.Drifted)
 		if hasDriftedCondition {
 			logging.FromContext(ctx).Debugf("removing drift status condition, drift has been disabled")
 		}
 		return reconcile.Result{}, nil
 	}
 	// 2. If NodeClaim is not launched, remove the drift status condition
-	if launchCond := nodeClaim.StatusConditions().GetCondition(v1beta1.Launched); launchCond == nil || launchCond.IsFalse() {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Drifted)
+	if !nodeClaim.StatusConditions().Get(v1beta1.Launched).IsTrue() {
+		_ = nodeClaim.StatusConditions().Clear(v1beta1.Drifted)
 		if hasDriftedCondition {
 			logging.FromContext(ctx).Debugf("removing drift status condition, isn't launched")
 		}
@@ -72,19 +70,14 @@ func (d *Drift) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nodeC
 	}
 	// 3. Otherwise, if the NodeClaim isn't drifted, but has the status condition, remove it.
 	if driftedReason == "" {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Drifted)
+		_ = nodeClaim.StatusConditions().Clear(v1beta1.Drifted)
 		if hasDriftedCondition {
 			logging.FromContext(ctx).Debugf("removing drifted status condition, not drifted")
 		}
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 	// 4. Finally, if the NodeClaim is drifted, but doesn't have status condition, add it.
-	nodeClaim.StatusConditions().SetCondition(apis.Condition{
-		Type:     v1beta1.Drifted,
-		Status:   v1.ConditionTrue,
-		Severity: apis.ConditionSeverityWarning,
-		Reason:   string(driftedReason),
-	})
+	nodeClaim.StatusConditions().SetTrueWithReason(v1beta1.Drifted, string(driftedReason), string(driftedReason))
 	if !hasDriftedCondition {
 		logging.FromContext(ctx).With("reason", string(driftedReason)).Debugf("marking drifted")
 		metrics.NodeClaimsDisruptedCounter.With(prometheus.Labels{

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -59,7 +58,7 @@ var _ = Describe("Drift", func() {
 			},
 		})
 		// NodeClaims are required to be launched before they can be evaluated for drift
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Launched)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Launched)
 	})
 	Context("Metrics", func() {
 		It("should fire a karpenter_nodeclaims_drifted metric when drifted", func() {
@@ -68,7 +67,7 @@ var _ = Describe("Drift", func() {
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
 			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_drifted", map[string]string{
 				"type":     "CloudProviderDrifted",
 				"nodepool": nodePool.Name,
@@ -90,8 +89,8 @@ var _ = Describe("Drift", func() {
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).Reason).To(Equal(string(disruption.RequirementsDrifted)))
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).Reason).To(Equal(string(disruption.RequirementsDrifted)))
 
 			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_drifted", map[string]string{
 				"type":     "RequirementsDrifted",
@@ -106,7 +105,7 @@ var _ = Describe("Drift", func() {
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
 
 			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_disrupted", map[string]string{
 				"type":     "drift",
@@ -122,7 +121,7 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
 	})
 	It("should detect static drift before cloud provider drift", func() {
 		cp.Drifted = "drifted"
@@ -138,8 +137,8 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).Reason).To(Equal(string(disruption.NodePoolDrifted)))
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).Reason).To(Equal(string(disruption.NodePoolDrifted)))
 	})
 	It("should detect node requirement drift before cloud provider drift", func() {
 		cp.Drifted = "drifted"
@@ -155,8 +154,8 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).Reason).To(Equal(string(disruption.RequirementsDrifted)))
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).Reason).To(Equal(string(disruption.RequirementsDrifted)))
 	})
 	It("should not detect drift if the feature flag is disabled", func() {
 		cp.Drifted = "drifted"
@@ -165,44 +164,42 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim if the feature flag is disabled", func() {
 		cp.Drifted = "drifted"
 		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
+	})
+	It("should remove the status condition from the nodeClaim when the nodeClaim launch condition is unknown", func() {
+		cp.Drifted = "drifted"
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+		nodeClaim.StatusConditions().SetUnknown(v1beta1.Launched)
+		ExpectApplied(ctx, env.Client, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim when the nodeClaim launch condition is false", func() {
 		cp.Drifted = "drifted"
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Launched, "", "")
+		nodeClaim.StatusConditions().SetFalse(v1beta1.Launched, "LaunchFailed", "LaunchFailed")
 		ExpectApplied(ctx, env.Client, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
-	})
-	It("should remove the status condition from the nodeClaim when the nodeClaim launch condition doesn't exist", func() {
-		cp.Drifted = "drifted"
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
-		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
-		nodeClaim.Status.Conditions = lo.Reject(nodeClaim.Status.Conditions, func(s apis.Condition, _ int) bool {
-			return s.Type == v1beta1.Launched
-		})
-		ExpectApplied(ctx, env.Client, nodeClaim)
-
-		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
-
-		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 	})
 	It("should not detect drift if the nodePool does not exist", func() {
 		cp.Drifted = "drifted"
@@ -210,17 +207,17 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim if the nodeClaim is no longer drifted", func() {
 		cp.Drifted = ""
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 	})
 	Context("NodeRequirement Drift", func() {
 		DescribeTable("",
@@ -232,16 +229,16 @@ var _ = Describe("Drift", func() {
 				ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 				ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-				Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+				Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 
 				nodePool.Spec.Template.Spec.Requirements = newNodePoolReq
 				ExpectApplied(ctx, env.Client, nodePool)
 				ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 				if drifted {
-					Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
+					Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
 				} else {
-					Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+					Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 				}
 			},
 			Entry(
@@ -400,15 +397,15 @@ var _ = Describe("Drift", func() {
 					ProviderID: test.RandomProviderID(),
 				},
 			})
-			nodeClaimTwo.StatusConditions().MarkTrue(v1beta1.Launched)
+			nodeClaimTwo.StatusConditions().SetTrue(v1beta1.Launched)
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, nodeClaimTwo)
 
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaimTwo))
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 			nodeClaimTwo = ExpectExists(ctx, env.Client, nodeClaimTwo)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
-			Expect(nodeClaimTwo.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
+			Expect(nodeClaimTwo.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 
 			// Removed Windows OS
 			nodePool.Spec.Template.Spec.Requirements = []v1beta1.NodeSelectorRequirementWithMinValues{
@@ -419,11 +416,11 @@ var _ = Describe("Drift", func() {
 
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaimTwo))
 			nodeClaimTwo = ExpectExists(ctx, env.Client, nodeClaimTwo)
-			Expect(nodeClaimTwo.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
+			Expect(nodeClaimTwo.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
 		})
 
 	})
@@ -503,7 +500,7 @@ var _ = Describe("Drift", func() {
 				ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
 				ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-				Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+				Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 
 				nodePool = ExpectExists(ctx, env.Client, nodePool)
 				Expect(mergo.Merge(nodePool, changes, mergo.WithOverride)).To(Succeed())
@@ -512,7 +509,7 @@ var _ = Describe("Drift", func() {
 				ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
 				ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-				Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
+				Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
 			},
 			Entry("Annoations", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{ObjectMeta: v1beta1.ObjectMeta{Annotations: map[string]string{"keyAnnotationTest": "valueAnnotationTest"}}}}}),
 			Entry("Labels", v1beta1.NodePool{Spec: v1beta1.NodePoolSpec{Template: v1beta1.NodeClaimTemplate{ObjectMeta: v1beta1.ObjectMeta{Labels: map[string]string{"keyLabelTest": "valueLabelTest"}}}}}),
@@ -539,7 +536,7 @@ var _ = Describe("Drift", func() {
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 		})
 		It("should not return drifted if karpenter.sh/nodepool-hash annotation is not present on the NodeClaim", func() {
 			nodeClaim.ObjectMeta.Annotations = map[string]string{
@@ -548,7 +545,7 @@ var _ = Describe("Drift", func() {
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 		})
 		It("should not return drifted if the NodeClaim's karpenter.sh/nodepool-hash-version annotation does not match the NodePool's", func() {
 			nodePool.ObjectMeta.Annotations = map[string]string{
@@ -562,7 +559,7 @@ var _ = Describe("Drift", func() {
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 		})
 		It("should not return drifted if karpenter.sh/nodepool-hash-version annotation is not present on the NodeClaim", func() {
 			nodeClaim.ObjectMeta.Annotations = map[string]string{
@@ -571,7 +568,7 @@ var _ = Describe("Drift", func() {
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
 		})
 	})
 })

--- a/pkg/controllers/nodeclaim/disruption/emptiness.go
+++ b/pkg/controllers/nodeclaim/disruption/emptiness.go
@@ -22,9 +22,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -45,7 +43,7 @@ type Emptiness struct {
 
 //nolint:gocyclo
 func (e *Emptiness) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	hasEmptyCondition := nodeClaim.StatusConditions().GetCondition(v1beta1.Empty) != nil
+	hasEmptyCondition := nodeClaim.StatusConditions().Get(v1beta1.Empty) != nil
 
 	// From here there are a few scenarios to handle:
 	// 1. If ConsolidationPolicyWhenEmpty is not configured or ConsolidateAfter isn't configured, remove the emptiness status condition
@@ -53,25 +51,25 @@ func (e *Emptiness) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, n
 		nodePool.Spec.Disruption.ConsolidateAfter == nil ||
 		nodePool.Spec.Disruption.ConsolidateAfter.Duration == nil {
 		if hasEmptyCondition {
-			_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Empty)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.Empty)
 			logging.FromContext(ctx).Debugf("removing emptiness status condition, emptiness is disabled")
 		}
 		return reconcile.Result{}, nil
 	}
 	// 2. If NodeClaim is not initialized, remove the emptiness status condition
-	if initCond := nodeClaim.StatusConditions().GetCondition(v1beta1.Initialized); initCond == nil || initCond.IsFalse() {
+	if !nodeClaim.StatusConditions().Get(v1beta1.Initialized).IsTrue() {
 		if hasEmptyCondition {
-			_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Empty)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.Empty)
 			logging.FromContext(ctx).Debugf("removing emptiness status condition, isn't initialized")
 		}
 		return reconcile.Result{}, nil
 	}
-	// Get the node to check for pods scheduled to it
+	// GetCondition the node to check for pods scheduled to it
 	n, err := nodeclaimutil.NodeForNodeClaim(ctx, e.kubeClient, nodeClaim)
 	if err != nil {
 		// 3. If Node mapping doesn't exist, remove the emptiness status condition
 		if nodeclaimutil.IsDuplicateNodeError(err) || nodeclaimutil.IsNodeNotFoundError(err) {
-			_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Empty)
+			_ = nodeClaim.StatusConditions().Clear(v1beta1.Empty)
 			if hasEmptyCondition {
 				logging.FromContext(ctx).Debugf("removing emptiness status condition, doesn't have a single node mapping")
 			}
@@ -84,7 +82,7 @@ func (e *Emptiness) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, n
 	// nomination time ends since we don't watch node nomination events
 	// 4. If the Node is nominated for pods to schedule to it, remove the emptiness status condition
 	if e.cluster.IsNodeNominated(n.Spec.ProviderID) {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Empty)
+		_ = nodeClaim.StatusConditions().Clear(v1beta1.Empty)
 		if hasEmptyCondition {
 			logging.FromContext(ctx).Debugf("removing emptiness status condition, is nominated for pods")
 		}
@@ -96,18 +94,14 @@ func (e *Emptiness) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, n
 	}
 	// 5. If there are pods that are actively scheduled to the Node, remove the emptiness status condition
 	if len(pods) > 0 {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Empty)
+		_ = nodeClaim.StatusConditions().Clear(v1beta1.Empty)
 		if hasEmptyCondition {
 			logging.FromContext(ctx).Debugf("removing emptiness status condition, not empty")
 		}
 		return reconcile.Result{}, nil
 	}
 	// 6. Otherwise, add the emptiness status condition
-	nodeClaim.StatusConditions().SetCondition(apis.Condition{
-		Type:     v1beta1.Empty,
-		Status:   v1.ConditionTrue,
-		Severity: apis.ConditionSeverityWarning,
-	})
+	nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
 	if !hasEmptyCondition {
 		logging.FromContext(ctx).Debugf("marking empty")
 		metrics.NodeClaimsDisruptedCounter.With(prometheus.Labels{

--- a/pkg/controllers/nodeclaim/disruption/emptiness_test.go
+++ b/pkg/controllers/nodeclaim/disruption/emptiness_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -60,7 +59,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
 
 			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_disrupted", map[string]string{
 				"type":     "emptiness",
@@ -77,7 +76,7 @@ var _ = Describe("Emptiness", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
 	})
 	It("should mark NodeClaims as empty that have only pods in terminating state", func() {
 		rs := test.ReplicaSet()
@@ -114,7 +113,7 @@ var _ = Describe("Emptiness", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
 	})
 	It("should mark NodeClaims as empty that have only DaemonSet pods", func() {
 		ds := test.DaemonSet()
@@ -145,57 +144,55 @@ var _ = Describe("Emptiness", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
 	})
 	It("should remove the status condition from the nodeClaim when emptiness is disabled", func() {
 		nodePool.Spec.Disruption.ConsolidateAfter.Duration = nil
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+	})
+	It("should remove the status condition from the nodeClaim when the nodeClaim initialization condition is unknown", func() {
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
+		nodeClaim.StatusConditions().SetUnknown(v1beta1.Initialized)
+		ExpectApplied(ctx, env.Client, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim when the nodeClaim initialization condition is false", func() {
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Initialized, "", "")
+		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "NotInitialized", "NotInitialized")
 		ExpectApplied(ctx, env.Client, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
-	})
-	It("should remove the status condition from the nodeClaim when the nodeClaim initialization condition doesn't exist", func() {
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
-		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
-		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
-		nodeClaim.Status.Conditions = lo.Reject(nodeClaim.Status.Conditions, func(s apis.Condition, _ int) bool {
-			return s.Type == v1beta1.Initialized
-		})
-		ExpectApplied(ctx, env.Client, nodeClaim)
-
-		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
-
-		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim when the node doesn't exist", func() {
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
 	})
 	It("should remove the status condition from non-empty NodeClaims", func() {
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
@@ -207,13 +204,13 @@ var _ = Describe("Emptiness", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
 	})
 	It("should remove the status condition from NodeClaims that have a StatefulSet pod in terminating state", func() {
 		ss := test.StatefulSet()
 		ExpectApplied(ctx, env.Client, ss)
 
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
@@ -243,10 +240,10 @@ var _ = Describe("Emptiness", func() {
 		// The node isn't empty even though it only has terminating pods
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
 	})
 	It("should remove the status condition when the cluster state node is nominated", func() {
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
@@ -258,6 +255,6 @@ var _ = Describe("Emptiness", func() {
 		Expect(result.RequeueAfter).To(Equal(time.Second * 30))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
 	})
 })

--- a/pkg/controllers/nodeclaim/disruption/emptiness_test.go
+++ b/pkg/controllers/nodeclaim/disruption/emptiness_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty).IsTrue()).To(BeTrue())
 
 			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_disrupted", map[string]string{
 				"type":     "emptiness",
@@ -76,7 +76,7 @@ var _ = Describe("Emptiness", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty).IsTrue()).To(BeTrue())
 	})
 	It("should mark NodeClaims as empty that have only pods in terminating state", func() {
 		rs := test.ReplicaSet()
@@ -113,7 +113,7 @@ var _ = Describe("Emptiness", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty).IsTrue()).To(BeTrue())
 	})
 	It("should mark NodeClaims as empty that have only DaemonSet pods", func() {
 		ds := test.DaemonSet()
@@ -144,55 +144,55 @@ var _ = Describe("Emptiness", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty).IsTrue()).To(BeTrue())
 	})
 	It("should remove the status condition from the nodeClaim when emptiness is disabled", func() {
 		nodePool.Spec.Disruption.ConsolidateAfter.Duration = nil
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim when the nodeClaim initialization condition is unknown", func() {
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
-		nodeClaim.StatusConditions().SetUnknown(v1beta1.Initialized)
+		nodeClaim.StatusConditions().SetUnknown(v1beta1.ConditionTypeInitialized)
 		ExpectApplied(ctx, env.Client, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim when the nodeClaim initialization condition is false", func() {
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
-		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "NotInitialized", "NotInitialized")
+		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "NotInitialized", "NotInitialized")
 		ExpectApplied(ctx, env.Client, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim when the node doesn't exist", func() {
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty)).To(BeNil())
 	})
 	It("should remove the status condition from non-empty NodeClaims", func() {
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
@@ -204,13 +204,13 @@ var _ = Describe("Emptiness", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty)).To(BeNil())
 	})
 	It("should remove the status condition from NodeClaims that have a StatefulSet pod in terminating state", func() {
 		ss := test.StatefulSet()
 		ExpectApplied(ctx, env.Client, ss)
 
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
@@ -240,10 +240,10 @@ var _ = Describe("Emptiness", func() {
 		// The node isn't empty even though it only has terminating pods
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty)).To(BeNil())
 	})
 	It("should remove the status condition when the cluster state node is nominated", func() {
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
@@ -255,6 +255,6 @@ var _ = Describe("Emptiness", func() {
 		Expect(result.RequeueAfter).To(Equal(time.Second * 30))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty)).To(BeNil())
 	})
 })

--- a/pkg/controllers/nodeclaim/disruption/expiration.go
+++ b/pkg/controllers/nodeclaim/disruption/expiration.go
@@ -20,9 +20,7 @@ import (
 	"context"
 
 	"github.com/prometheus/client_golang/prometheus"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -38,12 +36,12 @@ type Expiration struct {
 }
 
 func (e *Expiration) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	hasExpiredCondition := nodeClaim.StatusConditions().GetCondition(v1beta1.Expired) != nil
+	hasExpiredCondition := nodeClaim.StatusConditions().Get(v1beta1.Expired) != nil
 
 	// From here there are three scenarios to handle:
 	// 1. If ExpireAfter is not configured, remove the expired status condition
 	if nodePool.Spec.Disruption.ExpireAfter.Duration == nil {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Expired)
+		_ = nodeClaim.StatusConditions().Clear(v1beta1.Expired)
 		if hasExpiredCondition {
 			logging.FromContext(ctx).Debugf("removing expiration status condition, expiration has been disabled")
 		}
@@ -52,7 +50,7 @@ func (e *Expiration) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, 
 	expirationTime := nodeClaim.CreationTimestamp.Add(*nodePool.Spec.Disruption.ExpireAfter.Duration)
 	// 2. If the NodeClaim isn't expired, remove the status condition.
 	if e.clock.Now().Before(expirationTime) {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Expired)
+		_ = nodeClaim.StatusConditions().Clear(v1beta1.Expired)
 		if hasExpiredCondition {
 			logging.FromContext(ctx).Debugf("removing expired status condition, not expired")
 		}
@@ -61,11 +59,7 @@ func (e *Expiration) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, 
 		return reconcile.Result{RequeueAfter: expirationTime.Sub(e.clock.Now())}, nil
 	}
 	// 3. Otherwise, if the NodeClaim is expired, but doesn't have the status condition, add it.
-	nodeClaim.StatusConditions().SetCondition(apis.Condition{
-		Type:     v1beta1.Expired,
-		Status:   v1.ConditionTrue,
-		Severity: apis.ConditionSeverityWarning,
-	})
+	nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
 	if !hasExpiredCondition {
 		logging.FromContext(ctx).Debugf("marking expired")
 		metrics.NodeClaimsDisruptedCounter.With(prometheus.Labels{

--- a/pkg/controllers/nodeclaim/disruption/expiration_test.go
+++ b/pkg/controllers/nodeclaim/disruption/expiration_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Expiration", func() {
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired).IsTrue()).To(BeTrue())
 
 			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_disrupted", map[string]string{
 				"type":     "expiration",
@@ -67,13 +67,13 @@ var _ = Describe("Expiration", func() {
 	})
 	It("should remove the status condition from the NodeClaims when expiration is disabled", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired)).To(BeNil())
 	})
 	It("should mark NodeClaims as expired", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 30)
@@ -84,17 +84,17 @@ var _ = Describe("Expiration", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired).IsTrue()).To(BeTrue())
 	})
 	It("should remove the status condition from non-expired NodeClaims", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 200)
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired)).To(BeNil())
 	})
 	It("should mark NodeClaims as expired if the nodeClaim is expired but the node isn't", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 30)
@@ -106,7 +106,7 @@ var _ = Describe("Expiration", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired).IsTrue()).To(BeTrue())
 	})
 	It("should return the requeue interval for the time between now and when the nodeClaim expires", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 200)

--- a/pkg/controllers/nodeclaim/disruption/expiration_test.go
+++ b/pkg/controllers/nodeclaim/disruption/expiration_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Expiration", func() {
 			ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired).IsTrue()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()).To(BeTrue())
 
 			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_disrupted", map[string]string{
 				"type":     "expiration",
@@ -67,13 +67,13 @@ var _ = Describe("Expiration", func() {
 	})
 	It("should remove the status condition from the NodeClaims when expiration is disabled", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Expired)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired)).To(BeNil())
 	})
 	It("should mark NodeClaims as expired", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 30)
@@ -84,17 +84,17 @@ var _ = Describe("Expiration", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()).To(BeTrue())
 	})
 	It("should remove the status condition from non-expired NodeClaims", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 200)
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Expired)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired)).To(BeNil())
 	})
 	It("should mark NodeClaims as expired if the nodeClaim is expired but the node isn't", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 30)
@@ -106,7 +106,7 @@ var _ = Describe("Expiration", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()).To(BeTrue())
 	})
 	It("should return the requeue interval for the time between now and when the nodeClaim expires", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(time.Second * 200)

--- a/pkg/controllers/nodeclaim/disruption/suite_test.go
+++ b/pkg/controllers/nodeclaim/disruption/suite_test.go
@@ -111,17 +111,17 @@ var _ = Describe("Disruption", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeDrifted).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired).IsTrue()).To(BeTrue())
 	})
 	It("should remove multiple disruption conditions simultaneously", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
 		nodePool.Spec.Disruption.ConsolidateAfter = &v1beta1.NillableDuration{Duration: nil}
 
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeEmpty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeExpired)
 
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
@@ -131,8 +131,8 @@ var _ = Describe("Disruption", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeDrifted)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeEmpty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeExpired)).To(BeNil())
 	})
 })

--- a/pkg/controllers/nodeclaim/disruption/suite_test.go
+++ b/pkg/controllers/nodeclaim/disruption/suite_test.go
@@ -111,17 +111,17 @@ var _ = Describe("Disruption", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired).IsTrue()).To(BeTrue())
 	})
 	It("should remove multiple disruption conditions simultaneously", func() {
 		nodePool.Spec.Disruption.ExpireAfter.Duration = nil
 		nodePool.Spec.Disruption.ConsolidateAfter = &v1beta1.NillableDuration{Duration: nil}
 
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Expired)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Empty)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Expired)
 
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
@@ -131,8 +131,8 @@ var _ = Describe("Disruption", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted)).To(BeNil())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Empty)).To(BeNil())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Expired)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Drifted)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Empty)).To(BeNil())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Expired)).To(BeNil())
 	})
 })

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -77,7 +77,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// Only consider NodeClaims that are Registered since we don't want to fully rely on the CloudProvider
 	// API to trigger deletion of the Node. Instead, we'll wait for our registration timeout to trigger
 	nodeClaims := lo.Filter(lo.ToSlicePtr(nodeClaimList.Items), func(n *v1beta1.NodeClaim, _ int) bool {
-		return n.StatusConditions().GetCondition(v1beta1.Registered).IsTrue() &&
+		return n.StatusConditions().Get(v1beta1.Registered).IsTrue() &&
 			n.DeletionTimestamp.IsZero() &&
 			!cloudProviderProviderIDs.Has(n.Status.ProviderID)
 	})

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -77,7 +77,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// Only consider NodeClaims that are Registered since we don't want to fully rely on the CloudProvider
 	// API to trigger deletion of the Node. Instead, we'll wait for our registration timeout to trigger
 	nodeClaims := lo.Filter(lo.ToSlicePtr(nodeClaimList.Items), func(n *v1beta1.NodeClaim, _ int) bool {
-		return n.StatusConditions().Get(v1beta1.Registered).IsTrue() &&
+		return n.StatusConditions().Get(v1beta1.ConditionTypeRegistered).IsTrue() &&
 			n.DeletionTimestamp.IsZero() &&
 			!cloudProviderProviderIDs.Has(n.Status.ProviderID)
 	})

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -46,34 +46,34 @@ type Initialization struct {
 // c) all extended resources have been registered
 // This method handles both nil nodepools and nodes without extended resources gracefully.
 func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	if nodeClaim.StatusConditions().GetCondition(v1beta1.Initialized).IsTrue() {
+	if nodeClaim.StatusConditions().Get(v1beta1.Initialized).IsTrue() {
 		return reconcile.Result{}, nil
 	}
-	if !nodeClaim.StatusConditions().GetCondition(v1beta1.Launched).IsTrue() {
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Initialized, "NotLaunched", "Node not launched")
+	if !nodeClaim.StatusConditions().Get(v1beta1.Launched).IsTrue() {
+		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "NotLaunched", "Node not launched")
 		return reconcile.Result{}, nil
 	}
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provider-id", nodeClaim.Status.ProviderID))
 	node, err := nodeclaimutil.NodeForNodeClaim(ctx, i.kubeClient, nodeClaim)
 	if err != nil {
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Initialized, "NodeNotFound", "Node not registered with cluster")
+		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "NodeNotFound", "Node not registered with cluster")
 		return reconcile.Result{}, nil //nolint:nilerr
 	}
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", node.Name))
 	if nodeutil.GetCondition(node, v1.NodeReady).Status != v1.ConditionTrue {
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Initialized, "NodeNotReady", "Node status is NotReady")
+		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "NodeNotReady", "Node status is NotReady")
 		return reconcile.Result{}, nil
 	}
 	if taint, ok := StartupTaintsRemoved(node, nodeClaim); !ok {
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Initialized, "StartupTaintsExist", "StartupTaint %q still exists", formatTaint(taint))
+		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "StartupTaintsExist", fmt.Sprintf("StartupTaint %q still exists", formatTaint(taint)))
 		return reconcile.Result{}, nil
 	}
 	if taint, ok := KnownEphemeralTaintsRemoved(node); !ok {
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Initialized, "KnownEphemeralTaintsExist", "KnownEphemeralTaint %q still exists", formatTaint(taint))
+		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "KnownEphemeralTaintsExist", fmt.Sprintf("KnownEphemeralTaint %q still exists", formatTaint(taint)))
 		return reconcile.Result{}, nil
 	}
 	if name, ok := RequestedResourcesRegistered(node, nodeClaim); !ok {
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Initialized, "ResourceNotRegistered", "Resource %q was requested but not registered", name)
+		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "ResourceNotRegistered", fmt.Sprintf("Resource %q was requested but not registered", name))
 		return reconcile.Result{}, nil
 	}
 	stored := node.DeepCopy()
@@ -84,7 +84,7 @@ func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeC
 		}
 	}
 	logging.FromContext(ctx).With("allocatable", node.Status.Allocatable).Infof("initialized nodeclaim")
-	nodeClaim.StatusConditions().MarkTrue(v1beta1.Initialized)
+	nodeClaim.StatusConditions().SetTrue(v1beta1.Initialized)
 	metrics.NodeClaimsInitializedCounter.With(prometheus.Labels{
 		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 	}).Inc()

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -46,34 +46,34 @@ type Initialization struct {
 // c) all extended resources have been registered
 // This method handles both nil nodepools and nodes without extended resources gracefully.
 func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	if nodeClaim.StatusConditions().Get(v1beta1.Initialized).IsTrue() {
+	if nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeInitialized).IsTrue() {
 		return reconcile.Result{}, nil
 	}
-	if !nodeClaim.StatusConditions().Get(v1beta1.Launched).IsTrue() {
-		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "NotLaunched", "Node not launched")
+	if !nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeLaunched).IsTrue() {
+		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "NotLaunched", "Node not launched")
 		return reconcile.Result{}, nil
 	}
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provider-id", nodeClaim.Status.ProviderID))
 	node, err := nodeclaimutil.NodeForNodeClaim(ctx, i.kubeClient, nodeClaim)
 	if err != nil {
-		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "NodeNotFound", "Node not registered with cluster")
+		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "NodeNotFound", "Node not registered with cluster")
 		return reconcile.Result{}, nil //nolint:nilerr
 	}
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", node.Name))
 	if nodeutil.GetCondition(node, v1.NodeReady).Status != v1.ConditionTrue {
-		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "NodeNotReady", "Node status is NotReady")
+		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "NodeNotReady", "Node status is NotReady")
 		return reconcile.Result{}, nil
 	}
 	if taint, ok := StartupTaintsRemoved(node, nodeClaim); !ok {
-		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "StartupTaintsExist", fmt.Sprintf("StartupTaint %q still exists", formatTaint(taint)))
+		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "StartupTaintsExist", fmt.Sprintf("StartupTaint %q still exists", formatTaint(taint)))
 		return reconcile.Result{}, nil
 	}
 	if taint, ok := KnownEphemeralTaintsRemoved(node); !ok {
-		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "KnownEphemeralTaintsExist", fmt.Sprintf("KnownEphemeralTaint %q still exists", formatTaint(taint)))
+		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "KnownEphemeralTaintsExist", fmt.Sprintf("KnownEphemeralTaint %q still exists", formatTaint(taint)))
 		return reconcile.Result{}, nil
 	}
 	if name, ok := RequestedResourcesRegistered(node, nodeClaim); !ok {
-		nodeClaim.StatusConditions().SetFalse(v1beta1.Initialized, "ResourceNotRegistered", fmt.Sprintf("Resource %q was requested but not registered", name))
+		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "ResourceNotRegistered", fmt.Sprintf("Resource %q was requested but not registered", name))
 		return reconcile.Result{}, nil
 	}
 	stored := node.DeepCopy()
@@ -84,7 +84,7 @@ func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeC
 		}
 	}
 	logging.FromContext(ctx).With("allocatable", node.Status.Allocatable).Infof("initialized nodeclaim")
-	nodeClaim.StatusConditions().SetTrue(v1beta1.Initialized)
+	nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeInitialized)
 	metrics.NodeClaimsInitializedCounter.With(prometheus.Labels{
 		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 	}).Inc()

--- a/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
@@ -69,8 +69,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
 
 		node = ExpectExists(ctx, env.Client, node)
 		node.Status.Capacity = v1.ResourceList{
@@ -87,8 +87,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should add the initialization label to the node when the nodeClaim is initialized", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -171,8 +171,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
 	})
 	It("should not consider the Node to be initialized when all requested resources aren't registered", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -221,8 +221,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
 	})
 	It("should consider the node to be initialized once all the resources are registered", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -271,8 +271,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
 
 		// Node now registers the resource
 		node = ExpectExists(ctx, env.Client, node)
@@ -283,8 +283,8 @@ var _ = Describe("Initialization", func() {
 		// Reconcile the nodeClaim and the nodeClaim/Node should now be initilized
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should not consider the Node to be initialized when all startupTaints aren't removed", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -354,8 +354,8 @@ var _ = Describe("Initialization", func() {
 		// Shouldn't consider the node ready since the startup taints still exist
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
 	})
 	It("should consider the Node to be initialized once the startupTaints are removed", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -409,8 +409,8 @@ var _ = Describe("Initialization", func() {
 		// Shouldn't consider the node ready since the startup taints still exist
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
 
 		node = ExpectExists(ctx, env.Client, node)
 		node.Spec.Taints = []v1.Taint{}
@@ -419,8 +419,8 @@ var _ = Describe("Initialization", func() {
 		// nodeClaim should now be ready since all startup taints are removed
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should not consider the Node to be initialized when all ephemeralTaints aren't removed", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -488,8 +488,8 @@ var _ = Describe("Initialization", func() {
 		// Shouldn't consider the node ready since the ephemeral taints still exist
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
 	})
 	It("should consider the Node to be initialized once the ephemeralTaints are removed", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -557,8 +557,8 @@ var _ = Describe("Initialization", func() {
 		// Shouldn't consider the node ready since the ephemeral taints still exist
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
 
 		node = ExpectExists(ctx, env.Client, node)
 		node.Spec.Taints = []v1.Taint{}
@@ -567,7 +567,7 @@ var _ = Describe("Initialization", func() {
 		// nodeClaim should now be ready since all startup taints are removed
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 })

--- a/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
@@ -69,8 +69,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionFalse))
 
 		node = ExpectExists(ctx, env.Client, node)
 		node.Status.Capacity = v1.ResourceList{
@@ -87,8 +87,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should add the initialization label to the node when the nodeClaim is initialized", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -171,8 +171,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionFalse))
 	})
 	It("should not consider the Node to be initialized when all requested resources aren't registered", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -221,8 +221,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionFalse))
 	})
 	It("should consider the node to be initialized once all the resources are registered", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -271,8 +271,8 @@ var _ = Describe("Initialization", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionFalse))
 
 		// Node now registers the resource
 		node = ExpectExists(ctx, env.Client, node)
@@ -283,8 +283,8 @@ var _ = Describe("Initialization", func() {
 		// Reconcile the nodeClaim and the nodeClaim/Node should now be initilized
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should not consider the Node to be initialized when all startupTaints aren't removed", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -354,8 +354,8 @@ var _ = Describe("Initialization", func() {
 		// Shouldn't consider the node ready since the startup taints still exist
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionFalse))
 	})
 	It("should consider the Node to be initialized once the startupTaints are removed", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -409,8 +409,8 @@ var _ = Describe("Initialization", func() {
 		// Shouldn't consider the node ready since the startup taints still exist
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionFalse))
 
 		node = ExpectExists(ctx, env.Client, node)
 		node.Spec.Taints = []v1.Taint{}
@@ -419,8 +419,8 @@ var _ = Describe("Initialization", func() {
 		// nodeClaim should now be ready since all startup taints are removed
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should not consider the Node to be initialized when all ephemeralTaints aren't removed", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -488,8 +488,8 @@ var _ = Describe("Initialization", func() {
 		// Shouldn't consider the node ready since the ephemeral taints still exist
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionFalse))
 	})
 	It("should consider the Node to be initialized once the ephemeralTaints are removed", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
@@ -557,8 +557,8 @@ var _ = Describe("Initialization", func() {
 		// Shouldn't consider the node ready since the ephemeral taints still exist
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionFalse))
 
 		node = ExpectExists(ctx, env.Client, node)
 		node.Spec.Taints = []v1.Taint{}
@@ -567,7 +567,7 @@ var _ = Describe("Initialization", func() {
 		// nodeClaim should now be ready since all startup taints are removed
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Initialized).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 })

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -43,7 +43,7 @@ type Launch struct {
 }
 
 func (l *Launch) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	if nodeClaim.StatusConditions().Get(v1beta1.Launched).IsTrue() {
+	if nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeLaunched).IsTrue() {
 		return reconcile.Result{}, nil
 	}
 
@@ -69,7 +69,7 @@ func (l *Launch) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (r
 	}
 	l.cache.SetDefault(string(nodeClaim.UID), created)
 	nodeClaim = PopulateNodeClaimDetails(nodeClaim, created)
-	nodeClaim.StatusConditions().SetTrue(v1beta1.Launched)
+	nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeLaunched)
 	metrics.NodeClaimsLaunchedCounter.With(prometheus.Labels{
 		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 	}).Inc()
@@ -95,10 +95,10 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 			return nil, nil
 		case cloudprovider.IsNodeClassNotReadyError(err):
 			l.recorder.Publish(NodeClassNotReadyEvent(nodeClaim, err))
-			nodeClaim.StatusConditions().SetFalse(v1beta1.Launched, "LaunchFailed", truncateMessage(err.Error()))
+			nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeLaunched, "LaunchFailed", truncateMessage(err.Error()))
 			return nil, fmt.Errorf("launching nodeclaim, %w", err)
 		default:
-			nodeClaim.StatusConditions().SetFalse(v1beta1.Launched, "LaunchFailed", truncateMessage(err.Error()))
+			nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeLaunched, "LaunchFailed", truncateMessage(err.Error()))
 			return nil, fmt.Errorf("launching nodeclaim, %w", err)
 		}
 	}

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -43,7 +43,7 @@ type Launch struct {
 }
 
 func (l *Launch) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	if nodeClaim.StatusConditions().GetCondition(v1beta1.Launched).IsTrue() {
+	if nodeClaim.StatusConditions().Get(v1beta1.Launched).IsTrue() {
 		return reconcile.Result{}, nil
 	}
 
@@ -69,7 +69,7 @@ func (l *Launch) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (r
 	}
 	l.cache.SetDefault(string(nodeClaim.UID), created)
 	nodeClaim = PopulateNodeClaimDetails(nodeClaim, created)
-	nodeClaim.StatusConditions().MarkTrue(v1beta1.Launched)
+	nodeClaim.StatusConditions().SetTrue(v1beta1.Launched)
 	metrics.NodeClaimsLaunchedCounter.With(prometheus.Labels{
 		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 	}).Inc()
@@ -95,10 +95,10 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1beta1.NodeCla
 			return nil, nil
 		case cloudprovider.IsNodeClassNotReadyError(err):
 			l.recorder.Publish(NodeClassNotReadyEvent(nodeClaim, err))
-			nodeClaim.StatusConditions().MarkFalse(v1beta1.Launched, "LaunchFailed", truncateMessage(err.Error()))
+			nodeClaim.StatusConditions().SetFalse(v1beta1.Launched, "LaunchFailed", truncateMessage(err.Error()))
 			return nil, fmt.Errorf("launching nodeclaim, %w", err)
 		default:
-			nodeClaim.StatusConditions().MarkFalse(v1beta1.Launched, "LaunchFailed", truncateMessage(err.Error()))
+			nodeClaim.StatusConditions().SetFalse(v1beta1.Launched, "LaunchFailed", truncateMessage(err.Error()))
 			return nil, fmt.Errorf("launching nodeclaim, %w", err)
 		}
 	}

--- a/pkg/controllers/nodeclaim/lifecycle/launch_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Launch", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Launched).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeLaunched).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should delete the nodeclaim if InsufficientCapacity is returned from the cloudprovider", func() {
 		cloudProvider.NextCreateErr = cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all instance types were unavailable"))
@@ -85,6 +85,6 @@ var _ = Describe("Launch", func() {
 		Expect(res.Requeue).To(BeTrue())
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Launched).Status).To(Equal(metav1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeLaunched).Status).To(Equal(metav1.ConditionFalse))
 	})
 })

--- a/pkg/controllers/nodeclaim/lifecycle/launch_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch_test.go
@@ -19,7 +19,6 @@ package lifecycle_test
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -68,7 +67,7 @@ var _ = Describe("Launch", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Launched).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Launched).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should delete the nodeclaim if InsufficientCapacity is returned from the cloudprovider", func() {
 		cloudProvider.NextCreateErr = cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all instance types were unavailable"))
@@ -86,6 +85,6 @@ var _ = Describe("Launch", func() {
 		Expect(res.Requeue).To(BeTrue())
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Launched).Status).To(Equal(v1.ConditionFalse))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Launched).Status).To(Equal(metav1.ConditionFalse))
 	})
 })

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -40,7 +40,7 @@ type Liveness struct {
 const registrationTTL = time.Minute * 15
 
 func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	registered := nodeClaim.StatusConditions().Get(v1beta1.Registered)
+	registered := nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeRegistered)
 	if registered.IsTrue() {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -40,7 +40,7 @@ type Liveness struct {
 const registrationTTL = time.Minute * 15
 
 func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	registered := nodeClaim.StatusConditions().GetCondition(v1beta1.Registered)
+	registered := nodeClaim.StatusConditions().Get(v1beta1.Registered)
 	if registered.IsTrue() {
 		return reconcile.Result{}, nil
 	}
@@ -48,8 +48,8 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) 
 		return reconcile.Result{Requeue: true}, nil
 	}
 	// If the Registered statusCondition hasn't gone True during the TTL since we first updated it, we should terminate the NodeClaim
-	if l.clock.Since(registered.LastTransitionTime.Inner.Time) < registrationTTL {
-		return reconcile.Result{RequeueAfter: registrationTTL - l.clock.Since(registered.LastTransitionTime.Inner.Time)}, nil
+	if l.clock.Since(registered.LastTransitionTime.Time) < registrationTTL {
+		return reconcile.Result{RequeueAfter: registrationTTL - l.clock.Since(registered.LastTransitionTime.Time)}, nil
 	}
 	// Delete the NodeClaim if we believe the NodeClaim won't register since we haven't seen the node
 	if err := l.kubeClient.Delete(ctx, nodeClaim); err != nil {

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -40,11 +40,11 @@ type Registration struct {
 }
 
 func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	if nodeClaim.StatusConditions().Get(v1beta1.Registered).IsTrue() {
+	if nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeRegistered).IsTrue() {
 		return reconcile.Result{}, nil
 	}
-	if !nodeClaim.StatusConditions().Get(v1beta1.Launched).IsTrue() {
-		nodeClaim.StatusConditions().SetFalse(v1beta1.Registered, "NotLaunched", "Node not launched")
+	if !nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeLaunched).IsTrue() {
+		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeRegistered, "NotLaunched", "Node not launched")
 		return reconcile.Result{}, nil
 	}
 
@@ -52,11 +52,11 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeCla
 	node, err := nodeclaimutil.NodeForNodeClaim(ctx, r.kubeClient, nodeClaim)
 	if err != nil {
 		if nodeclaimutil.IsNodeNotFoundError(err) {
-			nodeClaim.StatusConditions().SetFalse(v1beta1.Registered, "NodeNotFound", "Node not registered with cluster")
+			nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeRegistered, "NodeNotFound", "Node not registered with cluster")
 			return reconcile.Result{}, nil
 		}
 		if nodeclaimutil.IsDuplicateNodeError(err) {
-			nodeClaim.StatusConditions().SetFalse(v1beta1.Registered, "MultipleNodesFound", "Invariant violated, matched multiple nodes")
+			nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeRegistered, "MultipleNodesFound", "Invariant violated, matched multiple nodes")
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, fmt.Errorf("getting node for nodeclaim, %w", err)
@@ -66,7 +66,7 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeCla
 		return reconcile.Result{}, fmt.Errorf("syncing node, %w", err)
 	}
 	logging.FromContext(ctx).Infof("registered nodeclaim")
-	nodeClaim.StatusConditions().SetTrue(v1beta1.Registered)
+	nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeRegistered)
 	nodeClaim.Status.NodeName = node.Name
 
 	metrics.NodeClaimsRegisteredCounter.With(prometheus.Labels{

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Registration", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
 		Expect(nodeClaim.Status.NodeName).To(Equal(node.Name))
 	})
 	It("should add the owner reference to the Node when the Node comes online", func() {

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Registration", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Registered).Status).To(Equal(metav1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.ConditionTypeRegistered).Status).To(Equal(metav1.ConditionTrue))
 		Expect(nodeClaim.Status.NodeName).To(Equal(node.Name))
 	})
 	It("should add the owner reference to the Node when the Node comes online", func() {

--- a/pkg/controllers/nodepool/hash/controller.go
+++ b/pkg/controllers/nodepool/hash/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) updateNodeClaimHash(ctx context.Context, np *v1beta1.NodePo
 
 			// Any NodeClaim that is already drifted will remain drifted if the karpenter.sh/nodepool-hash-version doesn't match
 			// Since the hashing mechanism has changed we will not be able to determine if the drifted status of the NodeClaim has changed
-			if nc.StatusConditions().GetCondition(v1beta1.Drifted) == nil {
+			if nc.StatusConditions().Get(v1beta1.Drifted) == nil {
 				nc.Annotations = lo.Assign(nc.Annotations, map[string]string{
 					v1beta1.NodePoolHashAnnotationKey: np.Hash(),
 				})

--- a/pkg/controllers/nodepool/hash/controller.go
+++ b/pkg/controllers/nodepool/hash/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) updateNodeClaimHash(ctx context.Context, np *v1beta1.NodePo
 
 			// Any NodeClaim that is already drifted will remain drifted if the karpenter.sh/nodepool-hash-version doesn't match
 			// Since the hashing mechanism has changed we will not be able to determine if the drifted status of the NodeClaim has changed
-			if nc.StatusConditions().Get(v1beta1.Drifted) == nil {
+			if nc.StatusConditions().Get(v1beta1.ConditionTypeDrifted) == nil {
 				nc.Annotations = lo.Assign(nc.Annotations, map[string]string{
 					v1beta1.NodePoolHashAnnotationKey: np.Hash(),
 				})

--- a/pkg/controllers/nodepool/hash/suite_test.go
+++ b/pkg/controllers/nodepool/hash/suite_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Static Drift Hash", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))

--- a/pkg/controllers/nodepool/hash/suite_test.go
+++ b/pkg/controllers/nodepool/hash/suite_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Static Drift Hash", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().SetTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().SetTrue(v1beta1.ConditionTypeDrifted)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -217,7 +217,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	instanceTypes := map[string][]*cloudprovider.InstanceType{}
 	domains := map[string]sets.Set[string]{}
 	for _, nodePool := range nodePoolList.Items {
-		// Get instance type options
+		// GetCondition instance type options
 		instanceTypeOptions, err := p.cloudProvider.GetInstanceTypes(ctx, lo.ToPtr(nodePool))
 		if err != nil {
 			// we just log an error and skip the provisioner to prevent a single mis-configured provisioner from stopping
@@ -296,12 +296,12 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	// the pods that are on these nodes so the MarkedForDeletion node capacity can't be considered.
 	nodes := p.cluster.Nodes()
 
-	// Get pods, exit if nothing to do
+	// GetCondition pods, exit if nothing to do
 	pendingPods, err := p.GetPendingPods(ctx)
 	if err != nil {
 		return scheduler.Results{}, err
 	}
-	// Get pods from nodes that are preparing for deletion
+	// GetCondition pods from nodes that are preparing for deletion
 	// We do this after getting the pending pods so that we undershoot if pods are
 	// actively migrating from a node that is being deleted
 	// NOTE: The assumption is that these nodes are cordoned and no additional pods will schedule to them

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -217,7 +217,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	instanceTypes := map[string][]*cloudprovider.InstanceType{}
 	domains := map[string]sets.Set[string]{}
 	for _, nodePool := range nodePoolList.Items {
-		// GetCondition instance type options
+		// Get instance type options
 		instanceTypeOptions, err := p.cloudProvider.GetInstanceTypes(ctx, lo.ToPtr(nodePool))
 		if err != nil {
 			// we just log an error and skip the provisioner to prevent a single mis-configured provisioner from stopping
@@ -296,12 +296,12 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	// the pods that are on these nodes so the MarkedForDeletion node capacity can't be considered.
 	nodes := p.cluster.Nodes()
 
-	// GetCondition pods, exit if nothing to do
+	// Get pods, exit if nothing to do
 	pendingPods, err := p.GetPendingPods(ctx)
 	if err != nil {
 		return scheduler.Results{}, err
 	}
-	// GetCondition pods from nodes that are preparing for deletion
+	// Get pods from nodes that are preparing for deletion
 	// We do this after getting the pending pods so that we undershoot if pods are
 	// actively migrating from a node that is being deleted
 	// NOTE: The assumption is that these nodes are cordoned and no additional pods will schedule to them

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2027,7 +2027,7 @@ var _ = Context("Scheduling", func() {
 
 				nodeClaim1 := bindings.Get(initialPod).NodeClaim
 				node1 := bindings.Get(initialPod).Node
-				nodeClaim1.StatusConditions().MarkTrue(v1beta1.Initialized)
+				nodeClaim1.StatusConditions().SetTrue(v1beta1.Initialized)
 				node1.Labels = lo.Assign(node1.Labels, map[string]string{v1beta1.NodeInitializedLabelKey: "true"})
 
 				// delete the pod so that the node is empty
@@ -2095,7 +2095,7 @@ var _ = Context("Scheduling", func() {
 
 				nodeClaim1 := bindings.Get(initialPod).NodeClaim
 				node1 := bindings.Get(initialPod).Node
-				nodeClaim1.StatusConditions().MarkTrue(v1beta1.Initialized)
+				nodeClaim1.StatusConditions().SetTrue(v1beta1.Initialized)
 				node1.Labels = lo.Assign(node1.Labels, map[string]string{v1beta1.NodeInitializedLabelKey: "true"})
 
 				node1.Spec.Taints = []v1.Taint{startupTaint}

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2027,7 +2027,7 @@ var _ = Context("Scheduling", func() {
 
 				nodeClaim1 := bindings.Get(initialPod).NodeClaim
 				node1 := bindings.Get(initialPod).Node
-				nodeClaim1.StatusConditions().SetTrue(v1beta1.Initialized)
+				nodeClaim1.StatusConditions().SetTrue(v1beta1.ConditionTypeInitialized)
 				node1.Labels = lo.Assign(node1.Labels, map[string]string{v1beta1.NodeInitializedLabelKey: "true"})
 
 				// delete the pod so that the node is empty
@@ -2095,7 +2095,7 @@ var _ = Context("Scheduling", func() {
 
 				nodeClaim1 := bindings.Get(initialPod).NodeClaim
 				node1 := bindings.Get(initialPod).Node
-				nodeClaim1.StatusConditions().SetTrue(v1beta1.Initialized)
+				nodeClaim1.StatusConditions().SetTrue(v1beta1.ConditionTypeInitialized)
 				node1.Labels = lo.Assign(node1.Labels, map[string]string{v1beta1.NodeInitializedLabelKey: "true"})
 
 				node1.Spec.Taints = []v1.Taint{startupTaint}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -312,7 +312,7 @@ func ExpectNodeClaimDeployedNoNode(ctx context.Context, c client.Client, cloudPr
 
 	// Make the nodeclaim ready in the status conditions
 	nc = lifecycle.PopulateNodeClaimDetails(nc, resolved)
-	nc.StatusConditions().SetTrue(v1beta1.Launched)
+	nc.StatusConditions().SetTrue(v1beta1.ConditionTypeLaunched)
 	ExpectApplied(ctx, c, nc)
 	return nc, nil
 }
@@ -324,7 +324,7 @@ func ExpectNodeClaimDeployed(ctx context.Context, c client.Client, cloudProvider
 	if err != nil {
 		return nc, nil, err
 	}
-	nc.StatusConditions().SetTrue(v1beta1.Registered)
+	nc.StatusConditions().SetTrue(v1beta1.ConditionTypeRegistered)
 
 	// Mock the nodeclaim launch and node joining at the apiserver
 	node := test.NodeClaimLinkedNode(nc)
@@ -367,9 +367,9 @@ func ExpectMakeNodeClaimsInitialized(ctx context.Context, c client.Client, nodeC
 	GinkgoHelper()
 	for i := range nodeClaims {
 		nodeClaims[i] = ExpectExists(ctx, c, nodeClaims[i])
-		nodeClaims[i].StatusConditions().SetTrue(v1beta1.Launched)
-		nodeClaims[i].StatusConditions().SetTrue(v1beta1.Registered)
-		nodeClaims[i].StatusConditions().SetTrue(v1beta1.Initialized)
+		nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeLaunched)
+		nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeRegistered)
+		nodeClaims[i].StatusConditions().SetTrue(v1beta1.ConditionTypeInitialized)
 		ExpectApplied(ctx, c, nodeClaims[i])
 	}
 }

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -215,10 +215,10 @@ func NewFromNode(node *v1.Node) *v1beta1.NodeClaim {
 		},
 	}
 	if _, ok := node.Labels[v1beta1.NodeInitializedLabelKey]; ok {
-		nc.StatusConditions().MarkTrue(v1beta1.Initialized)
+		nc.StatusConditions().SetTrue(v1beta1.Initialized)
 	}
-	nc.StatusConditions().MarkTrue(v1beta1.Launched)
-	nc.StatusConditions().MarkTrue(v1beta1.Registered)
+	nc.StatusConditions().SetTrue(v1beta1.Launched)
+	nc.StatusConditions().SetTrue(v1beta1.Registered)
 	return nc
 }
 

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -215,10 +215,10 @@ func NewFromNode(node *v1.Node) *v1beta1.NodeClaim {
 		},
 	}
 	if _, ok := node.Labels[v1beta1.NodeInitializedLabelKey]; ok {
-		nc.StatusConditions().SetTrue(v1beta1.Initialized)
+		nc.StatusConditions().SetTrue(v1beta1.ConditionTypeInitialized)
 	}
-	nc.StatusConditions().SetTrue(v1beta1.Launched)
-	nc.StatusConditions().SetTrue(v1beta1.Registered)
+	nc.StatusConditions().SetTrue(v1beta1.ConditionTypeLaunched)
+	nc.StatusConditions().SetTrue(v1beta1.ConditionTypeRegistered)
 	return nc
 }
 

--- a/pkg/utils/nodeclaim/suite_test.go
+++ b/pkg/utils/nodeclaim/suite_test.go
@@ -127,9 +127,9 @@ var _ = Describe("NodeClaimUtils", func() {
 		Expect(nodeClaim.Status.ProviderID).To(Equal(node.Spec.ProviderID))
 		Expect(nodeClaim.Status.Capacity).To(Equal(node.Status.Capacity))
 		Expect(nodeClaim.Status.Allocatable).To(Equal(node.Status.Allocatable))
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Launched).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Registered).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().Get(v1beta1.Initialized).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeLaunched).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeRegistered).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
 	})
 	It("should update the owner for a Node to a NodeClaim", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{

--- a/pkg/utils/nodeclaim/suite_test.go
+++ b/pkg/utils/nodeclaim/suite_test.go
@@ -127,9 +127,9 @@ var _ = Describe("NodeClaimUtils", func() {
 		Expect(nodeClaim.Status.ProviderID).To(Equal(node.Spec.ProviderID))
 		Expect(nodeClaim.Status.Capacity).To(Equal(node.Status.Capacity))
 		Expect(nodeClaim.Status.Allocatable).To(Equal(node.Status.Allocatable))
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Launched).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Registered).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Initialized).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Launched).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Registered).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1beta1.Initialized).IsTrue()).To(BeTrue())
 	})
 	It("should update the owner for a Node to a NodeClaim", func() {
 		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change converts knative's status conditions to operatorpkg `status.Conditions` package. This allows us to onboard to things like `status.Controller` that will give us additional metrics on our status conditions for free.

BREAKING: The `severity` field is removed from the conditions object. This field is not present in `metav1.Condition` but was present in the knative representation. 

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
