### PR TITLE
chore: Only Include the kubelet annotation when present in v1beta1

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	Group              = "karpenter.sh"
-	CompatabilityGroup = "compatibility." + Group
+	CompatibilityGroup = "compatibility." + Group
 )
 
 //go:generate controller-gen crd object:headerFile="../../hack/boilerplate.go.txt" paths="./..." output:crd:artifacts:config=crds

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -45,11 +45,11 @@ const (
 // Karpenter specific annotations
 const (
 	DoNotDisruptAnnotationKey                  = apis.Group + "/do-not-disrupt"
-	ProviderCompatabilityAnnotationKey         = apis.CompatabilityGroup + "/provider"
+	ProviderCompatibilityAnnotationKey         = apis.CompatibilityGroup + "/provider"
 	ManagedByAnnotationKey                     = apis.Group + "/managed-by"
 	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"
-	KubeletCompatabilityAnnotationKey          = apis.CompatabilityGroup + "/v1beta1-kubelet-conversion"
+	KubeletCompatibilityAnnotationKey          = apis.CompatibilityGroup + "/v1beta1-kubelet-conversion"
 	NodeClaimTerminationTimestampAnnotationKey = apis.Group + "/nodeclaim-termination-timestamp"
 )
 

--- a/pkg/apis/v1/nodeclaim_conversion_test.go
+++ b/pkg/apis/v1/nodeclaim_conversion_test.go
@@ -103,8 +103,8 @@ var _ = Describe("Convert v1 to v1beta1 NodeClaim API", func() {
 
 	It("should convert v1 nodeclaim metadata", func() {
 		v1nodeclaim.ObjectMeta = test.ObjectMeta()
-		Expect(v1nodeclaim.ConvertFrom(ctx, v1beta1nodeclaim)).To(Succeed())
-		v1beta1nodeclaim.Annotations = lo.Assign(v1beta1nodeclaim.Annotations, map[string]string{KubeletCompatabilityAnnotationKey: "null"})
+		Expect(v1nodeclaim.ConvertTo(ctx, v1beta1nodeclaim)).To(Succeed())
+		v1beta1nodeclaim.Annotations = nil
 		Expect(v1beta1nodeclaim.ObjectMeta).To(BeEquivalentTo(v1nodeclaim.ObjectMeta))
 	})
 	Context("NodeClaim Spec", func() {
@@ -326,7 +326,7 @@ var _ = Describe("Convert V1beta1 to V1 NodeClaim API", func() {
 	It("should convert v1beta1 nodeclaim metadata", func() {
 		v1beta1nodeclaim.ObjectMeta = test.ObjectMeta()
 		Expect(v1nodeclaim.ConvertFrom(ctx, v1beta1nodeclaim)).To(Succeed())
-		v1beta1nodeclaim.Annotations = lo.Assign(v1beta1nodeclaim.Annotations, map[string]string{KubeletCompatabilityAnnotationKey: "null"})
+		v1beta1nodeclaim.Annotations = map[string]string{}
 		Expect(v1nodeclaim.ObjectMeta).To(BeEquivalentTo(v1beta1nodeclaim.ObjectMeta))
 	})
 	Context("NodeClaim Spec", func() {
@@ -425,7 +425,7 @@ var _ = Describe("Convert V1beta1 to V1 NodeClaim API", func() {
 			Expect(v1nodeclaim.Annotations).To(BeNil())
 			Expect(v1nodeclaim.ConvertFrom(ctx, v1beta1nodeclaim)).To(Succeed())
 			kubelet := &v1beta1.KubeletConfiguration{}
-			kubeletString, found := v1nodeclaim.Annotations[KubeletCompatabilityAnnotationKey]
+			kubeletString, found := v1nodeclaim.Annotations[KubeletCompatibilityAnnotationKey]
 			Expect(found).To(BeTrue())
 			err := json.Unmarshal([]byte(kubeletString), kubelet)
 			Expect(err).To(BeNil())

--- a/pkg/apis/v1/nodepool_conversion_test.go
+++ b/pkg/apis/v1/nodepool_conversion_test.go
@@ -80,8 +80,7 @@ var _ = Describe("Convert V1 to V1beta1 NodePool API", func() {
 
 	It("should convert v1 nodepool metadata", func() {
 		v1nodepool.ObjectMeta = test.ObjectMeta()
-		Expect(v1nodepool.ConvertFrom(ctx, v1beta1nodepool)).To(Succeed())
-		v1beta1nodepool.Annotations = map[string]string{KubeletCompatabilityAnnotationKey: "null"}
+		Expect(v1nodepool.ConvertTo(ctx, v1beta1nodepool)).To(Succeed())
 		Expect(v1beta1nodepool.ObjectMeta).To(BeEquivalentTo(v1nodepool.ObjectMeta))
 	})
 	Context("NodePool Spec", func() {
@@ -112,7 +111,7 @@ var _ = Describe("Convert V1 to V1beta1 NodePool API", func() {
 						"test-key-2": "test-value-2",
 					},
 				}
-				Expect(v1nodepool.ConvertFrom(ctx, v1beta1nodepool)).To(Succeed())
+				Expect(v1nodepool.ConvertTo(ctx, v1beta1nodepool)).To(Succeed())
 				Expect(v1beta1nodepool.Spec.Template.ObjectMeta).To(BeEquivalentTo(v1nodepool.Spec.Template.ObjectMeta))
 			})
 			It("should convert v1 nodepool template taints", func() {
@@ -254,7 +253,7 @@ var _ = Describe("Convert V1 to V1beta1 NodePool API", func() {
 					v1nodepool.Spec.Disruption.Budgets = append(v1nodepool.Spec.Disruption.Budgets, Budget{
 						Reasons: []DisruptionReason{DisruptionReasonDrifted, DisruptionReasonUnderutilized, DisruptionReasonEmpty},
 					})
-					Expect(v1nodepool.ConvertFrom(ctx, v1beta1nodepool)).To(Succeed())
+					Expect(v1nodepool.ConvertTo(ctx, v1beta1nodepool)).To(Succeed())
 					for i := range v1nodepool.Spec.Disruption.Budgets {
 						expected := lo.Map(v1nodepool.Spec.Disruption.Budgets[i].Reasons, func(reason DisruptionReason, _ int) v1beta1.DisruptionReason {
 							return v1beta1.DisruptionReason(reason)
@@ -320,7 +319,7 @@ var _ = Describe("Convert V1beta1 to V1 NodePool API", func() {
 	It("should convert v1beta1 nodepool metadata", func() {
 		v1beta1nodepool.ObjectMeta = test.ObjectMeta()
 		Expect(v1nodepool.ConvertFrom(ctx, v1beta1nodepool)).To(Succeed())
-		v1beta1nodepool.Annotations = map[string]string{KubeletCompatabilityAnnotationKey: "null"}
+		v1nodepool.Annotations = nil
 		Expect(v1nodepool.ObjectMeta).To(BeEquivalentTo(v1beta1nodepool.ObjectMeta))
 	})
 	Context("NodePool Spec", func() {
@@ -437,7 +436,7 @@ var _ = Describe("Convert V1beta1 to V1 NodePool API", func() {
 				Expect(v1nodepool.Annotations).To(BeNil())
 				Expect(v1nodepool.ConvertFrom(ctx, v1beta1nodepool)).To(Succeed())
 				kubelet := &v1beta1.KubeletConfiguration{}
-				kubeletString, found := v1nodepool.Annotations[KubeletCompatabilityAnnotationKey]
+				kubeletString, found := v1nodepool.Annotations[KubeletCompatibilityAnnotationKey]
 				Expect(found).To(BeTrue())
 				err := json.Unmarshal([]byte(kubeletString), kubelet)
 				Expect(err).To(BeNil())

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -45,7 +45,7 @@ const (
 // Karpenter specific annotations
 const (
 	DoNotDisruptAnnotationKey             = apis.Group + "/do-not-disrupt"
-	ProviderCompatabilityAnnotationKey    = apis.CompatabilityGroup + "/provider"
+	ProviderCompatibilityAnnotationKey    = apis.CompatibilityGroup + "/provider"
 	ManagedByAnnotationKey                = apis.Group + "/managed-by"
 	NodePoolHashAnnotationKey             = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey      = apis.Group + "/nodepool-hash-version"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Added checking for conversion webhook to only include kubelet annotation, when sublet struct is present

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
