### PR TITLE
chore: Drop stored version annotation 33

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -47,6 +47,7 @@ const (
 	KubeletCompatibilityAnnotationKey          = CompatibilityGroup + "/v1beta1-kubelet-conversion"
 	NodeClassReferenceAnnotationKey            = CompatibilityGroup + "/v1beta1-nodeclass-reference"
 	NodeClaimTerminationTimestampAnnotationKey = Group + "/nodeclaim-termination-timestamp"
+	StoredVersionMigratedKey                   = Group + "/stored-version-migrated"
 )
 
 // Karpenter specific finalizers

--- a/pkg/apis/v1/nodeclaim_conversion.go
+++ b/pkg/apis/v1/nodeclaim_conversion.go
@@ -45,6 +45,8 @@ func (in *NodeClaim) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	// Remove the annotations from the v1beta1 NodeClaim on the convert back
 	delete(v1beta1NC.Annotations, KubeletCompatibilityAnnotationKey)
 	delete(v1beta1NC.Annotations, NodeClassReferenceAnnotationKey)
+	// Drop the annotation so when roundtripping from v1, to v1beta1, and back to v1 the migration resource controller can re-annotate it
+	delete(v1beta1NC.Annotations, StoredVersionMigratedKey)
 	return nil
 }
 

--- a/pkg/apis/v1/nodeclaim_conversion_test.go
+++ b/pkg/apis/v1/nodeclaim_conversion_test.go
@@ -98,6 +98,19 @@ var _ = Describe("Convert v1 to v1beta1 NodeClaim API", func() {
 		v1beta1nodeclaim.Annotations = nil
 		Expect(v1beta1nodeclaim.ObjectMeta).To(BeEquivalentTo(v1nodeclaim.ObjectMeta))
 	})
+	It("should drop v1 specific annotations on conversion", func() {
+		v1nodeclaim.ObjectMeta = test.ObjectMeta(
+			metav1.ObjectMeta{
+				Annotations: map[string]string{
+					StoredVersionMigratedKey: "true",
+				},
+			},
+		)
+		v1nc := v1nodeclaim.DeepCopy()
+		Expect(v1nodeclaim.ConvertTo(ctx, v1beta1nodeclaim)).To(Succeed())
+		Expect(v1nc.Annotations).To(HaveKey(StoredVersionMigratedKey))
+		Expect(v1beta1nodeclaim.Annotations).NotTo(HaveKey(StoredVersionMigratedKey))
+	})
 	Context("NodeClaim Spec", func() {
 		It("should convert v1 nodeclaim taints", func() {
 			v1nodeclaim.Spec.Taints = []v1.Taint{

--- a/pkg/apis/v1/nodepool_conversion.go
+++ b/pkg/apis/v1/nodepool_conversion.go
@@ -42,6 +42,8 @@ func (in *NodePool) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	// Remove the annotations from the v1beta1 NodeClaim on the convert back
 	delete(v1beta1NP.Annotations, KubeletCompatibilityAnnotationKey)
 	delete(v1beta1NP.Annotations, NodeClassReferenceAnnotationKey)
+	// Drop the annotation so when roundtripping from v1, to v1beta1, and back to v1 the migration resource controller can re-annotate it
+	delete(v1beta1NP.Annotations, StoredVersionMigratedKey)
 	return nil
 }
 

--- a/pkg/apis/v1/nodepool_conversion_test.go
+++ b/pkg/apis/v1/nodepool_conversion_test.go
@@ -76,6 +76,19 @@ var _ = Describe("Convert V1 to V1beta1 NodePool API", func() {
 		Expect(v1nodepool.ConvertTo(ctx, v1beta1nodepool)).To(Succeed())
 		Expect(v1beta1nodepool.ObjectMeta).To(BeEquivalentTo(v1nodepool.ObjectMeta))
 	})
+	It("should drop v1 specific annotations on conversion", func() {
+		v1nodepool.ObjectMeta = test.ObjectMeta(
+			metav1.ObjectMeta{
+				Annotations: map[string]string{
+					StoredVersionMigratedKey: "true",
+				},
+			},
+		)
+		v1np := v1nodepool.DeepCopy()
+		Expect(v1nodepool.ConvertTo(ctx, v1beta1nodepool)).To(Succeed())
+		Expect(v1np.Annotations).To(HaveKey(StoredVersionMigratedKey))
+		Expect(v1beta1nodepool.Annotations).NotTo(HaveKey(StoredVersionMigratedKey))
+	})
 	Context("NodePool Spec", func() {
 		It("should convert v1 nodepool weights", func() {
 			v1nodepool.Spec.Weight = lo.ToPtr(int32(62))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Backports the change for dropping the StorageVersionMigrated annotation.


**How was this change tested?**
unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
