### PR TITLE
chore: Fix possible Registration TTL race condition

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -48,8 +48,9 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 		return reconcile.Result{Requeue: true}, nil
 	}
 	// If the Registered statusCondition hasn't gone True during the TTL since we first updated it, we should terminate the NodeClaim
-	if l.clock.Since(registered.LastTransitionTime.Time) < registrationTTL {
-		return reconcile.Result{RequeueAfter: registrationTTL - l.clock.Since(registered.LastTransitionTime.Time)}, nil
+	// NOTE: ttl has to be stored and checked in the same place since l.clock can advance after the check causing a race
+	if ttl := registrationTTL - l.clock.Since(registered.LastTransitionTime.Time); ttl > 0 {
+		return reconcile.Result{RequeueAfter: ttl}, nil
 	}
 	// Delete the NodeClaim if we believe the NodeClaim won't register since we haven't seen the node
 	if err := l.kubeClient.Delete(ctx, nodeClaim); err != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The current liveness TTL has a small race condition. It's possible that the first condition check `l.clock.Since(registered.LastTransitionTime.Time) < registrationTTL` can return a `true` value where `registrationTTL - l.clock.Since(registered.LastTransitionTime.Time) > 0`; however, since the clock can advance while we are in this conditional statement, by the time we get to the line `return reconcile.Result{RequeueAfter: registrationTTL - l.clock.Since(registered.LastTransitionTime.Time)}, nil`, `registrationTTL - l.clock.Since(registered.LastTransitionTime.Time)` is no longer greater than 0 and is now either equal to 0 or negative.

In either case, `controller-runtime` does not respect any `RequeueAfter` value that is equal to or less than 0. Thus, this effectively results in us returning the response `reconcile.Result{}, nil`. This can leave the NodeClaim in a state where it never gets deleted since we returned an empty result.

**How was this change tested?**

`make presubmit`

No tests were added since it's basically impossible to reproduce this race condition in testing code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
