### PR TITLE
chore: Reduce requirement iteams  for v1beta1 to 30

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -629,7 +629,7 @@ spec:
                       - key
                       - operator
                     type: object
-                  maxItems: 100
+                  maxItems: 30
                   type: array
                   x-kubernetes-validations:
                     - message: requirements with operator 'In' must have a value defined

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -874,7 +874,7 @@ spec:
                               - key
                               - operator
                             type: object
-                          maxItems: 100
+                          maxItems: 30
                           type: array
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -625,7 +625,7 @@ spec:
                       - key
                       - operator
                     type: object
-                  maxItems: 100
+                  maxItems: 30
                   type: array
                   x-kubernetes-validations:
                     - message: requirements with operator 'In' must have a value defined

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -870,7 +870,7 @@ spec:
                               - key
                               - operator
                             type: object
-                          maxItems: 100
+                          maxItems: 30
                           type: array
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -37,7 +37,7 @@ type NodeClaimSpec struct {
 	// +kubebuilder:validation:XValidation:message="requirements with operator 'In' must have a value defined",rule="self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
 	// +kubebuilder:validation:XValidation:message="requirements operator 'Gt' or 'Lt' must have a single positive integer value",rule="self.all(x, (x.operator == 'Gt' || x.operator == 'Lt') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
 	// +kubebuilder:validation:XValidation:message="requirements with 'minValues' must have at least that many values specified in the 'values' field",rule="self.all(x, (x.operator == 'In' && has(x.minValues)) ? x.values.size() >= x.minValues : true)"
-	// +kubebuilder:validation:MaxItems:=100
+	// +kubebuilder:validation:MaxItems:=30
 	// +required
 	Requirements []NodeSelectorRequirementWithMinValues `json:"requirements" hash:"ignore"`
 	// Resources models the resource requirements for the NodeClaim to launch


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Reduce MaxIteams for v1beta1 APIs requiemetns from 100 -> 30. 
- This change is to make the v1beta1 APIs consistent with the v0.37.0
- https://github.com/kubernetes-sigs/karpenter/blob/38b4c32043724f6dafce910669777877295d89ec/pkg/apis/v1beta1/nodeclaim.go#L40

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
