### PR TITLE
chore: fix kwok offerings to use new requirements

### DIFF
--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -40,7 +40,7 @@ var (
 )
 
 // Wrap cloudprovider.Offerings with NodeSelectorRequirements for post-json processing translation
-type KwokOfferings []KWOKOffering
+type KWOKOfferings []KWOKOffering
 
 type KWOKOffering struct {
 	cloudprovider.Offering
@@ -49,7 +49,7 @@ type KWOKOffering struct {
 
 type InstanceTypeOptions struct {
 	Name             string          `json:"name"`
-	Offerings        KwokOfferings   `json:"offerings"`
+	Offerings        KWOKOfferings   `json:"offerings"`
 	Architecture     string          `json:"architecture"`
 	OperatingSystems []v1.OSName     `json:"operatingSystems"`
 	Resources        v1.ResourceList `json:"resources"`

--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -39,12 +39,20 @@ var (
 	familyDelim = regexp.MustCompile(`[.-]`)
 )
 
+// Wrap cloudprovider.Offerings with NodeSelectorRequirements for post-json processing translation
+type KwokOfferings []KwokOffering
+
+type KwokOffering struct {
+	cloudprovider.Offering
+	Requirements []v1.NodeSelectorRequirement
+}
+
 type InstanceTypeOptions struct {
-	Name             string                  `json:"name"`
-	Offerings        cloudprovider.Offerings `json:"offerings"`
-	Architecture     string                  `json:"architecture"`
-	OperatingSystems []v1.OSName             `json:"operatingSystems"`
-	Resources        v1.ResourceList         `json:"resources"`
+	Name             string          `json:"name"`
+	Offerings        KwokOfferings   `json:"offerings"`
+	Architecture     string          `json:"architecture"`
+	OperatingSystems []v1.OSName     `json:"operatingSystems"`
+	Resources        v1.ResourceList `json:"resources"`
 
 	// These are used for setting default requirements, they should not be used
 	// for setting arbitrary node labels.  Set the labels on the created NodePool for
@@ -137,16 +145,25 @@ func setDefaultOptions(opts InstanceTypeOptions) InstanceTypeOptions {
 func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 	osNames := lo.Map(options.OperatingSystems, func(os v1.OSName, _ int) string { return string(os) })
 
+	zones := lo.Uniq(lo.Flatten(lo.Map(options.Offerings, func(o KwokOffering, _ int) []string {
+		req, _ := lo.Find(o.Requirements, func(req v1.NodeSelectorRequirement) bool {
+			return req.Key == v1.LabelTopologyZone
+		})
+		return req.Values
+	})))
+	capacityTypes := lo.Uniq(lo.Flatten(lo.Map(options.Offerings, func(o KwokOffering, _ int) []string {
+		req, _ := lo.Find(o.Requirements, func(req v1.NodeSelectorRequirement) bool {
+			return req.Key == v1beta1.CapacityTypeLabelKey
+		})
+		return req.Values
+	})))
+
 	requirements := scheduling.NewRequirements(
 		scheduling.NewRequirement(v1.LabelInstanceTypeStable, v1.NodeSelectorOpIn, options.Name),
 		scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, options.Architecture),
 		scheduling.NewRequirement(v1.LabelOSStable, v1.NodeSelectorOpIn, osNames...),
-		scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, lo.Map(options.Offerings.Available(), func(o cloudprovider.Offering, _ int) string {
-			return o.Requirements.Get(v1.LabelTopologyZone).Any()
-		})...),
-		scheduling.NewRequirement(v1beta1.CapacityTypeLabelKey, v1.NodeSelectorOpIn, lo.Map(options.Offerings.Available(), func(o cloudprovider.Offering, _ int) string {
-			return o.Requirements.Get(v1beta1.CapacityTypeLabelKey).Any()
-		})...),
+		scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, zones...),
+		scheduling.NewRequirement(v1beta1.CapacityTypeLabelKey, v1.NodeSelectorOpIn, capacityTypes...),
 		scheduling.NewRequirement(v1alpha1.InstanceSizeLabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[v1alpha1.InstanceSizeLabelKey]),
 		scheduling.NewRequirement(v1alpha1.InstanceFamilyLabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[v1alpha1.InstanceFamilyLabelKey]),
 		scheduling.NewRequirement(v1alpha1.InstanceCPULabelKey, v1.NodeSelectorOpIn, options.instanceTypeLabels[v1alpha1.InstanceCPULabelKey]),
@@ -156,8 +173,10 @@ func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 	return &cloudprovider.InstanceType{
 		Name:         options.Name,
 		Requirements: requirements,
-		Offerings:    options.Offerings,
-		Capacity:     options.Resources,
+		Offerings: lo.Map(options.Offerings, func(off KwokOffering, _ int) cloudprovider.Offering {
+			return off.Offering
+		}),
+		Capacity: options.Resources,
 		Overhead: &cloudprovider.InstanceTypeOverhead{
 			KubeReserved: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("100m"),

--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -40,9 +40,9 @@ var (
 )
 
 // Wrap cloudprovider.Offerings with NodeSelectorRequirements for post-json processing translation
-type KwokOfferings []KwokOffering
+type KwokOfferings []KWOKOffering
 
-type KwokOffering struct {
+type KWOKOffering struct {
 	cloudprovider.Offering
 	Requirements []v1.NodeSelectorRequirement
 }
@@ -145,13 +145,13 @@ func setDefaultOptions(opts InstanceTypeOptions) InstanceTypeOptions {
 func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 	osNames := lo.Map(options.OperatingSystems, func(os v1.OSName, _ int) string { return string(os) })
 
-	zones := lo.Uniq(lo.Flatten(lo.Map(options.Offerings, func(o KwokOffering, _ int) []string {
+	zones := lo.Uniq(lo.Flatten(lo.Map(options.Offerings, func(o KWOKOffering, _ int) []string {
 		req, _ := lo.Find(o.Requirements, func(req v1.NodeSelectorRequirement) bool {
 			return req.Key == v1.LabelTopologyZone
 		})
 		return req.Values
 	})))
-	capacityTypes := lo.Uniq(lo.Flatten(lo.Map(options.Offerings, func(o KwokOffering, _ int) []string {
+	capacityTypes := lo.Uniq(lo.Flatten(lo.Map(options.Offerings, func(o KWOKOffering, _ int) []string {
 		req, _ := lo.Find(o.Requirements, func(req v1.NodeSelectorRequirement) bool {
 			return req.Key == v1beta1.CapacityTypeLabelKey
 		})
@@ -173,7 +173,7 @@ func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 	return &cloudprovider.InstanceType{
 		Name:         options.Name,
 		Requirements: requirements,
-		Offerings: lo.Map(options.Offerings, func(off KwokOffering, _ int) cloudprovider.Offering {
+		Offerings: lo.Map(options.Offerings, func(off KWOKOffering, _ int) cloudprovider.Offering {
 			return off.Offering
 		}),
 		Capacity: options.Resources,

--- a/kwok/cloudprovider/instance_types.json
+++ b/kwok/cloudprovider/instance_types.json
@@ -3,52 +3,164 @@
         "name": "c-1x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -66,52 +178,164 @@
         "name": "c-1x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -129,52 +353,164 @@
         "name": "c-1x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -192,52 +528,164 @@
         "name": "c-1x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.019003238553599998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.027147483648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -255,52 +703,164 @@
         "name": "s-1x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -318,52 +878,164 @@
         "name": "s-1x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -381,52 +1053,164 @@
         "name": "s-1x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -444,52 +1228,164 @@
         "name": "s-1x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.020506477107199998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.029294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -507,52 +1403,164 @@
         "name": "m-1x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -570,52 +1578,164 @@
         "name": "m-1x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -633,52 +1753,164 @@
         "name": "m-1x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -696,52 +1928,164 @@
         "name": "m-1x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.023512954214399997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.033589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -759,52 +2103,164 @@
         "name": "c-2x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -822,52 +2278,164 @@
         "name": "c-2x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -885,52 +2453,164 @@
         "name": "c-2x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -948,52 +2628,164 @@
         "name": "c-2x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.038006477107199996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.054294967296,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -1011,52 +2803,164 @@
         "name": "s-2x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -1074,52 +2978,164 @@
         "name": "s-2x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -1137,52 +3153,164 @@
         "name": "s-2x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -1200,52 +3328,164 @@
         "name": "s-2x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.041012954214399995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.058589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -1263,52 +3503,164 @@
         "name": "m-2x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -1326,52 +3678,164 @@
         "name": "m-2x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -1389,52 +3853,164 @@
         "name": "m-2x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -1452,52 +4028,164 @@
         "name": "m-2x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.047025908428799994,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.067179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -1515,52 +4203,164 @@
         "name": "c-4x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -1578,52 +4378,164 @@
         "name": "c-4x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -1641,52 +4553,164 @@
         "name": "c-4x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -1704,52 +4728,164 @@
         "name": "c-4x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.07601295421439999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.108589934592,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -1767,52 +4903,164 @@
         "name": "s-4x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -1830,52 +5078,164 @@
         "name": "s-4x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -1893,52 +5253,164 @@
         "name": "s-4x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -1956,52 +5428,164 @@
         "name": "s-4x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.08202590842879999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.117179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -2019,52 +5603,164 @@
         "name": "m-4x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -2082,52 +5778,164 @@
         "name": "m-4x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -2145,52 +5953,164 @@
         "name": "m-4x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -2208,52 +6128,164 @@
         "name": "m-4x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.09405181685759999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.134359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -2271,52 +6303,164 @@
         "name": "c-8x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -2334,52 +6478,164 @@
         "name": "c-8x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -2397,52 +6653,164 @@
         "name": "c-8x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -2460,52 +6828,164 @@
         "name": "c-8x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.15202590842879998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.217179869184,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -2523,52 +7003,164 @@
         "name": "s-8x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -2586,52 +7178,164 @@
         "name": "s-8x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -2649,52 +7353,164 @@
         "name": "s-8x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -2712,52 +7528,164 @@
         "name": "s-8x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.16405181685759998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.234359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -2775,52 +7703,164 @@
         "name": "m-8x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -2838,52 +7878,164 @@
         "name": "m-8x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -2901,52 +8053,164 @@
         "name": "m-8x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -2964,52 +8228,164 @@
         "name": "m-8x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.18810363371519997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.268719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -3027,52 +8403,164 @@
         "name": "c-16x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -3090,52 +8578,164 @@
         "name": "c-16x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -3153,52 +8753,164 @@
         "name": "c-16x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -3216,52 +8928,164 @@
         "name": "c-16x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.30405181685759997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.434359738368,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -3279,52 +9103,164 @@
         "name": "s-16x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -3342,52 +9278,164 @@
         "name": "s-16x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -3405,52 +9453,164 @@
         "name": "s-16x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -3468,52 +9628,164 @@
         "name": "s-16x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.32810363371519996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.468719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -3531,52 +9803,164 @@
         "name": "m-16x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -3594,52 +9978,164 @@
         "name": "m-16x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -3657,52 +10153,164 @@
         "name": "m-16x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -3720,52 +10328,164 @@
         "name": "m-16x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.37620726743039995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.537438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -3783,52 +10503,164 @@
         "name": "c-32x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -3846,52 +10678,164 @@
         "name": "c-32x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -3909,52 +10853,164 @@
         "name": "c-32x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -3972,52 +11028,164 @@
         "name": "c-32x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.6081036337151999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.868719476736,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -4035,52 +11203,164 @@
         "name": "s-32x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -4098,52 +11378,164 @@
         "name": "s-32x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -4161,52 +11553,164 @@
         "name": "s-32x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -4224,52 +11728,164 @@
         "name": "s-32x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.6562072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 0.937438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -4287,52 +11903,164 @@
         "name": "m-32x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -4350,52 +12078,164 @@
         "name": "m-32x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -4413,52 +12253,164 @@
         "name": "m-32x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -4476,52 +12428,164 @@
         "name": "m-32x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.7524145348607999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.074877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -4539,52 +12603,164 @@
         "name": "c-48x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -4602,52 +12778,164 @@
         "name": "c-48x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -4665,52 +12953,164 @@
         "name": "c-48x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -4728,52 +13128,164 @@
         "name": "c-48x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.9121554505728001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.3030792151040003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -4791,52 +13303,164 @@
         "name": "s-48x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -4854,52 +13478,164 @@
         "name": "s-48x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -4917,52 +13653,164 @@
         "name": "s-48x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -4980,52 +13828,164 @@
         "name": "s-48x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 0.9843109011456,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.4061584302080001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -5043,52 +14003,164 @@
         "name": "m-48x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -5106,52 +14178,164 @@
         "name": "m-48x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -5169,52 +14353,164 @@
         "name": "m-48x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -5232,52 +14528,164 @@
         "name": "m-48x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.1286218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.612316860416,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -5295,52 +14703,164 @@
         "name": "c-64x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -5358,52 +14878,164 @@
         "name": "c-64x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -5421,52 +15053,164 @@
         "name": "c-64x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -5484,52 +15228,164 @@
         "name": "c-64x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.2162072674303999,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.737438953472,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -5547,52 +15403,164 @@
         "name": "s-64x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -5610,52 +15578,164 @@
         "name": "s-64x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -5673,52 +15753,164 @@
         "name": "s-64x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -5736,52 +15928,164 @@
         "name": "s-64x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.3124145348607998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 1.874877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -5799,52 +16103,164 @@
         "name": "m-64x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -5862,52 +16278,164 @@
         "name": "m-64x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -5925,52 +16453,164 @@
         "name": "m-64x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -5988,52 +16628,164 @@
         "name": "m-64x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.5048290697215998,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.149755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -6051,52 +16803,164 @@
         "name": "c-96x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -6114,52 +16978,164 @@
         "name": "c-96x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
-                "Price": 1.8243109011456002,
-                "Available": true
+                "Price": 1.8243109011456,
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
-                "Price": 2.6061584302080005,
-                "Available": true
+                "Price": 2.606158430208,
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
-                "Price": 1.8243109011456002,
-                "Available": true
+                "Price": 1.8243109011456,
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
-                "Price": 2.6061584302080005,
-                "Available": true
+                "Price": 2.606158430208,
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
-                "Price": 1.8243109011456002,
-                "Available": true
+                "Price": 1.8243109011456,
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
-                "Price": 2.6061584302080005,
-                "Available": true
+                "Price": 2.606158430208,
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
-                "Price": 1.8243109011456002,
-                "Available": true
+                "Price": 1.8243109011456,
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
-                "Price": 2.6061584302080005,
-                "Available": true
+                "Price": 2.606158430208,
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -6177,52 +17153,164 @@
         "name": "c-96x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -6240,52 +17328,164 @@
         "name": "c-96x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.8243109011456002,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.6061584302080005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -6303,52 +17503,164 @@
         "name": "s-96x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -6366,52 +17678,164 @@
         "name": "s-96x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -6429,52 +17853,164 @@
         "name": "s-96x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -6492,52 +18028,164 @@
         "name": "s-96x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 1.9686218022912,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 2.8123168604160003,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -6555,52 +18203,164 @@
         "name": "m-96x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -6618,52 +18378,164 @@
         "name": "m-96x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -6681,52 +18553,164 @@
         "name": "m-96x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -6744,52 +18728,164 @@
         "name": "m-96x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.2572436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.224633720832,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -6807,52 +18903,164 @@
         "name": "c-128x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -6870,52 +19078,164 @@
         "name": "c-128x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -6933,52 +19253,164 @@
         "name": "c-128x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -6996,52 +19428,164 @@
         "name": "c-128x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.4324145348607997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.474877906944,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -7059,52 +19603,164 @@
         "name": "s-128x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -7122,52 +19778,164 @@
         "name": "s-128x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -7185,52 +19953,164 @@
         "name": "s-128x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -7248,52 +20128,164 @@
         "name": "s-128x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 2.6248290697215997,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 3.749755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -7311,52 +20303,164 @@
         "name": "m-128x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -7374,52 +20478,164 @@
         "name": "m-128x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -7437,52 +20653,164 @@
         "name": "m-128x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -7500,52 +20828,164 @@
         "name": "m-128x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.0096581394431996,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 4.299511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -7563,52 +21003,164 @@
         "name": "c-192x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -7626,52 +21178,164 @@
         "name": "c-192x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -7689,52 +21353,164 @@
         "name": "c-192x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -7752,52 +21528,164 @@
         "name": "c-192x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.6486218022912005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 5.212316860416001,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -7815,52 +21703,164 @@
         "name": "s-192x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -7878,52 +21878,164 @@
         "name": "s-192x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -7941,52 +22053,164 @@
         "name": "s-192x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -8004,52 +22228,164 @@
         "name": "s-192x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 3.9372436045824,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 5.6246337208320005,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -8067,52 +22403,164 @@
         "name": "m-192x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -8130,52 +22578,164 @@
         "name": "m-192x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -8193,52 +22753,164 @@
         "name": "m-192x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -8256,52 +22928,164 @@
         "name": "m-192x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 4.5144872091648,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 6.449267441664,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -8319,52 +23103,164 @@
         "name": "c-256x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -8382,52 +23278,164 @@
         "name": "c-256x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -8445,52 +23453,164 @@
         "name": "c-256x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -8508,52 +23628,164 @@
         "name": "c-256x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 4.8648290697215995,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 6.949755813888,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -8571,52 +23803,164 @@
         "name": "s-256x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -8634,52 +23978,164 @@
         "name": "s-256x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -8697,52 +24153,164 @@
         "name": "s-256x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -8760,52 +24328,164 @@
         "name": "s-256x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 5.249658139443199,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 7.499511627776,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -8823,52 +24503,164 @@
         "name": "m-256x-amd64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -8886,52 +24678,164 @@
         "name": "m-256x-arm64-linux",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",
@@ -8949,52 +24853,164 @@
         "name": "m-256x-amd64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "amd64",
@@ -9012,52 +25028,164 @@
         "name": "m-256x-arm64-windows",
         "offerings": [
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-a",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-a",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-a"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-b",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-b",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-b"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-c",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-c",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-c"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "spot",
-                "Zone": "test-zone-d",
                 "Price": 6.019316278886399,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "spot"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             },
             {
-                "CapacityType": "on-demand",
-                "Zone": "test-zone-d",
                 "Price": 8.599023255552,
-                "Available": true
+                "Available": true,
+                "Requirements": [
+                    {
+                        "key": "karpenter.sh/capacity-type",
+                        "operator": "In",
+                        "values": [
+                            "on-demand"
+                        ]
+                    },
+                    {
+                        "key": "topology.kubernetes.io/zone",
+                        "operator": "In",
+                        "values": [
+                            "test-zone-d"
+                        ]
+                    }
+                ]
             }
         ],
         "architecture": "arm64",

--- a/kwok/tools/gen_instance_types.go
+++ b/kwok/tools/gen_instance_types.go
@@ -28,7 +28,6 @@ import (
 	kwok "sigs.k8s.io/karpenter/kwok/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
-	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
 var (
@@ -90,16 +89,18 @@ func constructGenericInstanceTypes() []kwok.InstanceTypeOptions {
 					}
 					price := priceFromResources(opts.Resources)
 
-					opts.Offerings = cloudprovider.Offerings{}
+					opts.Offerings = []kwok.KwokOffering{}
 					for _, zone := range KwokZones {
 						for _, ct := range []string{v1beta1.CapacityTypeSpot, v1beta1.CapacityTypeOnDemand} {
-							opts.Offerings = append(opts.Offerings, cloudprovider.Offering{
-								Requirements: scheduling.NewLabelRequirements(map[string]string{
-									v1beta1.CapacityTypeLabelKey: ct,
-									v1.LabelTopologyZone:         zone,
-								}),
-								Price:     lo.Ternary(ct == v1beta1.CapacityTypeSpot, price*.7, price),
-								Available: true,
+							opts.Offerings = append(opts.Offerings, kwok.KwokOffering{
+								Requirements: []v1.NodeSelectorRequirement{
+									v1.NodeSelectorRequirement{Key: v1beta1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{ct}},
+									v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{zone}},
+								},
+								Offering: cloudprovider.Offering{
+									Price:     lo.Ternary(ct == v1beta1.CapacityTypeSpot, price*.7, price),
+									Available: true,
+								},
 							})
 						}
 					}

--- a/kwok/tools/gen_instance_types.go
+++ b/kwok/tools/gen_instance_types.go
@@ -89,10 +89,10 @@ func constructGenericInstanceTypes() []kwok.InstanceTypeOptions {
 					}
 					price := priceFromResources(opts.Resources)
 
-					opts.Offerings = []kwok.KwokOffering{}
+					opts.Offerings = []kwok.KWOKOffering{}
 					for _, zone := range KwokZones {
 						for _, ct := range []string{v1beta1.CapacityTypeSpot, v1beta1.CapacityTypeOnDemand} {
-							opts.Offerings = append(opts.Offerings, kwok.KwokOffering{
+							opts.Offerings = append(opts.Offerings, kwok.KWOKOffering{
 								Requirements: []v1.NodeSelectorRequirement{
 									v1.NodeSelectorRequirement{Key: v1beta1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{ct}},
 									v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{zone}},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
We changed offerings to use requirements rather than hard-coded strings for capacity type and zone. This made kwok offerings incompatible. 

**How was this change tested?**
make apply and scale up and scale down

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
