### PR TITLE
fix: add default disruption stanza

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -71,6 +71,8 @@ spec:
                 from a combination of nodepool and pod scheduling constraints.
               properties:
                 disruption:
+                  default:
+                    consolidateAfter: 0s
                   description: Disruption contains the parameters that relate to Karpenter's disruption logic
                   properties:
                     budgets:

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -71,6 +71,8 @@ spec:
                 from a combination of nodepool and pod scheduling constraints.
               properties:
                 disruption:
+                  default:
+                    consolidateAfter: 0s
                   description: Disruption contains the parameters that relate to Karpenter's disruption logic
                   properties:
                     budgets:

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -42,6 +42,7 @@ type NodePoolSpec struct {
 	// +required
 	Template NodeClaimTemplate `json:"template"`
 	// Disruption contains the parameters that relate to Karpenter's disruption logic
+	// +kubebuilder:default:={consolidationPolicy: "WhenEmptyOrUnderutilized", consolidateAfter: "0s"}
 	// +optional
 	Disruption Disruption `json:"disruption"`
 	// Limits define a set of bounds for provisioning capacity.

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -42,7 +42,7 @@ type NodePoolSpec struct {
 	// +required
 	Template NodeClaimTemplate `json:"template"`
 	// Disruption contains the parameters that relate to Karpenter's disruption logic
-	// +kubebuilder:default:={consolidationPolicy: "WhenEmptyOrUnderutilized", consolidateAfter: "0s"}
+	// +kubebuilder:default:={consolidateAfter: "0s"}
 	// +optional
 	Disruption Disruption `json:"disruption"`
 	// Limits define a set of bounds for provisioning capacity.

--- a/pkg/apis/v1/nodepool_default_test.go
+++ b/pkg/apis/v1/nodepool_default_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	. "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 

--- a/pkg/apis/v1/nodepool_default_test.go
+++ b/pkg/apis/v1/nodepool_default_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Pallinder/go-randomdata"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	. "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+var _ = Describe("CEL/Default", func() {
+	var nodePool *NodePool
+
+	BeforeEach(func() {
+		nodePool = &NodePool{
+			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			Spec: NodePoolSpec{
+				Template: NodeClaimTemplate{
+					Spec: NodeClaimTemplateSpec{
+						NodeClassRef: &NodeClassReference{
+							Kind: "NodeClaim",
+							Name: "default",
+						},
+						Requirements: []NodeSelectorRequirementWithMinValues{
+							{
+								NodeSelectorRequirement: v1.NodeSelectorRequirement{
+									Key:      CapacityTypeLabelKey,
+									Operator: v1.NodeSelectorOpExists,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	Context("Defaults/TopLevel", func() {
+		It("should default the disruption stanza when undefined", func() {
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(nodePool), nodePool)).To(Succeed())
+			Expect(nodePool.Spec.Disruption).ToNot(BeNil())
+			Expect(lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration)).To(Equal(0 * time.Second))
+			Expect(nodePool.Spec.Disruption.ConsolidationPolicy).To(Equal(ConsolidationPolicyWhenEmptyOrUnderutilized))
+			Expect(nodePool.Spec.Disruption.Budgets).To(Equal([]Budget{{Nodes: "10%"}}))
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds default disruption stanza in for v1 NodePools that was erroneously removed prior to v1. Users who applied the `v1` version of the nodepool without the disruption stanza will have Consolidation disabled. This fixes it so that applying the v1beta1 or v1 version of the same nodepool will return the same nodepool.

**How was this change tested?**
make test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
