### PR TITLE
fix: fix image digest parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build: ## Build the Karpenter KWOK controller images using ko build
 	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) KO_DOCKER_REPO="$(KWOK_REPO)" ko build -B sigs.k8s.io/karpenter/kwok))
 	$(eval IMG_REPOSITORY=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 1))
 	$(eval IMG_TAG=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 2 -s))
-	$(eval IMG_DIGEST=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 2))
+	$(eval IMG_DIGEST=$(shell echo $(CONTROLLER_IMG) | grep "@" > /dev/null && echo "$(CONTROLLER_IMG)" | cut -d "@" -f 2 || echo ""))
 	
 apply-with-kind: verify build-with-kind ## Deploy the kwok controller from the current state of your git repository into your ~/.kube/config cluster
 	kubectl apply -f kwok/charts/crds


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #none

**Description**

When I do test with kind&kwok, it has the following error:
```sh
root@LAPTOP-7A2QVS89 [11:51:16] [~/git/karpenter] [fix-3]
-> # make apply
2024/08/30 11:54:35 Using base cgr.dev/chainguard/static:latest@sha256:791657dd88dea8c1f9d3779815429f9c681a9a2778fc66dac3fbf550e1f1d9c8 for [[sigs.k8s.io/karpenter/kwok](http://sigs.k8s.io/karpenter/kwok)](http://sigs.k8s.io/karpenter/kwok)
2024/08/30 11:54:49 git is in a dirty state
Please check in your pipeline what can be changing the following files:
M Makefile

2024/08/30 11:54:49 Building [[sigs.k8s.io/karpenter/kwok](http://sigs.k8s.io/karpenter/kwok)](http://sigs.k8s.io/karpenter/kwok) for linux/amd64
2024/08/30 11:54:51 Loading kind.local/kwok:f8ae62a6a7b702fe8fe39dd104dc8501367a89ba6bcd656a77a5b60384444fa6
2024/08/30 11:54:54 Loaded kind.local/kwok:f8ae62a6a7b702fe8fe39dd104dc8501367a89ba6bcd656a77a5b60384444fa6
2024/08/30 11:54:54 Adding tag latest
2024/08/30 11:54:54 Added tag latest
kubectl apply -f kwok/charts/crds
[[customresourcedefinition.apiextensions.k8s.io/kwoknodeclasses.karpenter.kwok.sh](http://customresourcedefinition.apiextensions.k8s.io/kwoknodeclasses.karpenter.kwok.sh)](http://customresourcedefinition.apiextensions.k8s.io/kwoknodeclasses.karpenter.kwok.sh) created
[[customresourcedefinition.apiextensions.k8s.io/nodeclaims.karpenter.sh](http://customresourcedefinition.apiextensions.k8s.io/nodeclaims.karpenter.sh)](http://customresourcedefinition.apiextensions.k8s.io/nodeclaims.karpenter.sh) created
[[customresourcedefinition.apiextensions.k8s.io/nodepools.karpenter.sh](http://customresourcedefinition.apiextensions.k8s.io/nodepools.karpenter.sh)](http://customresourcedefinition.apiextensions.k8s.io/nodepools.karpenter.sh) created
helm upgrade --install karpenter kwok/charts --namespace kube-system --skip-crds \
--set logLevel=debug --set controller.resources.requests.cpu=1 --set controller.resources.requests.memory=1Gi --set controller.resources.limits.cpu=1 --set controller.resources.limits.memory=1Gi \
--set controller.image.repository=kind.local/kwok \
--set controller.image.tag=f8ae62a6a7b702fe8fe39dd104dc8501367a89ba6bcd656a77a5b60384444fa6 \
--set controller.image.digest=kind.local/kwok:f8ae62a6a7b702fe8fe39dd104dc8501367a89ba6bcd656a77a5b60384444fa6 \
--set-string controller.env[0].name=ENABLE_PROFILING \
--set-string controller.env[0].value=true
Release "karpenter" does not exist. Installing it now.
```

The digest should be empty, but it parsed as kind.local/kwok:f8ae62a6a7b702fe8fe39dd104dc8501367a89ba6bcd656a77a5b60384444fa6.

**How was this change tested?**

make apply

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
