### PR TITLE
chore: fix nodeClassRef conversion

### DIFF
--- a/pkg/apis/v1/nodeclaim_conversion.go
+++ b/pkg/apis/v1/nodeclaim_conversion.go
@@ -148,7 +148,7 @@ func (in *NodeClaimSpec) convertFrom(ctx context.Context, v1beta1nc *v1beta1.Nod
 	in.NodeClassRef = &NodeClassReference{
 		Name:  v1beta1nc.NodeClassRef.Name,
 		Kind:  lo.Ternary(v1beta1nc.NodeClassRef.Kind == "", defaultNodeClassGVK.Kind, v1beta1nc.NodeClassRef.Kind),
-		Group: lo.Ternary(v1beta1nc.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, nodeclassGroupVersion.Group),
+		Group: lo.Ternary(v1beta1nc.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, lo.Ternary(nodeclassGroupVersion.Group == "", nodeclassGroupVersion.Version, nodeclassGroupVersion.Group)),
 	}
 
 	if v1beta1nc.Kubelet != nil {

--- a/pkg/apis/v1/nodepool_conversion.go
+++ b/pkg/apis/v1/nodepool_conversion.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -176,13 +175,6 @@ func (in *NodeClaimTemplate) convertFrom(ctx context.Context, v1beta1np *v1beta1
 		}
 	})
 
-	nodeclasses := injection.GetNodeClasses(ctx)
-	in.Spec.NodeClassRef = &NodeClassReference{
-		Name:  v1beta1np.Spec.NodeClassRef.Name,
-		Kind:  lo.Ternary(v1beta1np.Spec.NodeClassRef.Kind == "", nodeclasses[0].Kind, v1beta1np.Spec.NodeClassRef.Kind),
-		Group: lo.Ternary(v1beta1np.Spec.NodeClassRef.APIVersion == "", nodeclasses[0].Group, strings.Split(v1beta1np.Spec.NodeClassRef.APIVersion, "/")[0]),
-	}
-
 	defaultNodeClassGVK := injection.GetNodeClasses(ctx)[0]
 	nodeclassGroupVersion, err := schema.ParseGroupVersion(v1beta1np.Spec.NodeClassRef.APIVersion)
 	if err != nil {
@@ -191,7 +183,7 @@ func (in *NodeClaimTemplate) convertFrom(ctx context.Context, v1beta1np *v1beta1
 	in.Spec.NodeClassRef = &NodeClassReference{
 		Name:  v1beta1np.Spec.NodeClassRef.Name,
 		Kind:  lo.Ternary(v1beta1np.Spec.NodeClassRef.Kind == "", defaultNodeClassGVK.Kind, v1beta1np.Spec.NodeClassRef.Kind),
-		Group: lo.Ternary(v1beta1np.Spec.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, nodeclassGroupVersion.Group),
+		Group: lo.Ternary(v1beta1np.Spec.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, lo.Ternary(nodeclassGroupVersion.Group == "", nodeclassGroupVersion.Version, nodeclassGroupVersion.Group)),
 	}
 
 	if v1beta1np.Spec.Kubelet != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
When converting nodeClassRef from v1beta1 to v1, group would be empty if apiVersion is of the type `karpenter.k8s.aws` i.e. it does not contain the version. This PR adds the fix for it.

**How was this change tested?**
Tested on local cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
