### PR TITLE
chore: do not set version to NodeClassRef on test environment.

### DIFF
--- a/kwok/README.md
+++ b/kwok/README.md
@@ -40,7 +40,7 @@ spec:
       nodeClassRef:
         name: default
         kind: KWOKNodeClass
-        group: karpenter.kwok.sh/v1alpha1
+        group: karpenter.kwok.sh
       expireAfter: 720h # 30 * 24h = 720h
   limits:
     cpu: 1000

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -162,7 +162,7 @@ func (env *Environment) DefaultNodePool(nodeClass *v1alpha1.KWOKNodeClass) *v1.N
 	nodePool.Spec.Template.Spec.NodeClassRef = &v1.NodeClassReference{
 		Name:  nodeClass.Name,
 		Kind:  object.GVK(nodeClass).Kind,
-		Group: object.GVK(nodeClass).GroupVersion().String(),
+		Group: object.GVK(nodeClass).Group,
 	}
 	nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirementWithMinValues{
 		{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

/kind failing-test 
/kind cleanup

**Description**

Now, e2e testing always failing, the reason is the `NodeClassRef` is not allow slash and kwok provider still using it.

so,this is follow up https://github.com/kubernetes-sigs/karpenter/pull/1516 , update NodeClassRef  for kwok provider.


/cc @jigisha620 @jonathan-innis

**How was this change tested?**

`.github/workflows/kind-e2e.yaml`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
