### PR TITLE
chore: stop adding spot requirement in consolidation

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -189,15 +189,6 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 		return Command{}, pscheduling.Results{}, nil
 	}
 
-	// We are consolidating a node from OD -> [OD,Spot] but have filtered the instance types by cost based on the
-	// assumption, that the spot variant will launch. We also need to add a requirement to the node to ensure that if
-	// spot capacity is insufficient we don't replace the node with a more expensive on-demand node.  Instead the launch
-	// should fail and we'll just leave the node alone.
-	ctReq := results.NewNodeClaims[0].Requirements.Get(v1.CapacityTypeLabelKey)
-	if ctReq.Has(v1.CapacityTypeSpot) && ctReq.Has(v1.CapacityTypeOnDemand) {
-		results.NewNodeClaims[0].Requirements.Add(scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, v1.CapacityTypeSpot))
-	}
-
 	return Command{
 		candidates:   candidates,
 		replacements: results.NewNodeClaims,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1605

**Description**

The karpenter core should not add `spot` to `nodeclaim` in consolidation. Which capacity type replaced with should be controlled by provider.

**How was this change tested?**

I hacked the provider code and maked all `spot` is not avaliable to simulate the all `spot` machines sold out case, and triggered a consolidation by modifying the nodepool with smaller `cpu` requirment. The nodeclaim will replaced by smaller/cheaper `on-demand` machine as expected.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
