### PR TITLE
chore: Update `nodeClassRef` to be Group instead of APIVersion

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -186,7 +186,7 @@ spec:
                 nodeClassRef:
                   description: NodeClassRef is a reference to an object that defines provider specific configuration
                   properties:
-                    apiVersion:
+                    group:
                       description: API version of the referent
                       type: string
                     kind:
@@ -196,6 +196,8 @@ spec:
                       description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                       type: string
                   required:
+                    - group
+                    - kind
                     - name
                   type: object
                 requirements:

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -310,7 +310,7 @@ spec:
                         nodeClassRef:
                           description: NodeClassRef is a reference to an object that defines provider specific configuration
                           properties:
-                            apiVersion:
+                            group:
                               description: API version of the referent
                               type: string
                             kind:
@@ -320,6 +320,8 @@ spec:
                               description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                               type: string
                           required:
+                            - group
+                            - kind
                             - name
                           type: object
                         requirements:

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -186,7 +186,7 @@ spec:
                 nodeClassRef:
                   description: NodeClassRef is a reference to an object that defines provider specific configuration
                   properties:
-                    apiVersion:
+                    group:
                       description: API version of the referent
                       type: string
                     kind:
@@ -196,6 +196,8 @@ spec:
                       description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                       type: string
                   required:
+                    - group
+                    - kind
                     - name
                   type: object
                 requirements:

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -310,7 +310,7 @@ spec:
                         nodeClassRef:
                           description: NodeClassRef is a reference to an object that defines provider specific configuration
                           properties:
-                            apiVersion:
+                            group:
                               description: API version of the referent
                               type: string
                             kind:
@@ -320,6 +320,8 @@ spec:
                               description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                               type: string
                           required:
+                            - group
+                            - kind
                             - name
                           type: object
                         requirements:

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -146,14 +146,14 @@ type KubeletConfiguration struct {
 
 type NodeClassReference struct {
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-	// +optional
-	Kind string `json:"kind,omitempty"`
+	// +required
+	Kind string `json:"kind"`
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	// +required
 	Name string `json:"name"`
 	// API version of the referent
-	// +optional
-	APIVersion string `json:"apiVersion,omitempty"`
+	// +required
+	Group string `json:"group"`
 }
 
 // +kubebuilder:object:generate=false


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #909 

**Description**
- Change apiVersion -> Group 
- Require Kind and Group for NodeClassRef
- V1 RFC: https://github.com/kubernetes-sigs/karpenter/pull/1222

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
