### PR TITLE
chore: Drop event recorder from provisioning controllers

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -58,8 +58,8 @@ func NewControllers(
 	return []controller.Controller{
 		p, evictionQueue, disruptionQueue,
 		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue),
-		provisioning.NewPodController(kubeClient, p, recorder),
-		provisioning.NewNodeController(kubeClient, p, recorder),
+		provisioning.NewPodController(kubeClient, p),
+		provisioning.NewNodeController(kubeClient, p),
 		nodepoolhash.NewController(kubeClient),
 		informer.NewDaemonSetController(kubeClient, cluster),
 		informer.NewNodeController(kubeClient, cluster),

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
@@ -39,15 +38,13 @@ import (
 type PodController struct {
 	kubeClient  client.Client
 	provisioner *Provisioner
-	recorder    events.Recorder
 }
 
 // NewPodController constructs a controller instance
-func NewPodController(kubeClient client.Client, provisioner *Provisioner, recorder events.Recorder) *PodController {
+func NewPodController(kubeClient client.Client, provisioner *Provisioner) *PodController {
 	return &PodController{
 		kubeClient:  kubeClient,
 		provisioner: provisioner,
-		recorder:    recorder,
 	}
 }
 
@@ -78,15 +75,13 @@ func (c *PodController) Register(_ context.Context, m manager.Manager) error {
 type NodeController struct {
 	kubeClient  client.Client
 	provisioner *Provisioner
-	recorder    events.Recorder
 }
 
 // NewNodeController constructs a controller instance
-func NewNodeController(kubeClient client.Client, provisioner *Provisioner, recorder events.Recorder) *NodeController {
+func NewNodeController(kubeClient client.Client, provisioner *Provisioner) *NodeController {
 	return &NodeController{
 		kubeClient:  kubeClient,
 		provisioner: provisioner,
-		recorder:    recorder,
 	}
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Drop unused event recorder from provisioning controllers

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
