### PR TITLE
[WIP] fix: Let karpenter service must be not empty.

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -113,6 +113,9 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 	if !lo.Contains(validLogLevels, o.LogLevel) {
 		return fmt.Errorf("validating cli flags / env vars, invalid log level %q", o.LogLevel)
 	}
+	if o.ServiceName == "" {
+		return errors.New("Karpenter-service must be not empty")
+	}
 	gates, err := ParseFeatureGates(o.FeatureGates.inputStr)
 	if err != nil {
 		return fmt.Errorf("parsing feature gates, %w", err)

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -261,6 +261,19 @@ var _ = Describe("Options", func() {
 				},
 			}))
 		})
+
+		It("service should not empty", func() {
+			fs = &options.FlagSet{
+				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
+			}
+			opts.AddFlags(fs)
+			err := opts.Parse(
+				fs,
+				"--karpenter-service", "",
+			)
+			Expect(err).ToNot(BeNil())
+		})
+
 	})
 
 	DescribeTable(


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The karpenter service is being used by a webhook and people can't even get any clue from the error log when the service is not set. This PR makes the service a required option so that karpenter tells people that they should set the service before starting.

```shell
...
{"level":"ERROR","time":"2024-08-07T05:49:42.010Z","logger":"webhook.ConversionWebhook","message":"Error fetching secret","knative.dev/traceid":"67018811-4199-4a29-83ba-cd279a328928","knative.dev/key":"nodepools.karpenter.sh","error":"secret \"-cert\" not found"}
{"level":"ERROR","time":"2024-08-07T05:49:42.011Z","logger":"webhook.ConversionWebhook","message":"Error fetching secret","knative.dev/traceid":"a3db5afa-26b8-4492-9f2a-e94a9462a6a1","knative.dev/key":"nodeclaims.karpenter.sh","error":"secret \"-cert\" not found"}
{"level":"ERROR","time":"2024-08-07T05:49:42.011Z","logger":"webhook.ConversionWebhook","message":"Reconcile error","knative.dev/traceid":"a3db5afa-26b8-4492-9f2a-e94a9462a6a1","knative.dev/key":"nodeclaims.karpenter.sh","duration":"47.829µs","error":"secret \"-cert\" not found"}
{"level":"ERROR","time":"2024-08-07T05:49:42.011Z","logger":"webhook.ConversionWebhook","message":"Reconcile error","knative.dev/traceid":"67018811-4199-4a29-83ba-cd279a328928","knative.dev/key":"nodepools.karpenter.sh","duration":"66.724µs","error":"secret \"-cert\" not found"}
...
```

Maybe this is only check when webhook is enabled?

**How was this change tested?**

Added a go test. `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
