### PR TITLE
chore: Validate do not disrupt annotation on node is true

### DIFF
--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -185,7 +185,7 @@ func (in *StateNode) ValidateDisruptable(ctx context.Context, kubeClient client.
 	if in.Nominated() {
 		return nil, fmt.Errorf("state node is nominated for a pending pod")
 	}
-	if _, ok := in.Annotations()[v1beta1.DoNotDisruptAnnotationKey]; ok {
+	if in.Annotations()[v1beta1.DoNotDisruptAnnotationKey] == "true" {
 		return nil, fmt.Errorf("disruption is blocked through the %q annotation", v1beta1.DoNotDisruptAnnotationKey)
 	}
 	// check whether the node has all the labels we need


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes <!-- issue number -->#1323

**Description**
Currently we don't validate if `do-not-disrupt` annotation on a node is set to `true` and only check if the annotation exists. This PR adds a change to add the validation.

**How was this change tested?**
Tested on local cluster. Added a functional test for the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
