### PR TITLE
chore: Don't require message or reason to be set for NodeClaim status conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ verify: ## Verify code. Includes codegen, docgen, dependencies, linting, formatt
 	hack/validation/requirements.sh
 	hack/validation/labels.sh
 	hack/validation/resources.sh
+	hack/validation/status.sh
 	hack/dependabot.sh
 	@# Use perl instead of sed due to https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux
 	@# We need to do this "sed replace" until controller-tools fixes this parameterized types issue: https://github.com/kubernetes-sigs/controller-tools/issues/756

--- a/hack/validation/status.sh
+++ b/hack/validation/status.sh
@@ -1,0 +1,4 @@
+# Updating the set of required items in our status conditions so that we support older versions of the condition
+# TODO: This can be removed once we upgrade to v1 and can do conversion to automatically set values for old versions of the condition
+yq eval 'del(.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.minLength)' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.required = ["lastTransitionTime","status","type"]' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -413,7 +413,6 @@ spec:
                           The value should be a CamelCase string.
                           This field may not be empty.
                         maxLength: 1024
-                        minLength: 1
                         pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                         type: string
                       status:
@@ -435,8 +434,6 @@ spec:
                         type: string
                     required:
                       - lastTransitionTime
-                      - message
-                      - reason
                       - status
                       - type
                     type: object


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change ensures that our use of `metav1.Condition` doesn't cause validation failures when making updates to the NodeClaim. We can drop this injected removal of these required fields when we get to v1, where we can use conversion to automatically set these values.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
