### PR TITLE
chore: Retain EC2NodeClass reference information during the conversion

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -49,6 +49,7 @@ const (
 	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"
 	KubeletCompatibilityAnnotationKey          = apis.CompatibilityGroup + "/v1beta1-kubelet-conversion"
+	NodeClassReferenceAnnotationKey            = apis.CompatibilityGroup + "/v1beta1-nodeclass-reference"
 	NodeClaimTerminationTimestampAnnotationKey = apis.Group + "/nodeclaim-termination-timestamp"
 )
 

--- a/pkg/apis/v1/nodeclaim_conversion.go
+++ b/pkg/apis/v1/nodeclaim_conversion.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 
@@ -37,11 +37,17 @@ func (in *NodeClaim) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	v1beta1NC := to.(*v1beta1.NodeClaim)
 	v1beta1NC.ObjectMeta = in.ObjectMeta
 
-	in.Status.convertTo((&v1beta1NC.Status))
-	return in.Spec.convertTo(ctx, &v1beta1NC.Spec, in.Annotations[KubeletCompatibilityAnnotationKey])
+	in.Status.convertTo(&v1beta1NC.Status)
+	if err := in.Spec.convertTo(&v1beta1NC.Spec, in.Annotations[KubeletCompatibilityAnnotationKey], in.Annotations[NodeClassReferenceAnnotationKey]); err != nil {
+		return err
+	}
+	// Remove the annotations from the v1beta1 NodeClaim on the convert back
+	delete(v1beta1NC.Annotations, KubeletCompatibilityAnnotationKey)
+	delete(v1beta1NC.Annotations, NodeClassReferenceAnnotationKey)
+	return nil
 }
 
-func (in *NodeClaimSpec) convertTo(ctx context.Context, v1beta1nc *v1beta1.NodeClaimSpec, kubeletAnnotation string) error {
+func (in *NodeClaimSpec) convertTo(v1beta1nc *v1beta1.NodeClaimSpec, kubeletAnnotation, nodeClassReferenceAnnotation string) error {
 	v1beta1nc.Taints = in.Taints
 	v1beta1nc.StartupTaints = in.StartupTaints
 	v1beta1nc.Resources = v1beta1.ResourceRequirements(in.Resources)
@@ -55,18 +61,16 @@ func (in *NodeClaimSpec) convertTo(ctx context.Context, v1beta1nc *v1beta1.NodeC
 			MinValues: v1Requirements.MinValues,
 		}
 	})
-
-	if in.NodeClassRef != nil {
-		nodeclass, found := lo.Find(injection.GetNodeClasses(ctx), func(nc schema.GroupVersionKind) bool {
-			return nc.Kind == in.NodeClassRef.Kind && nc.Group == in.NodeClassRef.Group
-		})
-		v1beta1nc.NodeClassRef = &v1beta1.NodeClassReference{
-			Kind:       in.NodeClassRef.Kind,
-			Name:       in.NodeClassRef.Name,
-			APIVersion: lo.Ternary(found, nodeclass.GroupVersion().String(), ""),
+	// Convert the NodeClassReference depending on whether the annotation exists
+	v1beta1nc.NodeClassRef = &v1beta1.NodeClassReference{}
+	if nodeClassReferenceAnnotation != "" {
+		if err := json.Unmarshal([]byte(nodeClassReferenceAnnotation), v1beta1nc.NodeClassRef); err != nil {
+			return fmt.Errorf("unmarshaling nodeClassRef annotation, %w", err)
 		}
+	} else {
+		v1beta1nc.NodeClassRef.Name = in.NodeClassRef.Name
+		v1beta1nc.NodeClassRef.Kind = in.NodeClassRef.Kind
 	}
-
 	if kubeletAnnotation != "" {
 		v1beta1kubelet := &v1beta1.KubeletConfiguration{}
 		err := json.Unmarshal([]byte(kubeletAnnotation), v1beta1kubelet)
@@ -102,6 +106,13 @@ func (in *NodeClaim) ConvertFrom(ctx context.Context, from apis.Convertible) err
 	} else {
 		in.Annotations = lo.Assign(in.Annotations, map[string]string{KubeletCompatibilityAnnotationKey: kubeletAnnotation})
 	}
+	nodeClassRefAnnotation, err := json.Marshal(v1beta1NC.Spec.NodeClassRef)
+	if err != nil {
+		return fmt.Errorf("marshaling nodeClassRef annotation, %w", err)
+	}
+	in.Annotations = lo.Assign(in.Annotations, map[string]string{
+		NodeClassReferenceAnnotationKey: string(nodeClassRefAnnotation),
+	})
 	return in.setExpireAfter(ctx, v1beta1NC)
 }
 
@@ -141,14 +152,10 @@ func (in *NodeClaimSpec) convertFrom(ctx context.Context, v1beta1nc *v1beta1.Nod
 	})
 
 	defaultNodeClassGVK := injection.GetNodeClasses(ctx)[0]
-	nodeclassGroupVersion, err := schema.ParseGroupVersion(v1beta1nc.NodeClassRef.APIVersion)
-	if err != nil {
-		return "", err
-	}
 	in.NodeClassRef = &NodeClassReference{
 		Name:  v1beta1nc.NodeClassRef.Name,
 		Kind:  lo.Ternary(v1beta1nc.NodeClassRef.Kind == "", defaultNodeClassGVK.Kind, v1beta1nc.NodeClassRef.Kind),
-		Group: lo.Ternary(v1beta1nc.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, lo.Ternary(nodeclassGroupVersion.Group == "", nodeclassGroupVersion.Version, nodeclassGroupVersion.Group)),
+		Group: lo.Ternary(v1beta1nc.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, strings.Split(v1beta1nc.NodeClassRef.APIVersion, "/")[0]),
 	}
 
 	if v1beta1nc.Kubelet != nil {

--- a/pkg/apis/v1/nodepool_conversion.go
+++ b/pkg/apis/v1/nodepool_conversion.go
@@ -20,12 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
@@ -40,17 +39,23 @@ func (in *NodePool) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	// Convert v1 status
 	v1beta1NP.Status.Resources = in.Status.Resources
 	v1beta1NP.Status.Conditions = in.Status.Conditions
-	return in.Spec.convertTo(ctx, &v1beta1NP.Spec, in.Annotations[KubeletCompatibilityAnnotationKey])
+	if err := in.Spec.convertTo(&v1beta1NP.Spec, in.Annotations[KubeletCompatibilityAnnotationKey], in.Annotations[NodeClassReferenceAnnotationKey]); err != nil {
+		return err
+	}
+	// Remove the annotations from the v1beta1 NodeClaim on the convert back
+	delete(v1beta1NP.Annotations, KubeletCompatibilityAnnotationKey)
+	delete(v1beta1NP.Annotations, NodeClassReferenceAnnotationKey)
+	return nil
 }
 
-func (in *NodePoolSpec) convertTo(ctx context.Context, v1beta1np *v1beta1.NodePoolSpec, kubeletAnnotation string) error {
+func (in *NodePoolSpec) convertTo(v1beta1np *v1beta1.NodePoolSpec, kubeletAnnotation, nodeClassReferenceAnnotation string) error {
 	v1beta1np.Weight = in.Weight
 	v1beta1np.Limits = v1beta1.Limits(in.Limits)
 	in.Disruption.convertTo(&v1beta1np.Disruption)
 	// Set the expireAfter to the nodeclaim template's expireAfter.
 	// Don't convert terminationGracePeriod, as this is only included in v1.
 	v1beta1np.Disruption.ExpireAfter = v1beta1.NillableDuration(in.Template.Spec.ExpireAfter)
-	return in.Template.convertTo(ctx, &v1beta1np.Template, kubeletAnnotation)
+	return in.Template.convertTo(&v1beta1np.Template, kubeletAnnotation, nodeClassReferenceAnnotation)
 }
 
 func (in *Disruption) convertTo(v1beta1np *v1beta1.Disruption) {
@@ -68,7 +73,7 @@ func (in *Disruption) convertTo(v1beta1np *v1beta1.Disruption) {
 	})
 }
 
-func (in *NodeClaimTemplate) convertTo(ctx context.Context, v1beta1np *v1beta1.NodeClaimTemplate, kubeletAnnotation string) error {
+func (in *NodeClaimTemplate) convertTo(v1beta1np *v1beta1.NodeClaimTemplate, kubeletAnnotation, nodeClassReferenceAnnotation string) error {
 	v1beta1np.ObjectMeta = v1beta1.ObjectMeta(in.ObjectMeta)
 	v1beta1np.Spec.Taints = in.Spec.Taints
 	v1beta1np.Spec.StartupTaints = in.Spec.StartupTaints
@@ -82,28 +87,16 @@ func (in *NodeClaimTemplate) convertTo(ctx context.Context, v1beta1np *v1beta1.N
 			MinValues: v1Requirements.MinValues,
 		}
 	})
-
-	nodeClasses := injection.GetNodeClasses(ctx)
-	// We are sorting the supported nodeclass, so that we are able to consistently find the same GVK,
-	// if multiple version of a nodeclass are supported
-	sort.Slice(nodeClasses, func(i int, j int) bool {
-		if nodeClasses[i].Group != nodeClasses[j].Group {
-			return nodeClasses[i].Group < nodeClasses[j].Group
+	// Convert the NodeClassReference depending on whether the annotation exists
+	v1beta1np.Spec.NodeClassRef = &v1beta1.NodeClassReference{}
+	if nodeClassReferenceAnnotation != "" {
+		if err := json.Unmarshal([]byte(nodeClassReferenceAnnotation), v1beta1np.Spec.NodeClassRef); err != nil {
+			return fmt.Errorf("unmarshaling nodeClassRef annotation, %w", err)
 		}
-		if nodeClasses[i].Version != nodeClasses[j].Version {
-			return nodeClasses[i].Version < nodeClasses[j].Version
-		}
-		return nodeClasses[i].Kind < nodeClasses[j].Kind
-	})
-	matchingNodeClass, found := lo.Find(nodeClasses, func(nc schema.GroupVersionKind) bool {
-		return nc.Kind == in.Spec.NodeClassRef.Kind && nc.Group == in.Spec.NodeClassRef.Group
-	})
-	v1beta1np.Spec.NodeClassRef = &v1beta1.NodeClassReference{
-		Kind:       in.Spec.NodeClassRef.Kind,
-		Name:       in.Spec.NodeClassRef.Name,
-		APIVersion: lo.Ternary(found, matchingNodeClass.GroupVersion().String(), ""),
+	} else {
+		v1beta1np.Spec.NodeClassRef.Name = in.Spec.NodeClassRef.Name
+		v1beta1np.Spec.NodeClassRef.Kind = in.Spec.NodeClassRef.Kind
 	}
-
 	if kubeletAnnotation != "" {
 		v1beta1kubelet := &v1beta1.KubeletConfiguration{}
 		err := json.Unmarshal([]byte(kubeletAnnotation), v1beta1kubelet)
@@ -134,6 +127,13 @@ func (in *NodePool) ConvertFrom(ctx context.Context, v1beta1np apis.Convertible)
 	} else {
 		in.Annotations = lo.Assign(in.Annotations, map[string]string{KubeletCompatibilityAnnotationKey: kubeletAnnotation})
 	}
+	nodeClassRefAnnotation, err := json.Marshal(v1beta1NP.Spec.Template.Spec.NodeClassRef)
+	if err != nil {
+		return fmt.Errorf("marshaling nodeClassRef annotation, %w", err)
+	}
+	in.Annotations = lo.Assign(in.Annotations, map[string]string{
+		NodeClassReferenceAnnotationKey: string(nodeClassRefAnnotation),
+	})
 	return nil
 }
 
@@ -176,16 +176,11 @@ func (in *NodeClaimTemplate) convertFrom(ctx context.Context, v1beta1np *v1beta1
 	})
 
 	defaultNodeClassGVK := injection.GetNodeClasses(ctx)[0]
-	nodeclassGroupVersion, err := schema.ParseGroupVersion(v1beta1np.Spec.NodeClassRef.APIVersion)
-	if err != nil {
-		return "", err
-	}
 	in.Spec.NodeClassRef = &NodeClassReference{
 		Name:  v1beta1np.Spec.NodeClassRef.Name,
 		Kind:  lo.Ternary(v1beta1np.Spec.NodeClassRef.Kind == "", defaultNodeClassGVK.Kind, v1beta1np.Spec.NodeClassRef.Kind),
-		Group: lo.Ternary(v1beta1np.Spec.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, lo.Ternary(nodeclassGroupVersion.Group == "", nodeclassGroupVersion.Version, nodeclassGroupVersion.Group)),
+		Group: lo.Ternary(v1beta1np.Spec.NodeClassRef.APIVersion == "", defaultNodeClassGVK.Group, strings.Split(v1beta1np.Spec.NodeClassRef.APIVersion, "/")[0]),
 	}
-
 	if v1beta1np.Spec.Kubelet != nil {
 		kubelet, err := json.Marshal(v1beta1np.Spec.Kubelet)
 		if err != nil {
@@ -193,6 +188,5 @@ func (in *NodeClaimTemplate) convertFrom(ctx context.Context, v1beta1np *v1beta1
 		}
 		return string(kubelet), nil
 	}
-
 	return "", nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Ensure that our EC2NodeClassReference information is retained during conversion from v1beta1 to v1 and back. This is to ensure that we don't drift when Karpenter starts reasoning in terms of the v1 version.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
