### PR TITLE
test: add output_dir env variable for timestamp exports

### DIFF
--- a/test/pkg/debug/collector.go
+++ b/test/pkg/debug/collector.go
@@ -142,10 +142,16 @@ func PrintTestTimes(times map[string][]TimeInterval) map[string][][]string {
 }
 
 // WriteTimestamps will create a temp directory and a .csv file for each suite test
+// If the OUTPUT_DIR environment variable is set, we'll print the csvs to that directory.
 func WriteTimestamps(path string, timestamps *TimeIntervalCollector) error {
-	directory, err := os.MkdirTemp("/tmp", "")
-	if err != nil {
-		return err
+	var directory string
+	var err error
+	directory, ok := os.LookupEnv("OUTPUT_DIR")
+	if !ok {
+		directory, err = os.MkdirTemp("/tmp", "")
+		if err != nil {
+			return err
+		}
 	}
 	for name, table := range PrintTestTimes(timestamps.suiteTimeIntervals) {
 		file, err := os.CreateTemp(directory, fmt.Sprintf("*-%s.csv", name))

--- a/test/pkg/debug/collector.go
+++ b/test/pkg/debug/collector.go
@@ -143,18 +143,16 @@ func PrintTestTimes(times map[string][]TimeInterval) map[string][][]string {
 
 // WriteTimestamps will create a temp directory and a .csv file for each suite test
 // If the OUTPUT_DIR environment variable is set, we'll print the csvs to that directory.
-func WriteTimestamps(path string, timestamps *TimeIntervalCollector) error {
-	var directory string
+func WriteTimestamps(outputDir string, timestamps *TimeIntervalCollector) error {
 	var err error
-	directory, ok := os.LookupEnv("OUTPUT_DIR")
-	if !ok {
-		directory, err = os.MkdirTemp("/tmp", "")
+	if outputDir == "" {
+		outputDir, err = os.MkdirTemp("/tmp", "")
 		if err != nil {
 			return err
 		}
 	}
 	for name, table := range PrintTestTimes(timestamps.suiteTimeIntervals) {
-		file, err := os.CreateTemp(directory, fmt.Sprintf("*-%s.csv", name))
+		file, err := os.CreateTemp(outputDir, fmt.Sprintf("*-%s.csv", name))
 		if err != nil {
 			return err
 		}

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -68,6 +68,7 @@ type Environment struct {
 	KubeClient            kubernetes.Interface
 	Monitor               *Monitor
 
+	OutputDir         string
 	StartingNodeCount int
 }
 
@@ -81,6 +82,8 @@ func NewEnvironment(t *testing.T) *Environment {
 	if val, ok := os.LookupEnv("GIT_REF"); ok {
 		ctx = context.WithValue(ctx, GitRefContextKey, val)
 	}
+	// Get the output dir if it's set
+	outputDir, _ := os.LookupEnv("OUTPUT_DIR")
 
 	gomega.SetDefaultEventuallyTimeout(5 * time.Minute)
 	gomega.SetDefaultEventuallyPollingInterval(1 * time.Second)
@@ -92,6 +95,7 @@ func NewEnvironment(t *testing.T) *Environment {
 		KubeClient:            kubernetes.NewForConfigOrDie(config),
 		Monitor:               NewMonitor(ctx, client),
 		TimeIntervalCollector: debug.NewTimestampCollector(),
+		OutputDir:             outputDir,
 	}
 }
 

--- a/test/suites/perf/scheduling_test.go
+++ b/test/suites/perf/scheduling_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/test"
 )
 
-var replicas int = 100
+var replicas int = 10
 
 var _ = Describe("Performance", func() {
 	Context("Provisioning", func() {

--- a/test/suites/perf/suite_test.go
+++ b/test/suites/perf/suite_test.go
@@ -53,7 +53,7 @@ func TestPerf(t *testing.T) {
 	})
 	AfterSuite(func() {
 		// Write out the timestamps from our tests
-		if err := debug.WriteTimestamps("path", env.TimeIntervalCollector); err != nil {
+		if err := debug.WriteTimestamps(env.OutputDir, env.TimeIntervalCollector); err != nil {
 			log.FromContext(env).Info(fmt.Sprintf("Failed to write timestamps to files, %s", err))
 		}
 		env.Stop()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds the ability to set OUTPUT_DIR with testing framework for timestamp exports

**How was this change tested?**
OUTPUT_DIR=$(mktemp -d) make e2etests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
