### PR TITLE
feat: Add karpenter client-go metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.4
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/awslabs/operatorpkg v0.0.0-20240605172541-88cf99023fa4
+	github.com/awslabs/operatorpkg v0.0.0-20240628210115-2457d6af0d2f
 	github.com/docker/docker v26.1.4+incompatible
 	github.com/go-logr/logr v1.4.2
 	github.com/imdario/mergo v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/awslabs/operatorpkg v0.0.0-20240605172541-88cf99023fa4 h1:EVFVrteX0PQuofO9Ah4rf4aGyUkBM3lLuKgzwilAEAg=
-github.com/awslabs/operatorpkg v0.0.0-20240605172541-88cf99023fa4/go.mod h1:OR0NDOTl6XUXKgcksUab5d7mCnpaZf7Ko4eWEbheJTY=
+github.com/awslabs/operatorpkg v0.0.0-20240628210115-2457d6af0d2f h1:QSA8dxtEmwMbObJjF7FkLfTz21qRis0zLMAAnS7aTNA=
+github.com/awslabs/operatorpkg v0.0.0-20240628210115-2457d6af0d2f/go.mod h1:RxolNq1josGwaVEB5I19Y7dX01MPJdDppaM6tI8R4Q0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/awslabs/operatorpkg/controller"
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	"k8s.io/klog/v2"
@@ -86,6 +87,8 @@ var Version = "unspecified"
 
 func init() {
 	crmetrics.Registry.MustRegister(BuildInfo)
+	opmetrics.RegisterClientMetrics(crmetrics.Registry)
+
 	BuildInfo.WithLabelValues(Version, runtime.Version(), runtime.GOARCH, changeset.Get()).Set(1)
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add client-go metrics to Karpenter for storing the number of API calls generated from each container to the apiserver

```
client_go_request_duration_seconds_count{group="",kind="events",subresource="",verb="PATCH",version="v1"} 10
client_go_request_duration_seconds_count{group="",kind="nodes",subresource="",verb="DELETE",version="v1"} 12
client_go_request_duration_seconds_count{group="",kind="nodes",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="",kind="nodes",subresource="",verb="PATCH",version="v1"} 12
client_go_request_duration_seconds_count{group="",kind="pods",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="",kind="pods",subresource="eviction",verb="CREATE",version="v1"} 29
client_go_request_duration_seconds_count{group="",kind="services",subresource="",verb="GET",version="v1"} 1
client_go_request_duration_seconds_count{group="apps",kind="daemonsets",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="coordination.k8s.io",kind="leases",subresource="",verb="GET",version="v1"} 3
client_go_request_duration_seconds_count{group="coordination.k8s.io",kind="leases",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="coordination.k8s.io",kind="leases",subresource="",verb="UPDATE",version="v1"} 78
client_go_request_duration_seconds_count{group="karpenter.k8s.aws",kind="ec2nodeclasses",subresource="",verb="LIST",version="v1beta1"} 2
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="",verb="CREATE",version="v1beta1"} 12
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="",verb="LIST",version="v1beta1"} 1
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="",verb="PATCH",version="v1beta1"} 24
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="status",verb="PATCH",version="v1beta1"} 12
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="status",verb="UPDATE",version="v1beta1"} 40
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodepools",subresource="",verb="LIST",version="v1beta1"} 1
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodepools",subresource="status",verb="PATCH",version="v1beta1"} 14
client_go_request_duration_seconds_count{group="policy",kind="poddisruptionbudgets",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="storage.k8s.io",kind="csinodes",subresource="",verb="LIST",version="v1"} 1
```

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
