### PR TITLE
fix: Fix spurious transport errors (v0.34.x)

### DIFF
--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -18,6 +18,7 @@ package webhooks
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -185,10 +186,16 @@ func Start(ctx context.Context, cfg *rest.Config, ctors ...knativeinjection.Cont
 }
 
 func HealthProbe(ctx context.Context) healthz.Checker {
+	// Create new transport that doesn't validate the TLS certificate
+	// This transport is just polling so validating the server certificate isn't necessary
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint:gosec
+	client := &http.Client{Transport: transport}
+
 	// TODO: Add knative health check port for webhooks when health port can be configured
 	// Issue: https://github.com/knative/pkg/issues/2765
 	return func(req *http.Request) (err error) {
-		res, err := http.Get(fmt.Sprintf("http://localhost:%d", options.FromContext(ctx).WebhookPort))
+		res, err := client.Get(fmt.Sprintf("https://localhost:%d", options.FromContext(ctx).WebhookPort))
 		// If the webhook connection errors out, liveness/readiness should fail
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change fixes spurious transport errors that we were having in our code. These errors were caused due to sending an HTTP request to an HTTPS endpoint in our health checker

```
{"level":"ERROR","time":"2024-09-05T01:09:36.463Z","logger":"webhook","message":"http: TLS handshake error from [::1]:50418: client sent an HTTP request to an HTTPS server\n","commit":"454ff97-dirty"}
{"level":"ERROR","time":"2024-09-05T01:09:46.462Z","logger":"webhook","message":"http: TLS handshake error from [::1]:48586: client sent an HTTP request to an HTTPS server\n","commit":"454ff97-dirty"}
{"level":"ERROR","time":"2024-09-05T01:09:56.463Z","logger":"webhook","message":"http: TLS handshake error from [::1]:50286: client sent an HTTP request to an HTTPS server\n","commit":"454ff97-dirty"}
{"level":"ERROR","time":"2024-09-05T01:09:59.225Z","logger":"webhook","message":"http: TLS handshake error from [::1]:57108: client sent an HTTP request to an HTTPS server\n","commit":"454ff97-dirty"}
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
