### PR TITLE
chore: Make NodeClaim Spec Immutable on v1 API

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -361,6 +361,9 @@ spec:
                 - nodeClassRef
                 - requirements
               type: object
+              x-kubernetes-validations:
+                - message: immutable field changed
+                  rule: self == oldSelf
             status:
               description: NodeClaimStatus defines the observed state of NodeClaim
               properties:

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -359,6 +359,9 @@ spec:
                 - nodeClassRef
                 - requirements
               type: object
+              x-kubernetes-validations:
+                - message: immutable field changed
+                  rule: self == oldSelf
             status:
               description: NodeClaimStatus defines the observed state of NodeClaim
               properties:

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -176,6 +176,7 @@ type NodeClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="immutable field changed"
 	// +required
 	Spec   NodeClaimSpec   `json:"spec"`
 	Status NodeClaimStatus `json:"status,omitempty"`


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Make NodeClaim Immutable on v1 API
- V1 RFC: https://github.com/kubernetes-sigs/karpenter/pull/1222

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
