### PR TITLE
chore: GetProvisionablePods list add status.nominatedNodeName

### DIFF
--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -134,7 +134,7 @@ func GetReschedulablePods(ctx context.Context, kubeClient client.Client, nodes .
 // GetProvisionablePods grabs all the pods from the passed nodes that satisfy the IsProvisionable criteria
 func GetProvisionablePods(ctx context.Context, kubeClient client.Client) ([]*corev1.Pod, error) {
 	var podList corev1.PodList
-	if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": ""}); err != nil {
+	if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": "", "status.nominatedNodeName": ""}); err != nil {
 		return nil, fmt.Errorf("listing pods, %w", err)
 	}
 	return lo.FilterMap(podList.Items, func(p corev1.Pod, _ int) (*corev1.Pod, bool) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

**Description**
`List` remove pods where status.nominatedNodeName is not empty

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
