### PR TITLE
feat: Ensure persistent volumes are detached before deleting node

### DIFF
--- a/kwok/charts/templates/clusterrole.yaml
+++ b/kwok/charts/templates/clusterrole.yaml
@@ -36,7 +36,7 @@ rules:
     resources: ["pods", "nodes", "persistentvolumes", "persistentvolumeclaims", "replicationcontrollers", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "volumeattachments"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -77,7 +77,7 @@ func NewControllers(
 		informer.NewPodController(kubeClient, cluster),
 		informer.NewNodePoolController(kubeClient, cluster),
 		informer.NewNodeClaimController(kubeClient, cluster),
-		termination.NewController(kubeClient, cloudProvider, terminator.NewTerminator(clock, kubeClient, evictionQueue, recorder), recorder),
+		termination.NewController(clock, kubeClient, cloudProvider, terminator.NewTerminator(clock, kubeClient, evictionQueue, recorder), recorder),
 		metricspod.NewController(kubeClient),
 		metricsnodepool.NewController(kubeClient),
 		metricsnode.NewController(cluster),

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -798,7 +798,7 @@ var _ = Describe("Termination", func() {
 						OwnerReferences: defaultOwnerRefs,
 					},
 					Tolerations: []corev1.Toleration{{
-						Key:      v1.DisruptionTaintKey,
+						Key:      v1.DisruptedTaintKey,
 						Operator: corev1.TolerationOpExists,
 					}},
 					PersistentVolumeClaims: []string{pvc.Name},

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -64,12 +64,12 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	fakeClock = clock.NewFakeClock(time.Now())
-	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...), test.WithFieldIndexers(test.NodeClaimFieldIndexer(ctx)))
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...), test.WithFieldIndexers(test.NodeClaimFieldIndexer(ctx), test.VolumeAttachmentFieldIndexer(ctx)))
 
 	cloudProvider = fake.NewCloudProvider()
 	recorder = test.NewEventRecorder()
 	queue = terminator.NewQueue(env.Client, recorder)
-	terminationController = termination.NewController(env.Client, cloudProvider, terminator.NewTerminator(fakeClock, env.Client, queue, recorder), recorder)
+	terminationController = termination.NewController(fakeClock, env.Client, cloudProvider, terminator.NewTerminator(fakeClock, env.Client, queue, recorder), recorder)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/changeset"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -218,6 +219,9 @@ func NewOperator() (context.Context, *Operator) {
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodePool{}, "spec.template.spec.nodeClassRef.name", func(o client.Object) []string {
 		return []string{o.(*v1.NodePool).Spec.Template.Spec.NodeClassRef.Name}
 	}), "failed to setup nodepool nodeclassref name indexer")
+	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &storagev1.VolumeAttachment{}, "spec.nodeName", func(o client.Object) []string {
+		return []string{o.(*storagev1.VolumeAttachment).Spec.NodeName}
+	}), "failed to setup volumeattachment indexer")
 
 	lo.Must0(mgr.AddHealthzCheck("healthz", healthz.Ping))
 	lo.Must0(mgr.AddReadyzCheck("readyz", healthz.Ping))

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/awslabs/operatorpkg/option"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes"
@@ -71,6 +72,14 @@ func NodeClaimFieldIndexer(ctx context.Context) func(cache.Cache) error {
 	return func(c cache.Cache) error {
 		return c.IndexField(ctx, &v1.NodeClaim{}, "status.providerID", func(obj client.Object) []string {
 			return []string{obj.(*v1.NodeClaim).Status.ProviderID}
+		})
+	}
+}
+
+func VolumeAttachmentFieldIndexer(ctx context.Context) func(cache.Cache) error {
+	return func(c cache.Cache) error {
+		return c.IndexField(ctx, &storagev1.VolumeAttachment{}, "spec.nodeName", func(obj client.Object) []string {
+			return []string{obj.(*storagev1.VolumeAttachment).Spec.NodeName}
 		})
 	}
 }

--- a/pkg/test/storage.go
+++ b/pkg/test/storage.go
@@ -153,3 +153,28 @@ func StorageClass(overrides ...StorageClassOptions) *storagev1.StorageClass {
 		VolumeBindingMode: options.VolumeBindingMode,
 	}
 }
+
+type VolumeAttachmentOptions struct {
+	metav1.ObjectMeta
+	NodeName   string
+	VolumeName string
+}
+
+func VolumeAttachment(overrides ...VolumeAttachmentOptions) *storagev1.VolumeAttachment {
+	options := VolumeAttachmentOptions{}
+	for _, opts := range overrides {
+		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("Failed to merge options: %s", err))
+		}
+	}
+	return &storagev1.VolumeAttachment{
+		ObjectMeta: ObjectMeta(options.ObjectMeta),
+		Spec: storagev1.VolumeAttachmentSpec{
+			NodeName: options.NodeName,
+			Attacher: "fake-csi",
+			Source: storagev1.VolumeAttachmentSource{
+				PersistentVolumeName: lo.ToPtr(options.VolumeName),
+			},
+		},
+	}
+}

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -148,11 +148,9 @@ func GetProvisionablePods(ctx context.Context, kubeClient client.Client) ([]*cor
 func GetVolumeAttachments(ctx context.Context, kubeClient client.Client, node *corev1.Node) ([]*storagev1.VolumeAttachment, error) {
 	var volumeAttachmentList storagev1.VolumeAttachmentList
 	if err := kubeClient.List(ctx, &volumeAttachmentList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
-		return nil, fmt.Errorf("listing volumeattachments, %w", err)
+		return nil, fmt.Errorf("listing volumeAttachments, %w", err)
 	}
-	return lo.FilterMap(volumeAttachmentList.Items, func(v storagev1.VolumeAttachment, _ int) (*storagev1.VolumeAttachment, bool) {
-		return &v, v.Spec.NodeName == node.Name
-	}), nil
+	return lo.ToSlicePtr(volumeAttachmentList.Items), nil
 }
 
 func GetCondition(n *corev1.Node, match corev1.NodeConditionType) corev1.NodeCondition {

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
@@ -140,6 +141,17 @@ func GetProvisionablePods(ctx context.Context, kubeClient client.Client) ([]*cor
 	}
 	return lo.FilterMap(podList.Items, func(p corev1.Pod, _ int) (*corev1.Pod, bool) {
 		return &p, pod.IsProvisionable(&p)
+	}), nil
+}
+
+// GetVolumeAttachments grabs all volumeAttachments associated with the passed node
+func GetVolumeAttachments(ctx context.Context, kubeClient client.Client, node *corev1.Node) ([]*storagev1.VolumeAttachment, error) {
+	var volumeAttachmentList storagev1.VolumeAttachmentList
+	if err := kubeClient.List(ctx, &volumeAttachmentList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
+		return nil, fmt.Errorf("listing volumeattachments, %w", err)
+	}
+	return lo.FilterMap(volumeAttachmentList.Items, func(v storagev1.VolumeAttachment, _ int) (*storagev1.VolumeAttachment, bool) {
+		return &v, v.Spec.NodeName == node.Name
 	}), nil
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fixes 6+ minute delays for disrupted EBS-Backed stateful workloads when starting on their new node. 

For more context see [RFC for solving 6+ minute delays for disrupted stateful workloads](https://github.com/aws/karpenter-provider-aws/pull/6336)

TLDR:

In order for a stateful pod to smoothly migrate from terminating node to new node...

0. Consolidation event starts
1. Stateful pods must terminate
2. EBS CSI Node pod must unmount all filesystems (NodeUnpublish & NodeUnstage RPCs)
3. EBS CSI Controller pod must detach all volumes from instance
4. Karpenter terminates EC2 Instance
6. Karpenter ensures Node object deleted from Kubernetes

Problems:
A. If 2 doesn't happen, today there's a 6+ minute delay in stateful pod migration because Kubernetes is afraid volume still attached and mounted to instance (6+ min delay)
B. If 3 doesn't happen, the new stateful pod can't start until consolidated instance is terminated which auto-detaches volumes (1+ min delay)

Solution:
Wait for volumeattachment objects associated with drainable pods & non-multi-attach volumes before deleting the node. 

**How was this change tested?**

Manual: Create statefulset + nodepool. Have nodes expire every 3 minutes. Check that stateful pods migrate to new node and start running in under a minute. 

Also tested that we do not block deletion when there are stateful workloads that tolerate all taints, or Node terminationGracePeriod elapsed. 

**Additional Notes**

Note 1: Must add read permissions for volumeattachments to clusterrole-core.yaml in `karpenter-provider-aws`

```
  - apiGroups: ["storage.k8s.io"]
    resources: ["storageclasses", "csinodes", "volumeattachments"]
    verbs: ["get", "watch", "list"]
```

Note 2: Separate PR to add e2e tests in karpenter-provider-aws: https://github.com/aws/karpenter-provider-aws/pull/6484

Note 3: It was decided in the RFC we will block node deletion for all volumeattachments, regardless of CSI Driver. In the future, we may decide to inject a list of CSI Drivers via the cloud provider instead. 

Note 4: There might be some rare cases where EBS CSI Node pod can get killed before it unmounts volumes. The solution would be karpenter (or some reliable automation) tainting node with `nodeshutdown:NoExecute` once node is terminated, as discussed in RFC. In design meeting consensus was that this could be added later if customers run into it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
