### PR TITLE
chore: fix kwok api version group

### DIFF
--- a/kwok/README.md
+++ b/kwok/README.md
@@ -47,7 +47,7 @@ spec:
     consolidationPolicy: WhenUnderutilized
     expireAfter: 720h # 30 * 24h = 720h
 ---
-apiVersion: kwok.karpenter.sh/v1alpha1
+apiVersion: karpenter.kwok.sh/v1alpha1
 kind: KWOKNodeClass
 metadata:
   name: default

--- a/kwok/apis/apis.go
+++ b/kwok/apis/apis.go
@@ -39,7 +39,7 @@ var (
 
 //go:generate controller-gen crd object:headerFile="../../hack/boilerplate.go.txt" paths="./..." output:crd:artifacts:config=crds
 var (
-	//go:embed crds/kwok.karpenter.sh_kwoknodeclasses.yaml
+	//go:embed crds/karpenter.kwok.sh_kwoknodeclasses.yaml
 	KWOKNodeClassCRD []byte
 	CRDs             = []*v1.CustomResourceDefinition{
 		lo.Must(functional.Unmarshal[v1.CustomResourceDefinition](KWOKNodeClassCRD)),

--- a/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml
+++ b/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: kwoknodeclasses.kwok.karpenter.sh
+  name: kwoknodeclasses.karpenter.kwok.sh
 spec:
-  group: kwok.karpenter.sh
+  group: karpenter.kwok.sh
   names:
     categories:
     - karpenter

--- a/kwok/apis/v1alpha1/doc.go
+++ b/kwok/apis/v1alpha1/doc.go
@@ -17,5 +17,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=kwok.karpenter.sh
+// +groupName=karpenter.kwok.sh
 package v1alpha1 // doc.go is discovered by codegen

--- a/kwok/apis/v1alpha1/labels.go
+++ b/kwok/apis/v1alpha1/labels.go
@@ -16,9 +16,10 @@ limitations under the License.
 
 package v1alpha1
 
+import "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+
 const (
 	// Labels that can be selected on and are propagated to the node
-	InstanceTypeLabelKey   = Group + "/instance-type"
 	InstanceSizeLabelKey   = Group + "/instance-size"
 	InstanceFamilyLabelKey = Group + "/instance-family"
 	InstanceMemoryLabelKey = Group + "/instance-memory"
@@ -30,3 +31,13 @@ const (
 	NodeViewerLabelKey    = "eks-node-viewer/instance-price"
 	KwokPartitionLabelKey = "kwok-partition"
 )
+
+func init() {
+	v1beta1.RestrictedLabelDomains = v1beta1.RestrictedLabelDomains.Insert(Group)
+	v1beta1.WellKnownLabels = v1beta1.WellKnownLabels.Insert(
+		InstanceSizeLabelKey,
+		InstanceFamilyLabelKey,
+		InstanceCPULabelKey,
+		InstanceMemoryLabelKey,
+	)
+}

--- a/kwok/apis/v1alpha1/register.go
+++ b/kwok/apis/v1alpha1/register.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	Group = "kwok.karpenter.sh"
+	Group = "karpenter.kwok.sh"
 )
 
 var (

--- a/kwok/charts/crds/karpenter.kwok.sh_kwoknodeclasses.yaml
+++ b/kwok/charts/crds/karpenter.kwok.sh_kwoknodeclasses.yaml
@@ -1,0 +1,1 @@
+../../apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml

--- a/kwok/charts/crds/kwok.karpenter.sh_kwoknodeclasses.yaml
+++ b/kwok/charts/crds/kwok.karpenter.sh_kwoknodeclasses.yaml
@@ -1,1 +1,0 @@
-../../apis/crds/kwok.karpenter.sh_kwoknodeclasses.yaml

--- a/kwok/charts/templates/clusterrole-kwok.yaml
+++ b/kwok/charts/templates/clusterrole-kwok.yaml
@@ -29,10 +29,10 @@ metadata:
   {{- end }}
 rules:
   # Read
-  - apiGroups: ["kwok.karpenter.sh"]
+  - apiGroups: ["karpenter.kwok.sh"]
     resources: ["kwoknodeclasses"]
     verbs: ["get", "list", "watch"]
   # Write
-  - apiGroups: ["kwok.karpenter.sh"]
+  - apiGroups: ["karpenter.kwok.sh"]
     resources: ["kwoknodeclasses", "kwoknodeclasses/status"]
     verbs: ["patch", "update"]

--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -122,7 +122,6 @@ func setDefaultOptions(opts InstanceTypeOptions) InstanceTypeOptions {
 	}
 
 	opts.instanceTypeLabels = map[string]string{
-		v1alpha1.InstanceTypeLabelKey:   opts.Name,
 		v1alpha1.InstanceSizeLabelKey:   parseSizeFromType(opts.Name, cpu),
 		v1alpha1.InstanceFamilyLabelKey: parseFamilyFromType(opts.Name),
 		v1alpha1.InstanceCPULabelKey:    cpu,

--- a/kwok/main.go
+++ b/kwok/main.go
@@ -19,24 +19,11 @@ package main
 import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"sigs.k8s.io/karpenter/kwok/apis/v1alpha1"
 	kwok "sigs.k8s.io/karpenter/kwok/cloudprovider"
-	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/controllers"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/operator"
 )
-
-func init() {
-	v1beta1.RestrictedLabelDomains = v1beta1.RestrictedLabelDomains.Insert(v1alpha1.Group)
-	v1beta1.WellKnownLabels = v1beta1.WellKnownLabels.Insert(
-		v1alpha1.InstanceTypeLabelKey,
-		v1alpha1.InstanceSizeLabelKey,
-		v1alpha1.InstanceFamilyLabelKey,
-		v1alpha1.InstanceCPULabelKey,
-		v1alpha1.InstanceMemoryLabelKey,
-	)
-}
 
 func main() {
 	ctx, op := operator.NewOperator()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This fixes the api group of the kwok node class, and by association its labels. It was incorrectly ordered, and should now match the validation. 

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
