### PR TITLE
fix: allow single character status condition reason

### DIFF
--- a/hack/validation/status.sh
+++ b/hack/validation/status.sh
@@ -1,5 +1,5 @@
 # Updating the set of required items in our status conditions so that we support older versions of the condition
 # TODO: This can be removed once we upgrade to v1 and can do conversion to automatically set values for old versions of the condition
 yq eval 'del(.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.minLength)' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
-yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.pattern = "(^([A-Za-z][A-Za-z0-9_,:]*[A-Za-z0-9_])?$)"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.pattern = "^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.required = ["lastTransitionTime","status","type"]' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml

--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -415,7 +415,7 @@ spec:
                           The value should be a CamelCase string.
                           This field may not be empty.
                         maxLength: 1024
-                        pattern: (^([A-Za-z][A-Za-z0-9_,:]*[A-Za-z0-9_])?$)
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
                         type: string
                       status:
                         description: status of the condition, one of True, False, Unknown.

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -413,7 +413,7 @@ spec:
                           The value should be a CamelCase string.
                           This field may not be empty.
                         maxLength: 1024
-                        pattern: (^([A-Za-z][A-Za-z0-9_,:]*[A-Za-z0-9_])?$)
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
                         type: string
                       status:
                         description: status of the condition, one of True, False, Unknown.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This updates the regex validation for the status condition reason on `NodeClaims`. A previous PR (https://github.com/kubernetes-sigs/karpenter/pull/1285) updated this regex to allow empty strings and unblock migration from previous versions to v0.37. It also inadvertently changed the regex such that if a string is provided it must be at least two characters. This doesn't have any immediate impact since none of the status conditions are a single character, but this PR corrects the regex.

**How was this change tested?**
Manual validation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
