### PR TITLE
fix: Add compat annotation key when using NodePool's kubelet config compat annotation

### DIFF
--- a/pkg/apis/v1/nodepool_conversion.go
+++ b/pkg/apis/v1/nodepool_conversion.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Convert v1 NodePool to v1beta1 NodePool
-func (in *NodePool) ConvertTo(ctx context.Context, to apis.Convertible) error {
+func (in *NodePool) ConvertTo(_ context.Context, to apis.Convertible) error {
 	v1beta1NP := to.(*v1beta1.NodePool)
 	v1beta1NP.ObjectMeta = in.ObjectMeta
 
@@ -123,7 +123,7 @@ func (in *NodePool) ConvertFrom(ctx context.Context, v1beta1np apis.Convertible)
 		return err
 	}
 	if kubeletAnnotation == "" {
-		in.Annotations = lo.OmitByKeys(in.Annotations, []string{KubeletCompatibilityAnnotationKey})
+		delete(in.Annotations, KubeletCompatibilityAnnotationKey)
 	} else {
 		in.Annotations = lo.Assign(in.Annotations, map[string]string{KubeletCompatibilityAnnotationKey: kubeletAnnotation})
 	}

--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -50,6 +50,11 @@ func NewNodeClaimTemplate(nodePool *v1.NodePool) *NodeClaimTemplate {
 		NodePoolName: nodePool.Name,
 		Requirements: scheduling.NewRequirements(),
 	}
+	if v, ok := nodePool.Annotations[v1.KubeletCompatibilityAnnotationKey]; ok {
+		nct.Annotations = lo.Assign(nct.Annotations, map[string]string{
+			v1.KubeletCompatibilityAnnotationKey: v,
+		})
+	}
 	nct.Labels = lo.Assign(nct.Labels, map[string]string{v1.NodePoolLabelKey: nodePool.Name})
 	nct.Requirements.Add(scheduling.NewNodeSelectorRequirementsWithMinValues(nct.Spec.Requirements...).Values()...)
 	nct.Requirements.Add(scheduling.NewLabelRequirements(nct.Labels).Values()...)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter-provider-aws/issues/6987

**Description**

Ensure that we add the `compatability.karpenter.sh/v1beta1-kubelet-conversion` is propagated onto NodeClaims when NodePool's use the kubelet configuration conversion during scheduling. 

Prior to this change, it was possible for the scheduler to call the GetInstanceTypes() API with one kubelet configuration (parsed by the the `compatability.karpenter.sh/v1beta1-kubelet-conversion` annotation) which results in higher capacity/allocatable values to be passed to the scheduler. The NodeClaim wouldn't contain this annotation, though; so, when a CloudProvider goes to launch the NodeClaim or when the NodeClaim is considered later for capacity/allocatable, it might use a completely different set of values.

This change ensures that the `compatability.karpenter.sh/v1beta1-kubelet-conversion` so that the CloudProvider is able to reason about this Kubelet Config consistently across NodePools and NodeClaims.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
