### PR TITLE
fix: handle webhook inability to connect error v36

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -246,6 +246,11 @@ func (o *Operator) Start(ctx context.Context, cp cloudprovider.CloudProvider) {
 			ctx = injection.WithClient(ctx, o.GetClient())
 			webhooks.Start(ctx, o.GetConfig(), o.webhooks...)
 		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			webhooks.ValidateConversionEnabled(ctx, o.GetClient())
+		}()
 	}
 	wg.Wait()
 }

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -210,14 +210,20 @@ func HealthProbe(ctx context.Context) healthz.Checker {
 }
 
 func ValidateConversionEnabled(ctx context.Context, kubeclient client.Client) {
-	// allow context to exist longer than cache sync timeout
+	// allow context to exist longer than cache sync timeout which has a default of 120 seconds
 	listCtx, cancel := context.WithTimeout(ctx, 130*time.Second)
 	defer cancel()
-	// sleep for cache hydration
-	// wait for cache to sync, controller-runtime defaults to 120 seconds
-	time.Sleep(120 * time.Second)
+	var err error
 	v1np := &v1.NodePoolList{}
-	if err := kubeclient.List(listCtx, v1np); err != nil {
-		panic("Conversion webhook enabled but unable to complete call: " + err.Error())
+	for {
+		err = kubeclient.List(listCtx, v1np, &client.ListOptions{Limit: 1})
+		if err == nil {
+			return
+		}
+		select {
+		case <-listCtx.Done():
+			panic("Conversion webhook enabled but unable to complete call: " + err.Error())
+		case <-time.After(10 * time.Second):
+		}
 	}
 }

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -41,6 +42,7 @@ import (
 	"knative.dev/pkg/webhook/resourcesemantics"
 	"knative.dev/pkg/webhook/resourcesemantics/conversion"
 	"knative.dev/pkg/webhook/resourcesemantics/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -204,5 +206,18 @@ func HealthProbe(ctx context.Context) healthz.Checker {
 			return fmt.Errorf("webhook probe failed with status code %d", res.StatusCode)
 		}
 		return nil
+	}
+}
+
+func ValidateConversionEnabled(ctx context.Context, kubeclient client.Client) {
+	// allow context to exist longer than cache sync timeout
+	listCtx, cancel := context.WithTimeout(ctx, 130*time.Second)
+	defer cancel()
+	// sleep for cache hydration
+	// wait for cache to sync, controller-runtime defaults to 120 seconds
+	time.Sleep(120 * time.Second)
+	v1np := &v1.NodePoolList{}
+	if err := kubeclient.List(listCtx, v1np); err != nil {
+		panic("Conversion webhook enabled but unable to complete call: " + err.Error())
 	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Now that webhooks are enabled by default, if a user has a network policy that blocks the webhook port and the webhook is enabled then Karpenter will crash.

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
