### PR TITLE
feat: expose nodeclaim disruption through new disruption condition, improves pod eviction event message

### DIFF
--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -30,6 +30,7 @@ const (
 	ConditionTypeDrifted              = "Drifted"
 	ConditionTypeInstanceTerminating  = "InstanceTerminating"
 	ConditionTypeConsistentStateFound = "ConsistentStateFound"
+	ConditionTypeDisruptionReason     = "DisruptionReason"
 )
 
 // NodeClaimStatus defines the observed state of NodeClaim

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -201,6 +201,7 @@ func (q *Queue) Reconcile(ctx context.Context) (reconcile.Result, error) {
 			consolidationTypeLabel: cmd.consolidationType,
 		})
 		multiErr := multierr.Combine(err, cmd.lastError, state.RequireNoScheduleTaint(ctx, q.kubeClient, false, cmd.candidates...))
+		multiErr = multierr.Combine(multiErr, state.ClearNodeClaimsCondition(ctx, q.kubeClient, v1.ConditionTypeDisruptionReason, cmd.candidates...))
 		// Log the error
 		log.FromContext(ctx).WithValues("nodes", strings.Join(lo.Map(cmd.candidates, func(s *state.StateNode, _ int) string {
 			return s.Name()

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			Expect(queue.Has(podSkip)).To(BeFalse())
+			Expect(queue.Has(node, podSkip)).To(BeFalse())
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Expect node to exist and be draining
@@ -233,7 +233,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			Expect(queue.Has(podSkip)).To(BeFalse())
+			Expect(queue.Has(node, podSkip)).To(BeFalse())
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Expect node to exist and be draining
@@ -243,7 +243,7 @@ var _ = Describe("Termination", func() {
 			EventuallyExpectTerminating(ctx, env.Client, podEvict)
 			ExpectDeleted(ctx, env.Client, podEvict)
 
-			Expect(queue.Has(podSkip)).To(BeFalse())
+			Expect(queue.Has(node, podSkip)).To(BeFalse())
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
@@ -357,13 +357,13 @@ var _ = Describe("Termination", func() {
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// Expect podNoEvict to be added to the queue
-			Expect(queue.Has(podNoEvict)).To(BeTrue())
+			Expect(queue.Has(node, podNoEvict)).To(BeTrue())
 
 			// Attempt to evict the pod, but fail to do so
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Expect podNoEvict to fail eviction due to PDB, and be retried
-			Expect(queue.Has(podNoEvict)).To(BeTrue())
+			Expect(queue.Has(node, podNoEvict)).To(BeTrue())
 
 			// Delete pod to simulate successful eviction
 			ExpectDeleted(ctx, env.Client, podNoEvict)
@@ -507,7 +507,7 @@ var _ = Describe("Termination", func() {
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Expect mirror pod to not be queued for eviction
-			Expect(queue.Has(podNoEvict)).To(BeFalse())
+			Expect(queue.Has(node, podNoEvict)).To(BeFalse())
 
 			// Expect podEvict to be enqueued for eviction then be successful
 			EventuallyExpectTerminating(ctx, env.Client, podEvict)
@@ -681,7 +681,7 @@ var _ = Describe("Termination", func() {
 			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
 
 			// Expect that the old pod's key still exists in the queue
-			Expect(queue.Has(pod)).To(BeTrue())
+			Expect(queue.Has(node, pod)).To(BeTrue())
 
 			// Re-create the pod and node, it should now have the same name, but a different UUID
 			node = test.Node(test.NodeOptions{

--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -26,12 +26,12 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 )
 
-func EvictPod(pod *corev1.Pod) events.Event {
+func EvictPod(pod *corev1.Pod, message string) events.Event {
 	return events.Event{
 		InvolvedObject: pod,
 		Type:           corev1.EventTypeNormal,
 		Reason:         "Evicted",
-		Message:        "Evicted pod",
+		Message:        "Evicted pod: " + message,
 		DedupeValues:   []string{pod.Name},
 	}
 }

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -109,7 +109,7 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 	for _, group := range podGroups {
 		if len(group) > 0 {
 			// Only add pods to the eviction queue that haven't been evicted yet
-			t.evictionQueue.Add(lo.Filter(group, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p) })...)
+			t.evictionQueue.Add(node, lo.Filter(group, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p) })...)
 			return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", lo.SumBy(podGroups, func(pods []*corev1.Pod) int { return len(pods) })))
 		}
 	}

--- a/pkg/events/suite_test.go
+++ b/pkg/events/suite_test.go
@@ -88,8 +88,8 @@ var _ = Describe("Event Creation", func() {
 		Expect(internalRecorder.Calls(schedulingevents.NominatePodEvent(PodWithUID(), NodeWithUID(), NodeClaimWithUID()).Reason)).To(Equal(1))
 	})
 	It("should create a EvictPod event", func() {
-		eventRecorder.Publish(terminatorevents.EvictPod(PodWithUID()))
-		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID()).Reason)).To(Equal(1))
+		eventRecorder.Publish(terminatorevents.EvictPod(PodWithUID(), ""))
+		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID(), "").Reason)).To(Equal(1))
 	})
 	It("should create a PodFailedToSchedule event", func() {
 		eventRecorder.Publish(schedulingevents.PodFailedToScheduleEvent(PodWithUID(), fmt.Errorf("")))
@@ -105,31 +105,31 @@ var _ = Describe("Dedupe", func() {
 	It("should only create a single event when many events are created quickly", func() {
 		pod := PodWithUID()
 		for i := 0; i < 100; i++ {
-			eventRecorder.Publish(terminatorevents.EvictPod(pod))
+			eventRecorder.Publish(terminatorevents.EvictPod(pod, ""))
 		}
-		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID()).Reason)).To(Equal(1))
+		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID(), "").Reason)).To(Equal(1))
 	})
 	It("should allow the dedupe timeout to be overridden", func() {
 		pod := PodWithUID()
-		evt := terminatorevents.EvictPod(pod)
+		evt := terminatorevents.EvictPod(pod, "")
 		evt.DedupeTimeout = time.Second * 2
 
 		// Generate a set of events within the dedupe timeout
 		for i := 0; i < 10; i++ {
 			eventRecorder.Publish(evt)
 		}
-		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID()).Reason)).To(Equal(1))
+		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID(), "").Reason)).To(Equal(1))
 
 		// Wait until after the overridden dedupe timeout
 		time.Sleep(time.Second * 3)
 		eventRecorder.Publish(evt)
-		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID()).Reason)).To(Equal(2))
+		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID(), "").Reason)).To(Equal(2))
 	})
 	It("should allow events with different entities to be created", func() {
 		for i := 0; i < 100; i++ {
-			eventRecorder.Publish(terminatorevents.EvictPod(PodWithUID()))
+			eventRecorder.Publish(terminatorevents.EvictPod(PodWithUID(), ""))
 		}
-		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID()).Reason)).To(Equal(100))
+		Expect(internalRecorder.Calls(terminatorevents.EvictPod(PodWithUID(), "").Reason)).To(Equal(100))
 	})
 })
 


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**

Add's a new nodeclaim condition `DisruptionCandidate` which is set when a nodeclaim is being disrupted, and is applied after the disruption taint is set. The `DisruptionCandidate` nodeclaim condition contains the reason why the nodeclaim is being terminated (e.g `node worker-mgn6n/ip-10-115-200-242.us-east-2.compute.internal  was single node consolidated`).

The motivation for this new nodeclaim condition is so that when evicting pods, we can look up this condition and use the condition's message in the pod event.

Example of what the pod events look like now from testing in our clusters:
```
keda                                          85s         Normal    Evicted                           pod/keda-admission-webhooks-5bd6b554ff-tn25h                                                Evicted pod: node worker-qa-czn28/ip-10-115-195-50.us-east-2.compute.internal drifted
keda                                          86s         Normal    Evicted                           pod/keda-operator-688bc9b887-7t4gd                                                          Evicted pod: node worker-qa-czn28/ip-10-115-195-50.us-east-2.compute.internal drifted
```

**How was this change tested?**

Built Karpenter with this change locally and tested in our clusters. Also `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
