### PR TITLE
fix: Wait for pods to be fully terminated in groups

### DIFF
--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -18,7 +18,6 @@ package terminator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -109,7 +108,7 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 		if len(group) > 0 {
 			// Only add pods to the eviction queue that haven't been evicted yet
 			t.evictionQueue.Add(lo.Filter(group, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p) })...)
-			return NewNodeDrainError(errors.New("pods are waiting to be evicted"))
+			return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", lo.SumBy(podGroups, func(pods []*corev1.Pod) int { return len(pods) })))
 		}
 	}
 	return nil

--- a/pkg/test/daemonsets.go
+++ b/pkg/test/daemonsets.go
@@ -42,22 +42,20 @@ func DaemonSet(overrides ...DaemonSetOptions) *appsv1.DaemonSet {
 			panic(fmt.Sprintf("Failed to merge daemonset options: %s", err))
 		}
 	}
-	if options.Name == "" {
-		options.Name = RandomName()
+	objectMeta := NamespacedObjectMeta(options.ObjectMeta)
+	if options.PodOptions.Labels == nil {
+		options.PodOptions.Labels = map[string]string{
+			"app": objectMeta.Name,
+		}
 	}
-	if options.Namespace == "" {
-		options.Namespace = "default"
-	}
-	if options.Selector == nil {
-		options.Selector = map[string]string{"app": options.Name}
-	}
+	pod := Pod(options.PodOptions)
 	return &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Name: options.Name, Namespace: options.Namespace},
+		ObjectMeta: objectMeta,
 		Spec: appsv1.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{MatchLabels: options.Selector},
+			Selector: &metav1.LabelSelector{MatchLabels: options.PodOptions.Labels},
 			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: options.Selector},
-				Spec:       Pod(options.PodOptions).Spec,
+				ObjectMeta: ObjectMeta(options.PodOptions.ObjectMeta),
+				Spec:       pod.Spec,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/kubernetes-sigs/karpenter/issues/1133
Fixes https://github.com/aws/karpenter-provider-aws/issues/5858

**Description**

This change updates the pod drain logic so that we fully wait for a pod group termination to complete before we proceed to the next eviction group

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
