### PR TITLE
perf: iterate node pool lists by index

### DIFF
--- a/pkg/apis/v1/suite_test.go
+++ b/pkg/apis/v1/suite_test.go
@@ -74,7 +74,8 @@ var _ = Describe("OrderByWeight", func() {
 		nodePoolList.OrderByWeight()
 
 		lastWeight := 101 // This is above the allowed weight values
-		for _, np := range nodePoolList.Items {
+		for i := range nodePoolList.Items {
+			np := &nodePoolList.Items[i]
 			Expect(lo.FromPtr(np.Spec.Weight)).To(BeNumerically("<=", lastWeight))
 			lastWeight = int(lo.FromPtr(np.Spec.Weight))
 		}
@@ -96,7 +97,8 @@ var _ = Describe("OrderByWeight", func() {
 		nodePoolList.OrderByWeight()
 
 		lastName := "zzzzzzzzzzzzzzzzzzzzzzzz" // large string value
-		for _, np := range nodePoolList.Items {
+		for i := range nodePoolList.Items {
+			np := &nodePoolList.Items[i]
 			Expect(np.Name < lastName).To(BeTrue())
 			lastName = np.Name
 		}

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -283,7 +283,8 @@ func (c *Controller) logInvalidBudgets(ctx context.Context) {
 		return
 	}
 	var buf bytes.Buffer
-	for _, np := range nodePoolList.Items {
+	for i := range nodePoolList.Items {
+		np := &nodePoolList.Items[i]
 		// Use a dummy value of 100 since we only care if this errors.
 		for _, method := range c.methods {
 			if _, err := np.GetAllowedDisruptionsByReason(c.clock, 100, method.Reason()); err != nil {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -237,9 +237,10 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*corev1.Pod, stat
 	instanceTypes := map[string][]*cloudprovider.InstanceType{}
 	domains := map[string]sets.Set[string]{}
 	var notReadyNodePools []string
-	for _, nodePool := range nodePoolList.Items {
+	for i := range nodePoolList.Items {
+		nodePool := &nodePoolList.Items[i]
 		// Get instance type options
-		instanceTypeOptions, err := p.cloudProvider.GetInstanceTypes(ctx, lo.ToPtr(nodePool))
+		instanceTypeOptions, err := p.cloudProvider.GetInstanceTypes(ctx, nodePool)
 		if err != nil {
 			// we just log an error and skip the provisioner to prevent a single mis-configured provisioner from stopping
 			// all scheduling


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

This stops the copying of node pools when iterating over ranges.

No functional changes, just a tiny bit faster.

I made a futile attempt at running the tests, but this one shall rely on github actions doing it a bit better.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
