### PR TITLE
fix: logger print KubeConfig error

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -124,6 +124,11 @@ func NewOperator() (context.Context, *Operator) {
 		GracePeriod: 5 * time.Second,
 	})
 
+	// Logging
+	logger := zapr.NewLogger(logging.NewLogger(ctx, component))
+	log.SetLogger(logger)
+	klog.SetLogger(logger)
+
 	// Client Config
 	config := ctrl.GetConfigOrDie()
 	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(float32(options.FromContext(ctx).KubeClientQPS), options.FromContext(ctx).KubeClientBurst)
@@ -131,11 +136,6 @@ func NewOperator() (context.Context, *Operator) {
 
 	// Client
 	kubernetesInterface := kubernetes.NewForConfigOrDie(config)
-
-	// Logging
-	logger := zapr.NewLogger(logging.NewLogger(ctx, component))
-	log.SetLogger(logger)
-	klog.SetLogger(logger)
 
 	log.FromContext(ctx).WithValues("version", Version).V(1).Info("discovered karpenter version")
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Moved logger forward, fixed that no prompts are output when KubeConfig is incorrect.

**How was this change tested?**

Before: no KubeConfig, no output.
```bash
/xxxx/___kwok

Process finished with exit code 1
```

After: no KubeConfig, has output.
```bash
/xxxx/___kwok
{"level":"ERROR","time":"2024-06-23T12:04:30.034+0000","logger":"controller.controller-runtime.client.config","message":"unable to load in-cluster config","commit":"9ddd790","error":"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"}
{"level":"ERROR","time":"2024-06-23T12:04:30.035+0000","logger":"controller.controller-runtime.client.config","message":"unable to get kubeconfig","commit":"9ddd790","error":"invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","errorCauses":[{"error":"no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}]}

Process finished with exit code 1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
