### PR TITLE
chore: Add status validation to v1

### DIFF
--- a/hack/validation/status.sh
+++ b/hack/validation/status.sh
@@ -1,5 +1,6 @@
 # Updating the set of required items in our status conditions so that we support older versions of the condition
-# TODO: This can be removed once we upgrade to v1 and can do conversion to automatically set values for old versions of the condition
-yq eval 'del(.spec.versions[1].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.minLength)' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
-yq eval '.spec.versions[1].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.pattern = "^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
-yq eval '.spec.versions[1].schema.openAPIV3Schema.properties.status.properties.conditions.items.required = ["lastTransitionTime","status","type"]' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+for Version in  $(seq 0 1); do 
+    yqVersion="$Version" yq eval 'del(.spec.versions[env(yqVersion)].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.minLength)' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+    yqVersion="$Version" yq eval '.spec.versions[env(yqVersion)].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.pattern = "^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+    yqVersion="$Version" yq eval '.spec.versions[env(yqVersion)].schema.openAPIV3Schema.properties.status.properties.conditions.items.required = ["lastTransitionTime","status","type"]' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+done

--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -339,8 +339,7 @@ spec:
                           The value should be a CamelCase string.
                           This field may not be empty.
                         maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
                         type: string
                       status:
                         description: status of the condition, one of True, False, Unknown.
@@ -361,8 +360,6 @@ spec:
                         type: string
                     required:
                       - lastTransitionTime
-                      - message
-                      - reason
                       - status
                       - type
                     type: object

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -337,8 +337,7 @@ spec:
                           The value should be a CamelCase string.
                           This field may not be empty.
                         maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
                         type: string
                       status:
                         description: status of the condition, one of True, False, Unknown.
@@ -359,8 +358,6 @@ spec:
                         type: string
                     required:
                       - lastTransitionTime
-                      - message
-                      - reason
                       - status
                       - type
                     type: object


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Add status validation for both v1 and v1beta1. Since `metav1.Condation` is being aliased, `operatorpkg.Status` will need to update the `status.Condition` for us to remove the injected vaildation  

**How was this change tested?**
- Manually Tested

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
