### PR TITLE
chore: update kwok to v0.5.2 and scale back replicas

### DIFF
--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -217,7 +217,7 @@ func addInstanceLabels(labels map[string]string, instanceType *cloudprovider.Ins
 	// Kwok has some scalability limitations.
 	// Randomly add each new node to one of the pre-created kwokPartitions.
 
-	ret[v1alpha1.KwokPartitionLabelKey] = lo.Sample(KwokPartitions)
+	ret[v1alpha1.KwokPartitionLabelKey] = lo.Sample(kwokPartitions)
 	ret[v1beta1.CapacityTypeLabelKey] = offering.Requirements.Get(v1beta1.CapacityTypeLabelKey).Any()
 	ret[v1.LabelTopologyZone] = offering.Requirements.Get(v1.LabelTopologyZone).Any()
 	ret[v1.LabelHostname] = nodeClaim.Name

--- a/kwok/cloudprovider/const.go
+++ b/kwok/cloudprovider/const.go
@@ -20,8 +20,4 @@ const (
 	kwokProviderPrefix = "kwok://"
 )
 
-// Hard coded Kwok values
-var (
-	KwokPartitions = []string{"partition-a", "partition-b", "partition-c", "partition-d", "partition-e",
-		"partition-f", "partition-g", "partition-h", "partition-i", "partition-j"}
-)
+var kwokPartitions = []string{"a"}

--- a/kwok/cloudprovider/instance_types.json
+++ b/kwok/cloudprovider/instance_types.json
@@ -13128,7 +13128,7 @@
         "name": "c-48x-arm64-windows",
         "offerings": [
             {
-                "Price": 0.9121554505728001,
+                "Price": 0.9121554505728,
                 "Available": true,
                 "Requirements": [
                     {
@@ -13148,7 +13148,7 @@
                 ]
             },
             {
-                "Price": 1.3030792151040003,
+                "Price": 1.303079215104,
                 "Available": true,
                 "Requirements": [
                     {
@@ -13168,7 +13168,7 @@
                 ]
             },
             {
-                "Price": 0.9121554505728001,
+                "Price": 0.9121554505728,
                 "Available": true,
                 "Requirements": [
                     {
@@ -13188,7 +13188,7 @@
                 ]
             },
             {
-                "Price": 1.3030792151040003,
+                "Price": 1.303079215104,
                 "Available": true,
                 "Requirements": [
                     {
@@ -13208,7 +13208,7 @@
                 ]
             },
             {
-                "Price": 0.9121554505728001,
+                "Price": 0.9121554505728,
                 "Available": true,
                 "Requirements": [
                     {
@@ -13228,7 +13228,7 @@
                 ]
             },
             {
-                "Price": 1.3030792151040003,
+                "Price": 1.303079215104,
                 "Available": true,
                 "Requirements": [
                     {
@@ -13248,7 +13248,7 @@
                 ]
             },
             {
-                "Price": 0.9121554505728001,
+                "Price": 0.9121554505728,
                 "Available": true,
                 "Requirements": [
                     {
@@ -13268,7 +13268,7 @@
                 ]
             },
             {
-                "Price": 1.3030792151040003,
+                "Price": 1.303079215104,
                 "Available": true,
                 "Requirements": [
                     {
@@ -16978,7 +16978,7 @@
         "name": "c-96x-arm64-linux",
         "offerings": [
             {
-                "Price": 1.8243109011456,
+                "Price": 1.8243109011456002,
                 "Available": true,
                 "Requirements": [
                     {
@@ -16998,7 +16998,7 @@
                 ]
             },
             {
-                "Price": 2.606158430208,
+                "Price": 2.6061584302080005,
                 "Available": true,
                 "Requirements": [
                     {
@@ -17018,7 +17018,7 @@
                 ]
             },
             {
-                "Price": 1.8243109011456,
+                "Price": 1.8243109011456002,
                 "Available": true,
                 "Requirements": [
                     {
@@ -17038,7 +17038,7 @@
                 ]
             },
             {
-                "Price": 2.606158430208,
+                "Price": 2.6061584302080005,
                 "Available": true,
                 "Requirements": [
                     {
@@ -17058,7 +17058,7 @@
                 ]
             },
             {
-                "Price": 1.8243109011456,
+                "Price": 1.8243109011456002,
                 "Available": true,
                 "Requirements": [
                     {
@@ -17078,7 +17078,7 @@
                 ]
             },
             {
-                "Price": 2.606158430208,
+                "Price": 2.6061584302080005,
                 "Available": true,
                 "Requirements": [
                     {
@@ -17098,7 +17098,7 @@
                 ]
             },
             {
-                "Price": 1.8243109011456,
+                "Price": 1.8243109011456002,
                 "Available": true,
                 "Requirements": [
                     {
@@ -17118,7 +17118,7 @@
                 ]
             },
             {
-                "Price": 2.606158430208,
+                "Price": 2.6061584302080005,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21003,7 +21003,7 @@
         "name": "c-192x-amd64-linux",
         "offerings": [
             {
-                "Price": 3.6486218022912,
+                "Price": 3.6486218022912005,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21023,7 +21023,7 @@
                 ]
             },
             {
-                "Price": 5.212316860416,
+                "Price": 5.212316860416001,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21043,7 +21043,7 @@
                 ]
             },
             {
-                "Price": 3.6486218022912,
+                "Price": 3.6486218022912005,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21063,7 +21063,7 @@
                 ]
             },
             {
-                "Price": 5.212316860416,
+                "Price": 5.212316860416001,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21083,7 +21083,7 @@
                 ]
             },
             {
-                "Price": 3.6486218022912,
+                "Price": 3.6486218022912005,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21103,7 +21103,7 @@
                 ]
             },
             {
-                "Price": 5.212316860416,
+                "Price": 5.212316860416001,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21123,7 +21123,7 @@
                 ]
             },
             {
-                "Price": 3.6486218022912,
+                "Price": 3.6486218022912005,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21143,7 +21143,7 @@
                 ]
             },
             {
-                "Price": 5.212316860416,
+                "Price": 5.212316860416001,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21178,7 +21178,7 @@
         "name": "c-192x-arm64-linux",
         "offerings": [
             {
-                "Price": 3.6486218022912005,
+                "Price": 3.6486218022912,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21198,7 +21198,7 @@
                 ]
             },
             {
-                "Price": 5.212316860416001,
+                "Price": 5.212316860416,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21218,7 +21218,7 @@
                 ]
             },
             {
-                "Price": 3.6486218022912005,
+                "Price": 3.6486218022912,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21238,7 +21238,7 @@
                 ]
             },
             {
-                "Price": 5.212316860416001,
+                "Price": 5.212316860416,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21258,7 +21258,7 @@
                 ]
             },
             {
-                "Price": 3.6486218022912005,
+                "Price": 3.6486218022912,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21278,7 +21278,7 @@
                 ]
             },
             {
-                "Price": 5.212316860416001,
+                "Price": 5.212316860416,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21298,7 +21298,7 @@
                 ]
             },
             {
-                "Price": 3.6486218022912005,
+                "Price": 3.6486218022912,
                 "Available": true,
                 "Requirements": [
                     {
@@ -21318,7 +21318,7 @@
                 ]
             },
             {
-                "Price": 5.212316860416001,
+                "Price": 5.212316860416,
                 "Available": true,
                 "Requirements": [
                     {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Upgrades kwok to the latest version, and scales back the number of partitions to 1, so that multiple kwok controllers aren't competing for a kind cluster's limited control plane resources.

Note: if you were using kwok before this PR, you'll need to `make uninstall-kwok` on a commit before this to fully clean up all kwok controllers/resources.

**How was this change tested?**
make install-kwok && make apply 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
