### PR TITLE
chore: move kwok labels to api based directory

### DIFF
--- a/kwok/apis/v1alpha1/labels.go
+++ b/kwok/apis/v1alpha1/labels.go
@@ -14,14 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kwok
+package v1alpha1
 
 const (
-	kwokProviderPrefix = "kwok://"
-)
+	// Labels that can be selected on and are propagated to the node
+	InstanceTypeLabelKey   = Group + "/instance-type"
+	InstanceSizeLabelKey   = Group + "/instance-size"
+	InstanceFamilyLabelKey = Group + "/instance-family"
+	InstanceMemoryLabelKey = Group + "/instance-memory"
+	InstanceCPULabelKey    = Group + "/instance-cpu"
 
-// Hard coded Kwok values
-var (
-	KwokPartitions = []string{"partition-a", "partition-b", "partition-c", "partition-d", "partition-e",
-		"partition-f", "partition-g", "partition-h", "partition-i", "partition-j"}
+	// Internal labels that are propagated to the node
+	KwokLabelKey          = "kwok.x-k8s.io/node"
+	KwokLabelValue        = "fake"
+	NodeViewerLabelKey    = "eks-node-viewer/instance-price"
+	KwokPartitionLabelKey = "kwok-partition"
 )

--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -210,15 +210,15 @@ func addInstanceLabels(labels map[string]string, instanceType *cloudprovider.Ins
 		}
 	}
 	// add in github.com/awslabs/eks-node-viewer label so that it shows up.
-	ret[nodeViewerLabelKey] = fmt.Sprintf("%f", offering.Price)
+	ret[v1alpha1.NodeViewerLabelKey] = fmt.Sprintf("%f", offering.Price)
 	// Kwok has some scalability limitations.
 	// Randomly add each new node to one of the pre-created kwokPartitions.
-	ret[kwokPartitionLabelKey] = lo.Sample(KwokPartitions)
+	ret[v1alpha1.KwokPartitionLabelKey] = lo.Sample(KwokPartitions)
 	ret[v1beta1.CapacityTypeLabelKey] = offering.CapacityType
 	ret[v1.LabelTopologyZone] = offering.Zone
 	ret[v1.LabelHostname] = nodeClaim.Name
 
-	ret[kwokLabelKey] = kwokLabelValue
+	ret[v1alpha1.KwokLabelKey] = v1alpha1.KwokLabelValue
 	return ret
 }
 
@@ -227,7 +227,7 @@ func addKwokAnnotation(annotations map[string]string) map[string]string {
 	for k, v := range annotations {
 		ret[k] = v
 	}
-	ret[kwokLabelKey] = kwokLabelValue
+	ret[v1alpha1.KwokLabelKey] = v1alpha1.KwokLabelValue
 	return ret
 }
 

--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"sigs.k8s.io/karpenter/kwok/apis/v1alpha1"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
@@ -113,11 +114,11 @@ func setDefaultOptions(opts InstanceTypeOptions) InstanceTypeOptions {
 	}
 
 	opts.instanceTypeLabels = map[string]string{
-		InstanceTypeLabelKey:   opts.Name,
-		InstanceSizeLabelKey:   parseSizeFromType(opts.Name, cpu),
-		InstanceFamilyLabelKey: parseFamilyFromType(opts.Name),
-		InstanceCPULabelKey:    cpu,
-		InstanceMemoryLabelKey: memory,
+		v1alpha1.InstanceTypeLabelKey:   opts.Name,
+		v1alpha1.InstanceSizeLabelKey:   parseSizeFromType(opts.Name, cpu),
+		v1alpha1.InstanceFamilyLabelKey: parseFamilyFromType(opts.Name),
+		v1alpha1.InstanceCPULabelKey:    cpu,
+		v1alpha1.InstanceMemoryLabelKey: memory,
 	}
 
 	// if the user specified a different pod limit, override the default
@@ -142,10 +143,10 @@ func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 		scheduling.NewRequirement(v1.LabelOSStable, v1.NodeSelectorOpIn, osNames...),
 		scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, lo.Map(options.Offerings.Available(), func(o cloudprovider.Offering, _ int) string { return o.Zone })...),
 		scheduling.NewRequirement(v1beta1.CapacityTypeLabelKey, v1.NodeSelectorOpIn, lo.Map(options.Offerings.Available(), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
-		scheduling.NewRequirement(InstanceSizeLabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[InstanceSizeLabelKey]),
-		scheduling.NewRequirement(InstanceFamilyLabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[InstanceFamilyLabelKey]),
-		scheduling.NewRequirement(InstanceCPULabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[InstanceCPULabelKey]),
-		scheduling.NewRequirement(InstanceMemoryLabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[InstanceMemoryLabelKey]),
+		scheduling.NewRequirement(v1alpha1.InstanceSizeLabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[v1alpha1.InstanceSizeLabelKey]),
+		scheduling.NewRequirement(v1alpha1.InstanceFamilyLabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[v1alpha1.InstanceFamilyLabelKey]),
+		scheduling.NewRequirement(v1alpha1.InstanceCPULabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[v1alpha1.InstanceCPULabelKey]),
+		scheduling.NewRequirement(v1alpha1.InstanceMemoryLabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[v1alpha1.InstanceMemoryLabelKey]),
 	)
 
 	return &cloudprovider.InstanceType{

--- a/kwok/main.go
+++ b/kwok/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"sigs.k8s.io/karpenter/kwok/apis/v1alpha1"
 	kwok "sigs.k8s.io/karpenter/kwok/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/controllers"
@@ -27,13 +28,13 @@ import (
 )
 
 func init() {
-	v1beta1.RestrictedLabelDomains = v1beta1.RestrictedLabelDomains.Insert(kwok.Group)
+	v1beta1.RestrictedLabelDomains = v1beta1.RestrictedLabelDomains.Insert(v1alpha1.Group)
 	v1beta1.WellKnownLabels = v1beta1.WellKnownLabels.Insert(
-		kwok.InstanceTypeLabelKey,
-		kwok.InstanceSizeLabelKey,
-		kwok.InstanceFamilyLabelKey,
-		kwok.InstanceCPULabelKey,
-		kwok.InstanceMemoryLabelKey,
+		v1alpha1.InstanceTypeLabelKey,
+		v1alpha1.InstanceSizeLabelKey,
+		v1alpha1.InstanceFamilyLabelKey,
+		v1alpha1.InstanceCPULabelKey,
+		v1alpha1.InstanceMemoryLabelKey,
 	)
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Moves the kwok based labels from inside the cloudprovider implementation code to the api directory where the kwok specific details now live

**How was this change tested?**
make verify

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
