### PR TITLE
fix: allow restricted labels in pod affinity/nodeSelector

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -103,13 +103,22 @@ var (
 	}
 )
 
-// IsRestrictedLabel returns an error if the label is restricted.
-func IsRestrictedLabel(key string) error {
+// IsRestrictedRequirements returns an error if the requirement label is restricted.
+func IsRestrictedRequirements(key string) error {
 	if WellKnownLabels.Has(key) {
 		return nil
 	}
+
+	// In the node pool requirements configuration, labels like kops.k8s.io/x should not be allowed, as they do not make sense.
+	labelDomain := GetLabelDomain(key)
+	for exceptionLabelDomain := range LabelDomainExceptions {
+		if strings.HasSuffix(labelDomain, exceptionLabelDomain) {
+			return fmt.Errorf("requirement label key %s is restricted; specify a well known label: %v, or a custom label that does not use a restricted domain: %v", key, sets.List(WellKnownLabels), sets.List(RestrictedLabelDomains))
+		}
+	}
+
 	if IsRestrictedNodeLabel(key) {
-		return fmt.Errorf("label %s is restricted; specify a well known label: %v, or a custom label that does not use a restricted domain: %v", key, sets.List(WellKnownLabels), sets.List(RestrictedLabelDomains))
+		return fmt.Errorf("requirement label key %s is restricted; specify a well known label: %v, or a custom label that does not use a restricted domain: %v", key, sets.List(WellKnownLabels), sets.List(RestrictedLabelDomains))
 	}
 	return nil
 }

--- a/pkg/apis/v1/nodepool_validation.go
+++ b/pkg/apis/v1/nodepool_validation.go
@@ -41,8 +41,8 @@ func (in *NodeClaimTemplate) validateLabels() (errs error) {
 		for _, err := range validation.IsValidLabelValue(value) {
 			errs = multierr.Append(errs, fmt.Errorf("invalid value: %s for label[%s], %s", value, key, err))
 		}
-		if err := IsRestrictedLabel(key); err != nil {
-			errs = multierr.Append(errs, fmt.Errorf("invalid key name %q in labels, %s", key, err.Error()))
+		if IsRestrictedNodeLabel(key) {
+			errs = multierr.Append(errs, fmt.Errorf("restricted key name %q in labels", key))
 		}
 	}
 	return errs

--- a/pkg/apis/v1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1/nodepool_validation_cel_test.go
@@ -411,26 +411,26 @@ var _ = Describe("CEL/Validation", func() {
 				Expect(nodePool.RuntimeValidate()).ToNot(Succeed())
 			}
 		})
-		It("should allow restricted domains exceptions", func() {
+		It("should fail for the allow restricted domains exceptions", func() {
 			oldNodePool := nodePool.DeepCopy()
 			for label := range LabelDomainExceptions {
 				nodePool.Spec.Template.Spec.Requirements = []NodeSelectorRequirementWithMinValues{
 					{NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: label + "/test", Operator: v1.NodeSelectorOpIn, Values: []string{"test"}}},
 				}
 				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
-				Expect(nodePool.RuntimeValidate()).To(Succeed())
+				Expect(nodePool.RuntimeValidate()).ToNot(Succeed())
 				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 				nodePool = oldNodePool.DeepCopy()
 			}
 		})
-		It("should allow restricted subdomains exceptions", func() {
+		It("should fail for allow restricted subdomains exceptions", func() {
 			oldNodePool := nodePool.DeepCopy()
 			for label := range LabelDomainExceptions {
 				nodePool.Spec.Template.Spec.Requirements = []NodeSelectorRequirementWithMinValues{
 					{NodeSelectorRequirement: v1.NodeSelectorRequirement{Key: "subdomain." + label + "/test", Operator: v1.NodeSelectorOpIn, Values: []string{"test"}}},
 				}
 				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
-				Expect(nodePool.RuntimeValidate()).To(Succeed())
+				Expect(nodePool.RuntimeValidate()).ToNot(Succeed())
 				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 				nodePool = oldNodePool.DeepCopy()
 			}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -512,7 +512,7 @@ func validateNodeSelectorTerm(term corev1.NodeSelectorTerm) (errs error) {
 	}
 	if term.MatchExpressions != nil {
 		for _, requirement := range term.MatchExpressions {
-			errs = multierr.Append(errs, v1.ValidateRequirement(v1.NodeSelectorRequirementWithMinValues{
+			errs = multierr.Append(errs, v1.ValidateBasicRequirements(v1.NodeSelectorRequirementWithMinValues{
 				NodeSelectorRequirement: requirement,
 			}))
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes  #1596

**Description**

In general, we should not filter out the pending pods that could trigger the node scaling out by label key. If the pods can't be scheduled, it will be ignored in the scheduling simulation process: https://github.com/kubernetes-sigs/karpenter/blob/75fcd2abcae13b7677a2c4d9ee2799662b2e9445/pkg/controllers/provisioning/scheduling/scheduler.go#L197

So, let's remove the limitations of the restricted label. Also, I checked the git blame, the related PR is: https://github.com/aws/karpenter-provider-aws/pull/2051

This PR, only tries to solve: `Implemented support for GT and LT requirement operators in pods`
It doesn't want to limit label key `kubernetes.io/hostname`, so let's cancel the limitations.

**How was this change tested?**

make e2etests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
