### PR TITLE
fix: Make failure reason message more clear

### DIFF
--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -227,10 +227,10 @@ func (r filterResults) FailureReason() string {
 		return "no instance type which met the scheduling requirements and had enough resources, had a required offering"
 	}
 	if r.fitsAndOffering {
-		return "no instance type which had enough resources and the required offering met the scheduling requirements"
+		return "no instance type which had enough resources and the required offering, met the scheduling requirements"
 	}
 	if r.requirementsAndOffering {
-		return "no instance type which met the scheduling requirements and the required offering had the required resources"
+		return "no instance type which met the scheduling requirements and the required offering, had the required resources"
 	}
 
 	// finally all instances were filtered out, but we had at least one instance that met each criteria, and met each


### PR DESCRIPTION
Fixes #N/A

**Description**

If I understand correctly what we are trying to say in these errors, the previous messages could lead to confusion and this simple `,` could make more clear what part is having trouble.

**How was this change tested?**

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
