### PR TITLE
chore: Include status validation for v1 NodeClaim in v0.35.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ verify: ## Verify code. Includes codegen, dependencies, linting, formatting, etc
 	hack/validation/requirements.sh
 	hack/validation/labels.sh
 	hack/validation/resources.sh
+	hack/validation/status.sh
 	hack/dependabot.sh
 	@# Use perl instead of sed due to https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux
 	@# We need to do this "sed replace" until controller-tools fixes this parameterized types issue: https://github.com/kubernetes-sigs/controller-tools/issues/756

--- a/hack/validation/status.sh
+++ b/hack/validation/status.sh
@@ -1,0 +1,3 @@
+yq eval 'del(.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.minLength)' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.properties.reason.pattern = "^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.conditions.items.required = ["lastTransitionTime","status","type"]' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -337,8 +337,7 @@ spec:
                           The value should be a CamelCase string.
                           This field may not be empty.
                         maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
                         type: string
                       status:
                         description: status of the condition, one of True, False, Unknown.
@@ -359,8 +358,6 @@ spec:
                         type: string
                     required:
                       - lastTransitionTime
-                      - message
-                      - reason
                       - status
                       - type
                     type: object


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Add in validation for when controller edit v1 version of the resource

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
