### PR TITLE
chore: rename disruption taint

### DIFF
--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Drift", func() {
 
 			nodes = ExpectNodes(ctx, env.Client)
 			Expect(len(lo.Filter(nodes, func(nc *corev1.Node, _ int) bool {
-				return lo.Contains(nc.Spec.Taints, v1.DisruptionNoScheduleTaint)
+				return lo.Contains(nc.Spec.Taints, v1.DisruptedNoScheduleTaint)
 			}))).To(Equal(3))
 			// Execute all commands in the queue, only deleting 3 nodes
 			for i := 0; i < 5; i++ {
@@ -765,7 +765,7 @@ var _ = Describe("Drift", func() {
 			ExpectSingletonReconciled(ctx, queue)
 			// We should have tried to create a new nodeClaim but failed to do so; therefore, we untainted the existing node
 			node = ExpectExists(ctx, env.Client, node)
-			Expect(node.Spec.Taints).ToNot(ContainElement(v1.DisruptionNoScheduleTaint))
+			Expect(node.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
 		})
 		It("can replace drifted nodes with multiple nodes", func() {
 			currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{

--- a/pkg/controllers/disruption/orchestration/suite_test.go
+++ b/pkg/controllers/disruption/orchestration/suite_test.go
@@ -138,8 +138,8 @@ var _ = Describe("Queue", func() {
 				},
 			},
 		)
-		node1.Spec.Taints = append(node1.Spec.Taints, v1.DisruptionNoScheduleTaint)
-		node2.Spec.Taints = append(node2.Spec.Taints, v1.DisruptionNoScheduleTaint)
+		node1.Spec.Taints = append(node1.Spec.Taints, v1.DisruptedNoScheduleTaint)
+		node2.Spec.Taints = append(node2.Spec.Taints, v1.DisruptedNoScheduleTaint)
 
 		ncName = test.RandomName()
 		replacements = []string{ncName}
@@ -170,7 +170,7 @@ var _ = Describe("Queue", func() {
 			Expect(queue.Add(orchestration.NewCommand(replacements, []*state.StateNode{stateNode}, "", "test-method", "fake-type"))).To(BeNil())
 
 			node1 = ExpectNodeExists(ctx, env.Client, node1.Name)
-			Expect(node1.Spec.Taints).To(ContainElement(v1.DisruptionNoScheduleTaint))
+			Expect(node1.Spec.Taints).To(ContainElement(v1.DisruptedNoScheduleTaint))
 
 			ExpectSingletonReconciled(ctx, queue)
 
@@ -178,7 +178,7 @@ var _ = Describe("Queue", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))
 			node1 = ExpectNodeExists(ctx, env.Client, node1.Name)
-			Expect(node1.Spec.Taints).To(ContainElement(v1.DisruptionNoScheduleTaint))
+			Expect(node1.Spec.Taints).To(ContainElement(v1.DisruptedNoScheduleTaint))
 		})
 		It("should not return an error when handling commands before the timeout", func() {
 			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool, replacementNodeClaim)
@@ -200,7 +200,7 @@ var _ = Describe("Queue", func() {
 
 			ExpectSingletonReconciled(ctx, queue)
 			node1 = ExpectNodeExists(ctx, env.Client, node1.Name)
-			Expect(node1.Spec.Taints).ToNot(ContainElement(v1.DisruptionNoScheduleTaint))
+			Expect(node1.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
 		})
 		It("should fully handle a command when replacements are initialized", func() {
 			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool, replacementNodeClaim, replacementNode)

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -512,7 +512,7 @@ var _ = Describe("Disruption Taints", func() {
 			},
 		})
 		nodePool.Spec.Disruption.ConsolidateAfter = &v1.NillableDuration{Duration: nil}
-		node.Spec.Taints = append(node.Spec.Taints, v1.DisruptionNoScheduleTaint)
+		node.Spec.Taints = append(node.Spec.Taints, v1.DisruptedNoScheduleTaint)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node, pod)
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
@@ -520,7 +520,7 @@ var _ = Describe("Disruption Taints", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 		ExpectSingletonReconciled(ctx, disruptionController)
 		node = ExpectNodeExists(ctx, env.Client, node.Name)
-		Expect(node.Spec.Taints).ToNot(ContainElement(v1.DisruptionNoScheduleTaint))
+		Expect(node.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
 	})
 	It("should add and remove taints from NodeClaims that fail to disrupt", func() {
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1.ConsolidationPolicyWhenUnderutilized
@@ -556,7 +556,7 @@ var _ = Describe("Disruption Taints", func() {
 			}
 		}
 		node = ExpectNodeExists(ctx, env.Client, node.Name)
-		Expect(node.Spec.Taints).To(ContainElement(v1.DisruptionNoScheduleTaint))
+		Expect(node.Spec.Taints).To(ContainElement(v1.DisruptedNoScheduleTaint))
 
 		createdNodeClaim := lo.Reject(ExpectNodeClaims(ctx, env.Client), func(nc *v1.NodeClaim, _ int) bool {
 			return nc.Name == nodeClaim.Name
@@ -572,7 +572,7 @@ var _ = Describe("Disruption Taints", func() {
 		ExpectSingletonReconciled(ctx, queue)
 
 		node = ExpectNodeExists(ctx, env.Client, node.Name)
-		Expect(node.Spec.Taints).ToNot(ContainElement(v1.DisruptionNoScheduleTaint))
+		Expect(node.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
 	})
 })
 
@@ -2093,7 +2093,7 @@ func ExpectToWait(wg *sync.WaitGroup) {
 func ExpectTaintedNodeCount(ctx context.Context, c client.Client, numTainted int) []*corev1.Node {
 	GinkgoHelper()
 	tainted := lo.Filter(ExpectNodes(ctx, c), func(n *corev1.Node, _ int) bool {
-		return lo.Contains(n.Spec.Taints, v1.DisruptionNoScheduleTaint)
+		return lo.Contains(n.Spec.Taints, v1.DisruptedNoScheduleTaint)
 	})
 	Expect(len(tainted)).To(Equal(numTainted))
 	return tainted

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -95,8 +95,8 @@ func (c *Controller) finalize(ctx context.Context, node *corev1.Node) (reconcile
 		return reconcile.Result{}, err
 	}
 
-	if err := c.terminator.Taint(ctx, node, v1.DisruptionNoScheduleTaint); err != nil {
-		return reconcile.Result{}, fmt.Errorf("tainting node with %s, %w", v1.DisruptionTaintKey, err)
+	if err := c.terminator.Taint(ctx, node, v1.DisruptedNoScheduleTaint); err != nil {
+		return reconcile.Result{}, fmt.Errorf("tainting node with %s, %w", v1.DisruptedTaintKey, err)
 	}
 	if err := c.terminator.Drain(ctx, node, nodeTerminationTime); err != nil {
 		if !terminator.IsNodeDrainError(err) {

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Termination", func() {
 			podEvict := test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})
 			podSkip := test.Pod(test.PodOptions{
 				NodeName:    node.Name,
-				Tolerations: []corev1.Toleration{{Key: v1.DisruptionTaintKey, Operator: corev1.TolerationOpEqual, Effect: v1.DisruptionNoScheduleTaint.Effect, Value: v1.DisruptionNoScheduleTaint.Value}},
+				Tolerations: []corev1.Toleration{{Key: v1.DisruptedTaintKey, Operator: corev1.TolerationOpEqual, Effect: v1.DisruptedNoScheduleTaint.Effect, Value: v1.DisruptedNoScheduleTaint.Value}},
 				ObjectMeta:  metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs},
 			})
 			ExpectApplied(ctx, env.Client, node, nodeClaim, podEvict, podSkip)
@@ -213,7 +213,7 @@ var _ = Describe("Termination", func() {
 			podEvict := test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})
 			podSkip := test.Pod(test.PodOptions{
 				NodeName:    node.Name,
-				Tolerations: []corev1.Toleration{{Key: v1.DisruptionTaintKey, Operator: corev1.TolerationOpExists, Effect: v1.DisruptionNoScheduleTaint.Effect}},
+				Tolerations: []corev1.Toleration{{Key: v1.DisruptedTaintKey, Operator: corev1.TolerationOpExists, Effect: v1.DisruptedNoScheduleTaint.Effect}},
 				ObjectMeta:  metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs},
 			})
 			ExpectApplied(ctx, env.Client, node, nodeClaim, podEvict, podSkip)
@@ -818,7 +818,7 @@ var _ = Describe("Termination", func() {
 func ExpectNodeWithNodeClaimDraining(c client.Client, nodeName string) *corev1.Node {
 	GinkgoHelper()
 	node := ExpectNodeExists(ctx, c, nodeName)
-	Expect(node.Spec.Taints).To(ContainElement(v1.DisruptionNoScheduleTaint))
+	Expect(node.Spec.Taints).To(ContainElement(v1.DisruptedNoScheduleTaint))
 	Expect(lo.Contains(node.Finalizers, v1.TerminationFinalizer)).To(BeTrue())
 	Expect(node.DeletionTimestamp).ToNot(BeNil())
 	return node

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -493,15 +493,15 @@ func RequireNoScheduleTaint(ctx context.Context, kubeClient client.Client, addTa
 		// If the taint is present and we want to remove the taint, remove it.
 		if !addTaint {
 			node.Spec.Taints = lo.Reject(node.Spec.Taints, func(taint corev1.Taint, _ int) bool {
-				return taint.Key == v1.DisruptionTaintKey
+				return v1.IsDisruptingTaint(taint)
 			})
 			// otherwise, add it.
 		} else if addTaint && !hasTaint {
 			// If the taint key is present (but with a different value or effect), remove it.
-			node.Spec.Taints = lo.Reject(node.Spec.Taints, func(t corev1.Taint, _ int) bool {
-				return t.Key == v1.DisruptionTaintKey
+			node.Spec.Taints = lo.Reject(node.Spec.Taints, func(taint corev1.Taint, _ int) bool {
+				return v1.IsDisruptingTaint(taint)
 			})
-			node.Spec.Taints = append(node.Spec.Taints, v1.DisruptionNoScheduleTaint)
+			node.Spec.Taints = append(node.Spec.Taints, v1.DisruptedNoScheduleTaint)
 		}
 		if !equality.Semantic.DeepEqual(stored, node) {
 			if err := kubeClient.Patch(ctx, node, client.StrategicMergeFrom(stored)); err != nil {

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -176,7 +176,7 @@ func HasDoNotDisrupt(pod *corev1.Pod) bool {
 
 // ToleratesDisruptionNoScheduleTaint returns true if the pod tolerates karpenter.sh/disruption:NoSchedule=Disrupting taint
 func ToleratesDisruptionNoScheduleTaint(pod *corev1.Pod) bool {
-	return scheduling.Taints([]corev1.Taint{v1.DisruptionNoScheduleTaint}).Tolerates(pod) == nil
+	return scheduling.Taints([]corev1.Taint{v1.DisruptedNoScheduleTaint}).Tolerates(pod) == nil
 }
 
 // HasRequiredPodAntiAffinity returns true if a non-empty PodAntiAffinity/RequiredDuringSchedulingIgnoredDuringExecution

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -127,7 +127,7 @@ func NewClient(ctx context.Context, config *rest.Config) client.Client {
 	lo.Must0(cache.IndexField(ctx, &corev1.Node{}, "spec.taints[*].karpenter.sh/disruption", func(o client.Object) []string {
 		node := o.(*corev1.Node)
 		t, _ := lo.Find(node.Spec.Taints, func(t corev1.Taint) bool {
-			return t.Key == v1.DisruptionTaintKey
+			return t.Key == v1.DisruptedTaintKey
 		})
 		return []string{t.Value}
 	}))

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -509,7 +509,7 @@ func (env *Environment) ConsistentlyExpectDisruptionsWithNodeCount(disruptingNod
 
 		nodes = lo.Filter(nodeList.Items, func(n corev1.Node, _ int) bool {
 			_, ok := lo.Find(n.Spec.Taints, func(t corev1.Taint) bool {
-				return v1.IsDisruptingTaint(t)
+				return t.MatchTaint(&v1.DisruptedNoScheduleTaint)
 			})
 			return ok
 		})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Replaces the disruption taint as per https://github.com/kubernetes-sigs/karpenter/pull/1222.

`karpenter.sh/disruption=disrupting:NoSchedule` -> `karpenter.sh/disrupted:NoSchedule`

When the taint is removed by the orchestration queue or disruption controller, we'll also remove the v1beta1 equivalent version of the taint. This ensures we don't leave nodes tainted if Karpenter is upgraded after they've been disrupted but before they've been terminated.

**How was this change tested?**
`make presubmit` and validation against the AWS provider (TODO)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
