### PR TITLE
chore: Group consolidation warning log lines together

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -179,46 +179,34 @@ func (p *Provisioner) GetPendingPods(ctx context.Context) ([]*v1.Pod, error) {
 
 // consolidationWarnings potentially writes logs warning about possible unexpected interactions
 // between scheduling constraints and consolidation
-// nolint:gocyclo
 func (p *Provisioner) consolidationWarnings(ctx context.Context, pods []*v1.Pod) {
-	// We keep track of exemplars which have the same generate name so that we print unique pods to start
-	// and then print the rest of the pods at the end
-	antiAffinityExemplars, topologySpreadExemplars := map[string]client.ObjectKey{}, map[string]client.ObjectKey{} // "{namespace}/{metadata.generateName}" -> pod key
-	var antiAffinityRemainingPods, topologySpreadRemainingPods []client.ObjectKey
-
 	// We have pending pods that have preferred anti-affinity or topology spread constraints.  These can interact
 	// unexpectedly with consolidation, so we warn once per hour when we see these pods.
-	for _, po := range pods {
-		exemplarKey := fmt.Sprintf("%s/%s", po.Namespace, po.GenerateName)
+	antiAffinityPods := lo.FilterMap(pods, func(po *v1.Pod, _ int) (client.ObjectKey, bool) {
 		if po.Spec.Affinity != nil && po.Spec.Affinity.PodAntiAffinity != nil {
 			if len(po.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0 {
 				if p.cm.HasChanged(string(po.UID), "pod-antiaffinity") {
-					if _, ok := antiAffinityExemplars[exemplarKey]; !ok {
-						antiAffinityExemplars[exemplarKey] = client.ObjectKeyFromObject(po)
-					} else {
-						antiAffinityRemainingPods = append(antiAffinityRemainingPods, client.ObjectKeyFromObject(po))
-					}
+					return client.ObjectKeyFromObject(po), true
 				}
 			}
 		}
+		return client.ObjectKey{}, false
+	})
+	topologySpreadPods := lo.FilterMap(pods, func(po *v1.Pod, _ int) (client.ObjectKey, bool) {
 		for _, tsc := range po.Spec.TopologySpreadConstraints {
 			if tsc.WhenUnsatisfiable == v1.ScheduleAnyway {
 				if p.cm.HasChanged(string(po.UID), "pod-topology-spread") {
-					if _, ok := topologySpreadExemplars[exemplarKey]; !ok {
-						topologySpreadExemplars[exemplarKey] = client.ObjectKeyFromObject(po)
-					} else {
-						topologySpreadRemainingPods = append(topologySpreadRemainingPods, client.ObjectKeyFromObject(po))
-					}
+					return client.ObjectKeyFromObject(po), true
 				}
 			}
 		}
-	}
+		return client.ObjectKey{}, false
+	})
 	// We reduce the amount of logging that we do per-pod by grouping log lines like this together
-	// We order the exemplars ahead of the remaining pods so that we make sure that we print unique pods first
-	if antiAffinityPods := append(lo.Values(antiAffinityExemplars), antiAffinityRemainingPods...); len(antiAffinityPods) > 0 {
+	if len(antiAffinityPods) > 0 {
 		log.FromContext(ctx).WithValues("pods", pretty.Slice(antiAffinityPods, 10)).Info("pod(s) have a preferred Anti-Affinity which can prevent consolidation")
 	}
-	if topologySpreadPods := append(lo.Values(topologySpreadExemplars), topologySpreadRemainingPods...); len(topologySpreadPods) > 0 {
+	if len(topologySpreadPods) > 0 {
 		log.FromContext(ctx).WithValues("pods", pretty.Slice(topologySpreadPods, 10)).Info("pod(s) have a preferred TopologySpreadConstraint which can prevent consolidation")
 	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Warnings for consolidation are useful for users to be aware that their consolidations can be blocked by preferences, but the number of warnings can be extremely verbose when there are a large number of replica pods that have the same configuration. This groups the logging messages together so there is only a single log line for a given set of pending pods during the provisioning loop.

**How was this change tested?**

`make presubmit`

### Before PR


```
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-fk7d6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-cglfs has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-f7q7t has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-fd4sw has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-rdpd6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-96t66 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-ds8km has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-bvxjv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-mdrpx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-nkpvc has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-8855d has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-8dzrl has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-n2rln has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-tgn86 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-4wnbd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-hw8dl has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-5kd5l has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-fq7t6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-kjswh has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-xj84v has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-p8x87 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-pf8rq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-fdwcd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-sgkbq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-x5d2s has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-bzv7f has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-wsc8m has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-hqt68 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-t2cwz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-fchsg has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-kbgkf has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-wbnrq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-mwl4k has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-z75qc has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-kkx5p has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-djb4c has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-5qq97 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-5gqhl has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-8zkbd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-9tnrz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-4dh88 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-cs4gr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-fx6q9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-6bksv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-q7t6z has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-qbvxl has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-72nzh has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-rvclg has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-2pdqv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-7q868 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-2qhlx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-pnlsv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-6qhkx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-g9776 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-4jgb8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-cwrx9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-mh4wv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-bz6ml has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-xtjrf has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-mk7ld has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-5s2xl has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-6cnrx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-gtmwq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-lthkd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-2n7ks has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-lgxdj has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-n2wgd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-2wwgn has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-ktv7k has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-n9mmx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-7k7sb has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-4q5n8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-lj9h8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-5v7n7 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-g7mw5 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-99p4q has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-cvl2w has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-wwcpn has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-vsgln has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-6cbc4 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-s6qr5 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-8gp7f has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-lrddt has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-qvl8t has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-tmnr4 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-9gqwl has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-k9grr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-68gjb has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-5g7l6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-5mjx9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-pblcz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-gm6cg has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-t7mqk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-nh7bq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-x9rpw has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-x55qm has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-ctsg2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/underwater-57bc5b9958-pqfgq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-28lqm has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-88x5z has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-q579g has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.143Z","logger":"controller","message":"pod default/inflate-77b4cd8856-4z6bs has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-cs2fq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-gsg7c has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-w4n9c has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-q4265 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-t5dfm has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-9lqpk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-bfwjf has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-5jvpt has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-6rt5h has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-qxwc8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-t25sv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-2mhhr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-mn27z has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-f44pb has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-49qtv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-rw572 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-dcthz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-sfhff has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-fzcnz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-jrdx2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-4ckwg has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-75c8t has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-qqd4m has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-svqz9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-vpwc8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-lm9wm has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-qkv9j has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-v9rpv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-prjjm has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-jqdmd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-jkl2t has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-9gl8g has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-bzjf2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-r7wts has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-jbqss has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-xtpsk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-8psrk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-h86kx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-twcdg has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-zw455 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-pzpkk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-564lr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-b5xns has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-zlgph has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-rqw5z has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-fczlr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-54qxz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-5t5fb has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-s6xfk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-7rt77 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-bm6bp has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-8c7vw has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-nwms6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-rqgx8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-wz8tk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-6xk7g has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-7lvrb has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-b62s7 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-g4g22 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-f2wdd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-h6gb5 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-tzg2c has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-ml7fx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-8wcr6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-zhvcj has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-rjfn2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-lf7ql has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-9pmbr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-l7pn8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-qnpxr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-pq4dw has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-dq8qr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-s4nwz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-gpw7d has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-p8dz8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-c5snt has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-nn6vm has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-sjxk6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-5ctkk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-zk2fm has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-qz7c6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-s27sj has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-z9j97 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-kkwhz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-x92rf has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-jrcgk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-jwt4z has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-btcsx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-q92sv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-x5dwm has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-8b9fw has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-ffrtl has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-jl6c5 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-42ntx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-9jvv2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-vvzbn has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-cx7z9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-9pccl has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-mvh67 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-thzzd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-vtqfg has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-9bmq2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-hmz2v has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-b95nt has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-5kx9w has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-mkjrd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-nvnnh has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-qwf9t has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-x899v has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-br96n has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-9xpkh has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-s6zkn has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-spvwn has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-994sq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-h8792 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-wqz6q has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/inflate-77b4cd8856-jqvm6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.144Z","logger":"controller","message":"pod default/underwater-57bc5b9958-pbls2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-vrkq5 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-kqhgx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-tnj7g has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-8mfbh has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-wmtj6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-mrjt4 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-jxgtw has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-pgqm8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-kq89k has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-qhktn has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-4xdwk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-6p65l has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-bz44q has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-zfww9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-zlfrz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-4thjg has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-9sf6r has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-vlbnb has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-8s2k9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-bbjdh has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-hqwhw has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-lzx6x has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-jth95 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-ljwx8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-8vd9l has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-tmv78 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-bs87h has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-b44jv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-p4z6b has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-cxcpr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-xkvtf has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-2bjcz has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-92xzr has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-krxv6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-pn2ls has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-tm762 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-42v4g has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-z6drc has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-h5wxs has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-9dsqt has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-7lsjc has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-gfwjk has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-hk65q has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-g7rxq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-qqq2f has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-tbf5r has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-xtxv5 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-bmfxd has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-k8jh9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-gztm4 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-vhhqf has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-bh8f7 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-fv9t9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-b9wjx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-r2wr9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-nksf4 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-scnjw has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-w57x8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-68xff has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-zrhr2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-fvsfb has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-jk6ql has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-9mhg2 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-ph5hx has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-hqt4w has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-xcx7c has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-xwhv6 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-gqz5g has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-kxmpb has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-gl8rv has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-bwxkq has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-ms75b has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/underwater-57bc5b9958-q9n2j has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-t9mh9 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-gwr5n has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default2/inflate-77b4cd8856-hdzkp has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-cmwbp has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-spkmn has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-vvxxs has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
{"level":"INFO","time":"2024-06-30T21:41:03.145Z","logger":"controller","message":"pod default/inflate-77b4cd8856-nvnv8 has a preferred Anti-Affinity which can prevent consolidation","commit":"490ef94","controller":"provisioner"}
```

### After PR

```
{"level":"INFO","time":"2024-06-30T21:39:12.258Z","logger":"controller","message":"pod(s) have a preferred Anti-Affinity which can prevent consolidation","commit":"914d8a9-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5ddcc054-fbad-4aef-8b2b-4085e6720f6e","pods":"default2/inflate-77b4cd8856-9bmq2, default/inflate-77b4cd8856-r2wr9, default/underwater-57bc5b9958-5kx9w, default2/inflate-77b4cd8856-z6drc, default/inflate-77b4cd8856-rqgx8, default/underwater-57bc5b9958-ffrtl, default2/inflate-77b4cd8856-h6gb5, default2/inflate-77b4cd8856-t25sv, default/inflate-77b4cd8856-k8jh9, default/underwater-57bc5b9958-lgxdj and 290 other(s)"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
