### PR TITLE
chore: Add an instancetype controller to encapsulate caching logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.5
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/awslabs/operatorpkg v0.0.0-20240628210115-2457d6af0d2f
+	github.com/awslabs/operatorpkg v0.0.0-20240701195752-116cbcffbcb4
 	github.com/docker/docker v27.0.2+incompatible
 	github.com/go-logr/logr v1.4.2
 	github.com/imdario/mergo v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/awslabs/operatorpkg v0.0.0-20240628210115-2457d6af0d2f h1:QSA8dxtEmwMbObJjF7FkLfTz21qRis0zLMAAnS7aTNA=
-github.com/awslabs/operatorpkg v0.0.0-20240628210115-2457d6af0d2f/go.mod h1:RxolNq1josGwaVEB5I19Y7dX01MPJdDppaM6tI8R4Q0=
+github.com/awslabs/operatorpkg v0.0.0-20240701195752-116cbcffbcb4 h1:mD24yp98VHBV3PympU2jTKAzKq1IIgpdZd9+aJOuxv8=
+github.com/awslabs/operatorpkg v0.0.0-20240701195752-116cbcffbcb4/go.mod h1:oQUBEhsmTceyAkUb7XRIYsMKvJkidoU3UpAa+beK/0w=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/apis/v1/doc.go
+++ b/pkg/apis/v1/doc.go
@@ -35,5 +35,6 @@ func init() {
 		&NodePool{},
 		&NodePoolList{},
 		&NodeClaim{},
-		&NodeClaimList{})
+		&NodeClaimList{},
+	)
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption/orchestration"
+	"sigs.k8s.io/karpenter/pkg/controllers/instancetype"
 	"sigs.k8s.io/karpenter/pkg/controllers/leasegarbagecollection"
 	metricsnode "sigs.k8s.io/karpenter/pkg/controllers/metrics/node"
 	metricsnodepool "sigs.k8s.io/karpenter/pkg/controllers/metrics/nodepool"
@@ -52,17 +53,18 @@ func NewControllers(
 	recorder events.Recorder,
 	cloudProvider cloudprovider.CloudProvider,
 ) []controller.Controller {
-
 	cluster := state.NewCluster(clock, kubeClient)
-	p := provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster)
+	instanceTypeProvider := instancetype.NewProvider(cloudProvider)
+	provisioner := provisioning.NewProvisioner(kubeClient, recorder, instanceTypeProvider, cluster)
+
 	evictionQueue := terminator.NewQueue(kubeClient, recorder)
-	disruptionQueue := orchestration.NewQueue(kubeClient, recorder, cluster, clock, p)
+	disruptionQueue := orchestration.NewQueue(kubeClient, recorder, cluster, clock, provisioner)
 
 	return []controller.Controller{
-		p, evictionQueue, disruptionQueue,
-		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue),
-		provisioning.NewPodController(kubeClient, p),
-		provisioning.NewNodeController(kubeClient, p),
+		provisioner, evictionQueue, disruptionQueue,
+		disruption.NewController(clock, kubeClient, provisioner, instanceTypeProvider, recorder, cluster, disruptionQueue),
+		provisioning.NewPodController(kubeClient, provisioner),
+		provisioning.NewNodeController(kubeClient, provisioner),
 		nodepoolhash.NewController(kubeClient),
 		informer.NewDaemonSetController(kubeClient, cluster),
 		informer.NewNodeController(kubeClient, cluster),

--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -29,9 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption/orchestration"
+	"sigs.k8s.io/karpenter/pkg/controllers/instancetype"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
@@ -55,21 +55,21 @@ type consolidation struct {
 	cluster                *state.Cluster
 	kubeClient             client.Client
 	provisioner            *provisioning.Provisioner
-	cloudProvider          cloudprovider.CloudProvider
+	instanceTypeProvider   *instancetype.Provider
 	recorder               events.Recorder
 	lastConsolidationState time.Time
 }
 
 func MakeConsolidation(clock clock.Clock, cluster *state.Cluster, kubeClient client.Client, provisioner *provisioning.Provisioner,
-	cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, queue *orchestration.Queue) consolidation {
+	instanceTypeProvider *instancetype.Provider, recorder events.Recorder, queue *orchestration.Queue) consolidation {
 	return consolidation{
-		queue:         queue,
-		clock:         clock,
-		cluster:       cluster,
-		kubeClient:    kubeClient,
-		provisioner:   provisioner,
-		cloudProvider: cloudProvider,
-		recorder:      recorder,
+		queue:                queue,
+		clock:                clock,
+		cluster:              cluster,
+		kubeClient:           kubeClient,
+		provisioner:          provisioner,
+		instanceTypeProvider: instanceTypeProvider,
+		recorder:             recorder,
 	}
 }
 

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -580,11 +580,11 @@ var _ = Describe("Consolidation", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
-			emptyConsolidation := disruption.NewEmptyNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			emptyConsolidation := disruption.NewEmptyNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, instanceTypeProvider, recorder, queue))
 			budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 			Expect(err).To(Succeed())
 
-			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, emptyConsolidation.ShouldDisrupt, queue)
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, instanceTypeProvider, emptyConsolidation.ShouldDisrupt, queue)
 			Expect(err).To(Succeed())
 
 			var wg sync.WaitGroup
@@ -644,11 +644,11 @@ var _ = Describe("Consolidation", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
-			emptyConsolidation := disruption.NewEmptyNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			emptyConsolidation := disruption.NewEmptyNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, instanceTypeProvider, recorder, queue))
 			budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 			Expect(err).To(Succeed())
 
-			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, emptyConsolidation.ShouldDisrupt, queue)
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, instanceTypeProvider, emptyConsolidation.ShouldDisrupt, queue)
 			Expect(err).To(Succeed())
 
 			var wg sync.WaitGroup
@@ -671,11 +671,11 @@ var _ = Describe("Consolidation", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
-			multiConsolidation := disruption.NewMultiNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			multiConsolidation := disruption.NewMultiNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, instanceTypeProvider, recorder, queue))
 			budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 			Expect(err).To(Succeed())
 
-			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, multiConsolidation.ShouldDisrupt, queue)
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, instanceTypeProvider, multiConsolidation.ShouldDisrupt, queue)
 			Expect(err).To(Succeed())
 
 			var wg sync.WaitGroup
@@ -735,11 +735,11 @@ var _ = Describe("Consolidation", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
-			multiConsolidation := disruption.NewMultiNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			multiConsolidation := disruption.NewMultiNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, instanceTypeProvider, recorder, queue))
 			budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 			Expect(err).To(Succeed())
 
-			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, multiConsolidation.ShouldDisrupt, queue)
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, instanceTypeProvider, multiConsolidation.ShouldDisrupt, queue)
 			Expect(err).To(Succeed())
 
 			var wg sync.WaitGroup
@@ -762,11 +762,11 @@ var _ = Describe("Consolidation", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
-			singleConsolidation := disruption.NewSingleNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			singleConsolidation := disruption.NewSingleNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, instanceTypeProvider, recorder, queue))
 			budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 			Expect(err).To(Succeed())
 
-			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, singleConsolidation.ShouldDisrupt, queue)
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, instanceTypeProvider, singleConsolidation.ShouldDisrupt, queue)
 			Expect(err).To(Succeed())
 
 			var wg sync.WaitGroup
@@ -826,11 +826,11 @@ var _ = Describe("Consolidation", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
-			singleConsolidation := disruption.NewSingleNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			singleConsolidation := disruption.NewSingleNodeConsolidation(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, instanceTypeProvider, recorder, queue))
 			budgets, err := disruption.BuildDisruptionBudgets(ctx, cluster, fakeClock, env.Client, recorder)
 			Expect(err).To(Succeed())
 
-			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, singleConsolidation.ShouldDisrupt, queue)
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, instanceTypeProvider, singleConsolidation.ShouldDisrupt, queue)
 			Expect(err).To(Succeed())
 
 			var wg sync.WaitGroup

--- a/pkg/controllers/disruption/emptynodeconsolidation.go
+++ b/pkg/controllers/disruption/emptynodeconsolidation.go
@@ -87,7 +87,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 	case <-c.clock.After(consolidationTTL):
 	}
 
-	v := NewValidation(c.clock, c.cluster, c.kubeClient, c.provisioner, c.cloudProvider, c.recorder, c.queue, v1beta1.DisruptionReasonEmpty)
+	v := NewValidation(c.clock, c.cluster, c.kubeClient, c.provisioner, c.instanceTypeProvider, c.recorder, c.queue, v1beta1.DisruptionReasonEmpty)
 	validatedCandidates, err := v.ValidateCandidates(ctx, cmd.candidates...)
 	if err != nil {
 		if IsValidationError(err) {

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -96,7 +96,7 @@ func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 		return cmd, scheduling.Results{}, nil
 	}
 
-	if err := NewValidation(m.clock, m.cluster, m.kubeClient, m.provisioner, m.cloudProvider, m.recorder, m.queue, v1beta1.DisruptionReasonUnderutilized).IsValid(ctx, cmd, consolidationTTL); err != nil {
+	if err := NewValidation(m.clock, m.cluster, m.kubeClient, m.provisioner, m.instanceTypeProvider, m.recorder, m.queue, v1beta1.DisruptionReasonUnderutilized).IsValid(ctx, cmd, consolidationTTL); err != nil {
 		if IsValidationError(err) {
 			log.FromContext(ctx).V(1).Info(fmt.Sprintf("abandoning multi-node consolidation attempt due to pod churn, command is no longer valid, %s", cmd))
 			return Command{}, scheduling.Results{}, nil

--- a/pkg/controllers/disruption/orchestration/suite_test.go
+++ b/pkg/controllers/disruption/orchestration/suite_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption/orchestration"
+	"sigs.k8s.io/karpenter/pkg/controllers/instancetype"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
@@ -51,6 +52,7 @@ var ctx context.Context
 var env *test.Environment
 var cluster *state.Cluster
 var cloudProvider *fake.CloudProvider
+var instanceTypeProvider *instancetype.Provider
 var nodeStateController *informer.NodeController
 var nodeClaimStateController *informer.NodeClaimController
 var fakeClock *clock.FakeClock
@@ -76,11 +78,12 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	fakeClock = clock.NewFakeClock(time.Now())
 	cloudProvider = fake.NewCloudProvider()
+	instanceTypeProvider = instancetype.NewProvider(cloudProvider)
 	cluster = state.NewCluster(fakeClock, env.Client)
 	nodeStateController = informer.NewNodeController(env.Client, cluster)
 	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cluster)
 	recorder = test.NewEventRecorder()
-	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster)
+	prov = provisioning.NewProvisioner(env.Client, recorder, instanceTypeProvider, cluster)
 	queue = orchestration.NewTestingQueue(env.Client, recorder, cluster, fakeClock, prov)
 })
 

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -47,7 +47,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 	}
 	candidates = s.sortCandidates(candidates)
 
-	v := NewValidation(s.clock, s.cluster, s.kubeClient, s.provisioner, s.cloudProvider, s.recorder, s.queue, v1beta1.DisruptionReasonUnderutilized)
+	v := NewValidation(s.clock, s.cluster, s.kubeClient, s.provisioner, s.instanceTypeProvider, s.recorder, s.queue, v1beta1.DisruptionReasonUnderutilized)
 
 	// Set a timeout
 	timeout := s.clock.Now().Add(SingleNodeConsolidationTimeoutDuration)

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption/orchestration"
+	"sigs.k8s.io/karpenter/pkg/controllers/instancetype"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
@@ -62,6 +63,7 @@ var cluster *state.Cluster
 var disruptionController *disruption.Controller
 var prov *provisioning.Provisioner
 var cloudProvider *fake.CloudProvider
+var instanceTypeProvider *instancetype.Provider
 var nodeStateController *informer.NodeController
 var nodeClaimStateController *informer.NodeClaimController
 var fakeClock *clock.FakeClock
@@ -85,14 +87,15 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(test.WithCRDs(coreapis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
+	instanceTypeProvider = instancetype.NewProvider(cloudProvider)
 	fakeClock = clock.NewFakeClock(time.Now())
 	cluster = state.NewCluster(fakeClock, env.Client)
 	nodeStateController = informer.NewNodeController(env.Client, cluster)
 	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cluster)
 	recorder = test.NewEventRecorder()
-	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster)
+	prov = provisioning.NewProvisioner(env.Client, recorder, instanceTypeProvider, cluster)
 	queue = orchestration.NewTestingQueue(env.Client, recorder, cluster, fakeClock, prov)
-	disruptionController = disruption.NewController(fakeClock, env.Client, prov, cloudProvider, recorder, cluster, queue)
+	disruptionController = disruption.NewController(fakeClock, env.Client, prov, instanceTypeProvider, recorder, cluster, queue)
 })
 
 var _ = AfterSuite(func() {
@@ -150,6 +153,7 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
 
+	instanceTypeProvider.Flush()
 	// Reset the metrics collectors
 	disruption.ActionsPerformedCounter.Reset()
 	disruption.NodesDisruptedCounter.Reset()
@@ -205,7 +209,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		// nodePool.Spec.Disruption.Budgets = []v1beta1.Budget{{Nodes: "100%"}}
 		// ExpectApplied(ctx, env.Client, nodePool)
 
-		nodePoolMap, nodePoolToInstanceTypesMap, err := disruption.BuildNodePoolMap(ctx, env.Client, cloudProvider)
+		nodePoolMap, nodePoolToInstanceTypesMap, err := disruption.BuildNodePoolMap(ctx, env.Client, instanceTypeProvider)
 		Expect(err).To(Succeed())
 
 		// Mark all nodeclaims as marked for deletion

--- a/pkg/controllers/instancetype/controller.go
+++ b/pkg/controllers/instancetype/controller.go
@@ -1,0 +1,54 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"context"
+
+	"github.com/awslabs/operatorpkg/reasonable"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+)
+
+type Controller struct {
+	provider *Provider
+}
+
+func NewController(provider *Provider) *Controller {
+	return &Controller{
+		provider: provider,
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool) (reconcile.Result, error) {
+	if _, err := c.provider.Get(ctx, nodePool); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{RequeueAfter: TTL}, nil
+}
+
+func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("instancetype").
+		For(&v1beta1.NodePool{}).
+		WithOptions(controller.Options{RateLimiter: reasonable.RateLimiter()}).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}

--- a/pkg/controllers/instancetype/provider.go
+++ b/pkg/controllers/instancetype/provider.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/awslabs/operatorpkg/option"
+	"github.com/patrickmn/go-cache"
+
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+)
+
+var TTL = 5 * time.Minute
+
+func NewProvider(cloudProvider cloudprovider.CloudProvider) *Provider {
+	return &Provider{
+		cloudProvider: cloudProvider,
+		instanceTypes: cache.New(TTL, TTL),
+	}
+}
+
+type Provider struct {
+	cloudProvider cloudprovider.CloudProvider
+	instanceTypes *cache.Cache
+}
+
+type Options struct {
+	Cached bool
+}
+
+func FromCache(cached bool) func(options *Options) {
+	return func(options *Options) {
+		options.Cached = cached
+	}
+}
+
+var DefaultOptions = []option.Function[Options]{
+	FromCache(false),
+}
+
+func (p *Provider) Get(ctx context.Context, nodePool *v1beta1.NodePool, optionFuncs ...option.Function[Options]) ([]*cloudprovider.InstanceType, error) {
+	options := option.Resolve(append(DefaultOptions, optionFuncs...)...)
+	if instanceTypes, ok := p.instanceTypes.Get(string(nodePool.UID)); options.Cached && ok {
+		return instanceTypes.([]*cloudprovider.InstanceType), nil
+	}
+	instanceTypes, err := p.get(ctx, nodePool)
+	if err != nil {
+		return nil, err
+	}
+	p.instanceTypes.SetDefault(string(nodePool.UID), instanceTypes)
+	return instanceTypes, nil
+}
+
+func (p *Provider) get(ctx context.Context, nodePool *v1beta1.NodePool) ([]*cloudprovider.InstanceType, error) {
+	instanceTypes, err := p.cloudProvider.GetInstanceTypes(ctx, nodePool)
+	if err != nil {
+		return nil, fmt.Errorf("getting instance types, %w", err)
+	}
+	return instanceTypes, nil
+}
+
+func (p *Provider) Flush() {
+	p.instanceTypes.Flush()
+}

--- a/pkg/controllers/instancetype/provider_test.go
+++ b/pkg/controllers/instancetype/provider_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancetype_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/instancetype"
+	"sigs.k8s.io/karpenter/pkg/test"
+)
+
+var _ = Describe("Provider", func() {
+
+	var _ = BeforeEach(func() {
+		cloudProvider.Reset()
+		cloudProvider.InstanceTypes = fake.InstanceTypes(6)
+		nodePool = test.NodePool()
+	})
+
+	It("should cache instance types", func() {
+		instancetypes, err := instanceTypeProvider.Get(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instancetypes).To(HaveLen(6))
+		cloudProvider.InstanceTypes = cloudProvider.InstanceTypes[1:]
+		// Read from cache
+		instancetypes, err = instanceTypeProvider.Get(ctx, nodePool, instancetype.FromCache(true))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instancetypes).To(HaveLen(6))
+		// Update the cache
+		instancetypes, err = instanceTypeProvider.Get(ctx, nodePool, instancetype.FromCache(false))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instancetypes).To(HaveLen(5))
+	})
+})

--- a/pkg/controllers/instancetype/suite_test.go
+++ b/pkg/controllers/instancetype/suite_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancetype_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"go.uber.org/zap/zaptest"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/instancetype"
+)
+
+var (
+	ctx                  context.Context
+	kubeClient           client.Client
+	cloudProvider        *fake.CloudProvider
+	instanceTypeProvider *instancetype.Provider
+	nodePool             *v1beta1.NodePool
+)
+
+func Test(t *testing.T) {
+	ctx = log.IntoContext(context.Background(), zapr.NewLogger(zaptest.NewLogger(t)))
+	env := envtest.Environment{Scheme: scheme.Scheme, CRDs: apis.CRDs}
+	defer func() { lo.Must0(env.Stop()) }()
+	kubeClient = lo.Must(client.New(lo.Must(env.Start()), client.Options{}))
+	cloudProvider = fake.NewCloudProvider()
+	instanceTypeProvider = instancetype.NewProvider(cloudProvider)
+
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Eviction")
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This is a first step in a multi-PR change that causes the Karpenter codebase to get instance types from an abstraction layer. In the future, we will hang Ice caching and #1305 on top of this provider.

**How was this change tested?**
* `make presubmit`
* Manually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
