### PR TITLE
fix: add deletiontimestamp check for kwok termination

### DIFF
--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -82,6 +82,9 @@ func (c CloudProvider) Get(ctx context.Context, providerID string) (*v1beta1.Nod
 		}
 		return nil, fmt.Errorf("finding node, %w", err)
 	}
+	if node.DeletionTimestamp != nil {
+		return nil, cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("nodeclaim not found"))
+	}
 	return c.toNodeClaim(node)
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Karpenter now waits for the nodeclaim to be not found with the cloudprovider.Get() call, which this implements the fix for the kwok cloud provider

**How was this change tested?**
make apply 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
