### PR TITLE
chore: Remove min-Value from being set on conversion v1 -> v1beta1 

### DIFF
--- a/pkg/apis/v1/nodeclaim_conversion.go
+++ b/pkg/apis/v1/nodeclaim_conversion.go
@@ -142,7 +142,6 @@ func (in *NodeClaimSpec) convertFrom(ctx context.Context, v1beta1nc *v1beta1.Nod
 				Operator: v1beta1Requirements.Operator,
 				Values:   v1beta1Requirements.Values,
 			},
-			MinValues: lo.ToPtr(0),
 		}
 	})
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Remove the minValue filed when converting from v1 -> v1beta1

**How was this change tested?**
- `make presubmit` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
