### PR TITLE
BREAKING: Drop logger name injection and add consistent formatting for K8s objects

### DIFF
--- a/pkg/controllers/leasegarbagecollection/controller.go
+++ b/pkg/controllers/leasegarbagecollection/controller.go
@@ -46,7 +46,6 @@ func NewController(kubeClient client.Client) *Controller {
 
 // Reconcile the resource
 func (c *Controller) Reconcile(ctx context.Context, l *v1.Lease) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("lease.garbagecollection").WithValues("lease", client.ObjectKeyFromObject(l)))
 	ctx = injection.WithControllerName(ctx, "lease.garbagecollection")
 
 	if l.OwnerReferences != nil || l.Namespace != "kube-node-lease" {

--- a/pkg/controllers/metrics/nodepool/controller.go
+++ b/pkg/controllers/metrics/nodepool/controller.go
@@ -21,11 +21,9 @@ import (
 	"strings"
 	"time"
 
-	controllerruntime "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
@@ -92,7 +90,6 @@ func NewController(kubeClient client.Client) *Controller {
 
 // Reconcile executes a termination control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("metrics.nodepool").WithValues("nodepool", req.Name))
 	ctx = injection.WithControllerName(ctx, "metrics.nodepool")
 
 	nodePool := &v1beta1.NodePool{}

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -119,7 +118,6 @@ func (c *Controller) Name() string {
 
 // Reconcile executes a termination control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("metrics.pod").WithValues("pod", req.String()))
 	ctx = injection.WithControllerName(ctx, "metrics.pod")
 
 	pod := &v1.Pod{}

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -65,7 +65,6 @@ func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudPr
 }
 
 func (c *Controller) Reconcile(ctx context.Context, n *v1.Node) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("node.termination").WithValues("node", n.Name))
 	ctx = injection.WithControllerName(ctx, "node.termination")
 
 	if !n.GetDeletionTimestamp().IsZero() {

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -152,7 +153,7 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 
 // Evict returns true if successful eviction call, and false if not an eviction-related error
 func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("pod", key.NamespacedName))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Pod", klog.KRef(key.Namespace, key.Name)))
 	if err := q.kubeClient.SubResource("eviction").Create(ctx,
 		&v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}},
 		&policyv1.Eviction{

--- a/pkg/controllers/nodeclaim/consistency/controller.go
+++ b/pkg/controllers/nodeclaim/consistency/controller.go
@@ -73,7 +73,6 @@ func NewController(clk clock.Clock, kubeClient client.Client, recorder events.Re
 }
 
 func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodeclaim.consistency").WithValues("nodeclaim", nodeClaim.Name))
 	ctx = injection.WithControllerName(ctx, "nodeclaim.consistency")
 
 	if nodeClaim.Status.ProviderID == "" {

--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -29,7 +29,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -70,7 +69,6 @@ func NewController(clk clock.Clock, kubeClient client.Client, cluster *state.Clu
 
 // Reconcile executes a control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodeclaim.disruption").WithValues("nodeclaim", nodeClaim.Name))
 	ctx = injection.WithControllerName(ctx, "nodeclaim.disruption")
 
 	if !nodeClaim.DeletionTimestamp.IsZero() {

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -97,7 +98,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			return
 		}
 		log.FromContext(ctx).WithValues(
-			"nodeclaim", nodeClaims[i].Name,
+			"NodeClaim", klog.KRef("", nodeClaims[i].Name),
 			"provider-id", nodeClaims[i].Status.ProviderID,
 			"nodepool", nodeClaims[i].Labels[v1beta1.NodePoolLabelKey],
 		).V(1).Info("garbage collecting nodeclaim with no cloudprovider representation")

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
@@ -77,7 +76,6 @@ func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider clou
 }
 
 func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodeclaim.lifecycle").WithValues("nodeclaim", nodeClaim.Name))
 	ctx = injection.WithControllerName(ctx, "nodeclaim.lifecycle")
 
 	if !nodeClaim.DeletionTimestamp.IsZero() {

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -24,6 +24,7 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -59,7 +60,7 @@ func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeC
 		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "NodeNotFound", "Node not registered with cluster")
 		return reconcile.Result{}, nil //nolint:nilerr
 	}
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("node", node.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Node", klog.KRef("", node.Name)))
 	if nodeutil.GetCondition(node, v1.NodeReady).Status != v1.ConditionTrue {
 		nodeClaim.StatusConditions().SetFalse(v1beta1.ConditionTypeInitialized, "NodeNotReady", "Node status is NotReady")
 		return reconcile.Result{}, nil

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -24,6 +24,7 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -60,7 +61,7 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeCla
 		}
 		return reconcile.Result{}, fmt.Errorf("getting node for nodeclaim, %w", err)
 	}
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("node", node.Name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Node", klog.KRef("", node.Name)))
 	if err = r.syncNode(ctx, nodeClaim, node); err != nil {
 		return reconcile.Result{}, fmt.Errorf("syncing node, %w", err)
 	}

--- a/pkg/controllers/nodeclaim/termination/controller.go
+++ b/pkg/controllers/nodeclaim/termination/controller.go
@@ -60,7 +60,6 @@ func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudPr
 }
 
 func (c *Controller) Reconcile(ctx context.Context, n *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodeclaim.termination").WithValues("nodeclaim", n.Name))
 	ctx = injection.WithControllerName(ctx, "nodeclaim.termination")
 
 	if !n.GetDeletionTimestamp().IsZero() {

--- a/pkg/controllers/nodeclaim/termination/controller.go
+++ b/pkg/controllers/nodeclaim/termination/controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,7 +71,7 @@ func (c *Controller) Reconcile(ctx context.Context, n *v1beta1.NodeClaim) (recon
 
 //nolint:gocyclo
 func (c *Controller) finalize(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("node", nodeClaim.Status.NodeName, "provider-id", nodeClaim.Status.ProviderID))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Node", klog.KRef("", nodeClaim.Status.NodeName), "provider-id", nodeClaim.Status.ProviderID))
 	stored := nodeClaim.DeepCopy()
 	if !controllerutil.ContainsFinalizer(nodeClaim, v1beta1.TerminationFinalizer) {
 		return reconcile.Result{}, nil

--- a/pkg/controllers/nodepool/counter/controller.go
+++ b/pkg/controllers/nodepool/counter/controller.go
@@ -25,8 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -58,7 +56,6 @@ func NewController(kubeClient client.Client, cluster *state.Cluster) *Controller
 
 // Reconcile a control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodepool.counter").WithValues("nodepool", nodePool.Name))
 	ctx = injection.WithControllerName(ctx, "nodepool.counter")
 
 	// We need to ensure that our internal cluster state mechanism is synced before we proceed

--- a/pkg/controllers/nodepool/counter/controller.go
+++ b/pkg/controllers/nodepool/counter/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/nodepool/hash/controller.go
+++ b/pkg/controllers/nodepool/hash/controller.go
@@ -25,7 +25,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -48,7 +47,6 @@ func NewController(kubeClient client.Client) *Controller {
 
 // Reconcile the resource
 func (c *Controller) Reconcile(ctx context.Context, np *v1beta1.NodePool) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("nodepool.hash").WithValues("nodepool", np.Name))
 	ctx = injection.WithControllerName(ctx, "nodepool.hash")
 
 	stored := np.DeepCopy()

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -25,7 +25,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -54,8 +53,7 @@ func NewPodController(kubeClient client.Client, provisioner *Provisioner, record
 
 // Reconcile the resource
 func (c *PodController) Reconcile(ctx context.Context, p *v1.Pod) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("provisioner.trigger.pod").WithValues("pod", client.ObjectKeyFromObject(p).String())) //nolint:ineffassign,staticcheck
-	ctx = injection.WithControllerName(ctx, "provisioner.trigger.pod")                                                                             //nolint:ineffassign,staticcheck
+	ctx = injection.WithControllerName(ctx, "provisioner.trigger.pod") //nolint:ineffassign,staticcheck
 
 	if !pod.IsProvisionable(p) {
 		return reconcile.Result{}, nil
@@ -95,8 +93,7 @@ func NewNodeController(kubeClient client.Client, provisioner *Provisioner, recor
 // Reconcile the resource
 func (c *NodeController) Reconcile(ctx context.Context, n *v1.Node) (reconcile.Result, error) {
 	//nolint:ineffassign
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("provisioner.trigger.node").WithValues("node", n.Name)) //nolint:ineffassign,staticcheck
-	ctx = injection.WithControllerName(ctx, "provisioner.trigger.node")                                              //nolint:ineffassign,staticcheck
+	ctx = injection.WithControllerName(ctx, "provisioner.trigger.node") //nolint:ineffassign,staticcheck
 
 	// If the disruption taint doesn't exist or the deletion timestamp isn't set, it's not being disrupted.
 	// We don't check the deletion timestamp here, as we expect the termination controller to eventually set

--- a/pkg/controllers/provisioning/scheduling/preferences.go
+++ b/pkg/controllers/provisioning/scheduling/preferences.go
@@ -23,8 +23,7 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
@@ -37,7 +36,7 @@ type Preferences struct {
 }
 
 func (p *Preferences) Relax(ctx context.Context, pod *v1.Pod) bool {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(pod)))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Pod", klog.KRef(pod.Namespace, pod.Name)))
 	relaxations := []func(*v1.Pod) *string{
 		p.removeRequiredNodeAffinityTerm,
 		p.removePreferredPodAffinityTerm,

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -104,7 +105,7 @@ type Results struct {
 func (r Results) Record(ctx context.Context, recorder events.Recorder, cluster *state.Cluster) {
 	// Report failures and nominations
 	for p, err := range r.PodErrors {
-		log.FromContext(ctx).WithValues("pod", client.ObjectKeyFromObject(p)).Error(err, "could not schedule pod")
+		log.FromContext(ctx).WithValues("Pod", klog.KRef(p.Namespace, p.Name)).Error(err, "could not schedule pod")
 		recorder.Publish(PodFailedToScheduleEvent(p, err))
 	}
 	for _, existing := range r.ExistingNodes {
@@ -274,7 +275,7 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 				continue
 			} else if len(s.instanceTypes[nodeClaimTemplate.NodePoolName]) != len(instanceTypes) {
 
-				log.FromContext(ctx).V(1).WithValues("nodepool", nodeClaimTemplate.NodePoolName).Info(fmt.Sprintf("%d out of %d instance types were excluded because they would breach limits",
+				log.FromContext(ctx).V(1).WithValues("NodePool", klog.KRef("", nodeClaimTemplate.NodePoolName)).Info(fmt.Sprintf("%d out of %d instance types were excluded because they would breach limits",
 					len(s.instanceTypes[nodeClaimTemplate.NodePoolName])-len(instanceTypes), len(s.instanceTypes[nodeClaimTemplate.NodePoolName])))
 			}
 		}

--- a/pkg/controllers/provisioning/scheduling/volumetopology.go
+++ b/pkg/controllers/provisioning/scheduling/volumetopology.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -71,7 +72,7 @@ func (v *VolumeTopology) Inject(ctx context.Context, pod *v1.Pod) error {
 	}
 
 	log.FromContext(ctx).
-		WithValues("pod", client.ObjectKeyFromObject(pod)).
+		WithValues("Pod", klog.KRef(pod.Namespace, pod.Name)).
 		V(1).Info(fmt.Sprintf("adding requirements derived from pod volumes, %s", requirements))
 	return nil
 }

--- a/pkg/controllers/state/informer/daemonset.go
+++ b/pkg/controllers/state/informer/daemonset.go
@@ -25,7 +25,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -47,7 +46,6 @@ func NewDaemonSetController(kubeClient client.Client, cluster *state.Cluster) *D
 }
 
 func (c *DaemonSetController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.daemonset").WithValues("daemonset", req.String()))
 	ctx = injection.WithControllerName(ctx, "state.daemonset")
 
 	daemonSet := appsv1.DaemonSet{}

--- a/pkg/controllers/state/informer/node.go
+++ b/pkg/controllers/state/informer/node.go
@@ -25,7 +25,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -49,7 +48,6 @@ func NewNodeController(kubeClient client.Client, cluster *state.Cluster) *NodeCo
 }
 
 func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.node").WithValues("node", req.Name))
 	ctx = injection.WithControllerName(ctx, "state.node")
 
 	node := &v1.Node{}

--- a/pkg/controllers/state/informer/nodeclaim.go
+++ b/pkg/controllers/state/informer/nodeclaim.go
@@ -23,7 +23,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -48,7 +47,6 @@ func NewNodeClaimController(kubeClient client.Client, cluster *state.Cluster) *N
 }
 
 func (c *NodeClaimController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.nodeclaim").WithValues("nodeclaim", req.Name))
 	ctx = injection.WithControllerName(ctx, "state.nodeclaim")
 
 	nodeClaim := &v1beta1.NodeClaim{}

--- a/pkg/controllers/state/informer/nodepool.go
+++ b/pkg/controllers/state/informer/nodepool.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -49,8 +48,7 @@ func NewNodePoolController(kubeClient client.Client, cluster *state.Cluster) *No
 
 func (c *NodePoolController) Reconcile(ctx context.Context, np *v1beta1.NodePool) (reconcile.Result, error) {
 	//nolint:ineffassign
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.nodepool").WithValues("nodepool", np.Name)) //nolint:ineffassign,staticcheck
-	ctx = injection.WithControllerName(ctx, "state.nodepool")                                                   //nolint:ineffassign,staticcheck
+	ctx = injection.WithControllerName(ctx, "state.nodepool") //nolint:ineffassign,staticcheck
 
 	// Something changed in the NodePool so we should re-consider consolidation
 	c.cluster.MarkUnconsolidated()

--- a/pkg/controllers/state/informer/pod.go
+++ b/pkg/controllers/state/informer/pod.go
@@ -25,7 +25,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -50,7 +49,6 @@ func NewPodController(kubeClient client.Client, cluster *state.Cluster) *PodCont
 }
 
 func (c *PodController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("state.pod").WithValues("pod", req.String()))
 	ctx = injection.WithControllerName(ctx, "state.pod")
 
 	pod := &v1.Pod{}

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -94,7 +94,7 @@ var singletonRequest = reconcile.Request{}
 
 func (s *Singleton) Start(ctx context.Context) error {
 	ctx = injection.WithControllerName(ctx, s.name)
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName(s.name))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("controller", s.name))
 	log.FromContext(ctx).Info("Starting controller")
 	defer log.FromContext(ctx).Info("Stopping controller")
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Drop logger name injection at the top of controllers and add consistent formatting for K8s objects

#### Before PR

```
{"level":"INFO","time":"2024-05-22T18:36:18.697Z","logger":"controller.nodeclaim.lifecycle","message":"launched nodeclaim","commit":"d39fdb5","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"arm64-kt2kk"},"namespace":"","name":"arm64-kt2kk","reconcileID":"20941b16-c9ac-4d9d-92a8-5f06022a5fc2","nodeclaim":"arm64-kt2kk","provider-id":"aws:///us-west-2b/i-075ceb3922cf96cec","instance-type":"c6g.medium","zone":"us-west-2b","capacity-type":"on-demand","allocatable":{"cpu":"940m","ephemeral-storage":"17Gi","memory":"1392Mi","pods":"8","vpc.amazonaws.com/pod-eni":"4"}}
```

#### After PR

```
{"level":"INFO","time":"2024-05-22T18:45:24.738Z","logger":"controller","message":"launched nodeclaim","commit":"1169b7a","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"arm64-w9vhr"},"namespace":"","name":"arm64-w9vhr","reconcileID":"50643688-c4ce-4f4f-ac27-a69cf3ccf855","provider-id":"aws:///us-west-2b/i-0130c60d86809741b","instance-type":"c7gn.medium","zone":"us-west-2b","capacity-type":"spot","allocatable":{"cpu":"940m","ephemeral-storage":"17Gi","memory":"1392Mi","pods":"8","vpc.amazonaws.com/pod-eni":"4"}}
```

Looking at the difference between these two log lines, you can see that we no longer have duplicate keys for `nodeclaim` and we changed our naming mechanism for the logger name.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
