### PR TITLE
chore: non-constant format string in call to fmt.Errorf

### DIFF
--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -163,7 +163,7 @@ func (v *Validation) ValidateCommand(ctx context.Context, cmd Command, candidate
 		return fmt.Errorf("simluating scheduling, %w", err)
 	}
 	if !results.AllNonPendingPodsScheduled() {
-		return NewValidationError(fmt.Errorf(results.NonPendingPodSchedulingErrors()))
+		return NewValidationError(errors.New(results.NonPendingPodSchedulingErrors()))
 	}
 
 	// We want to ensure that the re-simulated scheduling using the current cluster state produces the same result.

--- a/pkg/controllers/nodeclaim/consistency/controller.go
+++ b/pkg/controllers/nodeclaim/consistency/controller.go
@@ -18,6 +18,7 @@ package consistency
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"time"
 
@@ -122,7 +123,7 @@ func (c *Controller) checkConsistency(ctx context.Context, nodeClaim *v1.NodeCla
 			return fmt.Errorf("checking node with %T, %w", check, err)
 		}
 		for _, issue := range issues {
-			log.FromContext(ctx).Error(fmt.Errorf(string(issue)), "consistency error")
+			log.FromContext(ctx).Error(stderrors.New(string(issue)), "consistency error")
 			c.recorder.Publish(FailedConsistencyCheckEvent(nodeClaim, string(issue)))
 		}
 		hasIssues = hasIssues || (len(issues) > 0)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
fix golangci-lint check error
```bash
❯ make verify
go mod tidy
go generate ./...
hack/validation/kubelet.sh
hack/validation/taint.sh
hack/validation/requirements.sh
hack/validation/labels.sh
hack/validation/resources.sh
hack/validation/status.sh
cp -r pkg/apis/crds kwok/charts
hack/kwok/requirements.sh
hack/kwok/conversion.sh
hack/dependabot.sh
hack/boilerplate.sh
go vet ./...
cd kwok/charts && helm-docs
INFO[2024-08-17T22:48:35+08:00] Found Chart directories [.]                  
INFO[2024-08-17T22:48:35+08:00] Generating README Documentation for chart .  
golangci-lint run
pkg/controllers/nodeclaim/consistency/controller.go:125:42: printf: non-constant format string in call to fmt.Errorf (govet)
                        log.FromContext(ctx).Error(fmt.Errorf(string(issue)), "consistency error")
                                                              ^
pkg/controllers/disruption/validation.go:166:40: printf: non-constant format string in call to fmt.Errorf (govet)
                return NewValidationError(fmt.Errorf(results.NonPendingPodSchedulingErrors()))
                                                     ^
make: *** [Makefile:113: verify] Error 1
```
**How was this change tested?**
make verify

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
