### PR TITLE
test: fix kind cluster test cleanup flakes

### DIFF
--- a/hack/install-kwok.sh
+++ b/hack/install-kwok.sh
@@ -112,8 +112,8 @@ crdURL="https://github.com/${KWOK_REPO}/releases/download/${KWOK_RELEASE}/stage-
 # Set UNINSTALL_KWOK=true if you want to uninstall.
 if [[ ${UNINSTALL_KWOK} = "true" ]]
 then
-  kubectl delete -f ${HOME_DIR}/kwok.yaml
   kubectl delete -f ${crdURL}
+  kubectl delete -f ${HOME_DIR}/kwok.yaml
 else
   kubectl apply -f ${HOME_DIR}/kwok.yaml
   kubectl apply -f ${crdURL}

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -56,12 +56,12 @@ var (
 		&v1.PersistentVolumeClaim{},
 		&v1.PersistentVolume{},
 		&storagev1.StorageClass{},
-		&v1beta1.NodePool{},
-		&v1.LimitRange{},
-		&schedulingv1.PriorityClass{},
 		&v1.Node{},
 		&v1beta1.NodeClaim{},
+		&v1beta1.NodePool{},
 		&v1alpha1.KWOKNodeClass{},
+		&v1.LimitRange{},
+		&schedulingv1.PriorityClass{},
 	}
 )
 

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -135,7 +135,6 @@ func (env *Environment) CleanupObjects(cleanableObjects ...client.Object) {
 					defer GinkgoRecover()
 					g.Expect(env.ExpectTestingFinalizerRemoved(&metaList.Items[i])).To(Succeed())
 					g.Expect(client.IgnoreNotFound(env.Client.Delete(env, &metaList.Items[i],
-						// client.PropagationPolicy(metav1.DeletePropagationForeground),
 						&client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
 				})
 				// If the deletes eventually succeed, we should have no elements here at the end of the test

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -135,7 +135,7 @@ func (env *Environment) CleanupObjects(cleanableObjects ...client.Object) {
 					defer GinkgoRecover()
 					g.Expect(env.ExpectTestingFinalizerRemoved(&metaList.Items[i])).To(Succeed())
 					g.Expect(client.IgnoreNotFound(env.Client.Delete(env, &metaList.Items[i],
-						client.PropagationPolicy(metav1.DeletePropagationForeground),
+						// client.PropagationPolicy(metav1.DeletePropagationForeground),
 						&client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
 				})
 				// If the deletes eventually succeed, we should have no elements here at the end of the test

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -56,12 +56,12 @@ var (
 		&v1.PersistentVolumeClaim{},
 		&v1.PersistentVolume{},
 		&storagev1.StorageClass{},
-		&v1.Node{},
-		&v1beta1.NodeClaim{},
 		&v1beta1.NodePool{},
-		&v1alpha1.KWOKNodeClass{},
 		&v1.LimitRange{},
 		&schedulingv1.PriorityClass{},
+		&v1.Node{},
+		&v1beta1.NodeClaim{},
+		&v1alpha1.KWOKNodeClass{},
 	}
 )
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fix test flakes that were preventing kind clusters from cleaning up. Resources were stuck in a foreground deleting, where these resources are all fake, so we don't need to wait for all resources to be cleaned up. 

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
