### PR TITLE
fix: Fix handling for multiple Daemonset nodeAffinity selectorTerms

### DIFF
--- a/pkg/controllers/provisioning/scheduling/preferences.go
+++ b/pkg/controllers/provisioning/scheduling/preferences.go
@@ -36,7 +36,6 @@ type Preferences struct {
 }
 
 func (p *Preferences) Relax(ctx context.Context, pod *v1.Pod) bool {
-	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Pod", klog.KRef(pod.Namespace, pod.Name)))
 	relaxations := []func(*v1.Pod) *string{
 		p.removeRequiredNodeAffinityTerm,
 		p.removePreferredPodAffinityTerm,
@@ -50,7 +49,7 @@ func (p *Preferences) Relax(ctx context.Context, pod *v1.Pod) bool {
 
 	for _, relaxFunc := range relaxations {
 		if reason := relaxFunc(pod); reason != nil {
-			log.FromContext(ctx).V(1).Info(fmt.Sprintf("relaxing soft constraints for pod since it previously failed to schedule, %s", lo.FromPtr(reason)))
+			log.FromContext(ctx).WithValues("Pod", klog.KRef(pod.Namespace, pod.Name)).V(1).Info(fmt.Sprintf("relaxing soft constraints for pod since it previously failed to schedule, %s", lo.FromPtr(reason)))
 			return true
 		}
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -352,23 +352,33 @@ func (s *Scheduler) calculateExistingNodeClaims(stateNodes []*state.StateNode, d
 	})
 }
 
+// getDaemonOverhead determines the overhead for each NodeClaimTemplate required for daemons to schedule for any node provisioned by the NodeClaimTemplate
 func getDaemonOverhead(nodeClaimTemplates []*NodeClaimTemplate, daemonSetPods []*corev1.Pod) map[*NodeClaimTemplate]corev1.ResourceList {
-	overhead := map[*NodeClaimTemplate]corev1.ResourceList{}
+	return lo.SliceToMap(nodeClaimTemplates, func(nct *NodeClaimTemplate) (*NodeClaimTemplate, corev1.ResourceList) {
+		return nct, resources.RequestsForPods(lo.Filter(daemonSetPods, func(p *corev1.Pod, _ int) bool { return isDaemonPodCompatible(nct, p) })...)
+	})
+}
 
-	for _, nodeClaimTemplate := range nodeClaimTemplates {
-		var daemons []*corev1.Pod
-		for _, p := range daemonSetPods {
-			if err := scheduling.Taints(nodeClaimTemplate.Spec.Taints).Tolerates(p); err != nil {
-				continue
-			}
-			if err := nodeClaimTemplate.Requirements.Compatible(scheduling.NewPodRequirements(p), scheduling.AllowUndefinedWellKnownLabels); err != nil {
-				continue
-			}
-			daemons = append(daemons, p)
-		}
-		overhead[nodeClaimTemplate] = resources.RequestsForPods(daemons...)
+// isDaemonPodCompatible determines if the daemon pod is compatible with the NodeClaimTemplate for daemon scheduling
+func isDaemonPodCompatible(nodeClaimTemplate *NodeClaimTemplate, pod *corev1.Pod) bool {
+	preferences := &Preferences{}
+	// Add a toleration for PreferNoSchedule since a daemon pod shouldn't respect the preference
+	_ = preferences.toleratePreferNoScheduleTaints(pod)
+	if err := scheduling.Taints(nodeClaimTemplate.Spec.Taints).Tolerates(pod); err != nil {
+		return false
 	}
-	return overhead
+	for {
+		// We don't consider pod preferences for scheduling requirements since we know that pod preferences won't matter with Daemonset scheduling
+		if nodeClaimTemplate.Requirements.IsCompatible(scheduling.NewStrictPodRequirements(pod), scheduling.AllowUndefinedWellKnownLabels) {
+			return true
+		}
+		// If relaxing the Node Affinity term didn't succeed, then this DaemonSet can't schedule to this NodePool
+		// We don't consider other forms of relaxation here since we don't consider pod affinities/anti-affinities
+		// when considering DaemonSet schedulability
+		if preferences.removeRequiredNodeAffinityTerm(pod) == nil {
+			return false
+		}
+	}
 }
 
 // subtractMax returns the remaining resources after subtracting the max resource quantity per instance type. To avoid


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/kubernetes-sigs/karpenter/issues/1337

**Description**

This change ensures that we consider _all_ nodeAffinity terms when determining if the DS is going to schedule to the node.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
