### PR TITLE
test: remove kind due to flakes

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -2,7 +2,6 @@ name: kind-e2e
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 jobs:
   kind-e2e:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Removes kind e2es from presubmit so that we don't have flakes blocking PRs. Keeps it on push so that we can still have it run whenever a PR is merged.

**How was this change tested?**
Testing here

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
