### PR TITLE
feat: Remove karpenter.sh/managed-by var

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -46,7 +46,6 @@ const (
 const (
 	DoNotDisruptAnnotationKey                  = apis.Group + "/do-not-disrupt"
 	ProviderCompatibilityAnnotationKey         = apis.CompatibilityGroup + "/provider"
-	ManagedByAnnotationKey                     = apis.Group + "/managed-by"
 	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"
 	KubeletCompatibilityAnnotationKey          = apis.CompatibilityGroup + "/v1beta1-kubelet-conversion"

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -46,7 +46,6 @@ const (
 const (
 	DoNotDisruptAnnotationKey             = apis.Group + "/do-not-disrupt"
 	ProviderCompatibilityAnnotationKey    = apis.CompatibilityGroup + "/provider"
-	ManagedByAnnotationKey                = apis.Group + "/managed-by"
 	NodePoolHashAnnotationKey             = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey      = apis.Group + "/nodepool-hash-version"
 	NodeTerminationTimestampAnnotationKey = apis.Group + "/node-termination-timestamp"

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -46,6 +46,7 @@ const (
 const (
 	DoNotDisruptAnnotationKey             = apis.Group + "/do-not-disrupt"
 	ProviderCompatibilityAnnotationKey    = apis.CompatibilityGroup + "/provider"
+	ManagedByAnnotationKey                = apis.Group + "/managed-by"
 	NodePoolHashAnnotationKey             = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey      = apis.Group + "/nodepool-hash-version"
 	NodeTerminationTimestampAnnotationKey = apis.Group + "/node-termination-timestamp"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Dropping `karpenter.sh/managed-by` as it is an artifact of a migration path and not something needed in the future. Adding `eks:eks-cluster-name` to support pod identity sessions.

**How was this change tested?**
make test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
