### PR TITLE
fix: Ignore released volumes when deleting a node

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -225,6 +225,7 @@ func filterVolumeAttachments(ctx context.Context, kubeClient client.Client, node
 			}
 		}
 	}
+
 	filteredVolumeAttachments := lo.Reject(volumeAttachments, func(v *storagev1.VolumeAttachment, _ int) bool {
 		pvName := v.Spec.Source.PersistentVolumeName
 		return pvName == nil || shouldFilterOutVolume.Has(*pvName)


### PR DESCRIPTION
Fixes #1684

**Description**

Ignore released volumes when waiting for volume attachments
    
When deciding whether a node can be terminated, ignore persistent
volumes that have already been released (perhaps attached to a pod
that has since been drained)


**How was this change tested?**

Using `make test`. This change is split into two commits, the first is a test that fails before the change in the second commit and succeeds afterwards

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
