### PR TITLE
fix: when all replicas of a deployment are on one node, restart the deployment instead of evicting it

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -49,6 +49,8 @@ const (
 	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"
 	NodeClaimTerminationTimestampAnnotationKey = apis.Group + "/nodeclaim-termination-timestamp"
+	// When a deployment is restarted, this annotation is used to mark which node was terminated and restarted.
+	DeploymentRestartNodeAnnotationKey = apis.Group + "/restart-node"
 )
 
 // Karpenter specific finalizers

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -19,9 +19,11 @@ package terminator
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
 	"sigs.k8s.io/karpenter/pkg/events"
 	nodeutil "sigs.k8s.io/karpenter/pkg/utils/node"
@@ -36,18 +39,21 @@ import (
 )
 
 type Terminator struct {
-	clock         clock.Clock
-	kubeClient    client.Client
-	evictionQueue *Queue
-	recorder      events.Recorder
+	sync.RWMutex
+	clock                  clock.Clock
+	kubeClient             client.Client
+	nodeRestartDeployments map[string]map[string]struct{}
+	evictionQueue          *Queue
+	recorder               events.Recorder
 }
 
 func NewTerminator(clk clock.Clock, kubeClient client.Client, eq *Queue, recorder events.Recorder) *Terminator {
 	return &Terminator{
-		clock:         clk,
-		kubeClient:    kubeClient,
-		evictionQueue: eq,
-		recorder:      recorder,
+		clock:                  clk,
+		kubeClient:             kubeClient,
+		nodeRestartDeployments: make(map[string]map[string]struct{}),
+		evictionQueue:          eq,
+		recorder:               recorder,
 	}
 }
 
@@ -108,11 +114,37 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 	podGroups := t.groupPodsByPriority(lo.Filter(pods, func(p *corev1.Pod, _ int) bool { return podutil.IsWaitingEviction(p, t.clock) }))
 	for _, group := range podGroups {
 		if len(group) > 0 {
+			// If the deployment corresponding to the pod has only one pod,
+			// or all the pods of the deployment are on this node,
+			// restarting the deployment can reduce the service interruption time.
+			var drainPods []*corev1.Pod
+			var restartDeployments []*appsv1.Deployment
+			deletionDeadline := node.GetDeletionTimestamp().Add(5 * time.Minute)
+
+			// 5 minutes is roughly based on (maximum time) = 2 minutes to pull the node + 2 minutes to start the service + 1 minute to terminate.
+			// If the restart is not completed after this time, it is possible that the new pod of the deployment cannot be started and the old pod will not be deleted.
+			if time.Now().Before(deletionDeadline) {
+				restartDeployments, drainPods, err = t.GetRestartdeploymentsAndDrainPods(ctx, group, node.Name)
+				if err != nil {
+					return fmt.Errorf("get deployment and drain pod from node %w", err)
+				}
+			} else {
+				drainPods = pods
+			}
+
+			if err = t.RestartDeployments(ctx, restartDeployments, node.Name); err != nil {
+				return fmt.Errorf("restart deployments from node %s, %w", node.Name, err)
+			}
+
 			// Only add pods to the eviction queue that haven't been evicted yet
-			t.evictionQueue.Add(lo.Filter(group, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p) })...)
+			t.evictionQueue.Add(lo.Filter(drainPods, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p) })...)
 			return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", lo.SumBy(podGroups, func(pods []*corev1.Pod) int { return len(pods) })))
 		}
 	}
+
+	t.Lock()
+	delete(t.nodeRestartDeployments, node.Name)
+	t.Unlock()
 	return nil
 }
 
@@ -174,4 +206,146 @@ func (t *Terminator) podDeleteTimeWithGracePeriod(nodeGracePeriodExpirationTime 
 	// eg: if a node will be force terminated in 30m, but the current pod has a grace period of 45m, we return a time of 15m ago
 	deleteTime := nodeGracePeriodExpirationTime.Add(time.Duration(*pod.Spec.TerminationGracePeriodSeconds) * time.Second * -1)
 	return &deleteTime
+}
+
+func (t *Terminator) GetDeploymentFromPod(ctx context.Context, pod *corev1.Pod) (*appsv1.Deployment, error) {
+	rs, err := t.getOwnerReplicaSet(ctx, pod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ReplicaSet from Pod: %w", err)
+	}
+	if rs == nil {
+		return nil, nil
+	}
+
+	deployment, err := t.getOwnerDeployment(ctx, rs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Deployment from ReplicaSet: %w", err)
+	}
+	return deployment, nil
+
+}
+
+func (t *Terminator) getOwnerReplicaSet(ctx context.Context, pod *corev1.Pod) (*appsv1.ReplicaSet, error) {
+	for _, ownerRef := range pod.GetOwnerReferences() {
+		if ownerRef.Controller != nil && ownerRef.Kind == "ReplicaSet" {
+			rs := &appsv1.ReplicaSet{}
+			if err := t.kubeClient.Get(ctx, client.ObjectKey{Name: ownerRef.Name, Namespace: pod.Namespace}, rs); err != nil {
+				return nil, fmt.Errorf("get ReplicaSet: %w", err)
+			}
+			return rs, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (t *Terminator) getOwnerDeployment(ctx context.Context, rs *appsv1.ReplicaSet) (*appsv1.Deployment, error) {
+	for _, ownerRef := range rs.GetOwnerReferences() {
+		if ownerRef.Controller != nil && ownerRef.Kind == "Deployment" {
+			deployment := &appsv1.Deployment{}
+			if err := t.kubeClient.Get(ctx, client.ObjectKey{Name: ownerRef.Name, Namespace: rs.Namespace}, deployment); err != nil {
+				return nil, fmt.Errorf("get Deployment: %w", err)
+			}
+			return deployment, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (t *Terminator) RestartDeployments(ctx context.Context, deployments []*appsv1.Deployment, nodeName string) error {
+	var updateErrors []error
+
+	for _, deployment := range deployments {
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = make(map[string]string)
+		}
+		restartedNode, exists := deployment.Spec.Template.Annotations[v1.DeploymentRestartNodeAnnotationKey]
+		if exists && restartedNode == nodeName {
+			continue
+		}
+
+		t.Lock()
+		if t.nodeRestartDeployments[nodeName] == nil {
+			t.nodeRestartDeployments[nodeName] = make(map[string]struct{})
+		}
+		t.nodeRestartDeployments[nodeName][deployment.Namespace+"/"+deployment.Name] = struct{}{}
+		t.Unlock()
+
+		deployment.Spec.Template.Annotations[v1.DeploymentRestartNodeAnnotationKey] = nodeName
+		if err := t.kubeClient.Update(ctx, deployment); err != nil {
+			updateErrors = append(updateErrors, err)
+			continue
+		}
+
+	}
+
+	if len(updateErrors) > 0 {
+		return fmt.Errorf("failed to restart some deployment: %v", updateErrors)
+	}
+
+	return nil
+}
+
+func (t *Terminator) GetRestartdeploymentsAndDrainPods(ctx context.Context, pods []*corev1.Pod, nodeName string) ([]*appsv1.Deployment, []*corev1.Pod, error) {
+	var drainPods []*corev1.Pod
+	var restartDeployments []*appsv1.Deployment
+	nodeDeploymentReplicas := make(map[string]int32)
+	deploymentCache := make(map[string]*appsv1.Deployment)
+	uniqueDeployments := make(map[string]struct{})
+
+	for _, pod := range pods {
+		deployment, err := t.getDeploymentFromCache(ctx, pod, deploymentCache)
+		if err != nil {
+			return nil, nil, err
+		}
+		if deployment != nil {
+			nodeDeploymentReplicas[deployment.Namespace+"/"+deployment.Name]++
+		}
+	}
+
+	for _, pod := range pods {
+		deployment := deploymentCache[pod.Namespace+"/"+pod.Name]
+
+		if deployment != nil {
+			key := deployment.Namespace + "/" + deployment.Name
+			if nodeDeploymentReplicas[key] >= *deployment.Spec.Replicas {
+				// If a deployment has multiple pods on this node, there will be multiple deployments here, and deduplication is required.
+				if _, exists := uniqueDeployments[key]; !exists {
+					uniqueDeployments[key] = struct{}{}
+					restartDeployments = append(restartDeployments, deployment)
+				}
+				continue
+			} else {
+				// If a deployment has multiple copies, all of which are on this node,
+				// when the restart begins, the number of copies of the deployment on this node will gradually decrease.
+				// This situation needs to be judged separately.
+				t.RLock()
+				_, exists := t.nodeRestartDeployments[nodeName][key]
+				t.RUnlock()
+				if exists {
+					continue
+				}
+			}
+		}
+
+		drainPods = append(drainPods, pod)
+	}
+
+	return restartDeployments, drainPods, nil
+}
+
+func (t *Terminator) getDeploymentFromCache(ctx context.Context, pod *corev1.Pod, cache map[string]*appsv1.Deployment) (*appsv1.Deployment, error) {
+	key := pod.Namespace + "/" + pod.Name
+	if deployment, exists := cache[key]; exists {
+		return deployment, nil
+	}
+
+	deployment, err := t.GetDeploymentFromPod(ctx, pod)
+	if err != nil {
+		return nil, err
+	}
+
+	cache[key] = deployment
+	return deployment, nil
 }


### PR DESCRIPTION

Fixes   [1674](https://github.com/kubernetes-sigs/karpenter/issues/1674)


**Description**
When all replicas of a Deployment are on the same node, for example, a deployment has 2 pods on this node, and the 2 pods are evicted when the node is terminated. From the time the 2 pods are evicted to the time the 2 pods are created and run successfully on the new node, the deployment has no pods to provide services.
This also happens when a Deployment has only one replica.

During Evicting, a judgment will be made here. If all replicas of the Deployment are on this node, or the Deployment has only one replica, restarting the Deployment is more elegant than evicting. This operation will first create a pod on the new node, wait for the new pod to run successfully, and then terminate the old pod, which will reduce service interruption time.


**How was this change tested?**
- make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.