### PR TITLE
chore: update nodepool readiness to rely on nodeClass deletion timestamp

### DIFF
--- a/pkg/controllers/nodepool/readiness/controller.go
+++ b/pkg/controllers/nodepool/readiness/controller.go
@@ -63,6 +63,8 @@ func (c *Controller) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool) 
 	}
 	if nodeClass == nil {
 		nodePool.StatusConditions().SetFalse(v1beta1.ConditionTypeNodeClassReady, "UnresolvedNodeClass", "Unable to resolve nodeClass")
+	} else if !nodeClass.GetDeletionTimestamp().IsZero() {
+		nodePool.StatusConditions().SetFalse(v1beta1.ConditionTypeNodeClassReady, "NodeClassTerminating", "NodeClass is Terminating")
 	} else {
 		c.setReadyCondition(nodePool, nodeClass)
 	}

--- a/pkg/controllers/nodepool/readiness/suite_test.go
+++ b/pkg/controllers/nodepool/readiness/suite_test.go
@@ -112,4 +112,11 @@ var _ = Describe("Readiness", func() {
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().IsTrue(status.ConditionReady)).To(BeFalse())
 	})
+	It("should mark NodeClassReady status condition on nodePool as NotReady if nodeClass is terminating", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		ExpectDeletionTimestampSet(ctx, env.Client, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+		Expect(nodePool.StatusConditions().Get(status.ConditionReady).IsFalse()).To(BeTrue())
+	})
 })

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -238,10 +238,6 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	domains := map[string]sets.Set[string]{}
 	var notReadyNodePools []string
 	for _, nodePool := range nodePoolList.Items {
-		if !nodePool.StatusConditions().IsTrue(status.ConditionReady) {
-			notReadyNodePools = append(notReadyNodePools, nodePool.Name)
-			continue
-		}
 		// Get instance type options
 		instanceTypeOptions, err := p.cloudProvider.GetInstanceTypes(ctx, lo.ToPtr(nodePool))
 		if err != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Nodepool readiness condition should rely on nodeClass. If nodeClass has a deletion timestamp set then nodepool will become non-ready.
Also removed duplicate check for nodePool readiness.

**How was this change tested?**
Tested on local cluster. Added functional tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
