### PR TITLE
fix: conditionally enable migration controllers based on webhook enablement

### DIFF
--- a/kwok/main.go
+++ b/kwok/main.go
@@ -36,6 +36,7 @@ func main() {
 	op.
 		WithWebhooks(ctx, webhooks.NewWebhooks()...).
 		WithControllers(ctx, controllers.NewControllers(
+			ctx,
 			op.Manager,
 			op.Clock,
 			op.GetClient(),

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -25,8 +25,6 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
-	migrationcrd "sigs.k8s.io/karpenter/pkg/controllers/migration/crd"
-	migration "sigs.k8s.io/karpenter/pkg/controllers/migration/resource"
 	nodepoolreadiness "sigs.k8s.io/karpenter/pkg/controllers/nodepool/readiness"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -95,8 +93,5 @@ func NewControllers(
 		leasegarbagecollection.NewController(kubeClient),
 		status.NewController[*v1.NodeClaim](kubeClient, mgr.GetEventRecorderFor("karpenter")),
 		status.NewController[*v1.NodePool](kubeClient, mgr.GetEventRecorderFor("karpenter")),
-		migration.NewController[*v1.NodeClaim](kubeClient),
-		migration.NewController[*v1.NodePool](kubeClient),
-		migrationcrd.NewController(kubeClient, cloudProvider),
 	}
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
+
 	"github.com/awslabs/operatorpkg/controller"
 	"github.com/awslabs/operatorpkg/status"
 	"k8s.io/utils/clock"
@@ -24,7 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 
+	migrationcrd "sigs.k8s.io/karpenter/pkg/controllers/migration/crd"
+	migration "sigs.k8s.io/karpenter/pkg/controllers/migration/resource"
 	nodepoolreadiness "sigs.k8s.io/karpenter/pkg/controllers/nodepool/readiness"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -53,6 +58,7 @@ import (
 )
 
 func NewControllers(
+	ctx context.Context,
 	mgr manager.Manager,
 	clock clock.Clock,
 	kubeClient client.Client,
@@ -65,7 +71,7 @@ func NewControllers(
 	evictionQueue := terminator.NewQueue(kubeClient, recorder)
 	disruptionQueue := orchestration.NewQueue(kubeClient, recorder, cluster, clock, p)
 
-	return []controller.Controller{
+	controllers := []controller.Controller{
 		p, evictionQueue, disruptionQueue,
 		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue),
 		provisioning.NewPodController(kubeClient, p),
@@ -94,4 +100,12 @@ func NewControllers(
 		status.NewController[*v1.NodeClaim](kubeClient, mgr.GetEventRecorderFor("karpenter")),
 		status.NewController[*v1.NodePool](kubeClient, mgr.GetEventRecorderFor("karpenter")),
 	}
+
+	if !options.FromContext(ctx).DisableWebhook {
+		controllers = append(controllers, migration.NewController[*v1.NodeClaim](kubeClient))
+		controllers = append(controllers, migration.NewController[*v1.NodePool](kubeClient))
+		controllers = append(controllers, migrationcrd.NewController(kubeClient, cloudProvider))
+	}
+
+	return controllers
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Conditionally enable migration controllers when webhooks are also enabled.

**How was this change tested?**
Make presubmit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
