### PR TITLE
chore: Add pattern check for group in nodeClassRef

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -86,6 +86,7 @@ spec:
                   properties:
                     group:
                       description: API version of the referent
+                      pattern: ^[^/]*$
                       type: string
                     kind:
                       description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -225,6 +225,7 @@ spec:
                           properties:
                             group:
                               description: API version of the referent
+                              pattern: ^[^/]*$
                               type: string
                             kind:
                               description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -86,6 +86,7 @@ spec:
                   properties:
                     group:
                       description: API version of the referent
+                      pattern: ^[^/]*$
                       type: string
                     kind:
                       description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -225,6 +225,7 @@ spec:
                           properties:
                             group:
                               description: API version of the referent
+                              pattern: ^[^/]*$
                               type: string
                             kind:
                               description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -103,6 +103,7 @@ type NodeClassReference struct {
 	// +required
 	Name string `json:"name"`
 	// API version of the referent
+	// +kubebuilder:validation:Pattern=`^[^/]*$`
 	// +required
 	Group string `json:"group"`
 }

--- a/pkg/apis/v1/nodeclaim_validation_cel_test.go
+++ b/pkg/apis/v1/nodeclaim_validation_cel_test.go
@@ -21,6 +21,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/awslabs/operatorpkg/object"
+
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+
 	"sigs.k8s.io/karpenter/pkg/test"
 
 	"github.com/Pallinder/go-randomdata"
@@ -93,6 +97,24 @@ var _ = Describe("Validation", func() {
 				{Key: "a", Effect: v1.TaintEffectNoExecute},
 			}
 			Expect(env.Client.Create(ctx, nodeClaim)).To(Succeed())
+		})
+	})
+	Context("NodeClassRef", func() {
+		It("should succeed for valid group", func() {
+			nodeClaim.Spec.NodeClassRef = &NodeClassReference{
+				Kind:  object.GVK(&v1alpha1.TestNodeClass{}).Kind,
+				Name:  "nodeclass-test",
+				Group: object.GVK(&v1alpha1.TestNodeClass{}).Group,
+			}
+			Expect(env.Client.Create(ctx, nodeClaim)).To(Succeed())
+		})
+		It("should fail for invalid group", func() {
+			nodeClaim.Spec.NodeClassRef = &NodeClassReference{
+				Kind:  object.GVK(&v1alpha1.TestNodeClass{}).Kind,
+				Name:  "nodeclass-test",
+				Group: "karpenter.test.sh/v1",
+			}
+			Expect(env.Client.Create(ctx, nodeClaim)).ToNot(Succeed())
 		})
 	})
 	Context("Requirements", func() {

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -368,7 +368,7 @@ var _ = Describe("Drift", func() {
 							NodeClassRef: &v1.NodeClassReference{
 								Kind:  "fakeKind",
 								Name:  "fakeName",
-								Group: "fakeGroup/fakeVerion",
+								Group: "fakeGroup",
 							},
 							Taints: []corev1.Taint{
 								{

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -1260,7 +1260,7 @@ var _ = Describe("Provisioning", func() {
 					Template: v1.NodeClaimTemplate{
 						Spec: v1.NodeClaimTemplateSpec{
 							NodeClassRef: &v1.NodeClassReference{
-								Group: "cloudprovider.karpenter.sh/v1",
+								Group: "cloudprovider.karpenter.sh",
 								Kind:  "CloudProvider",
 								Name:  "default",
 							},
@@ -1275,7 +1275,7 @@ var _ = Describe("Provisioning", func() {
 			Expect(cloudProvider.CreateCalls).To(HaveLen(1))
 			Expect(cloudProvider.CreateCalls[0].Spec.NodeClassRef).To(Equal(
 				&v1.NodeClassReference{
-					Group: "cloudprovider.karpenter.sh/v1",
+					Group: "cloudprovider.karpenter.sh",
 					Kind:  "CloudProvider",
 					Name:  "default",
 				},

--- a/pkg/utils/node/suite_test.go
+++ b/pkg/utils/node/suite_test.go
@@ -69,7 +69,7 @@ var _ = Describe("NodeUtils", func() {
 			Spec: v1.NodeClaimSpec{
 				NodeClassRef: &v1.NodeClassReference{
 					Kind:  "NodeClassRef",
-					Group: "test.cloudprovider/v1",
+					Group: "test.cloudprovider",
 					Name:  "default",
 				},
 			},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
If a user creates a nodePool with nodeClassRef as shown below, nodePool fails to watch the nodeClass and nodePool remains stuck in not ready condition if EC2NodeClass is created before nodePool.
```
nodeClassRef:
  group: karpenter.k8s.aws/v1
  kind: EC2NodeClass
  name: default
```
A check has been added for the field `group` such that it will not allow slash.

**How was this change tested?**
Added test for the change. Tested on local cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
