### PR TITLE
perf: don't include terminated nodes in budget

### DIFF
--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -212,7 +212,7 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 		// Additionally, don't consider nodeclaims that have the terminating condition. A nodeclaim should have
 		// the Terminating condition only when the node is drained and cloudprovider.Delete() was successful
 		// on the underlying cloud provider machine.
-		if nc := node.NodeClaim; nc != nil && nc.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue() {
+		if node.NodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue() {
 			continue
 		}
 

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -209,6 +209,13 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 			continue
 		}
 
+		// Additionally, don't consider nodeclaims that have the terminating condition. A nodeclaim should have
+		// the Terminating condition only when the node is drained and cloudprovider.Delete() was successful
+		// on the underlying cloud provider machine.
+		if nc := node.NodeClaim; nc != nil && nc.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue() {
+			continue
+		}
+
 		nodePool := node.Labels()[v1.NodePoolLabelKey]
 		numNodes[nodePool]++
 

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -411,10 +411,10 @@ func (in *StateNode) PodLimits() corev1.ResourceList {
 func (in *StateNode) MarkedForDeletion() bool {
 	// The Node is marked for deletion if:
 	//  1. The Node has MarkedForDeletion set
-	//  2. The Node has a NodeClaim counterpart and is actively deleting
+	//  2. The Node has a NodeClaim counterpart and is actively deleting (or the nodeclaim is marked as terminating)
 	//  3. The Node has no NodeClaim counterpart and is actively deleting
 	return in.markedForDeletion ||
-		(in.NodeClaim != nil && !in.NodeClaim.DeletionTimestamp.IsZero()) ||
+		(in.NodeClaim != nil && (!in.NodeClaim.DeletionTimestamp.IsZero() || in.NodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue())) ||
 		(in.Node != nil && in.NodeClaim == nil && !in.Node.DeletionTimestamp.IsZero())
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Nodes that have the `InstanceTerminating` status condition have had cloudprovider.Delete() succeed. In cases where this delete happens asynchronously in the cloud provider (transitions from Running -> Terminating in AWS), Karpenter will wait to remove the finalizer until the cloud provider machine no longer exists (transitions from Terminating -> Terminated in AWS). Instance termination can vary from seconds to minutes, and counting these against the budget (when there's no pods on the nodes) only impacts expected performance of the disruption controller.

**How was this change tested?**
make presubmit and testing locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
