### PR TITLE
chore: don't emit disruption events for non-karpenter nodes

### DIFF
--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -1492,7 +1492,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.Nodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, cluster.Nodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("state node doesn't contain both a node and a nodeclaim"))
+		Expect(err.Error()).To(Equal("state node does not have a nodeclaim representation"))
 	})
 	It("should not consider candidate that has just a NodeClaim representation", func() {
 		nodeClaim, _ := test.NodeClaimAndNode(v1.NodeClaim{
@@ -1511,7 +1511,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.Nodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, cluster.Nodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("state node doesn't contain both a node and a nodeclaim"))
+		Expect(err.Error()).To(Equal("state node does not have a node representation"))
 	})
 	It("should not consider candidates that are nominated", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -72,7 +72,10 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	var err error
 	var pods []*corev1.Pod
 	if err = node.ValidateNodeDisruptable(ctx, kubeClient); err != nil {
-		recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, err.Error())...)
+		// Only emit an event if the NodeClaim is not nil, ensuring that we only emit events for Karpenter-managed nodes
+		if node.NodeClaim != nil {
+			recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, err.Error())...)
+		}
 		return nil, err
 	}
 	// If the orchestration queue is already considering a candidate we want to disrupt, don't consider it a candidate.

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -189,8 +189,11 @@ func (in *StateNode) Pods(ctx context.Context, kubeClient client.Client) ([]*cor
 //
 //nolint:gocyclo
 func (in *StateNode) ValidateNodeDisruptable(ctx context.Context, kubeClient client.Client) error {
-	if in.Node == nil || in.NodeClaim == nil {
-		return fmt.Errorf("state node doesn't contain both a node and a nodeclaim")
+	if in.NodeClaim == nil {
+		return fmt.Errorf("state node does not have a nodeclaim representation")
+	}
+	if in.Node == nil {
+		return fmt.Errorf("state node does not have a node representation")
 	}
 	if !in.Initialized() {
 		return fmt.Errorf("state node isn't initialized")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Removes eventing for state nodes that don't have NodeClaims (non-Karpenter managed nodes)

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
