### PR TITLE
fix: Backport nodeClassRef conversion fix for v0.35.x

### DIFF
--- a/pkg/apis/v1/nodeclaim_conversion.go
+++ b/pkg/apis/v1/nodeclaim_conversion.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
@@ -151,15 +152,11 @@ func (in *NodeClaimSpec) convertFrom(ctx context.Context, v1beta1nc *v1beta1.Nod
 		}
 	})
 
-	defaultNodeClassGVK := injection.GetNodeClasses(ctx)[0]
-	nodeclassGroupVersion, err := schema.ParseGroupVersion(v1beta1nc.NodeClassRef.APIVersion)
-	if err != nil {
-		return "", err
-	}
+	nodeclasses := injection.GetNodeClasses(ctx)
 	in.NodeClassRef = &NodeClassReference{
 		Name:  v1beta1nc.NodeClassRef.Name,
-		Kind:  lo.Ternary(v1beta1nc.NodeClassRef.Kind == "", defaultNodeClassGVK.Kind, v1beta1nc.NodeClassRef.Kind),
-		Group: lo.Ternary(v1beta1nc.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, nodeclassGroupVersion.Group),
+		Kind:  lo.Ternary(v1beta1nc.NodeClassRef.Kind == "", nodeclasses[0].Kind, v1beta1nc.NodeClassRef.Kind),
+		Group: lo.Ternary(v1beta1nc.NodeClassRef.APIVersion == "", nodeclasses[0].Group, strings.Split(v1beta1nc.NodeClassRef.APIVersion, "/")[0]),
 	}
 
 	if v1beta1nc.Kubelet != nil {

--- a/pkg/apis/v1/nodepool_conversion.go
+++ b/pkg/apis/v1/nodepool_conversion.go
@@ -181,17 +181,6 @@ func (in *NodeClaimTemplate) convertFrom(ctx context.Context, v1beta1np *v1beta1
 		Group: lo.Ternary(v1beta1np.Spec.NodeClassRef.APIVersion == "", nodeclasses[0].Group, strings.Split(v1beta1np.Spec.NodeClassRef.APIVersion, "/")[0]),
 	}
 
-	defaultNodeClassGVK := injection.GetNodeClasses(ctx)[0]
-	nodeclassGroupVersion, err := schema.ParseGroupVersion(v1beta1np.Spec.NodeClassRef.APIVersion)
-	if err != nil {
-		return "", err
-	}
-	in.Spec.NodeClassRef = &NodeClassReference{
-		Name:  v1beta1np.Spec.NodeClassRef.Name,
-		Kind:  lo.Ternary(v1beta1np.Spec.NodeClassRef.Kind == "", defaultNodeClassGVK.Kind, v1beta1np.Spec.NodeClassRef.Kind),
-		Group: lo.Ternary(v1beta1np.Spec.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, nodeclassGroupVersion.Group),
-	}
-
 	if v1beta1np.Spec.Kubelet != nil {
 		kubelet, err := json.Marshal(v1beta1np.Spec.Kubelet)
 		if err != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Backport nodeClassRef fix
- https://github.com/kubernetes-sigs/karpenter/pull/1534

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
