### PR TITLE
feat: Adding printer columns on v1 NodeClaims

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -20,6 +20,9 @@ spec:
         - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
           name: Type
           type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
         - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
           name: Zone
           type: string
@@ -32,8 +35,8 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
-          name: Capacity
+        - jsonPath: .status.providerID
+          name: ID
           priority: 1
           type: string
         - jsonPath: .metadata.labels.karpenter\.sh/nodepool

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -20,6 +20,9 @@ spec:
         - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
           name: Type
           type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
         - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
           name: Zone
           type: string
@@ -32,8 +35,8 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
-          name: Capacity
+        - jsonPath: .status.providerID
+          name: ID
           priority: 1
           type: string
         - jsonPath: .metadata.labels.karpenter\.sh/nodepool

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -164,11 +164,12 @@ type Provider = runtime.RawExtension
 // +kubebuilder:resource:path=nodeclaims,scope=Cluster,categories=karpenter
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".metadata.labels.node\\.kubernetes\\.io/instance-type",description=""
+// +kubebuilder:printcolumn:name="Capacity",type="string",JSONPath=".metadata.labels.karpenter\\.sh/capacity-type",description=""
 // +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".metadata.labels.topology\\.kubernetes\\.io/zone",description=""
 // +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.nodeName",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:printcolumn:name="Capacity",type="string",JSONPath=".metadata.labels.karpenter\\.sh/capacity-type",priority=1,description=""
+// +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.providerID",priority=1,description=""
 // +kubebuilder:printcolumn:name="NodePool",type="string",JSONPath=".metadata.labels.karpenter\\.sh/nodepool",priority=1,description=""
 // +kubebuilder:printcolumn:name="NodeClass",type="string",JSONPath=".spec.nodeClassRef.name",priority=1,description=""
 type NodeClaim struct {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Old Printer Column 
```
NAME            TYPE         ZONE         NODE                                            READY   AGE    CAPACITY   NODEPOOL   NODECLASS
default-7lh6k   c6gn.large   us-west-2b   ip-192-168-183-234.us-west-2.compute.internal   True    2d7h   spot       default    default
```
- New Printer Column 
```
NAME               TYPE       CAPACITY   ZONE         NODE                                            READY   AGE   ID                                      NODEPOOL     NODECLASS
default-v1-2z2h5   t3.small   spot       us-west-2b   ip-192-168-42-3.us-west-2.compute.internal      True    29m   aws:///us-west-2b/i-0805c4361a70ee3fb   default-v1   default
```
- v1 RFC: https://github.com/kubernetes-sigs/karpenter/pull/1222

**How was this change tested?**
- manually tested

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
