### PR TITLE
chore: Add check for conflict during registration flow

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -24,6 +24,7 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -71,6 +72,9 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeCla
 	}
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Node", klog.KRef("", node.Name)))
 	if err = r.syncNode(ctx, nodeClaim, node); err != nil {
+		if errors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		return reconcile.Result{}, err
 	}
 	log.FromContext(ctx).Info("registered nodeclaim")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add check for conflict error during registration flow to reduce errors fired by the NodeClaim lifecycle controller

```console
{"level":"INFO","time":"2024-07-10T07:03:08.041Z","logger":"controller","message":"registered nodeclaim","commit":"ff0dc7d","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-64wj8"},"namespace":"","name":"default-64wj8","reconcileID":"c4f8281e-21b2-41bb-b120-a63f06483da8","provider-id":"aws:///us-west-2c/i-0b692de472e2796ea","Node":{"name":"ip-192-168-126-131.us-west-2.compute.internal"}}
{"level":"ERROR","time":"2024-07-10T07:03:08.616Z","logger":"controller","message":"Reconciler error","commit":"ff0dc7d","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-2jcck"},"namespace":"","name":"default-2jcck","reconcileID":"8a994ca3-5210-4f8c-a44f-fa48934152af","error":"syncing node, Operation cannot be fulfilled on nodes \"ip-192-168-99-138.us-west-2.compute.internal\": the object has been modified; please apply your changes to the latest version and try again"}
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
