### PR TITLE
fix: increase the eviction cost baseline value for do-not-disruptable pods

### DIFF
--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -796,6 +796,16 @@ var _ = Describe("Pod Eviction Cost", func() {
 		})
 		Expect(cost).To(BeNumerically("<", standardPodCost))
 	})
+	It("should have a high disruptionCost for a pod with a do-not-disrupt annotation set", func() {
+		cost := disruptionutils.EvictionCost(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1.DoNotDisruptAnnotationKey: "true",
+				},
+			},
+		})
+		Expect(cost).To(BeNumerically(">", standardPodCost))
+	})
 })
 
 var _ = Describe("Candidate Filtering", func() {

--- a/pkg/utils/disruption/disruption.go
+++ b/pkg/utils/disruption/disruption.go
@@ -48,6 +48,10 @@ func LifetimeRemaining(clock clock.Clock, nodePool *v1.NodePool, nodeClaim *v1.N
 // EvictionCost returns the disruption cost computed for evicting the given pod.
 func EvictionCost(ctx context.Context, p *corev1.Pod) float64 {
 	cost := 1.0
+	// karpenter won't evict these pods, so we set the cost high to model that when disrupting nodes
+	if _, ok := p.Annotations[v1.DoNotDisruptAnnotationKey]; ok {
+		cost = 10.0
+	}
 	podDeletionCostStr, ok := p.Annotations[corev1.PodDeletionCost]
 	if ok {
 		podDeletionCost, err := strconv.ParseFloat(podDeletionCostStr, 64)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Karpenter manages the order for disruption based on the total disruption cost of the pods on a node. However, this does not take into account pods Karpenter can not evict due to the  `karpenter.sh/do-not-disrupt: true`. As a result, nodes that can't have all their pods evicted may be selected as candidates for disruption before nodes with equal or greater number of pods that are all evictable. When this occur, the unevictable node wastes the nodepool's disruption budget.

This change fixes that bug by increasing the base pod eviction cost for pods annotated with `karpenter.sh/do-not-disrupt: true` in Karpenter's simulation models. 

**How was this change tested?**

Unit tests + real workloads in our clusters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
