### PR TITLE
test: remove k8s 1.23 and 1.24 tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8sVersion: ["1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x", "1.28.x", "1.29.x", "1.30.x"]
+        k8sVersion: ["1.25.x", "1.26.x", "1.27.x", "1.28.x", "1.29.x", "1.30.x"]
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Set up Python 3.10

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          k8sVersion: ["1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x", "1.28.x", "1.29.x", "1.30.x"]
+          k8sVersion: ["1.25.x", "1.26.x", "1.27.x", "1.28.x", "1.29.x", "1.30.x"]
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - uses: ./.github/actions/install-deps

--- a/test/suites/perf/scheduling_test.go
+++ b/test/suites/perf/scheduling_test.go
@@ -93,11 +93,14 @@ var _ = Describe("Performance", func() {
 		It("should do complex provisioning", func() {
 			deployments := []*appsv1.Deployment{}
 			podOptions := test.MakeDiversePodOptions()
+			totalReplicas := 0
 			for _, option := range podOptions {
+				podDensity := replicas / len(podOptions)
+				totalReplicas += podDensity
 				deployments = append(deployments, test.Deployment(
 					test.DeploymentOptions{
 						PodOptions: option,
-						Replicas:   int32(replicas / len(podOptions)),
+						Replicas:   int32(podDensity),
 					},
 				))
 			}
@@ -106,17 +109,20 @@ var _ = Describe("Performance", func() {
 			}
 			env.TimeIntervalCollector.Start("PostDeployment")
 			env.ExpectCreated(nodePool, nodeClass)
-			env.EventuallyExpectHealthyPodCountWithTimeout(10*time.Minute, labelSelector, len(deployments)*replicas)
+			env.EventuallyExpectHealthyPodCountWithTimeout(10*time.Minute, labelSelector, totalReplicas)
 			env.TimeIntervalCollector.End("PostDeployment")
 		})
 		It("should do complex provisioning and complex drift", func() {
 			deployments := []*appsv1.Deployment{}
 			podOptions := test.MakeDiversePodOptions()
+			totalReplicas := 0
 			for _, option := range podOptions {
+				podDensity := replicas / len(podOptions)
+				totalReplicas += podDensity
 				deployments = append(deployments, test.Deployment(
 					test.DeploymentOptions{
 						PodOptions: option,
-						Replicas:   int32(replicas / len(podOptions)),
+						Replicas:   int32(podDensity),
 					},
 				))
 			}
@@ -125,7 +131,7 @@ var _ = Describe("Performance", func() {
 			}
 
 			env.ExpectCreated(nodePool, nodeClass)
-			env.EventuallyExpectHealthyPodCountWithTimeout(10*time.Minute, labelSelector, len(deployments)*replicas)
+			env.EventuallyExpectHealthyPodCountWithTimeout(10*time.Minute, labelSelector, totalReplicas)
 
 			env.TimeIntervalCollector.Start("Drift")
 			nodePool.Spec.Template.ObjectMeta.Labels = lo.Assign(nodePool.Spec.Template.ObjectMeta.Labels, map[string]string{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
At v1, we'll only need to support 1.25 as we'll rely on CEL for CRD validation which is only available 1.25+. 

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
