### PR TITLE
feat(options): Add consolidation timeout options

### DIFF
--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -117,7 +117,7 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 	lastSavedCommand := Command{}
 	lastSavedResults := scheduling.Results{}
 	// Set a timeout
-	timeout := m.clock.Now().Add(options.FromContext(ctx).SinglenodeConsolidationTimeout)
+	timeout := m.clock.Now().Add(options.FromContext(ctx).MultiNodeConsolidationTimeout)
 	// binary search to find the maximum number of NodeClaims we can terminate
 	for min <= max {
 		if m.clock.Now().After(timeout) {

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -29,10 +28,9 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	scheduler "sigs.k8s.io/karpenter/pkg/scheduling"
 )
-
-const MultiNodeConsolidationTimeoutDuration = 1 * time.Minute
 
 type MultiNodeConsolidation struct {
 	consolidation
@@ -119,7 +117,7 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 	lastSavedCommand := Command{}
 	lastSavedResults := scheduling.Results{}
 	// Set a timeout
-	timeout := m.clock.Now().Add(MultiNodeConsolidationTimeoutDuration)
+	timeout := m.clock.Now().Add(options.FromContext(ctx).SinglenodeConsolidationTimeout)
 	// binary search to find the maximum number of NodeClaims we can terminate
 	for min <= max {
 		if m.clock.Now().After(timeout) {

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -19,15 +19,13 @@ package disruption
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 )
-
-const SingleNodeConsolidationTimeoutDuration = 3 * time.Minute
 
 // SingleNodeConsolidation is the consolidation controller that performs single-node consolidation.
 type SingleNodeConsolidation struct {
@@ -49,7 +47,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 	v := NewValidation(s.clock, s.cluster, s.kubeClient, s.provisioner, s.cloudProvider, s.recorder, s.queue, s.Reason())
 
 	// Set a timeout
-	timeout := s.clock.Now().Add(SingleNodeConsolidationTimeoutDuration)
+	timeout := s.clock.Now().Add(options.FromContext(ctx).SinglenodeConsolidationTimeout)
 	constrainedByBudgets := false
 
 	// binary search to find the maximum number of NodeClaims we can terminate

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -47,7 +47,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 	v := NewValidation(s.clock, s.cluster, s.kubeClient, s.provisioner, s.cloudProvider, s.recorder, s.queue, s.Reason())
 
 	// Set a timeout
-	timeout := s.clock.Now().Add(options.FromContext(ctx).SinglenodeConsolidationTimeout)
+	timeout := s.clock.Now().Add(options.FromContext(ctx).SingleNodeConsolidationTimeout)
 	constrainedByBudgets := false
 
 	// binary search to find the maximum number of NodeClaims we can terminate

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -61,8 +61,8 @@ type Options struct {
 	BatchMaxDuration               time.Duration
 	BatchIdleDuration              time.Duration
 	FeatureGates                   FeatureGates
-	MultinodeConsolidationTimeout  time.Duration
-	SinglenodeConsolidationTimeout time.Duration
+	MultiNodeConsolidationTimeout  time.Duration
+	SingleNodeConsolidationTimeout time.Duration
 }
 
 type FlagSet struct {
@@ -98,8 +98,8 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "SpotToSpotConsolidation=false"), "Optional features can be enabled / disabled using feature gates. Current options are: SpotToSpotConsolidation")
-	fs.DurationVar(&o.MultinodeConsolidationTimeout, "multi-node-consolidation-timeout", env.WithDefaultDuration("MULTI_NODE_CONSOLIDATION_TIMEOUT", 1*time.Minute), "The maximum amount of time that can be spent doing multinode consolidation before timing out. Defaults to 1 minute")
-	fs.DurationVar(&o.SinglenodeConsolidationTimeout, "single-node-consolidation-timeout", env.WithDefaultDuration("SINGLE_NODE_CONSOLIDATION_TIMEOUT", 3*time.Minute), "The maximum amount of time that can be spent doing single node consolidation before timing out. Defaults to 3 minute")
+	fs.DurationVar(&o.MultiNodeConsolidationTimeout, "multi-node-consolidation-timeout", env.WithDefaultDuration("MULTI_NODE_CONSOLIDATION_TIMEOUT", 1*time.Minute), "The maximum amount of time that can be spent doing multinode consolidation before timing out.")
+	fs.DurationVar(&o.SingleNodeConsolidationTimeout, "single-node-consolidation-timeout", env.WithDefaultDuration("SINGLE_NODE_CONSOLIDATION_TIMEOUT", 3*time.Minute), "The maximum amount of time that can be spent doing single node consolidation before timing out.")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -46,21 +46,23 @@ type FeatureGates struct {
 
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
 type Options struct {
-	ServiceName             string
-	MetricsPort             int
-	HealthProbePort         int
-	KubeClientQPS           int
-	KubeClientBurst         int
-	EnableProfiling         bool
-	DisableLeaderElection   bool
-	LeaderElectionNamespace string
-	MemoryLimit             int64
-	LogLevel                string
-	LogOutputPaths          string
-	LogErrorOutputPaths     string
-	BatchMaxDuration        time.Duration
-	BatchIdleDuration       time.Duration
-	FeatureGates            FeatureGates
+	ServiceName                    string
+	MetricsPort                    int
+	HealthProbePort                int
+	KubeClientQPS                  int
+	KubeClientBurst                int
+	EnableProfiling                bool
+	DisableLeaderElection          bool
+	LeaderElectionNamespace        string
+	MemoryLimit                    int64
+	LogLevel                       string
+	LogOutputPaths                 string
+	LogErrorOutputPaths            string
+	BatchMaxDuration               time.Duration
+	BatchIdleDuration              time.Duration
+	FeatureGates                   FeatureGates
+	MultinodeConsolidationTimeout  time.Duration
+	SinglenodeConsolidationTimeout time.Duration
 }
 
 type FlagSet struct {
@@ -96,6 +98,8 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "SpotToSpotConsolidation=false"), "Optional features can be enabled / disabled using feature gates. Current options are: SpotToSpotConsolidation")
+	fs.DurationVar(&o.MultinodeConsolidationTimeout, "multi-node-consolidation-timeout", env.WithDefaultDuration("MULTI_NODE_CONSOLIDATION_TIMEOUT", 1*time.Minute), "The maximum amount of time that can be spent doing multinode consolidation before timing out. Defaults to 1 minute")
+	fs.DurationVar(&o.SinglenodeConsolidationTimeout, "single-node-consolidation-timeout", env.WithDefaultDuration("SINGLE_NODE_CONSOLIDATION_TIMEOUT", 3*time.Minute), "The maximum amount of time that can be spent doing single node consolidation before timing out. Defaults to 3 minute")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {


### PR DESCRIPTION
Adds two options for the following timeouts
- multinodeconsolidation
- singlenodeconsolidation

These are exposed on the following ways:
- `--multi-node-consolidation-timeout` or `MULTI_NODE_CONSOLIDATION_TIMEOUT`
- `--single-node-consolidation-timeout` or `SINGLE_NODE_CONSOLIDATION_TIMEOUT`

The primary way of testing this was by building the image and running within dev and production clusters within Grafana Labs fleet.

---

- refs #1733

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
