### PR TITLE
fix: Fix unintentionally importing envtest when running NewTestingQueue

### DIFF
--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -45,7 +45,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
-	"sigs.k8s.io/karpenter/pkg/test"
 )
 
 const (
@@ -137,23 +136,6 @@ func NewQueue(kubeClient client.Client, recorder events.Recorder, cluster *state
 		cluster:             cluster,
 		clock:               clock,
 		provisioner:         provisioner,
-	}
-	return queue
-}
-
-func NewTestingQueue(kubeClient client.Client, recorder events.Recorder, cluster *state.Cluster, clock clock.Clock,
-	provisioner *provisioning.Provisioner) *Queue {
-
-	queue := &Queue{
-		// nolint:staticcheck
-		// We need to implement a deprecated interface since Command currently doesn't implement "comparable"
-		RateLimitingInterface: test.NewRateLimitingInterface(workqueue.QueueConfig{Name: "disruption.workqueue"}),
-		providerIDToCommand:   map[string]*Command{},
-		kubeClient:            kubeClient,
-		recorder:              recorder,
-		cluster:               cluster,
-		clock:                 clock,
-		provisioner:           provisioner,
 	}
 	return queue
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fix unintentionally importing envtest in our main code path. This was causing us to import `sigs.k8s.io/controller-runtime/envtest` which was causing startup to fail with

```
panic: mkdir /tmp/kubebuilder-envtest: read-only file system

goroutine 1 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/testing/addr.init.0()
        sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/testing/addr/manager.go:57 +0x15c
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
