### PR TITLE
chore: Increase nodeClaim spec.requirements to 100

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -257,7 +257,7 @@ spec:
                       - key
                       - operator
                     type: object
-                  maxItems: 30
+                  maxItems: 100
                   type: array
                   x-kubernetes-validations:
                     - message: requirements with operator 'In' must have a value defined

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -383,7 +383,7 @@ spec:
                               - key
                               - operator
                             type: object
-                          maxItems: 30
+                          maxItems: 100
                           type: array
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -255,7 +255,7 @@ spec:
                       - key
                       - operator
                     type: object
-                  maxItems: 30
+                  maxItems: 100
                   type: array
                   x-kubernetes-validations:
                     - message: requirements with operator 'In' must have a value defined

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -381,7 +381,7 @@ spec:
                               - key
                               - operator
                             type: object
-                          maxItems: 30
+                          maxItems: 100
                           type: array
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -37,7 +37,7 @@ type NodeClaimSpec struct {
 	// +kubebuilder:validation:XValidation:message="requirements with operator 'In' must have a value defined",rule="self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
 	// +kubebuilder:validation:XValidation:message="requirements operator 'Gt' or 'Lt' must have a single positive integer value",rule="self.all(x, (x.operator == 'Gt' || x.operator == 'Lt') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
 	// +kubebuilder:validation:XValidation:message="requirements with 'minValues' must have at least that many values specified in the 'values' field",rule="self.all(x, (x.operator == 'In' && has(x.minValues)) ? x.values.size() >= x.minValues : true)"
-	// +kubebuilder:validation:MaxItems:=30
+	// +kubebuilder:validation:MaxItems:=100
 	// +required
 	Requirements []NodeSelectorRequirementWithMinValues `json:"requirements" hash:"ignore"`
 	// Resources models the resource requirements for the NodeClaim to launch

--- a/pkg/apis/v1/nodeclaim_validation_cel_test.go
+++ b/pkg/apis/v1/nodeclaim_validation_cel_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"sigs.k8s.io/karpenter/pkg/test"
+
 	"github.com/Pallinder/go-randomdata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -213,6 +215,14 @@ var _ = Describe("Validation", func() {
 				{NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"insance-type-1"}}, MinValues: lo.ToPtr(2)},
 			}
 			Expect(nodeClaim.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should error when requirements is greater than 100", func() {
+			var req []NodeSelectorRequirementWithMinValues
+			for i := 0; i < 101; i++ {
+				req = append(req, NodeSelectorRequirementWithMinValues{NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: test.RandomName(), Operator: v1.NodeSelectorOpIn, Values: []string{test.RandomName()}}})
+			}
+			nodeClaim.Spec.Requirements = req
+			Expect(env.Client.Create(ctx, nodeClaim)).ToNot(Succeed())
 		})
 	})
 	Context("Kubelet", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
In response to the issue - https://github.com/aws/karpenter-provider-aws/issues/6387
Currently nodeclaim spec.requirements is restricted to 30. This PR increases the limit to 100.

**How was this change tested?**
Tested on local cluster and also added a functional test for this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
