### PR TITLE
test: Improved Disruption Test Suite duration from 527 seconds to 38 seconds

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -2994,7 +2994,7 @@ var _ = Describe("Consolidation", func() {
 			})
 			Expect(ok).To(BeTrue())
 		})
-		FIt("should consider initialized nodes before uninitialized nodes", func() {
+		It("should consider initialized nodes before uninitialized nodes", func() {
 			defaultInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name: "default-instance-type",
 				Resources: corev1.ResourceList{
@@ -3123,7 +3123,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
-			// time.Sleep(time.Second * 8)
 
 			// Process the item so that the nodes can be deleted.
 			ExpectSingletonReconciled(ctx, queue)
@@ -3826,7 +3825,7 @@ var _ = Describe("Consolidation", func() {
 				},
 			})
 		})
-		FDescribeTable("can merge 3 nodes into 1", func(spotToSpot bool) {
+		DescribeTable("can merge 3 nodes into 1", func(spotToSpot bool) {
 			nodeClaims = lo.Ternary(spotToSpot, spotNodeClaims, nodeClaims)
 			nodes = lo.Ternary(spotToSpot, spotNodes, nodes)
 			// create our RS so we can link a pod to it
@@ -3863,7 +3862,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
-			// time.Sleep(time.Second * 8)
 
 			// Process the item so that the nodes can be deleted.
 			ExpectSingletonReconciled(ctx, queue)
@@ -4391,7 +4389,7 @@ var _ = Describe("Consolidation", func() {
 			})
 			oldNodeClaimNames = sets.New(nodeClaims[0].Name, nodeClaims[1].Name, nodeClaims[2].Name)
 		})
-		FIt("can replace node maintaining zonal topology spread", func() {
+		It("can replace node maintaining zonal topology spread", func() {
 			labels = map[string]string{
 				"app": "test-zonal-spread",
 			}
@@ -4441,7 +4439,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
-			// time.Sleep(time.Second * 8)
 
 			// Process the item so that the nodes can be deleted.
 			ExpectSingletonReconciled(ctx, queue)

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -3619,10 +3619,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectApplied(ctx, env.Client, doNotDisruptPod)
 			ExpectManualBinding(ctx, env.Client, doNotDisruptPod, node)
 
-			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectToWait(&wg)
-			wg.Wait()
-
 			// we would normally be able to replace a node, but we are blocked by the do-not-disrupt pods during validation
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
@@ -3669,10 +3665,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectApplied(ctx, env.Client, blockingPDBPod, pdb)
 			ExpectManualBinding(ctx, env.Client, blockingPDBPod, node)
 
-			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectToWait(&wg)
-			wg.Wait()
-
 			// we would normally be able to replace a node, but we are blocked by the PDB during validation
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
@@ -3718,10 +3710,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectApplied(ctx, env.Client, doNotDisruptPods[0], doNotDisruptPods[1])
 			ExpectManualBinding(ctx, env.Client, doNotDisruptPods[0], nodes[0])
 			ExpectManualBinding(ctx, env.Client, doNotDisruptPods[1], nodes[1])
-
-			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectToWait(&wg)
-			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-disrupt pods during validation
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))
@@ -3771,10 +3759,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectApplied(ctx, env.Client, blockingPDBPods[0], blockingPDBPods[1], pdb)
 			ExpectManualBinding(ctx, env.Client, blockingPDBPods[0], nodes[0])
 			ExpectManualBinding(ctx, env.Client, blockingPDBPods[1], nodes[1])
-
-			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectToWait(&wg)
-			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the PDB during validation
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -105,11 +105,7 @@ var _ = Describe("Consolidation", func() {
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			Expect(recorder.Calls("Unconsolidatable")).To(Equal(0))
 		})
 		It("should fire an event for ConsolidationDisabled when the NodePool has consolidateAfter set to 'Never'", func() {
@@ -119,12 +115,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, pod, node)
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			// We get six calls here because we have Nodes and NodeClaims that fired for this event
 			// and each of the consolidation mechanisms specifies that this event should be fired
 			Expect(recorder.Calls("Unconsolidatable")).To(Equal(6))
@@ -147,11 +138,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			for _, ct := range consolidationTypes {
 				ExpectMetricGaugeValue(disruption.EligibleNodesGauge, 0, map[string]string{
 					"method":             "consolidation",
@@ -165,7 +152,8 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-			ExpectTriggerVerifyAction(&wg)
+			wg := sync.WaitGroup{}
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -214,7 +202,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -240,7 +228,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -264,13 +252,7 @@ var _ = Describe("Consolidation", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
-
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
@@ -319,7 +301,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -364,9 +346,9 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
+			ExpectToSleep(&wg)
 			// Reconcile 5 times, enqueuing 3 commands total.
 			for i := 0; i < 5; i++ {
-				ExpectTriggerVerifyAction(&wg)
 				ExpectSingletonReconciled(ctx, disruptionController)
 			}
 			wg.Wait()
@@ -426,7 +408,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -490,7 +472,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -552,12 +534,7 @@ var _ = Describe("Consolidation", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			for _, np := range nps {
 				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
@@ -587,13 +564,10 @@ var _ = Describe("Consolidation", func() {
 			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, emptyConsolidation.ShouldDisrupt, emptyConsolidation.Class(), queue)
 			Expect(err).To(Succeed())
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			cmd, results, err := emptyConsolidation.ComputeCommand(ctx, budgets, candidates...)
 			Expect(err).To(Succeed())
 			Expect(results).To(Equal(pscheduling.Results{}))
 			Expect(cmd).To(Equal(disruption.Command{}))
-			wg.Wait()
 
 			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
 		})
@@ -651,13 +625,10 @@ var _ = Describe("Consolidation", func() {
 			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, emptyConsolidation.ShouldDisrupt, emptyConsolidation.Class(), queue)
 			Expect(err).To(Succeed())
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			cmd, results, err := emptyConsolidation.ComputeCommand(ctx, budgets, candidates...)
 			Expect(err).To(Succeed())
 			Expect(results).To(Equal(pscheduling.Results{}))
 			Expect(cmd).To(Equal(disruption.Command{}))
-			wg.Wait()
 
 			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
 		})
@@ -678,13 +649,10 @@ var _ = Describe("Consolidation", func() {
 			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, multiConsolidation.ShouldDisrupt, multiConsolidation.Class(), queue)
 			Expect(err).To(Succeed())
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			cmd, results, err := multiConsolidation.ComputeCommand(ctx, budgets, candidates...)
 			Expect(err).To(Succeed())
 			Expect(results).To(Equal(pscheduling.Results{}))
 			Expect(cmd).To(Equal(disruption.Command{}))
-			wg.Wait()
 
 			Expect(multiConsolidation.IsConsolidated()).To(BeFalse())
 		})
@@ -742,13 +710,10 @@ var _ = Describe("Consolidation", func() {
 			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, multiConsolidation.ShouldDisrupt, multiConsolidation.Class(), queue)
 			Expect(err).To(Succeed())
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			cmd, results, err := multiConsolidation.ComputeCommand(ctx, budgets, candidates...)
 			Expect(err).To(Succeed())
 			Expect(results).To(Equal(pscheduling.Results{}))
 			Expect(cmd).To(Equal(disruption.Command{}))
-			wg.Wait()
 
 			Expect(multiConsolidation.IsConsolidated()).To(BeFalse())
 		})
@@ -769,13 +734,10 @@ var _ = Describe("Consolidation", func() {
 			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, singleConsolidation.ShouldDisrupt, singleConsolidation.Class(), queue)
 			Expect(err).To(Succeed())
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			cmd, results, err := singleConsolidation.ComputeCommand(ctx, budgets, candidates...)
 			Expect(err).To(Succeed())
 			Expect(results).To(Equal(pscheduling.Results{}))
 			Expect(cmd).To(Equal(disruption.Command{}))
-			wg.Wait()
 
 			Expect(singleConsolidation.IsConsolidated()).To(BeFalse())
 		})
@@ -833,13 +795,10 @@ var _ = Describe("Consolidation", func() {
 			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, singleConsolidation.ShouldDisrupt, singleConsolidation.Class(), queue)
 			Expect(err).To(Succeed())
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			cmd, results, err := singleConsolidation.ComputeCommand(ctx, budgets, candidates...)
 			Expect(err).To(Succeed())
 			Expect(results).To(Equal(pscheduling.Results{}))
 			Expect(cmd).To(Equal(disruption.Command{}))
-			wg.Wait()
 
 			Expect(singleConsolidation.IsConsolidated()).To(BeFalse())
 		})
@@ -875,7 +834,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -897,7 +856,7 @@ var _ = Describe("Consolidation", func() {
 
 			fakeClock.Step(10 * time.Minute)
 			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -1012,7 +971,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -1077,7 +1036,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -1136,11 +1095,7 @@ var _ = Describe("Consolidation", func() {
 
 			fakeClock.Step(10 * time.Minute)
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -1187,7 +1142,7 @@ var _ = Describe("Consolidation", func() {
 
 				// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
+				ExpectToSleep(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -1278,11 +1233,8 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			ExpectSingletonReconciled(ctx, queue)
-			wg.Wait()
 
 			// shouldn't delete the node
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
@@ -1324,11 +1276,8 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			ExpectSingletonReconciled(ctx, queue)
-			wg.Wait()
 
 			// shouldn't delete the node
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
@@ -1402,10 +1351,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			// we didn't create a new nodeclaim or delete the old one
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -1492,7 +1438,7 @@ var _ = Describe("Consolidation", func() {
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -1617,7 +1563,7 @@ var _ = Describe("Consolidation", func() {
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -1742,7 +1688,7 @@ var _ = Describe("Consolidation", func() {
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -1863,10 +1809,7 @@ var _ = Describe("Consolidation", func() {
 				fakeClock.Step(10 * time.Minute)
 
 				// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
-				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
 				ExpectSingletonReconciled(ctx, disruptionController)
-				wg.Wait()
 
 				// we didn't create a new nodeclaim or delete the old one
 				Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -1913,7 +1856,7 @@ var _ = Describe("Consolidation", func() {
 
 				// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
+				ExpectToSleep(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2065,7 +2008,7 @@ var _ = Describe("Consolidation", func() {
 
 				// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
+				ExpectToSleep(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2139,7 +2082,7 @@ var _ = Describe("Consolidation", func() {
 
 				// consolidation won't delete the old node until the new node is ready
 				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
+				ExpectToSleep(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2234,7 +2177,7 @@ var _ = Describe("Consolidation", func() {
 				fakeClock.Step(10 * time.Minute)
 
 				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
+				ExpectToSleep(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2325,7 +2268,7 @@ var _ = Describe("Consolidation", func() {
 				fakeClock.Step(10 * time.Minute)
 
 				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
+				ExpectToSleep(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2419,10 +2362,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			// Expect to not create or delete more nodeclaims
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -2523,10 +2463,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			// Expect to not create or delete more nodeclaims
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -2586,7 +2523,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2633,7 +2570,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2687,7 +2624,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2749,7 +2686,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2801,7 +2738,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2849,7 +2786,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2901,12 +2838,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[0], nodes[1]}, []*v1.NodeClaim{nodeClaims[0], nodeClaims[1]})
 
 			fakeClock.Step(10 * time.Minute)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -2955,12 +2887,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[0], nodes[1]}, []*v1.NodeClaim{nodeClaims[0], nodeClaims[1]})
 
 			fakeClock.Step(10 * time.Minute)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -3005,7 +2932,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -3050,11 +2977,8 @@ var _ = Describe("Consolidation", func() {
 			ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nodeClaims[0]))
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[1]}, []*v1.NodeClaim{nodeClaims[1]})
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			ExpectSingletonReconciled(ctx, queue)
-			wg.Wait()
 
 			// shouldn't delete the node
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
@@ -3196,7 +3120,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{consolidatableNode}, []*v1.NodeClaim{consolidatableNodeClaim})
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -3252,7 +3176,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -3362,7 +3286,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -3696,7 +3620,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotDisruptPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the do-not-disrupt pods during validation
@@ -3746,7 +3670,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, blockingPDBPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the PDB during validation
@@ -3796,7 +3720,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotDisruptPods[1], nodes[1])
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-disrupt pods during validation
@@ -3849,7 +3773,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, blockingPDBPods[1], nodes[1])
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the PDB during validation
@@ -3859,7 +3783,6 @@ var _ = Describe("Consolidation", func() {
 			ExpectExists(ctx, env.Client, nodes[1])
 		})
 	})
-
 	Context("Multi-NodeClaim", func() {
 		var nodeClaims, spotNodeClaims []*v1.NodeClaim
 		var nodes, spotNodes []*corev1.Node
@@ -3936,7 +3859,7 @@ var _ = Describe("Consolidation", func() {
 				fakeClock.Step(10 * time.Minute)
 
 				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
+				ExpectToSleep(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -4000,7 +3923,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -4073,7 +3996,7 @@ var _ = Describe("Consolidation", func() {
 				fakeClock.Step(10 * time.Minute)
 
 				var wg sync.WaitGroup
-				ExpectTriggerVerifyAction(&wg)
+				ExpectToSleep(&wg)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
 
@@ -4404,7 +4327,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.SetTime(time.Now())
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -4513,7 +4436,7 @@ var _ = Describe("Consolidation", func() {
 
 			// consolidation won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -4596,11 +4519,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[0], nodes[1], nodes[2]}, []*v1.NodeClaim{nodeClaims[0], nodeClaims[1], nodeClaims[2]})
 
 			fakeClock.Step(10 * time.Minute)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			// our nodes are already the cheapest available, so we can't replace them.  If we delete, it would
 			// violate the anti-affinity rule, so we can't do anything.
@@ -4649,7 +4568,7 @@ var _ = Describe("Consolidation", func() {
 			// Run the processing loop in parallel in the background with environment context
 			var wg sync.WaitGroup
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			go func() {
 				defer GinkgoRecover()
 				_, _ = disruptionController.Reconcile(ctx)
@@ -4719,9 +4638,6 @@ var _ = Describe("Consolidation", func() {
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nil)
 
-			// Wait for the nomination cache to expire
-			time.Sleep(time.Second * 11)
-
 			// Re-create the pods to re-bind them
 			for i := 0; i < 2; i++ {
 				ExpectDeleted(ctx, env.Client, pods[i])
@@ -4733,9 +4649,6 @@ var _ = Describe("Consolidation", func() {
 			// Trigger a reconciliation run which should take into account the deleting node
 			// consolidation shouldn't trigger additional actions
 			fakeClock.Step(10 * time.Minute)
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
-
 			result, err := disruptionController.Reconcile(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Consolidation", func() {
 
 			fakeClock.Step(10 * time.Minute)
 			wg := sync.WaitGroup{}
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -202,7 +202,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -228,7 +228,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -301,7 +301,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -346,7 +346,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			// Reconcile 5 times, enqueuing 3 commands total.
 			for i := 0; i < 5; i++ {
 				ExpectSingletonReconciled(ctx, disruptionController)
@@ -408,7 +408,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -472,7 +472,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -834,7 +834,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -856,7 +856,7 @@ var _ = Describe("Consolidation", func() {
 
 			fakeClock.Step(10 * time.Minute)
 			wg := sync.WaitGroup{}
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -971,7 +971,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -1036,7 +1036,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -1142,7 +1142,7 @@ var _ = Describe("Consolidation", func() {
 
 				// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 				var wg sync.WaitGroup
-				ExpectToSleep(&wg)
+				ExpectToWait(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -1438,7 +1438,7 @@ var _ = Describe("Consolidation", func() {
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -1563,7 +1563,7 @@ var _ = Describe("Consolidation", func() {
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -1688,7 +1688,7 @@ var _ = Describe("Consolidation", func() {
 
 			// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -1856,7 +1856,7 @@ var _ = Describe("Consolidation", func() {
 
 				// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 				var wg sync.WaitGroup
-				ExpectToSleep(&wg)
+				ExpectToWait(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2008,7 +2008,7 @@ var _ = Describe("Consolidation", func() {
 
 				// consolidation won't delete the old nodeclaim until the new nodeclaim is ready
 				var wg sync.WaitGroup
-				ExpectToSleep(&wg)
+				ExpectToWait(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2082,7 +2082,7 @@ var _ = Describe("Consolidation", func() {
 
 				// consolidation won't delete the old node until the new node is ready
 				var wg sync.WaitGroup
-				ExpectToSleep(&wg)
+				ExpectToWait(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2177,7 +2177,7 @@ var _ = Describe("Consolidation", func() {
 				fakeClock.Step(10 * time.Minute)
 
 				var wg sync.WaitGroup
-				ExpectToSleep(&wg)
+				ExpectToWait(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2268,7 +2268,7 @@ var _ = Describe("Consolidation", func() {
 				fakeClock.Step(10 * time.Minute)
 
 				var wg sync.WaitGroup
-				ExpectToSleep(&wg)
+				ExpectToWait(&wg)
 				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
@@ -2523,7 +2523,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2570,7 +2570,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2624,7 +2624,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2686,7 +2686,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2738,7 +2738,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2786,7 +2786,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2932,7 +2932,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -2994,7 +2994,7 @@ var _ = Describe("Consolidation", func() {
 			})
 			Expect(ok).To(BeTrue())
 		})
-		It("should consider initialized nodes before uninitialized nodes", func() {
+		FIt("should consider initialized nodes before uninitialized nodes", func() {
 			defaultInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name: "default-instance-type",
 				Resources: corev1.ResourceList{
@@ -3120,9 +3120,10 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{consolidatableNode}, []*v1.NodeClaim{consolidatableNodeClaim})
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
+			// time.Sleep(time.Second * 8)
 
 			// Process the item so that the nodes can be deleted.
 			ExpectSingletonReconciled(ctx, queue)
@@ -3176,7 +3177,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -3286,7 +3287,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -3620,7 +3621,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotDisruptPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the do-not-disrupt pods during validation
@@ -3670,7 +3671,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, blockingPDBPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the PDB during validation
@@ -3720,7 +3721,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotDisruptPods[1], nodes[1])
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-disrupt pods during validation
@@ -3773,7 +3774,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, blockingPDBPods[1], nodes[1])
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the PDB during validation
@@ -3825,56 +3826,56 @@ var _ = Describe("Consolidation", func() {
 				},
 			})
 		})
-		DescribeTable("can merge 3 nodes into 1",
-			func(spotToSpot bool) {
-				nodeClaims = lo.Ternary(spotToSpot, spotNodeClaims, nodeClaims)
-				nodes = lo.Ternary(spotToSpot, spotNodes, nodes)
-				// create our RS so we can link a pod to it
-				rs := test.ReplicaSet()
-				ExpectApplied(ctx, env.Client, rs)
-				pods := test.Pods(3, test.PodOptions{
-					ObjectMeta: metav1.ObjectMeta{Labels: labels,
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion:         "apps/v1",
-								Kind:               "ReplicaSet",
-								Name:               rs.Name,
-								UID:                rs.UID,
-								Controller:         lo.ToPtr(true),
-								BlockOwnerDeletion: lo.ToPtr(true),
-							},
-						}}})
+		FDescribeTable("can merge 3 nodes into 1", func(spotToSpot bool) {
+			nodeClaims = lo.Ternary(spotToSpot, spotNodeClaims, nodeClaims)
+			nodes = lo.Ternary(spotToSpot, spotNodes, nodes)
+			// create our RS so we can link a pod to it
+			rs := test.ReplicaSet()
+			ExpectApplied(ctx, env.Client, rs)
+			pods := test.Pods(3, test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "ReplicaSet",
+							Name:               rs.Name,
+							UID:                rs.UID,
+							Controller:         lo.ToPtr(true),
+							BlockOwnerDeletion: lo.ToPtr(true),
+						},
+					}}})
 
-				ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodeClaims[2], nodes[2], nodePool)
-				ExpectMakeNodesInitialized(ctx, env.Client, nodes[0], nodes[1], nodes[2])
+			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodeClaims[2], nodes[2], nodePool)
+			ExpectMakeNodesInitialized(ctx, env.Client, nodes[0], nodes[1], nodes[2])
 
-				// bind pods to nodes
-				ExpectManualBinding(ctx, env.Client, pods[0], nodes[0])
-				ExpectManualBinding(ctx, env.Client, pods[1], nodes[1])
-				ExpectManualBinding(ctx, env.Client, pods[2], nodes[2])
+			// bind pods to nodes
+			ExpectManualBinding(ctx, env.Client, pods[0], nodes[0])
+			ExpectManualBinding(ctx, env.Client, pods[1], nodes[1])
+			ExpectManualBinding(ctx, env.Client, pods[2], nodes[2])
 
-				// inform cluster state about nodes and nodeclaims
-				ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[0], nodes[1], nodes[2]}, []*v1.NodeClaim{nodeClaims[0], nodeClaims[1], nodeClaims[2]})
+			// inform cluster state about nodes and nodeclaims
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[0], nodes[1], nodes[2]}, []*v1.NodeClaim{nodeClaims[0], nodeClaims[1], nodeClaims[2]})
 
-				fakeClock.Step(10 * time.Minute)
+			fakeClock.Step(10 * time.Minute)
 
-				var wg sync.WaitGroup
-				ExpectToSleep(&wg)
-				ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-				ExpectSingletonReconciled(ctx, disruptionController)
-				wg.Wait()
+			var wg sync.WaitGroup
+			ExpectToWait(&wg)
+			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
+			ExpectSingletonReconciled(ctx, disruptionController)
+			wg.Wait()
+			// time.Sleep(time.Second * 8)
 
-				// Process the item so that the nodes can be deleted.
-				ExpectSingletonReconciled(ctx, queue)
+			// Process the item so that the nodes can be deleted.
+			ExpectSingletonReconciled(ctx, queue)
 
-				// Cascade any deletion of the nodeclaim to the node
-				ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaims[0], nodeClaims[1], nodeClaims[2])
+			// Cascade any deletion of the nodeclaim to the node
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaims[0], nodeClaims[1], nodeClaims[2])
 
-				// three nodeclaims should be replaced with a single nodeclaim
-				Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
-				Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-				ExpectNotFound(ctx, env.Client, nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodeClaims[2], nodes[2])
-			},
+			// three nodeclaims should be replaced with a single nodeclaim
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+			ExpectNotFound(ctx, env.Client, nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodeClaims[2], nodes[2])
+		},
 			Entry("if the candidate is on-demand node", false),
 			Entry("if the candidate is spot node", true),
 		)
@@ -3923,7 +3924,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -3996,7 +3997,7 @@ var _ = Describe("Consolidation", func() {
 				fakeClock.Step(10 * time.Minute)
 
 				var wg sync.WaitGroup
-				ExpectToSleep(&wg)
+				ExpectToWait(&wg)
 				ExpectSingletonReconciled(ctx, disruptionController)
 				wg.Wait()
 
@@ -4327,7 +4328,7 @@ var _ = Describe("Consolidation", func() {
 			fakeClock.SetTime(time.Now())
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -4390,7 +4391,7 @@ var _ = Describe("Consolidation", func() {
 			})
 			oldNodeClaimNames = sets.New(nodeClaims[0].Name, nodeClaims[1].Name, nodeClaims[2].Name)
 		})
-		It("can replace node maintaining zonal topology spread", func() {
+		FIt("can replace node maintaining zonal topology spread", func() {
 			labels = map[string]string{
 				"app": "test-zonal-spread",
 			}
@@ -4436,10 +4437,11 @@ var _ = Describe("Consolidation", func() {
 
 			// consolidation won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
+			// time.Sleep(time.Second * 8)
 
 			// Process the item so that the nodes can be deleted.
 			ExpectSingletonReconciled(ctx, queue)
@@ -4568,7 +4570,7 @@ var _ = Describe("Consolidation", func() {
 			// Run the processing loop in parallel in the background with environment context
 			var wg sync.WaitGroup
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			go func() {
 				defer GinkgoRecover()
 				_, _ = disruptionController.Reconcile(ctx)
@@ -4637,6 +4639,9 @@ var _ = Describe("Consolidation", func() {
 			newNode, _ := lo.Find(nodes, func(n *corev1.Node) bool { return n.Name != oldNodeName })
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nil)
+
+			// Wait for the nomination cache to expire
+			time.Sleep(time.Second * 11)
 
 			// Re-create the pods to re-bind them
 			for i := 0; i < 2; i++ {

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -95,11 +95,7 @@ var _ = Describe("Drift", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			ExpectMetricGaugeValue(disruption.EligibleNodesGauge, 0, eligibleNodesLabels)
 
 			// remove the do-not-disrupt annotation to make the node eligible for drift and update cluster state
@@ -108,10 +104,7 @@ var _ = Describe("Drift", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			ExpectMetricGaugeValue(disruption.EligibleNodesGauge, 1, eligibleNodesLabels)
 		})
 	})
@@ -156,11 +149,7 @@ var _ = Describe("Drift", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
@@ -199,11 +188,7 @@ var _ = Describe("Drift", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
@@ -242,12 +227,7 @@ var _ = Describe("Drift", func() {
 			}
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
@@ -315,13 +295,10 @@ var _ = Describe("Drift", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			// Reconcile 5 times, enqueuing 3 commands total.
 			for i := 0; i < 5; i++ {
 				ExpectSingletonReconciled(ctx, disruptionController)
 			}
-			wg.Wait()
 
 			nodes = ExpectNodes(ctx, env.Client)
 			Expect(len(lo.Filter(nodes, func(nc *corev1.Node, _ int) bool {
@@ -386,11 +363,7 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			for _, np := range nps {
 				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
@@ -451,11 +424,7 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			for _, np := range nps {
 				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
@@ -470,7 +439,6 @@ var _ = Describe("Drift", func() {
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(0))
 		})
 	})
-
 	Context("Drift", func() {
 		It("should continue to the next drifted node if the first cannot reschedule all pods", func() {
 			pod := test.Pod(test.PodOptions{
@@ -519,7 +487,6 @@ var _ = Describe("Drift", func() {
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -652,12 +619,7 @@ var _ = Describe("Drift", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			// Process the item so that the nodes can be deleted.
 			ExpectSingletonReconciled(ctx, queue)
 			// Cascade any deletion of the nodeClaim to the node
@@ -696,11 +658,7 @@ var _ = Describe("Drift", func() {
 
 			// inform cluster state about nodes and nodeClaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			// Process the item so that the nodes can be deleted.
 			ExpectSingletonReconciled(ctx, queue)
@@ -745,7 +703,6 @@ var _ = Describe("Drift", func() {
 
 			// disruption won't delete the old nodeClaim until the new nodeClaim is ready
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -799,11 +756,12 @@ var _ = Describe("Drift", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectNewNodeClaimsDeleted(ctx, env.Client, &wg, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
+			// Wait > 5 seconds for eventual consistency hack in orchestration.Queue
+			fakeClock.Step(5*time.Second + time.Nanosecond*1)
 			ExpectSingletonReconciled(ctx, queue)
 			// We should have tried to create a new nodeClaim but failed to do so; therefore, we untainted the existing node
 			node = ExpectExists(ctx, env.Client, node)
@@ -889,7 +847,6 @@ var _ = Describe("Drift", func() {
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 3)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -965,7 +922,6 @@ var _ = Describe("Drift", func() {
 
 			// disruption won't delete the old node until the new node is ready
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
@@ -989,12 +945,7 @@ var _ = Describe("Drift", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			// Process the item so that the nodes can be deleted.
 			ExpectSingletonReconciled(ctx, queue)
 			// Cascade any deletion of the nodeClaim to the node

--- a/pkg/controllers/disruption/emptiness_test.go
+++ b/pkg/controllers/disruption/emptiness_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
+			ExpectToSleep(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
@@ -91,11 +91,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim, nodePool)
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			// We get six calls here because we have Nodes and NodeClaims that fired for this event
 			// and each of the consolidation mechanisms specifies that this event should be fired
@@ -116,22 +112,12 @@ var _ = Describe("Emptiness", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			ExpectMetricGaugeValue(disruption.EligibleNodesGauge, 0, eligibleNodesEmptinessLabels)
-
 			// delete pod and update cluster state, node should now be disruptable
 			ExpectDeleted(ctx, env.Client, pod)
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			ExpectMetricGaugeValue(disruption.EligibleNodesGauge, 1, eligibleNodesEmptinessLabels)
 		})
 	})
@@ -169,12 +155,7 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
@@ -215,11 +196,7 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
@@ -261,12 +238,7 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 				"nodepool": nodePool.Name,
 			})
@@ -329,11 +301,7 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
 
 			for _, np := range nps {
 				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
@@ -398,12 +366,7 @@ var _ = Describe("Emptiness", func() {
 
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
-
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			for _, np := range nps {
 				metric, found := FindMetricWithLabelValues("karpenter_disruption_budgets_allowed_disruptions", map[string]string{
 					"nodepool": np.Name,
@@ -425,11 +388,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			fakeClock.Step(10 * time.Minute)
-			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
-			wg.Wait()
-
 			ExpectSingletonReconciled(ctx, queue)
 			// Cascade any deletion of the nodeClaim to the node
 			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)

--- a/pkg/controllers/disruption/emptiness_test.go
+++ b/pkg/controllers/disruption/emptiness_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Emptiness", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			var wg sync.WaitGroup
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -422,7 +422,7 @@ var _ = Describe("Simulate Scheduling", func() {
 
 		// disruption won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
-		ExpectToSleep(&wg)
+		ExpectToWait(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 		ExpectSingletonReconciled(ctx, disruptionController)
 		wg.Wait()
@@ -544,7 +544,7 @@ var _ = Describe("Disruption Taints", func() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ExpectToSleep(&wg)
+			ExpectToWait(&wg)
 			ExpectSingletonReconciled(ctx, disruptionController)
 		}()
 
@@ -1913,7 +1913,7 @@ var _ = Describe("Metrics", func() {
 		fakeClock.Step(10 * time.Minute)
 
 		var wg sync.WaitGroup
-		ExpectToSleep(&wg)
+		ExpectToWait(&wg)
 		ExpectSingletonReconciled(ctx, disruptionController)
 		wg.Wait()
 
@@ -1984,7 +1984,7 @@ var _ = Describe("Metrics", func() {
 		fakeClock.Step(10 * time.Minute)
 
 		var wg sync.WaitGroup
-		ExpectToSleep(&wg)
+		ExpectToWait(&wg)
 		ExpectSingletonReconciled(ctx, disruptionController)
 		wg.Wait()
 
@@ -2056,7 +2056,7 @@ var _ = Describe("Metrics", func() {
 		fakeClock.Step(10 * time.Minute)
 
 		var wg sync.WaitGroup
-		ExpectToSleep(&wg)
+		ExpectToWait(&wg)
 		ExpectSingletonReconciled(ctx, disruptionController)
 		wg.Wait()
 
@@ -2107,7 +2107,7 @@ func fromInt(i int) *intstr.IntOrString {
 
 // This continually polls the wait group to see if there
 // is a timer waiting, incrementing the clock if not.
-func ExpectToSleep(wg *sync.WaitGroup) {
+func ExpectToWait(wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
Fixes #1434

**Description**

I ran a script in the linked issue to identify the slowest tests in the Karpenter codebase. This brought me to one of the `SimulateScheduling` tests, which called `ExpectTriggerVerifyAction` multiple times. I discovered that this test was not exercising code paths that waited in the clock (e.g `time.Sleep`), so this test helper was looping and sleeping for 8 seconds before bailing. Since the test didn't rely on any sleep, I removed the helper and saw an 8 * 4 second gain for each time this helper was called in the `SimulateScheduling` test. 

I then rewrote `ExpectTriggerVerifyAction` using expectations to assert that the sleep was actually used, and I broke dozens of tests. It seems as if we've been (understandably) writing our tests in this package with a lot of copy paste, leading to unnecessary sleeping all over the suite.

Put simply:
* If a test doesn't hit a sleep, we can just call `ExpectSingletonReconciled` synchronously
* If a test hits the code path with a sleep (e.g. consolidation's `time.Sleep(15 * time.Second)`), we need to call `ExpectTriggerVerifyAction()`

I also identified some other tests that were neither sleeping nor passing when `ExpectTriggerVerifyAction` was removed. These tests were transiently relying on the `fakeClock.Step(45 * time.Second)` at the end of the helper.

### Before

```
❯ ginkgo --json-report=report.json ./pkg/controllers/disruption
Running Suite: Disruption - /Users/etarn/go/src/github.com/kubernetes-sigs/karpenter/pkg/controllers/disruption
===============================================================================================================
Random Seed: 1721243948

Will run 173 of 173 specs
•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••

Ran 173 of 173 Specs in 527.916 seconds
SUCCESS! -- 173 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```

### After

```
❯ ginkgo --json-report=report.json ./pkg/controllers/disruption
Running Suite: Disruption - /Users/etarn/go/src/github.com/kubernetes-sigs/karpenter/pkg/controllers/disruption
===============================================================================================================
Random Seed: 1721244855

Will run 173 of 173 specs
•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••

Ran 173 of 173 Specs in 38.655 seconds
SUCCESS! -- 173 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```

### Report
```
❯ cat report.json | jq -r '
    [
        .[].SpecReports.[]?
        | select( .State | match("passed") )
        | select( .LeafNodeType | match("It"))
        | {
            Context: ( .ContainerHierarchyTexts | join("/")),
            Test: .LeafNodeText,
            Duration: (.RunTime * .000000001)
        }
    ]
    | sort_by( .Duration )
    | reverse
' 
[
  {
    "Context": "Drift/Drift",
    "Test": "should disrupt all empty drifted nodes in parallel",
    "Duration": 2.283935791
  },
  {
    "Context": "Consolidation/Node Lifetime Consideration",
    "Test": "should consider node lifetime remaining when calculating disruption cost",
    "Duration": 2.1650905000000003
  },
  {
    "Context": "Consolidation/Events",
    "Test": "should not fire an event for ConsolidationDisabled when the NodePool has consolidation set to WhenEmpty",
    "Duration": 2.11577675
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "should consider initialized nodes before uninitialized nodes",
    "Duration": 1.4470254580000002
  },
  {
    "Context": "Drift/Budgets",
    "Test": "should allow all nodes from each nodePool to be deleted",
    "Duration": 0.959368875
  },
  {
    "Context": "Emptiness/Budgets",
    "Test": "should allow 2 nodes from each nodePool to be deleted",
    "Duration": 0.805857625
  },
  {
    "Context": "Drift/Budgets",
    "Test": "should allow 2 nodes from each nodePool to be deleted",
    "Duration": 0.7990222920000001
  },
  {
    "Context": "Emptiness/Budgets",
    "Test": "should allow all nodes from each nodePool to be deleted",
    "Duration": 0.7247100000000001
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should not mark empty node consolidated if all candidates can't be disrupted due to budgets with many nodepools",
    "Duration": 0.712611167
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should allow no nodes from each nodePool to be deleted",
    "Duration": 0.70768975
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should allow 2 nodes from each nodePool to be deleted",
    "Duration": 0.666863167
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should allow all nodes from each nodePool to be deleted",
    "Duration": 0.650883583
  },
  {
    "Context": "Simulate Scheduling",
    "Test": "should allow multiple replace operations to happen successively",
    "Duration": 0.639902541
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should not mark single node consolidated if all candidates can't be disrupted due to budgets with many nodepools",
    "Duration": 0.622139792
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should not mark multi node consolidated if all candidates can't be disrupted due to budgets with many nodepools",
    "Duration": 0.60825425
  },
  {
    "Context": "Drift/Budgets",
    "Test": "should disrupt 3 nodes, taking into account commands in progress",
    "Duration": 0.5485535
  },
  {
    "Context": "Emptiness/Budgets",
    "Test": "should allow no empty nodes to be disrupted",
    "Duration": 0.38986454200000004
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should only allow 3 nodes to be deleted in single node consolidation delete",
    "Duration": 0.36420125000000003
  },
  {
    "Context": "Emptiness/Budgets",
    "Test": "should only allow 3 empty nodes to be disrupted",
    "Duration": 0.287213041
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should only allow 3 nodes to be deleted in multi node consolidation delete",
    "Duration": 0.283282083
  },
  {
    "Context": "Drift/Budgets",
    "Test": "should allow all empty nodes to be disrupted",
    "Duration": 0.278754125
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/can merge 3 nodes into 1",
    "Test": "if the candidate is spot node",
    "Duration": 0.264832458
  },
  {
    "Context": "Simulate Scheduling",
    "Test": "should allow pods on deleting nodes to reschedule to uninitialized nodes",
    "Duration": 0.260549958
  },
  {
    "Context": "Consolidation/Topology Consideration",
    "Test": "can replace node maintaining zonal topology spread",
    "Duration": 0.260548958
  },
  {
    "Context": "Drift/Budgets",
    "Test": "should allow no empty nodes to be disrupted",
    "Duration": 0.25711241700000004
  },
  {
    "Context": "Emptiness/Budgets",
    "Test": "should allow all empty nodes to be disrupted",
    "Duration": 0.256182167
  },
  {
    "Context": "BuildDisruptionBudgetMapping",
    "Test": "should not return a negative disruption value",
    "Duration": 0.25525200000000003
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/should continue to multi-nodeclaim consolidation when emptiness fails validation after the node ttl",
    "Test": "if the candidate is spot node",
    "Duration": 0.252942333
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/can merge 3 nodes into 1",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.25291504200000003
  },
  {
    "Context": "Consolidation/Multi-NodeClaim",
    "Test": "can merge 3 nodes into 1 if the candidates have both spot and on-demand",
    "Duration": 0.25039262500000004
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should only allow 3 empty nodes to be disrupted",
    "Duration": 0.25006662500000004
  },
  {
    "Context": "BuildDisruptionBudgetMapping",
    "Test": "should consider not ready nodes to the disruption count",
    "Duration": 0.247577708
  },
  {
    "Context": "Drift/Budgets",
    "Test": "should only allow 3 empty nodes to be disrupted",
    "Duration": 0.243093833
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/should continue to multi-nodeclaim consolidation when emptiness fails validation after the node ttl",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.24128658300000003
  },
  {
    "Context": "BuildDisruptionBudgetMapping",
    "Test": "should not consider nodes that are not managed as part of disruption count",
    "Duration": 0.24039895800000002
  },
  {
    "Context": "BuildDisruptionBudgetMapping",
    "Test": "should not consider nodes that are not initialized as part of disruption count",
    "Duration": 0.23271158300000003
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should allow no empty nodes to be disrupted",
    "Duration": 0.231593083
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, considers karpenter.sh/do-not-disrupt on pods",
    "Test": "if the candidate is spot node",
    "Duration": 0.22774112500000002
  },
  {
    "Context": "BuildDisruptionBudgetMapping",
    "Test": "should consider nodes with a deletion timestamp set and MarkedForDeletion to the disruption count",
    "Duration": 0.22556287500000002
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/should wait for the node TTL for non-empty nodes before consolidating (multi-node)",
    "Test": "if the candidate is spot node",
    "Duration": 0.22521775000000002
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should allow all empty nodes to be disrupted",
    "Duration": 0.2228995
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, considers karpenter.sh/do-not-disrupt on pods",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.214320208
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/should wait for the node TTL for non-empty nodes before consolidating (multi-node)",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.21355358300000002
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, considers PDB policy",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.213367834
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, considers PDB policy",
    "Test": "if the candidate is spot node",
    "Duration": 0.205057334
  },
  {
    "Context": "Consolidation/Parallelization",
    "Test": "should schedule an additional node when receiving pending pods while consolidating",
    "Duration": 0.20349929200000003
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/should continue to single nodeclaim consolidation when multi-nodeclaim consolidation fails validation after the node ttl",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.20209416600000002
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should not mark single node consolidated if the candidates can't be disrupted due to budgets with one nodepool",
    "Duration": 0.20173020900000002
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/should continue to single nodeclaim consolidation when multi-nodeclaim consolidation fails validation after the node ttl",
    "Test": "if the candidate is spot node",
    "Duration": 0.199865333
  },
  {
    "Context": "Simulate Scheduling",
    "Test": "can replace node with a local PV (ignoring hostname affinity)",
    "Duration": 0.199011709
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should not mark empty node consolidated if the candidates can't be disrupted due to budgets with one nodepool",
    "Duration": 0.19805291600000002
  },
  {
    "Context": "Consolidation/Replace/can replace nodes if another nodePool returns no instance types",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.19635470900000002
  },
  {
    "Context": "Drift/Drift",
    "Test": "can replace drifted nodes with multiple nodes",
    "Duration": 0.19412779100000002
  },
  {
    "Context": "Consolidation/Parallelization",
    "Test": "should not consolidate a node that is launched for pods on a deleting node",
    "Duration": 0.19373858300000002
  },
  {
    "Context": "Consolidation/TTL",
    "Test": "should not delete node if pods schedule with a blocking PDB during the TTL wait",
    "Duration": 0.193060167
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, PDB namespace must match",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.19279220900000002
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, PDB namespace must match",
    "Test": "if the candidate is spot node",
    "Duration": 0.19262375
  },
  {
    "Context": "Consolidation/Budgets",
    "Test": "should not mark multi node consolidated if the candidates can't be disrupted due to budgets with one nodepool",
    "Duration": 0.19126575
  },
  {
    "Context": "Consolidation/Replace/can replace nodes if another nodePool returns no instance types",
    "Test": "if the candidate is spot node",
    "Duration": 0.189911208
  },
  {
    "Context": "Metrics",
    "Test": "should fire metrics for multi-node replace disruption",
    "Duration": 0.187797875
  },
  {
    "Context": "Consolidation/TTL",
    "Test": "should not delete node if pods schedule with karpenter.sh/do-not-disrupt during the TTL wait",
    "Duration": 0.18541258400000002
  },
  {
    "Context": "Consolidation/Topology Consideration",
    "Test": "won't delete node if it would violate pod anti-affinity",
    "Duration": 0.18318466700000002
  },
  {
    "Context": "Consolidation/TTL",
    "Test": "should not replace node if a pod schedules with a blocking PDB during the TTL wait",
    "Duration": 0.16763075000000002
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, considers karpenter.sh/do-not-disrupt on nodes",
    "Test": "if the candidate is spot node",
    "Duration": 0.166949584
  },
  {
    "Context": "Drift/Drift",
    "Test": "should drift one non-empty node at a time, starting with the earliest drift",
    "Duration": 0.16107100000000002
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, considers karpenter.sh/do-not-disrupt on nodes",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.160929541
  },
  {
    "Context": "Drift/Drift",
    "Test": "should continue to the next drifted node if the first cannot reschedule all pods",
    "Duration": 0.158045041
  },
  {
    "Context": "Disruption Taints",
    "Test": "should add and remove taints from NodeClaims that fail to disrupt",
    "Duration": 0.15387125000000001
  },
  {
    "Context": "Consolidation/TTL",
    "Test": "should not replace node if a pod schedules with karpenter.sh/do-not-disrupt during the TTL wait",
    "Duration": 0.152931
  },
  {
    "Context": "Metrics",
    "Test": "should fire metrics for multi-node delete disruption",
    "Duration": 0.1500055
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/won't merge 2 nodes into 1 of the same type",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.146695041
  },
  {
    "Context": "Consolidation/TTL",
    "Test": "should wait for the node TTL for non-empty nodes before consolidating",
    "Duration": 0.144886375
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes while an invalid node pool exists",
    "Duration": 0.142185542
  },
  {
    "Context": "Consolidation/Multi-NodeClaim/won't merge 2 nodes into 1 of the same type",
    "Test": "if the candidate is spot node",
    "Duration": 0.13791229100000002
  },
  {
    "Context": "Consolidation/Replace",
    "Test": "spot to spot consolidation should consider the max of default and minimum number of instanceTypeOptions from minValues in requirement for truncation if minimum number of instanceTypeOptions from minValues in requirement is greater than 15.",
    "Duration": 0.136718416
  },
  {
    "Context": "Consolidation/Replace",
    "Test": "spot to spot consolidation should consider the default for truncation if minimum number of instanceTypeOptions from minValues in requirement is less than 15.",
    "Duration": 0.1356405
  },
  {
    "Context": "Drift/Drift",
    "Test": "can replace drifted nodes",
    "Duration": 0.131438208
  },
  {
    "Context": "Consolidation/Replace/can replace node",
    "Test": "if the candidate is spot node",
    "Duration": 0.129738458
  },
  {
    "Context": "Consolidation/Replace",
    "Test": "spot to spot consolidation should order the instance types by price before enforcing minimum flexibility.",
    "Duration": 0.128231958
  },
  {
    "Context": "Consolidation/Replace/can replace node",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.126934125
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes with a permanently pending pod",
    "Duration": 0.124004917
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes",
    "Duration": 0.123485833
  },
  {
    "Context": "Consolidation/Metrics",
    "Test": "should correctly report eligible nodes",
    "Duration": 0.121704667
  },
  {
    "Context": "Drift/Metrics",
    "Test": "should correctly report eligible nodes",
    "Duration": 0.11943600000000001
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes if another nodePool has no node template",
    "Duration": 0.118383625
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes, evicts pods without an ownerRef",
    "Duration": 0.115385917
  },
  {
    "Context": "Consolidation/TTL",
    "Test": "should not consolidate if the action picks different instance types after the node TTL wait",
    "Duration": 0.10385237500000001
  },
  {
    "Context": "Metrics",
    "Test": "should fire metrics for multi-node empty disruption",
    "Duration": 0.100251583
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes, considers karpenter.sh/do-not-disrupt on pods",
    "Duration": 0.09955712500000001
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes, considers PDB",
    "Duration": 0.09908554200000001
  },
  {
    "Context": "Drift/Drift",
    "Test": "should untaint nodes when drift replacement fails",
    "Duration": 0.09898820800000001
  },
  {
    "Context": "Metrics",
    "Test": "should fire metrics for single node delete disruption",
    "Duration": 0.09673250000000001
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes, when non-Karpenter capacity can fit pods",
    "Duration": 0.095068208
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "won't delete nodes if it would make a non-pending pod go pending",
    "Duration": 0.093795083
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "can delete nodes, considers karpenter.sh/do-not-disrupt on nodes",
    "Duration": 0.093329458
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "does not consolidate nodes with karpenter.sh/do-not-disrupt on pods when the NodePool's TerminationGracePeriod is not nil",
    "Duration": 0.09022675000000001
  },
  {
    "Context": "Metrics",
    "Test": "should fire metrics for single node replace disruption",
    "Duration": 0.086922542
  },
  {
    "Context": "Consolidation/Replace",
    "Test": "cannot replace spot with spot if the spotToSpotConsolidation is disabled",
    "Duration": 0.083259042
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "does not consolidate nodes with pods with blocking PDBs when the NodePool's TerminationGracePeriod is not nil",
    "Duration": 0.081843417
  },
  {
    "Context": "Drift/Drift",
    "Test": "should drift nodes that have pods with the karpenter.sh/do-not-disrupt annotation when the NodePool's TerminationGracePeriod is not nil",
    "Duration": 0.08021054200000001
  },
  {
    "Context": "Emptiness/Metrics",
    "Test": "should correctly report eligible nodes",
    "Duration": 0.07477370900000001
  },
  {
    "Context": "Consolidation/Delete",
    "Test": "won't delete node if it would require pods to schedule on an uninitialized node",
    "Duration": 0.07441400000000001
  },
  {
    "Context": "Consolidation/Empty",
    "Test": "will not consider a node with a terminating StatefulSet pod as empty",
    "Duration": 0.07417204200000001
  },
  {
    "Context": "Drift/Drift",
    "Test": "should drift nodes that have pods with the blocking PDBs when the NodePool's TerminationGracePeriod is not nil",
    "Duration": 0.073373083
  },
  {
    "Context": "Consolidation/TTL",
    "Test": "should not consolidate if the action becomes invalid during the node TTL wait",
    "Duration": 0.071475458
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, considers PDB",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.068013458
  },
  {
    "Context": "Consolidation/Replace/can replace nodes, considers PDB",
    "Test": "if the candidate is spot node",
    "Duration": 0.066881042
  },
  {
    "Context": "Disruption Taints",
    "Test": "should remove taints from NodeClaims that were left tainted from a previous disruption action",
    "Duration": 0.064854125
  },
  {
    "Context": "Consolidation/Replace",
    "Test": "cannot replace spot with spot if it is part of the 15 cheapest instance types.",
    "Duration": 0.06477425
  },
  {
    "Context": "Consolidation/Replace",
    "Test": "won't replace on-demand node if on-demand replacement is more expensive",
    "Duration": 0.063852667
  },
  {
    "Context": "Consolidation/Empty",
    "Test": "can delete multiple empty nodes",
    "Duration": 0.063686584
  },
  {
    "Context": "Consolidation/Empty",
    "Test": "considers pending pods when consolidating",
    "Duration": 0.061551667000000004
  },
  {
    "Context": "Consolidation/Replace",
    "Test": "won't replace node if any spot replacement is more expensive",
    "Duration": 0.0612035
  },
  {
    "Context": "Consolidation/Replace",
    "Test": "cannot replace spot with spot if less than minimum InstanceTypes flexibility",
    "Duration": 0.060377625000000004
  },
  {
    "Context": "Consolidation/TTL",
    "Test": "should wait for the node TTL for empty nodes before consolidating",
    "Duration": 0.06026075
  },
  {
    "Context": "Consolidation/Empty",
    "Test": "will consider a node with terminating Deployment pods as empty",
    "Duration": 0.059332208000000004
  },
  {
    "Context": "Consolidation/Replace/Consolidation should fail if filterByPrice breaks the minimum requirement from the NodePools.",
    "Test": "if the candidate is spot node",
    "Duration": 0.05864250000000001
  },
  {
    "Context": "Drift/Drift",
    "Test": "should delete nodes with the karpenter.sh/do-not-disrupt annotation set to false",
    "Duration": 0.057385375
  },
  {
    "Context": "Drift/Drift",
    "Test": "should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation",
    "Duration": 0.05566925
  },
  {
    "Context": "Consolidation/Replace/Consolidation should fail if filterByPrice breaks the minimum requirement from the NodePools.",
    "Test": "if the candidate is on-demand node",
    "Duration": 0.053661125000000004
  },
  {
    "Context": "Emptiness/Emptiness",
    "Test": "should ignore nodes that have pods",
    "Duration": 0.053588125
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have PDB-blocked pods scheduled with a terminationGracePeriod set for graceful disruption",
    "Duration": 0.053130959000000005
  },
  {
    "Context": "Drift/Drift",
    "Test": "should ignore nodes without the drifted status condition",
    "Duration": 0.053095417000000006
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should consider candidates that have fully blocking PDBs on terminal pods",
    "Duration": 0.052732292
  },
  {
    "Context": "Emptiness/Events",
    "Test": "should not fire an event for ConsolidationDisabled when the NodePool has consolidation set to WhenUnderutilized",
    "Duration": 0.052617000000000004
  },
  {
    "Context": "Drift/Drift",
    "Test": "should ignore nodes with the drifted status condition set to false",
    "Duration": 0.05258137500000001
  },
  {
    "Context": "Consolidation/Empty",
    "Test": "will consider a node with a DaemonSet pod as empty",
    "Duration": 0.051598125
  },
  {
    "Context": "Consolidation/Events",
    "Test": "should fire an event for ConsolidationDisabled when the NodePool has consolidateAfter set to 'Never'",
    "Duration": 0.050590542
  },
  {
    "Context": "Emptiness/Events",
    "Test": "should fire an event for ConsolidationDisabled when the NodePool has consolidateAfter set to 'Never'",
    "Duration": 0.050172834000000006
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have fully blocking PDBs on daemonset pods",
    "Duration": 0.04944475
  },
  {
    "Context": "Drift/Drift",
    "Test": "can delete drifted nodes",
    "Duration": 0.049038250000000005
  },
  {
    "Context": "Emptiness/Emptiness",
    "Test": "should ignore nodes without the empty status condition",
    "Duration": 0.047777792000000006
  },
  {
    "Context": "Metrics",
    "Test": "should fire metrics for single node empty disruption",
    "Duration": 0.047618292
  },
  {
    "Context": "Consolidation/Empty",
    "Test": "can delete empty nodes",
    "Duration": 0.047439542
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have do-not-disrupt daemonset pods scheduled",
    "Duration": 0.047365500000000005
  },
  {
    "Context": "Emptiness/Emptiness",
    "Test": "should ignore nodes with the karpenter.sh/do-not-disrupt annotation",
    "Duration": 0.047046833
  },
  {
    "Context": "Emptiness/Emptiness",
    "Test": "should ignore nodes with the empty status condition set to false",
    "Duration": 0.046888167
  },
  {
    "Context": "Drift/Drift",
    "Test": "should ignore nodes with the karpenter.sh/do-not-disrupt annotation",
    "Duration": 0.046597583000000005
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should consider candidates that have fully blocking PDBs on mirror pods",
    "Duration": 0.044853458000000006
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should consider candidates that have fully blocking PDBs on terminating pods",
    "Duration": 0.044837333
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should consider candidates that have PDB-blocked pods scheduled with a terminationGracePeriod set for eventual disruption",
    "Duration": 0.044444500000000005
  },
  {
    "Context": "Emptiness/Emptiness",
    "Test": "can delete empty nodes",
    "Duration": 0.044170708
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have fully blocking PDBs without a terminationGracePeriod set for graceful disruption",
    "Duration": 0.043868167
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have do-not-disrupt pods scheduled without a terminationGracePeriod set for eventual disruption",
    "Duration": 0.043617125
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have fully blocking PDBs",
    "Duration": 0.043168416
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have do-not-disrupt pods scheduled with a terminationGracePeriod set for graceful disruption",
    "Duration": 0.042966917
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have do-not-disrupt mirror pods scheduled",
    "Duration": 0.042881083
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that do not have the node.kubernetes.io/instance-type label",
    "Duration": 0.042544500000000006
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should consider candidates that have do-not-disrupt terminating pods",
    "Duration": 0.042016500000000005
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should consider candidates that have do-not-disrupt pods scheduled with a terminationGracePeriod set for eventual disruption",
    "Duration": 0.041994041
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have do-not-disrupt pods without a terminationGracePeriod set for graceful disruption",
    "Duration": 0.041939875
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have do-not-disrupt pods scheduled and no terminationGracePeriod",
    "Duration": 0.041621833000000004
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that are deleting",
    "Duration": 0.041062875000000006
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should consider candidates that have do-not-disrupt terminal pods",
    "Duration": 0.040649417
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have PDB-blocked pods scheduled without a terminationGracePeriod set for eventual disruption",
    "Duration": 0.040406583
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that do not have the topology.kubernetes.io/zone label",
    "Duration": 0.040157042000000004
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that are nominated",
    "Duration": 0.039203792
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that are MarkedForDeletion",
    "Duration": 0.037718625000000006
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have do-not-disrupt on nodes",
    "Duration": 0.037520958
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that are not owned by a NodePool (no karpenter.sh/nodepool label)",
    "Duration": 0.036110125
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that have an instance type that cannot be resolved",
    "Duration": 0.035995917
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that are actively being processed in the queue",
    "Duration": 0.035498375000000006
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that do not have the karpenter.sh/capacity-type label",
    "Duration": 0.034641250000000005
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that are have a non-existent NodePool",
    "Duration": 0.031486875000000004
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that aren't yet initialized",
    "Duration": 0.027789834000000003
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidate that has just a NodeClaim representation",
    "Duration": 0.025876167000000002
  },
  {
    "Context": "Candidate Filtering",
    "Test": "should not consider candidates that has just a Node representation",
    "Duration": 0.025566125000000002
  },
  {
    "Context": "Pod Eviction Cost",
    "Test": "should have a higher disruptionCost for a pod with a higher priority",
    "Duration": 0.013986708
  },
  {
    "Context": "Pod Eviction Cost",
    "Test": "should have a higher disruptionCost for a pod with a positive deletion disruptionCost",
    "Duration": 0.013296667000000002
  },
  {
    "Context": "Pod Eviction Cost",
    "Test": "should have higher costs for higher deletion costs",
    "Duration": 0.012931416000000001
  },
  {
    "Context": "Pod Eviction Cost",
    "Test": "should have a standard disruptionCost for a pod with no priority or disruptionCost specified",
    "Duration": 0.0126145
  },
  {
    "Context": "Pod Eviction Cost",
    "Test": "should have a lower disruptionCost for a pod with a positive deletion disruptionCost",
    "Duration": 0.012426125000000001
  },
  {
    "Context": "Pod Eviction Cost",
    "Test": "should have a lower disruptionCost for a pod with a lower priority",
    "Duration": 0.01184725
  }
]
```

## Before


**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
