### PR TITLE
chore: Remove usage of `knative.dev` logger

### DIFF
--- a/pkg/apis/v1/suite_test.go
+++ b/pkg/apis/v1/suite_test.go
@@ -24,7 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -112,10 +112,6 @@ func NewController(kubeClient client.Client) *Controller {
 	}
 }
 
-func (c *Controller) Name() string {
-	return "metrics.pod"
-}
-
 // Reconcile executes a termination control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	ctx = injection.WithControllerName(ctx, "metrics.pod")

--- a/pkg/controllers/nodeclaim/termination/controller.go
+++ b/pkg/controllers/nodeclaim/termination/controller.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"knative.dev/pkg/logging"
-
 	"sigs.k8s.io/karpenter/pkg/utils/termination"
 
 	"sigs.k8s.io/karpenter/pkg/metrics"
@@ -136,13 +134,8 @@ func (c *Controller) finalize(ctx context.Context, nodeClaim *v1beta1.NodeClaim)
 		NodeClaimTerminationDuration.With(map[string]string{
 			metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],
 		}).Observe(time.Since(stored.DeletionTimestamp.Time).Seconds())
-		logging.FromContext(ctx).Infof("deleted nodeclaim")
 	}
 	return reconcile.Result{}, nil
-}
-
-func (*Controller) Name() string {
-	return ""
 }
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {

--- a/pkg/utils/disruption/disruption.go
+++ b/pkg/utils/disruption/disruption.go
@@ -18,14 +18,15 @@ package disruption
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"strconv"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 )
@@ -51,8 +52,8 @@ func EvictionCost(ctx context.Context, p *v1.Pod) float64 {
 	if ok {
 		podDeletionCost, err := strconv.ParseFloat(podDeletionCostStr, 64)
 		if err != nil {
-			logging.FromContext(ctx).Errorf("parsing %s=%s from pod %s, %s",
-				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p), err)
+			log.FromContext(ctx).Error(err, fmt.Sprintf("failed parsing %s=%s from pod %s",
+				v1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p)))
 		} else {
 			// the pod deletion disruptionCost is in [-2147483647, 2147483647]
 			// the min pod disruptionCost makes one pod ~ -15 pods, and the max pod disruptionCost to ~ 17 pods.

--- a/pkg/utils/node/suite_test.go
+++ b/pkg/utils/node/suite_test.go
@@ -25,7 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"

--- a/pkg/utils/termination/suite_test.go
+++ b/pkg/utils/termination/suite_test.go
@@ -27,7 +27,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "knative.dev/pkg/logging/testing"
+
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Remove spurious log line for `terminated nodeclaim` that was causing the following log line with the fallback logger

```
{"level":"info","ts":1719908125.4508243,"logger":"fallback","caller":"termination/controller.go:139","msg":"deleted nodeclaim"}
```

This also replaces the usage of the `logging.FromContext(ctx).Error()` call that was being made in the disruption controller

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
