### PR TITLE
fix: spurious logging from migration controller

### DIFF
--- a/pkg/controllers/migration/crd/controller.go
+++ b/pkg/controllers/migration/crd/controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -99,11 +100,13 @@ func (c *Controller) Reconcile(ctx context.Context, crd *apiextensionsv1.CustomR
 	// if all custom resources have been updated, patch the CRD
 	stored := crd.DeepCopy()
 	crd.Status.StoredVersions = []string{"v1"}
-	if err := c.kubeClient.Status().Patch(ctx, crd, client.StrategicMergeFrom(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
-		if errors.IsConflict(err) {
-			return reconcile.Result{Requeue: true}, nil
+	if !equality.Semantic.DeepEqual(stored, crd) {
+		if err := c.kubeClient.Status().Patch(ctx, crd, client.StrategicMergeFrom(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
+			if errors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
+			return reconcile.Result{}, fmt.Errorf("patching crd status version %s, %w", crd.Name, err)
 		}
-		return reconcile.Result{}, fmt.Errorf("patching crd status version %s, %w", crd.Name, err)
 	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/migration/crd/controller.go
+++ b/pkg/controllers/migration/crd/controller.go
@@ -99,7 +99,7 @@ func (c *Controller) Reconcile(ctx context.Context, crd *apiextensionsv1.CustomR
 	// if all custom resources have been updated, patch the CRD
 	stored := crd.DeepCopy()
 	crd.Status.StoredVersions = []string{"v1"}
-	if err := c.kubeClient.Status().Patch(ctx, crd, client.StrategicMergeFrom(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+	if err := c.kubeClient.Status().Patch(ctx, crd, client.StrategicMergeFrom(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
 		if errors.IsConflict(err) {
 			return reconcile.Result{Requeue: true}, nil
 		}

--- a/pkg/controllers/migration/crd/controller.go
+++ b/pkg/controllers/migration/crd/controller.go
@@ -54,6 +54,7 @@ func NewController(client client.Client, cloudProvider cloudprovider.CloudProvid
 	}
 }
 
+// nolint:gocyclo
 func (c *Controller) Reconcile(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) (reconcile.Result, error) {
 	ctx = injection.WithControllerName(ctx, "migration.crd")
 

--- a/pkg/controllers/migration/crd/controller.go
+++ b/pkg/controllers/migration/crd/controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -99,6 +100,9 @@ func (c *Controller) Reconcile(ctx context.Context, crd *apiextensionsv1.CustomR
 	stored := crd.DeepCopy()
 	crd.Status.StoredVersions = []string{"v1"}
 	if err := c.kubeClient.Status().Patch(ctx, crd, client.StrategicMergeFrom(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+		if errors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		return reconcile.Result{}, fmt.Errorf("patching crd status version %s, %w", crd.Name, err)
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controllers/migration/resource/controller.go
+++ b/pkg/controllers/migration/resource/controller.go
@@ -69,8 +69,8 @@ func (c *Controller[T]) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}))
 	// update annotation on CR
 	if !equality.Semantic.DeepEqual(stored, o) {
-		if err := c.kubeClient.Patch(ctx, o, client.MergeFrom(stored.(client.Object))); err != nil {
-			return reconcile.Result{}, client.IgnoreNotFound(fmt.Errorf("adding %s annotation to %s, %w", v1.StoredVersionMigratedKey, object.GVK(o), err))
+		if err := c.kubeClient.Patch(ctx, o, client.MergeFrom(stored.(client.Object))); client.IgnoreNotFound(err) != nil {
+			return reconcile.Result{}, fmt.Errorf("adding %s annotation to %s, %w", v1.StoredVersionMigratedKey, object.GVK(o), err)
 		}
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controllers/migration/resource/controller.go
+++ b/pkg/controllers/migration/resource/controller.go
@@ -69,8 +69,8 @@ func (c *Controller[T]) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}))
 	// update annotation on CR
 	if !equality.Semantic.DeepEqual(stored, o) {
-		if err := c.kubeClient.Patch(ctx, o, client.MergeFromWithOptions(stored.(client.Object), client.MergeFromWithOptimisticLock{})); err != nil {
-			return reconcile.Result{}, fmt.Errorf("adding %s annotation to %s, %w", v1.StoredVersionMigratedKey, object.GVK(o), err)
+		if err := c.kubeClient.Patch(ctx, o, client.MergeFrom(stored.(client.Object))); err != nil {
+			return reconcile.Result{}, client.IgnoreNotFound(fmt.Errorf("adding %s annotation to %s, %w", v1.StoredVersionMigratedKey, object.GVK(o), err))
 		}
 	}
 	return reconcile.Result{}, nil


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Suppresses conflict errors on custom resources by no longer using optimistic locking for an annotation we own and suppresses not found errors.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
