### PR TITLE
Changes to add KPIs to e2e action

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -14,10 +14,18 @@ jobs:
       matrix:
         k8sVersion: ["1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x", "1.28.x", "1.29.x", "1.30.x"]
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+    - uses: actions/checkout@v4
+      with:
+        repository: nathangeology/karpenter_evaluate
+        path: ./karpenter_eval/ #<-- clone https://github.com/org1/repo1
     - uses: ./.github/actions/install-deps
       with:
           k8sVersion: ${{ matrix.k8sVersion }}
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
     - name: Kind Cluster
       uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
     - name: check kind cluster and taint nodes
@@ -43,10 +51,21 @@ jobs:
         kubectl get nodepools
         kubectl get pods -A
         kubectl describe nodes
+    - name: install KPI report dependencies
+      shell: bash
+      run: |
+        pip install awswrangler
+        pip install prometheus-api-client
+        pip install ./karpenter_eval/
     - name: run test suites
       shell: bash
       run: | 
         make e2etests
+    - name: run KPI report
+      shell: bash
+      run: |
+        echo "run KPIs here"
+        python ./karpenter_eval/main.py your_file_here.csv
     - name: cleanup 
       shell: bash
       run: | 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Changes the e2e tests to allow for using a python script to extract KPIs from prometheus during the e2e testing. 
**How was this change tested?**
Work in progress. Testing via actions and testing in experimental EKS clusters with Nick Tran. 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
