### PR TITLE
ci: Update golangci-lint config to latest

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,19 +1,9 @@
 # See https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
 run:
   tests: true
-
   timeout: 5m
-
   build-tags:
     - test_performance
-
-  skip-dirs:
-    - tools
-    - website
-    - hack
-    - charts
-    - designs
-
 linters:
   enable:
     - asciicheck
@@ -34,12 +24,13 @@ linters:
     - nilerr
   disable:
     - prealloc
-
 linters-settings:
   gocyclo:
     min-complexity: 11
   govet:
-    check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
   revive:
     rules:
       - name: dot-imports
@@ -71,6 +62,12 @@ linters-settings:
 issues:
   fix: true
   exclude: ['declaration of "(err|ctx)" shadows declaration at']
+  exclude-dirs:
+    - tools
+    - website
+    - hack
+    - charts
+    - designs
   exclude-rules:
   - linters:
     - goheader


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Update golangci-lint config to the latest, removing deprecating settings `run.skip-dirs` and `govet.check-shadowing`. This also enables more strict checking on `govet`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
