### PR TITLE
chore: remove readiness check on cache sync

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -219,9 +219,6 @@ func NewOperator() (context.Context, *Operator) {
 		return []string{o.(*v1.NodePool).Spec.Template.Spec.NodeClassRef.Name}
 	}), "failed to setup nodepool nodeclassref name indexer")
 
-	lo.Must0(mgr.AddReadyzCheck("manager", func(req *http.Request) error {
-		return lo.Ternary(mgr.GetCache().WaitForCacheSync(req.Context()), nil, fmt.Errorf("failed to sync caches"))
-	}))
 	lo.Must0(mgr.AddHealthzCheck("healthz", healthz.Ping))
 	lo.Must0(mgr.AddReadyzCheck("readyz", healthz.Ping))
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Temporarily removes the readiness check on cache sync ahead of v1. This check was introduced by #401, but has an unexpected consequence for the upgrade path to v1. Consider the following scenario:
- A cluster is upgraded from v0.37.0 to a version with the v1 APIs / conversion webhooks
- The newly deployed Karpenter pods must list all resources before going ready
- This list call is going to attempt to invoke the conversion webhook
- Karpenter's endpoint is not ready since the pod is not ready, and the webhook can't be called through the service

In this scenario, Karpenter will be stuck in an unready state and be unable to progress.

**How was this change tested?**
manual validation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
