### PR TITLE
fix: add nil check for required nodeclassref field

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -19,6 +19,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	golog "log"
 	"net/http"
 	"net/http/pprof"
 	"runtime"
@@ -194,13 +195,25 @@ func NewOperator() (context.Context, *Operator) {
 		return []string{o.(*v1beta1.NodeClaim).Status.ProviderID}
 	}), "failed to setup nodeclaim provider id indexer")
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1beta1.NodeClaim{}, "spec.nodeClassRef.apiVersion", func(o client.Object) []string {
-		return []string{o.(*v1beta1.NodeClaim).Spec.NodeClassRef.APIVersion}
+		nc := o.(*v1beta1.NodeClaim)
+		if nc.Spec.NodeClassRef == nil {
+			golog.Fatalf("failed to setup nodeclaim nodeclassref apiversion indexer, nodeclaim %q has a missing nodeclassref", nc.Name)
+		}
+		return []string{nc.Spec.NodeClassRef.APIVersion}
 	}), "failed to setup nodeclaim nodeclassref apiversion indexer")
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1beta1.NodeClaim{}, "spec.nodeClassRef.kind", func(o client.Object) []string {
-		return []string{o.(*v1beta1.NodeClaim).Spec.NodeClassRef.Kind}
+		nc := o.(*v1beta1.NodeClaim)
+		if nc.Spec.NodeClassRef == nil {
+			golog.Fatalf("failed to setup nodeclaim nodeclassref kind indexer, nodeclaim %q has a missing nodeclassref", nc.Name)
+		}
+		return []string{nc.Spec.NodeClassRef.Kind}
 	}), "failed to setup nodeclaim nodeclassref kind indexer")
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1beta1.NodeClaim{}, "spec.nodeClassRef.name", func(o client.Object) []string {
-		return []string{o.(*v1beta1.NodeClaim).Spec.NodeClassRef.Name}
+		nc := o.(*v1beta1.NodeClaim)
+		if nc.Spec.NodeClassRef == nil {
+			golog.Fatalf("failed to setup nodeclaim nodeclassref name indexer, nodeclaim %q has a missing nodeclassref", nc.Name)
+		}
+		return []string{nc.Spec.NodeClassRef.Name}
 	}), "failed to setup nodeclaim nodeclassref name indexer")
 
 	lo.Must0(mgr.AddReadyzCheck("manager", func(req *http.Request) error {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -19,7 +19,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	golog "log"
 	"net/http"
 	"net/http/pprof"
 	"runtime"
@@ -197,21 +196,21 @@ func NewOperator() (context.Context, *Operator) {
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1beta1.NodeClaim{}, "spec.nodeClassRef.apiVersion", func(o client.Object) []string {
 		nc := o.(*v1beta1.NodeClaim)
 		if nc.Spec.NodeClassRef == nil {
-			golog.Fatalf("failed to setup nodeclaim nodeclassref apiversion indexer, nodeclaim %q has a missing nodeclassref", nc.Name)
+			return []string{""}
 		}
 		return []string{nc.Spec.NodeClassRef.APIVersion}
 	}), "failed to setup nodeclaim nodeclassref apiversion indexer")
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1beta1.NodeClaim{}, "spec.nodeClassRef.kind", func(o client.Object) []string {
 		nc := o.(*v1beta1.NodeClaim)
 		if nc.Spec.NodeClassRef == nil {
-			golog.Fatalf("failed to setup nodeclaim nodeclassref kind indexer, nodeclaim %q has a missing nodeclassref", nc.Name)
+			return []string{""}
 		}
 		return []string{nc.Spec.NodeClassRef.Kind}
 	}), "failed to setup nodeclaim nodeclassref kind indexer")
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1beta1.NodeClaim{}, "spec.nodeClassRef.name", func(o client.Object) []string {
 		nc := o.(*v1beta1.NodeClaim)
 		if nc.Spec.NodeClassRef == nil {
-			golog.Fatalf("failed to setup nodeclaim nodeclassref name indexer, nodeclaim %q has a missing nodeclassref", nc.Name)
+			return []string{""}
 		}
 		return []string{nc.Spec.NodeClassRef.Name}
 	}), "failed to setup nodeclaim nodeclassref name indexer")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds explicit `nil` checks when we set up the indexers for nodeclaim nodeclassrefs. This fields is required, and that requirement should be enforced through validation, but it is possible to circumvent navigation and remove this field (e.g. editing the CEL or removing the validating webhook). This change makes Karpenter fail open rather than crash in this scenario.

**How was this change tested?**
Manual validation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
