### PR TITLE
fix: fix occasional e2e failure

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -50,7 +50,7 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (
 	if err != nil {
 		if nodeclaimutil.IsNodeNotFoundError(err) {
 			nodeClaim.StatusConditions().SetUnknownWithReason(v1.ConditionTypeRegistered, "NodeNotFound", "Node not registered with cluster")
-			return reconcile.Result{}, nil
+			return reconcile.Result{Requeue: true}, nil
 		}
 		if nodeclaimutil.IsDuplicateNodeError(err) {
 			nodeClaim.StatusConditions().SetFalse(v1.ConditionTypeRegistered, "MultipleNodesFound", "Invariant violated, matched multiple nodes")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

When I run `make e2etests`, one failure is: https://github.com/kubernetes-sigs/karpenter/actions/runs/10590933040/job/29347492851

The context is as follows:
nodeclaim:
![image](https://github.com/user-attachments/assets/f34ca730-e293-42b6-8166-e0b896aa8ae7)

corresponding node:
![image](https://github.com/user-attachments/assets/5727ab4f-6b53-4657-9eb0-8ab30c1a3818)

So this PR tries to re-enqueue the item.

**How was this change tested?**

It always has failure if you try about 8 times, and I tried 20+ times, the following failure disappear
```sh
 [FAIL] Performance Provisioning [It] should do complex provisioning and complex drift
  /home/runner/work/karpenter/karpenter/test/suites/perf/scheduling_test.go:134
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
