### PR TITLE
chore: Add operator status condition metrics

### DIFF
--- a/kwok/main.go
+++ b/kwok/main.go
@@ -34,6 +34,7 @@ func main() {
 	cloudProvider := kwok.NewCloudProvider(ctx, op.GetClient(), instanceTypes)
 	op.
 		WithControllers(ctx, controllers.NewControllers(
+			op.Manager,
 			op.Clock,
 			op.GetClient(),
 			op.EventRecorder,

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -18,8 +18,12 @@ package controllers
 
 import (
 	"github.com/awslabs/operatorpkg/controller"
+	"github.com/awslabs/operatorpkg/status"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 
 	nodepoolreadiness "sigs.k8s.io/karpenter/pkg/controllers/nodepool/readiness"
 
@@ -47,6 +51,7 @@ import (
 )
 
 func NewControllers(
+	mgr manager.Manager,
 	clock clock.Clock,
 	kubeClient client.Client,
 	recorder events.Recorder,
@@ -82,5 +87,7 @@ func NewControllers(
 		nodeclaimtermination.NewController(kubeClient, cloudProvider),
 		nodeclaimdisruption.NewController(clock, kubeClient, cluster, cloudProvider),
 		leasegarbagecollection.NewController(kubeClient),
+		status.NewController[*v1beta1.NodeClaim](kubeClient, mgr.GetEventRecorderFor("karpenter")),
+		status.NewController[*v1beta1.NodePool](kubeClient, mgr.GetEventRecorderFor("karpenter")),
 	}
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -41,6 +41,8 @@ import (
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/events"
+
 	"sigs.k8s.io/karpenter/pkg/metrics"
 
 	"github.com/samber/lo"
@@ -63,7 +65,6 @@ import (
 	"github.com/go-logr/zapr"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
-	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	"sigs.k8s.io/karpenter/pkg/operator/logging"
 	"sigs.k8s.io/karpenter/pkg/operator/options"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add `operator_status_condition_count` and `operator_status_condition_transition_seconds` from operatorpkg for NodePool and NodeClaim

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
