### PR TITLE
fix: update nodeClassRef.apiVersion refs to group

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -200,7 +200,7 @@ func NewOperator() (context.Context, *Operator) {
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodeClaim{}, "status.providerID", func(o client.Object) []string {
 		return []string{o.(*v1.NodeClaim).Status.ProviderID}
 	}), "failed to setup nodeclaim provider id indexer")
-	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodeClaim{}, "spec.nodeClassRef.apiVersion", func(o client.Object) []string {
+	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodeClaim{}, "spec.nodeClassRef.group", func(o client.Object) []string {
 		return []string{o.(*v1.NodeClaim).Spec.NodeClassRef.Group}
 	}), "failed to setup nodeclaim nodeclassref apiversion indexer")
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodeClaim{}, "spec.nodeClassRef.kind", func(o client.Object) []string {
@@ -209,7 +209,7 @@ func NewOperator() (context.Context, *Operator) {
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodeClaim{}, "spec.nodeClassRef.name", func(o client.Object) []string {
 		return []string{o.(*v1.NodeClaim).Spec.NodeClassRef.Name}
 	}), "failed to setup nodeclaim nodeclassref name indexer")
-	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodePool{}, "spec.template.spec.nodeClassRef.apiVersion", func(o client.Object) []string {
+	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodePool{}, "spec.template.spec.nodeClassRef.group", func(o client.Object) []string {
 		return []string{o.(*v1.NodePool).Spec.Template.Spec.NodeClassRef.Group}
 	}), "failed to setup nodepool nodeclassref apiversion indexer")
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1.NodePool{}, "spec.template.spec.nodeClassRef.kind", func(o client.Object) []string {

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -95,9 +95,9 @@ func NodeClassEventHandler(c client.Client) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) (requests []reconcile.Request) {
 		nodeClaimList := &v1.NodeClaimList{}
 		if err := c.List(ctx, nodeClaimList, client.MatchingFields{
-			"spec.nodeClassRef.apiVersion": object.GVK(o).GroupVersion().String(),
-			"spec.nodeClassRef.kind":       object.GVK(o).Kind,
-			"spec.nodeClassRef.name":       o.GetName(),
+			"spec.nodeClassRef.group": object.GVK(o).Group,
+			"spec.nodeClassRef.kind":  object.GVK(o).Kind,
+			"spec.nodeClassRef.name":  o.GetName(),
 		}); err != nil {
 			return requests
 		}

--- a/pkg/utils/nodepool/nodepool.go
+++ b/pkg/utils/nodepool/nodepool.go
@@ -35,9 +35,9 @@ func NodeClassEventHandler(c client.Client) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) (requests []reconcile.Request) {
 		nodePoolList := &v1.NodePoolList{}
 		if err := c.List(ctx, nodePoolList, client.MatchingFields{
-			"spec.template.spec.nodeClassRef.apiVersion": object.GVK(o).GroupVersion().String(),
-			"spec.template.spec.nodeClassRef.kind":       object.GVK(o).Kind,
-			"spec.template.spec.nodeClassRef.name":       o.GetName(),
+			"spec.template.spec.nodeClassRef.group": object.GVK(o).Group,
+			"spec.template.spec.nodeClassRef.kind":  object.GVK(o).Kind,
+			"spec.template.spec.nodeClassRef.name":  o.GetName(),
 		}); err != nil {
 			return requests
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Update previous refs to `nodeClassRef.apiVersion` to properly refer to `nodeClassRef.group`. This was causing NodePool readiness failures since we were trying to match against a NodeClass with a group that matches the apiVersion. 

**How was this change tested?**
Tested against the AWS provider

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
