### PR TITLE
chore: Reconfigure metrics that are duplicated

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -233,7 +233,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -253,7 +253,7 @@ var _ = Describe("Consolidation", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -413,7 +413,7 @@ var _ = Describe("Consolidation", func() {
 			wg.Wait()
 
 			for _, np := range nps {
-				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
 				})
 				Expect(found).To(BeTrue())
@@ -477,7 +477,7 @@ var _ = Describe("Consolidation", func() {
 			wg.Wait()
 
 			for _, np := range nps {
-				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
 				})
 				Expect(found).To(BeTrue())
@@ -536,7 +536,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			for _, np := range nps {
-				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
 				})
 				Expect(found).To(BeTrue())

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -229,18 +229,12 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command, 
 	}
 
 	// An action is only performed and pods/nodes are only disrupted after a successful add to the queue
-	ActionsPerformedCounter.With(map[string]string{
+	DecisionsPerformedCounter.With(map[string]string{
 		actionLabel:            string(cmd.Action()),
 		methodLabel:            m.Type(),
 		consolidationTypeLabel: m.ConsolidationType(),
 	}).Inc()
 	for _, cd := range cmd.candidates {
-		NodesDisruptedCounter.With(map[string]string{
-			metrics.NodePoolLabel:  cd.nodePool.Name,
-			actionLabel:            string(cmd.Action()),
-			methodLabel:            m.Type(),
-			consolidationTypeLabel: m.ConsolidationType(),
-		}).Inc()
 		PodsDisruptedCounter.With(map[string]string{
 			metrics.NodePoolLabel:  cd.nodePool.Name,
 			actionLabel:            string(cmd.Action()),

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Drift", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
 
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -190,7 +190,7 @@ var _ = Describe("Drift", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
 
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -228,7 +228,7 @@ var _ = Describe("Drift", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -366,7 +366,7 @@ var _ = Describe("Drift", func() {
 			ExpectSingletonReconciled(ctx, disruptionController)
 
 			for _, np := range nps {
-				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
 				})
 				Expect(found).To(BeTrue())
@@ -427,7 +427,7 @@ var _ = Describe("Drift", func() {
 			ExpectSingletonReconciled(ctx, disruptionController)
 
 			for _, np := range nps {
-				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
 				})
 				Expect(found).To(BeTrue())

--- a/pkg/controllers/disruption/emptiness_test.go
+++ b/pkg/controllers/disruption/emptiness_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Emptiness", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -198,7 +198,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
 
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -239,7 +239,7 @@ var _ = Describe("Emptiness", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
 			Expect(found).To(BeTrue())
@@ -304,7 +304,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectSingletonReconciled(ctx, disruptionController)
 
 			for _, np := range nps {
-				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
 				})
 				Expect(found).To(BeTrue())
@@ -368,7 +368,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			for _, np := range nps {
-				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
+				metric, found := FindMetricWithLabelValues("karpenter_nodepool_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
 				})
 				Expect(found).To(BeTrue())

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -239,7 +239,7 @@ func BuildDisruptionBudgets(ctx context.Context, cluster *state.Cluster, clk clo
 			disruptionBudgetMapping[nodePool.Name][reason] = allowedDisruptions
 
 			allowedDisruptionsTotal += allowedDisruptions
-			BudgetsAllowedDisruptionsGauge.With(map[string]string{
+			NodePoolAllowedDisruptionsGauge.With(map[string]string{
 				metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
 			}).Set(float64(allowedDisruptions))
 			if allowedDisruptions == 0 {

--- a/pkg/controllers/disruption/metrics.go
+++ b/pkg/controllers/disruption/metrics.go
@@ -26,12 +26,11 @@ import (
 func init() {
 	crmetrics.Registry.MustRegister(
 		EvaluationDurationHistogram,
-		ActionsPerformedCounter,
-		NodesDisruptedCounter,
+		DecisionsPerformedCounter,
 		PodsDisruptedCounter,
 		EligibleNodesGauge,
 		ConsolidationTimeoutTotalCounter,
-		BudgetsAllowedDisruptionsGauge,
+		NodePoolAllowedDisruptionsGauge,
 	)
 }
 
@@ -53,23 +52,14 @@ var (
 		},
 		[]string{methodLabel, consolidationTypeLabel},
 	)
-	ActionsPerformedCounter = prometheus.NewCounterVec(
+	DecisionsPerformedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: disruptionSubsystem,
-			Name:      "actions_performed_total",
-			Help:      "Number of disruption actions performed. Labeled by disruption action, method, and consolidation type.",
+			Name:      "decisions_total",
+			Help:      "Number of disruption decisions performed. Labeled by disruption action, method, and consolidation type.",
 		},
 		[]string{actionLabel, methodLabel, consolidationTypeLabel},
-	)
-	NodesDisruptedCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metrics.Namespace,
-			Subsystem: disruptionSubsystem,
-			Name:      "nodes_disrupted_total",
-			Help:      "Total number of nodes disrupted. Labeled by NodePool, disruption action, method, and consolidation type.",
-		},
-		[]string{metrics.NodePoolLabel, actionLabel, methodLabel, consolidationTypeLabel},
 	)
 	PodsDisruptedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -98,12 +88,12 @@ var (
 		},
 		[]string{consolidationTypeLabel},
 	)
-	BudgetsAllowedDisruptionsGauge = prometheus.NewGaugeVec(
+	NodePoolAllowedDisruptionsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: disruptionSubsystem,
-			Name:      "budgets_allowed_disruptions",
-			Help:      "The number of nodes for a given NodePool that can be disrupted at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.",
+			Subsystem: metrics.NodePoolSubsystem,
+			Name:      "allowed_disruptions",
+			Help:      "The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.",
 		},
 		[]string{metrics.NodePoolLabel, metrics.ReasonLabel},
 	)

--- a/pkg/controllers/disruption/orchestration/metrics.go
+++ b/pkg/controllers/disruption/orchestration/metrics.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(disruptionReplacementNodeClaimInitializedHistogram, disruptionReplacementNodeClaimFailedCounter, disruptionQueueDepthGauge)
+	crmetrics.Registry.MustRegister(disruptionReplacementNodeClaimInitializedHistogram, disruptionQueueFailedCounter, disruptionQueueDepthGauge)
 }
 
 const (
@@ -43,12 +43,12 @@ var (
 			Buckets:   metrics.DurationBuckets(),
 		},
 	)
-	disruptionReplacementNodeClaimFailedCounter = prometheus.NewCounterVec(
+	disruptionQueueFailedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: disruptionSubsystem,
-			Name:      "replacement_nodeclaim_failures_total",
-			Help:      "The number of times that Karpenter failed to launch a replacement node for disruption. Labeled by disruption method.",
+			Name:      "queue_failures_total",
+			Help:      "The number of times that an enqueued disruption decision failed. Labeled by disruption method.",
 		},
 		[]string{methodLabel, consolidationTypeLabel},
 	)

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -202,7 +202,7 @@ func (q *Queue) Reconcile(ctx context.Context) (reconcile.Result, error) {
 		failedLaunches := lo.Filter(cmd.Replacements, func(r Replacement, _ int) bool {
 			return !r.Initialized
 		})
-		disruptionReplacementNodeClaimFailedCounter.With(map[string]string{
+		disruptionQueueFailedCounter.With(map[string]string{
 			methodLabel:            cmd.method,
 			consolidationTypeLabel: cmd.consolidationType,
 		}).Add(float64(len(failedLaunches)))

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -151,8 +151,7 @@ var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
 
 	// Reset the metrics collectors
-	disruption.ActionsPerformedCounter.Reset()
-	disruption.NodesDisruptedCounter.Reset()
+	disruption.DecisionsPerformedCounter.Reset()
 	disruption.PodsDisruptedCounter.Reset()
 })
 
@@ -1773,14 +1772,9 @@ var _ = Describe("Metrics", func() {
 		fakeClock.Step(10 * time.Minute)
 		ExpectSingletonReconciled(ctx, disruptionController)
 
-		ExpectMetricCounterValue(disruption.ActionsPerformedCounter, 1, map[string]string{
+		ExpectMetricCounterValue(disruption.DecisionsPerformedCounter, 1, map[string]string{
 			"action": "delete",
 			"method": "drift",
-		})
-		ExpectMetricCounterValue(disruption.NodesDisruptedCounter, 1, map[string]string{
-			"nodepool": nodePool.Name,
-			"action":   "delete",
-			"method":   "drift",
 		})
 		ExpectMetricCounterValue(disruption.PodsDisruptedCounter, 0, map[string]string{
 			"nodepool": nodePool.Name,
@@ -1823,14 +1817,9 @@ var _ = Describe("Metrics", func() {
 		fakeClock.Step(10 * time.Minute)
 		ExpectSingletonReconciled(ctx, disruptionController)
 
-		ExpectMetricCounterValue(disruption.ActionsPerformedCounter, 1, map[string]string{
+		ExpectMetricCounterValue(disruption.DecisionsPerformedCounter, 1, map[string]string{
 			"action": "delete",
 			"method": "drift",
-		})
-		ExpectMetricCounterValue(disruption.NodesDisruptedCounter, 1, map[string]string{
-			"nodepool": nodePool.Name,
-			"action":   "delete",
-			"method":   "drift",
 		})
 		ExpectMetricCounterValue(disruption.PodsDisruptedCounter, 2, map[string]string{
 			"nodepool": nodePool.Name,
@@ -1873,14 +1862,9 @@ var _ = Describe("Metrics", func() {
 		fakeClock.Step(10 * time.Minute)
 		ExpectSingletonReconciled(ctx, disruptionController)
 
-		ExpectMetricCounterValue(disruption.ActionsPerformedCounter, 1, map[string]string{
+		ExpectMetricCounterValue(disruption.DecisionsPerformedCounter, 1, map[string]string{
 			"action": "replace",
 			"method": "drift",
-		})
-		ExpectMetricCounterValue(disruption.NodesDisruptedCounter, 1, map[string]string{
-			"nodepool": nodePool.Name,
-			"action":   "replace",
-			"method":   "drift",
 		})
 		ExpectMetricCounterValue(disruption.PodsDisruptedCounter, 4, map[string]string{
 			"nodepool": nodePool.Name,
@@ -1917,13 +1901,7 @@ var _ = Describe("Metrics", func() {
 		ExpectSingletonReconciled(ctx, disruptionController)
 		wg.Wait()
 
-		ExpectMetricCounterValue(disruption.ActionsPerformedCounter, 1, map[string]string{
-			"action":             "delete",
-			"method":             "consolidation",
-			"consolidation_type": "empty",
-		})
-		ExpectMetricCounterValue(disruption.NodesDisruptedCounter, 3, map[string]string{
-			"nodepool":           nodePool.Name,
+		ExpectMetricCounterValue(disruption.DecisionsPerformedCounter, 1, map[string]string{
 			"action":             "delete",
 			"method":             "consolidation",
 			"consolidation_type": "empty",
@@ -1988,13 +1966,7 @@ var _ = Describe("Metrics", func() {
 		ExpectSingletonReconciled(ctx, disruptionController)
 		wg.Wait()
 
-		ExpectMetricCounterValue(disruption.ActionsPerformedCounter, 1, map[string]string{
-			"action":             "delete",
-			"method":             "consolidation",
-			"consolidation_type": "multi",
-		})
-		ExpectMetricCounterValue(disruption.NodesDisruptedCounter, 2, map[string]string{
-			"nodepool":           nodePool.Name,
+		ExpectMetricCounterValue(disruption.DecisionsPerformedCounter, 1, map[string]string{
 			"action":             "delete",
 			"method":             "consolidation",
 			"consolidation_type": "multi",
@@ -2060,13 +2032,7 @@ var _ = Describe("Metrics", func() {
 		ExpectSingletonReconciled(ctx, disruptionController)
 		wg.Wait()
 
-		ExpectMetricCounterValue(disruption.ActionsPerformedCounter, 1, map[string]string{
-			"action":             "replace",
-			"method":             "consolidation",
-			"consolidation_type": "multi",
-		})
-		ExpectMetricCounterValue(disruption.NodesDisruptedCounter, 3, map[string]string{
-			"nodepool":           nodePool.Name,
+		ExpectMetricCounterValue(disruption.DecisionsPerformedCounter, 1, map[string]string{
 			"action":             "replace",
 			"method":             "consolidation",
 			"consolidation_type": "multi",

--- a/pkg/controllers/metrics/nodepool/controller.go
+++ b/pkg/controllers/metrics/nodepool/controller.go
@@ -41,16 +41,15 @@ import (
 const (
 	resourceTypeLabel = "resource_type"
 	nodePoolNameLabel = "nodepool"
-	nodePoolSubsystem = "nodepool"
 )
 
 var (
 	limitGaugeVec = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: nodePoolSubsystem,
+			Subsystem: metrics.NodePoolSubsystem,
 			Name:      "limit",
-			Help:      "The nodepool limits are the limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.",
+			Help:      "Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.",
 		},
 		[]string{
 			resourceTypeLabel,
@@ -60,9 +59,9 @@ var (
 	usageGaugeVec = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: nodePoolSubsystem,
+			Subsystem: metrics.NodePoolSubsystem,
 			Name:      "usage",
-			Help:      "The nodepool usage is the amount of resources that have been provisioned by a particular nodepool. Labeled by nodepool name and resource type.",
+			Help:      "The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.",
 		},
 		[]string{
 			resourceTypeLabel,

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -58,7 +58,7 @@ var (
 	podGaugeVec = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "karpenter",
-			Subsystem: "pods",
+			Subsystem: metrics.PodSubsystem,
 			Name:      "state",
 			Help:      "Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type and pod phase.",
 		},
@@ -67,7 +67,7 @@ var (
 	podStartupTimeSummary = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace:  "karpenter",
-			Subsystem:  "pods",
+			Subsystem:  metrics.PodSubsystem,
 			Name:       "startup_time_seconds",
 			Help:       "The time from pod creation until the pod is running.",
 			Objectives: metrics.SummaryObjectives(),

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -786,7 +786,7 @@ var _ = Describe("Termination", func() {
 			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
 			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
 
-			m, ok := FindMetricWithLabelValues("karpenter_nodes_terminated", map[string]string{"nodepool": node.Labels[v1.NodePoolLabelKey]})
+			m, ok := FindMetricWithLabelValues("karpenter_nodes_terminated_total", map[string]string{"nodepool": node.Labels[v1.NodePoolLabelKey]})
 			Expect(ok).To(BeTrue())
 			Expect(lo.FromPtr(m.GetCounter().Value)).To(BeNumerically("==", 1))
 		})

--- a/pkg/controllers/nodeclaim/expiration/suite_test.go
+++ b/pkg/controllers/nodeclaim/expiration/suite_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Expiration", func() {
 			ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
 
 			ExpectNotFound(ctx, env.Client, nodeClaim)
-			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_terminated", map[string]string{
+			metric, found := FindMetricWithLabelValues("karpenter_nodeclaims_terminated_total", map[string]string{
 				"reason":        "expiration",
 				"nodepool":      nodePool.Name,
 				"capacity_type": nodeClaim.Labels[v1.CapacityTypeLabelKey],

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,6 +24,8 @@ import (
 const (
 	NodeSubsystem      = "nodes"
 	NodeClaimSubsystem = "nodeclaims"
+	NodePoolSubsystem  = "nodepool"
+	PodSubsystem       = "pods"
 )
 
 var (
@@ -44,7 +46,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: NodeClaimSubsystem,
-			Name:      "terminated",
+			Name:      "terminated_total",
 			Help:      "Number of nodeclaims terminated in total by Karpenter. Labeled by reason the nodeclaim was terminated and the owning nodepool.",
 		},
 		[]string{
@@ -125,7 +127,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: NodeSubsystem,
-			Name:      "terminated",
+			Name:      "terminated_total",
 			Help:      "Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.",
 		},
 		[]string{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Reconfigured Karpenter metrics that are duplicated (workqueue metrics, renames of existing metrics).

1. Changed the name of `karpenter_disruption_budgets_allowed_disruptions` to the NodePool subsystem so that it is `karpenter_nodepools_allowed_disruptions`
2. Changed `karpenter_disruption_actions_performed_total` to `karpenter_disruption_decisions_total`
3. Changed `karpenter_disruption_replacement_nodeclaim_failures_total` to `karpenter_disruption_queue_failures_total`
4. Convert `karpenter_nodeclaims_terminated` to `karpenter_nodeclaims_terminated_total` and convert `karpenter_nodes_terminated` to `karpenter_nodes_terminated_total`
5. Remove `karpenter_disruption_nodes_disrupted_total` since this is already captured by `karpenter_nodeclaims_terminated_total`

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
