### PR TITLE
fix: kwok offerings to use correct requirements

### DIFF
--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -157,6 +157,7 @@ func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 		})
 		return req.Values
 	})))
+
 	requirements := scheduling.NewRequirements(
 		scheduling.NewRequirement(v1.LabelInstanceTypeStable, v1.NodeSelectorOpIn, options.Name),
 		scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, options.Architecture),
@@ -173,7 +174,13 @@ func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 		Name:         options.Name,
 		Requirements: requirements,
 		Offerings: lo.Map(options.Offerings, func(off KWOKOffering, _ int) cloudprovider.Offering {
-			return off.Offering
+			return cloudprovider.Offering{
+				Requirements: scheduling.NewRequirements(lo.Map(off.Requirements, func(req v1.NodeSelectorRequirement, _ int) *scheduling.Requirement {
+					return scheduling.NewRequirement(req.Key, req.Operator, req.Values...)
+				})...),
+				Price:     off.Offering.Price,
+				Available: off.Offering.Available,
+			}
 		}),
 		Capacity: options.Resources,
 		Overhead: &cloudprovider.InstanceTypeOverhead{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
The kwok instance types use a differently typed requirements. The instance types have the right requirements, but the offerings don't have any requirements. This fixes that bug and adds them in

**How was this change tested?**
make apply

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
