### PR TITLE
docs: Change example NodePool in kwok readme from v1beta to v1.

### DIFF
--- a/kwok/README.md
+++ b/kwok/README.md
@@ -20,7 +20,7 @@ Once kwok is installed and Karpenter successfully applies to the cluster, you sh
 
 ```bash
 cat <<EOF | envsubst | kubectl apply -f -
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: default
@@ -40,12 +40,12 @@ spec:
       nodeClassRef:
         name: default
         kind: KWOKNodeClass
-        apiVersion: v1alpha1
+        group: karpenter.kwok.sh/v1alpha1
+      expireAfter: 720h # 30 * 24h = 720h
   limits:
     cpu: 1000
   disruption:
     consolidationPolicy: WhenUnderutilized
-    expireAfter: 720h # 30 * 24h = 720h
 ---
 apiVersion: karpenter.kwok.sh/v1alpha1
 kind: KWOKNodeClass


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
When run the kwoks examples, I found that I had to configure the webhook to convert versions. So change example NodePool in kwok readme from v1beta to v1 to run the example directly.


**How was this change tested?**
Only docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
