### PR TITLE
ci: Enable `copyloopvar` in linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,7 @@ linters:
     - asciicheck
     - bidichk
     - errorlint
-    - exportloopref
+    - copyloopvar
     - gosec
     - revive
     - stylecheck

--- a/test/pkg/environment/common/monitor.go
+++ b/test/pkg/environment/common/monitor.go
@@ -135,7 +135,6 @@ func (m *Monitor) DeletedNodes() []*corev1.Node {
 func (m *Monitor) PendingPods(selector labels.Selector) []*corev1.Pod {
 	var pods []*corev1.Pod
 	for _, pod := range m.poll().pods.Items {
-		pod := pod
 		if pod.Status.Phase != corev1.PodPending {
 			continue
 		}
@@ -154,7 +153,6 @@ func (m *Monitor) PendingPodsCount(selector labels.Selector) int {
 func (m *Monitor) RunningPods(selector labels.Selector) []*corev1.Pod {
 	var pods []*corev1.Pod
 	for _, pod := range m.poll().pods.Items {
-		pod := pod
 		if pod.Status.Phase != corev1.PodRunning {
 			continue
 		}


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**

Replace `exportloopref` with `copyloopvar` (see https://go.dev/blog/loopvar-preview for more detail)

```console
cd . && golangci-lint run 
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
```

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.