### PR TITLE
chore: update nodeclaim status condition from terminating to instance…

### DIFF
--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -28,7 +28,7 @@ const (
 	ConditionTypeInitialized          = "Initialized"
 	ConditionTypeConsolidatable       = "Consolidatable"
 	ConditionTypeDrifted              = "Drifted"
-	ConditionTypeTerminating          = "Terminating"
+	ConditionTypeInstanceTerminating  = "InstanceTerminating"
 	ConditionTypeConsistentStateFound = "ConsistentStateFound"
 )
 

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Termination", func() {
 			// The first reconciliation should trigger the Delete, and set the terminating status condition
 			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
 			nc := ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nc.StatusConditions().Get(v1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
+			Expect(nc.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue()).To(BeTrue())
 			ExpectNodeExists(ctx, env.Client, node.Name)
 
 			// The second reconciliation should call get, see the "instance" is terminated, and remove the node.

--- a/pkg/controllers/nodeclaim/termination/controller.go
+++ b/pkg/controllers/nodeclaim/termination/controller.go
@@ -128,7 +128,7 @@ func (c *Controller) finalize(ctx context.Context, nodeClaim *v1.NodeClaim) (rec
 		}
 		InstanceTerminationDurationSeconds.With(map[string]string{
 			metrics.NodePoolLabel: nodeClaim.Labels[v1.NodePoolLabelKey],
-		}).Observe(time.Since(nodeClaim.StatusConditions().Get(v1.ConditionTypeTerminating).LastTransitionTime.Time).Seconds())
+		}).Observe(time.Since(nodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).LastTransitionTime.Time).Seconds())
 	}
 	controllerutil.RemoveFinalizer(nodeClaim, v1.TerminationFinalizer)
 	if !equality.Semantic.DeepEqual(stored, nodeClaim) {

--- a/pkg/controllers/nodeclaim/termination/suite_test.go
+++ b/pkg/controllers/nodeclaim/termination/suite_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Termination", func() {
 		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // now all the nodes are gone so nodeClaim deletion continues
 		Expect(result.RequeueAfter).To(BeEquivalentTo(5 * time.Second))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue()).To(BeTrue())
 
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // this will call cloudProvider Get to check if the instance is still around
 
@@ -182,7 +182,7 @@ var _ = Describe("Termination", func() {
 		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimTerminationController, nodeClaim) // this will ensure that we call cloudProvider Get to check if the instance is still around
 		Expect(result.RequeueAfter).To(BeEquivalentTo(5 * time.Second))
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue()).To(BeTrue())
 	})
 	It("should delete multiple Nodes if multiple Nodes map to the NodeClaim", func() {
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)

--- a/pkg/utils/termination/suite_test.go
+++ b/pkg/utils/termination/suite_test.go
@@ -72,7 +72,7 @@ var _ = Describe("TerminationUtils", func() {
 		cloudProvider.CreatedNodeClaims[nodeClaim.Status.ProviderID] = nodeClaim
 	})
 	It("should not call cloudProvider Delete if the status condition is already Terminating", func() {
-		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeTerminating)
+		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeInstanceTerminating)
 		ExpectApplied(ctx, env.Client, nodeClaim)
 		instanceTerminated, err := EnsureTerminated(ctx, env.Client, nodeClaim, cloudProvider)
 		Expect(len(cloudProvider.DeleteCalls)).To(BeEquivalentTo(0))
@@ -87,7 +87,7 @@ var _ = Describe("TerminationUtils", func() {
 		Expect(len(cloudProvider.DeleteCalls)).To(BeEquivalentTo(1))
 		Expect(instanceTerminated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue()).To(BeTrue())
 
 		//This will call cloudProvider.Get(). Instance is terminated at this point
 		instanceTerminated, err = EnsureTerminated(ctx, env.Client, nodeClaim, cloudProvider)
@@ -103,7 +103,7 @@ var _ = Describe("TerminationUtils", func() {
 		Expect(len(cloudProvider.DeleteCalls)).To(BeEquivalentTo(1))
 		Expect(instanceTerminated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeTerminating).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue()).To(BeTrue())
 
 		// The delete call that happened first will remove the cloudProvider instance from cloudProvider.CreatedNodeClaims[].
 		// To model the behavior of having cloudProvider instance not terminated, we add it back here.

--- a/pkg/utils/termination/termination.go
+++ b/pkg/utils/termination/termination.go
@@ -32,11 +32,11 @@ import (
 // conflict or a NotFound error if we encounter it while updating the status on nodeClaim.
 func EnsureTerminated(ctx context.Context, c client.Client, nodeClaim *v1.NodeClaim, cloudProvider cloudprovider.CloudProvider) (terminated bool, err error) {
 	// Check if the status condition on nodeClaim is Terminating
-	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeTerminating).IsTrue() {
+	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue() {
 		// If not then call Delete on cloudProvider to trigger termination and always requeue reconciliation
 		if err := cloudProvider.Delete(ctx, nodeClaim); err != nil {
 			if cloudprovider.IsNodeClaimNotFoundError(err) {
-				nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeTerminating)
+				nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeInstanceTerminating)
 				// We call Update() here rather than Patch() because patching a list with a JSON merge patch
 				// can cause races due to the fact that it fully replaces the list on a change
 				// https://github.com/kubernetes/kubernetes/issues/111643#issuecomment-2016489732
@@ -49,7 +49,7 @@ func EnsureTerminated(ctx context.Context, c client.Client, nodeClaim *v1.NodeCl
 			return false, fmt.Errorf("terminating cloudprovider instance, %w", err)
 		}
 
-		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeTerminating)
+		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeInstanceTerminating)
 		// We call Update() here rather than Patch() because patching a list with a JSON merge patch
 		// can cause races due to the fact that it fully replaces the list on a change
 		// https://github.com/kubernetes/kubernetes/issues/111643#issuecomment-2016489732


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updated nodeclaim status condition from `terminating` to `instanceTerminating` to convey correct meaning.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
