### PR TITLE
feat: Add VMReserved to InstanceTypeOverhead

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -220,10 +220,12 @@ type InstanceTypeOverhead struct {
 	SystemReserved corev1.ResourceList
 	// EvictionThreshold returns the resources used to maintain a hard eviction threshold
 	EvictionThreshold corev1.ResourceList
+	// VmReserved returns the additional overhead resources reserved for things like hypervisor or OS
+	VmReserved corev1.ResourceList
 }
 
 func (i InstanceTypeOverhead) Total() corev1.ResourceList {
-	return resources.Merge(i.KubeReserved, i.SystemReserved, i.EvictionThreshold)
+	return resources.Merge(i.KubeReserved, i.SystemReserved, i.EvictionThreshold, i.VmReserved)
 }
 
 // An Offering describes where an InstanceType is available to be used, with the expectation that its properties

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -220,12 +220,12 @@ type InstanceTypeOverhead struct {
 	SystemReserved corev1.ResourceList
 	// EvictionThreshold returns the resources used to maintain a hard eviction threshold
 	EvictionThreshold corev1.ResourceList
-	// VmReserved returns the additional overhead resources reserved for things like hypervisor or OS
-	VmReserved corev1.ResourceList
+	// VMReserved returns the additional overhead resources reserved for things like hypervisor or OS
+	VMReserved corev1.ResourceList
 }
 
 func (i InstanceTypeOverhead) Total() corev1.ResourceList {
-	return resources.Merge(i.KubeReserved, i.SystemReserved, i.EvictionThreshold, i.VmReserved)
+	return resources.Merge(i.KubeReserved, i.SystemReserved, i.EvictionThreshold, i.VMReserved)
 }
 
 // An Offering describes where an InstanceType is available to be used, with the expectation that its properties


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Relates:
- https://github.com/aws/karpenter-provider-aws/issues/5161
- https://github.com/aws/karpenter-provider-aws/pull/7004

**Description**
The underlying OS or VM hypervisor consumes additional resources that should be tracked as overhead. In the linked PR this overhead is being subtracted from the overall capacity but it may be preferable to instead add them here.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
