### PR TITLE
feat: Node Repair implementation

### DIFF
--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -130,6 +130,10 @@ func (c CloudProvider) GetSupportedNodeClasses() []status.Object {
 	return []status.Object{&v1alpha1.KWOKNodeClass{}}
 }
 
+func (c *CloudProvider) RepairPolicy() []cloudprovider.RepairPolicy {
+	return []cloudprovider.RepairPolicy{}
+}
+
 func (c CloudProvider) getInstanceType(instanceTypeName string) (*cloudprovider.InstanceType, error) {
 	it, found := lo.Find(c.instanceTypes, func(it *cloudprovider.InstanceType) bool {
 		return it.Name == instanceTypeName

--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -130,8 +130,8 @@ func (c CloudProvider) GetSupportedNodeClasses() []status.Object {
 	return []status.Object{&v1alpha1.KWOKNodeClass{}}
 }
 
-func (c *CloudProvider) RepairPolicy() []cloudprovider.RepairStatement {
-	return []cloudprovider.RepairStatement{}
+func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
+	return []cloudprovider.RepairPolicy{}
 }
 
 func (c CloudProvider) getInstanceType(instanceTypeName string) (*cloudprovider.InstanceType, error) {

--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -130,8 +130,8 @@ func (c CloudProvider) GetSupportedNodeClasses() []status.Object {
 	return []status.Object{&v1alpha1.KWOKNodeClass{}}
 }
 
-func (c *CloudProvider) RepairPolicy() []cloudprovider.RepairPolicy {
-	return []cloudprovider.RepairPolicy{}
+func (c *CloudProvider) RepairPolicy() []cloudprovider.RepairStatement {
+	return []cloudprovider.RepairStatement{}
 }
 
 func (c CloudProvider) getInstanceType(instanceTypeName string) (*cloudprovider.InstanceType, error) {

--- a/kwok/main.go
+++ b/kwok/main.go
@@ -34,6 +34,7 @@ func main() {
 	cloudProvider := kwok.NewCloudProvider(ctx, op.GetClient(), instanceTypes)
 	op.
 		WithControllers(ctx, controllers.NewControllers(
+			ctx,
 			op.Manager,
 			op.Clock,
 			op.GetClient(),

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -263,8 +263,8 @@ func (c *CloudProvider) IsDrifted(context.Context, *v1.NodeClaim) (cloudprovider
 	return c.Drifted, nil
 }
 
-func (c *CloudProvider) RepairPolicy() []cloudprovider.RepairPolicy {
-	return []cloudprovider.RepairPolicy{
+func (c *CloudProvider) RepairPolicy() []cloudprovider.RepairStatement {
+	return []cloudprovider.RepairStatement{
 		{
 			Type:               "HealthyNode",
 			Status:             corev1.ConditionFalse,

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -263,11 +263,11 @@ func (c *CloudProvider) IsDrifted(context.Context, *v1.NodeClaim) (cloudprovider
 	return c.Drifted, nil
 }
 
-func (c *CloudProvider) RepairPolicy() []cloudprovider.RepairStatement {
-	return []cloudprovider.RepairStatement{
+func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
+	return []cloudprovider.RepairPolicy{
 		{
-			Type:               "HealthyNode",
-			Status:             corev1.ConditionFalse,
+			ConditionType:      "BadNode",
+			ConditionStatus:    corev1.ConditionFalse,
 			TolerationDuration: 30 * time.Minute,
 		},
 	}

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -60,6 +60,7 @@ type CloudProvider struct {
 	CreatedNodeClaims         map[string]*v1.NodeClaim
 	Drifted                   cloudprovider.DriftReason
 	NodeClassGroupVersionKind []schema.GroupVersionKind
+	RepairPolicy              []cloudprovider.RepairPolicy
 }
 
 func NewCloudProvider() *CloudProvider {
@@ -92,6 +93,13 @@ func (c *CloudProvider) Reset() {
 			Group:   "",
 			Version: "",
 			Kind:    "",
+		},
+	}
+	c.RepairPolicy = []cloudprovider.RepairPolicy{
+		{
+			ConditionType:      "BadNode",
+			ConditionStatus:    corev1.ConditionFalse,
+			TolerationDuration: 30 * time.Minute,
 		},
 	}
 }
@@ -264,13 +272,7 @@ func (c *CloudProvider) IsDrifted(context.Context, *v1.NodeClaim) (cloudprovider
 }
 
 func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
-	return []cloudprovider.RepairPolicy{
-		{
-			ConditionType:      "BadNode",
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
-	}
+	return c.RepairPolicy
 }
 
 // Name returns the CloudProvider implementation name.

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
@@ -260,6 +261,16 @@ func (c *CloudProvider) IsDrifted(context.Context, *v1.NodeClaim) (cloudprovider
 	defer c.mu.RUnlock()
 
 	return c.Drifted, nil
+}
+
+func (c *CloudProvider) RepairPolicy() []cloudprovider.RepairPolicy {
+	return []cloudprovider.RepairPolicy{
+		{
+			Type:               "HealthyNode",
+			Status:             corev1.ConditionFalse,
+			TolerationDuration: 30 * time.Minute,
+		},
+	}
 }
 
 // Name returns the CloudProvider implementation name.

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
@@ -40,6 +41,16 @@ var (
 )
 
 type DriftReason string
+
+type RepairPolicy struct {
+	// Type of unhealthy state that is found on the node
+	Type corev1.NodeConditionType
+	// Status condition of when a node is unhealthy
+	Status corev1.ConditionStatus
+	// TolerationDuration is the duration the controller will wait
+	// before attempting to terminate nodes that are underutilized.
+	TolerationDuration time.Duration
+}
 
 // CloudProvider interface is implemented by cloud providers to support provisioning.
 type CloudProvider interface {
@@ -63,6 +74,9 @@ type CloudProvider interface {
 	// IsDrifted returns whether a NodeClaim has drifted from the provisioning requirements
 	// it is tied to.
 	IsDrifted(context.Context, *v1.NodeClaim) (DriftReason, error)
+	// RepairPolicy is for CloudProviders to define a set Unhealthy condition for Karpenter
+	// to monitor on the node.
+	RepairPolicy() []RepairPolicy
 	// Name returns the CloudProvider implementation name.
 	Name() string
 	// GetSupportedNodeClasses returns CloudProvider NodeClass that implements status.Object

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -42,13 +42,13 @@ var (
 
 type DriftReason string
 
-type RepairPolicy struct {
+type RepairStatement struct {
 	// Type of unhealthy state that is found on the node
 	Type corev1.NodeConditionType
-	// Status condition of when a node is unhealthy
+	// Status condition when a node is unhealthy
 	Status corev1.ConditionStatus
 	// TolerationDuration is the duration the controller will wait
-	// before attempting to terminate nodes that are underutilized.
+	// before force terminating nodes that are unhealthy.
 	TolerationDuration time.Duration
 }
 
@@ -76,7 +76,7 @@ type CloudProvider interface {
 	IsDrifted(context.Context, *v1.NodeClaim) (DriftReason, error)
 	// RepairPolicy is for CloudProviders to define a set Unhealthy condition for Karpenter
 	// to monitor on the node.
-	RepairPolicy() []RepairPolicy
+	RepairPolicy() []RepairStatement
 	// Name returns the CloudProvider implementation name.
 	Name() string
 	// GetSupportedNodeClasses returns CloudProvider NodeClass that implements status.Object

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -42,11 +42,11 @@ var (
 
 type DriftReason string
 
-type RepairStatement struct {
-	// Type of unhealthy state that is found on the node
-	Type corev1.NodeConditionType
-	// Status condition when a node is unhealthy
-	Status corev1.ConditionStatus
+type RepairPolicy struct {
+	// ConditionType of unhealthy state that is found on the node
+	ConditionType corev1.NodeConditionType
+	// ConditionStatus condition when a node is unhealthy
+	ConditionStatus corev1.ConditionStatus
 	// TolerationDuration is the duration the controller will wait
 	// before force terminating nodes that are unhealthy.
 	TolerationDuration time.Duration
@@ -76,7 +76,7 @@ type CloudProvider interface {
 	IsDrifted(context.Context, *v1.NodeClaim) (DriftReason, error)
 	// RepairPolicy is for CloudProviders to define a set Unhealthy condition for Karpenter
 	// to monitor on the node.
-	RepairPolicy() []RepairStatement
+	RepairPolicies() []RepairPolicy
 	// Name returns the CloudProvider implementation name.
 	Name() string
 	// GetSupportedNodeClasses returns CloudProvider NodeClass that implements status.Object

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -98,8 +98,8 @@ func NewControllers(
 		health.NewController(kubeClient, cloudProvider, clock),
 	}
 
-	// The cloud provider must define status conation for the node repair controller to used for detecting unhealthy nodes
-	if len(cloudProvider.RepairPolicy()) != 0 && options.FromContext(ctx).FeatureGates.NodeRepair {
+	// The cloud provider must define status conditions for the node repair controller to use to detect unhealthy nodes
+	if len(cloudProvider.RepairPolicies()) != 0 && options.FromContext(ctx).FeatureGates.NodeRepair {
 		controllers = append(controllers, health.NewController(kubeClient, cloudProvider, clock))
 	}
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -32,6 +32,7 @@ import (
 	metricsnode "sigs.k8s.io/karpenter/pkg/controllers/metrics/node"
 	metricsnodepool "sigs.k8s.io/karpenter/pkg/controllers/metrics/nodepool"
 	metricspod "sigs.k8s.io/karpenter/pkg/controllers/metrics/pod"
+	"sigs.k8s.io/karpenter/pkg/controllers/node/health"
 	"sigs.k8s.io/karpenter/pkg/controllers/node/termination"
 	"sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator"
 	nodeclaimconsistency "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/consistency"
@@ -90,5 +91,6 @@ func NewControllers(
 		status.NewController[*v1.NodeClaim](kubeClient, mgr.GetEventRecorderFor("karpenter"), status.EmitDeprecatedMetrics),
 		status.NewController[*v1.NodePool](kubeClient, mgr.GetEventRecorderFor("karpenter"), status.EmitDeprecatedMetrics),
 		status.NewGenericObjectController[*corev1.Node](kubeClient, mgr.GetEventRecorderFor("karpenter")),
+		health.NewController(kubeClient, cloudProvider, clock),
 	}
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -23,7 +23,6 @@ import (
 	"github.com/awslabs/operatorpkg/status"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	corev1 "k8s.io/api/core/v1"
@@ -99,11 +98,9 @@ func NewControllers(
 		health.NewController(kubeClient, cloudProvider, clock),
 	}
 
-	// The cloud proivder must define status condation for the node repair controller to used for dectecting unhealthy nodes
-	if len(cloudProvider.RepairPolicy()) != 0 && !options.FromContext(ctx).FeatureGates.NodeRepair {
+	// The cloud provider must define status conation for the node repair controller to used for detecting unhealthy nodes
+	if len(cloudProvider.RepairPolicy()) != 0 && options.FromContext(ctx).FeatureGates.NodeRepair {
 		controllers = append(controllers, health.NewController(kubeClient, cloudProvider, clock))
-	} else {
-		log.FromContext(ctx).V(1).Info("node repair has been disabled")
 	}
 
 	return controllers

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -1,0 +1,143 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
+	"golang.org/x/time/rate"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/metrics"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
+)
+
+// Controller for the resource
+type Controller struct {
+	clock         clock.Clock
+	kubeClient    client.Client
+	cloudProvider cloudprovider.CloudProvider
+}
+
+// NewController constructs a controller instance
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, clock clock.Clock) *Controller {
+	return &Controller{
+		kubeClient:    kubeClient,
+		cloudProvider: cloudProvider,
+		clock:         clock,
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcile.Result, error) {
+	ctx = injection.WithControllerName(ctx, "node.health")
+	nodeHealthCondation := corev1.NodeCondition{}
+	cloudProivderPolicy := cloudprovider.RepairPolicy{}
+
+	if !node.GetDeletionTimestamp().IsZero() {
+		return reconcile.Result{}, nil
+	}
+
+	for _, policy := range c.cloudProvider.RepairPolicy() {
+		nodeHealthCondation = nodeutils.GetCondition(node, policy.Type)
+		if nodeHealthCondation.Status == policy.Status {
+			cloudProivderPolicy = policy
+			break
+		}
+	}
+
+	// From here there are three scenarios to handle:
+	// 1. If node is healthy, exit node healhty loop
+	if cloudProivderPolicy.Type == "" {
+		return reconcile.Result{}, nil
+	}
+
+	// 2. If the Node is unhealthy, but has not reached it's full toleration disruption, exit the loop
+	dusruptionTime := nodeHealthCondation.LastTransitionTime.Add(cloudProivderPolicy.TolerationDuration)
+	if c.clock.Now().Before(dusruptionTime) {
+		// Use t.Sub(clock.Now()) instead of time.Until() to ensure we're using the injected clock.
+		return reconcile.Result{RequeueAfter: dusruptionTime.Sub(c.clock.Now())}, nil
+	}
+
+	nodeClaims, err := nodeutils.GetNodeClaims(ctx, node, c.kubeClient)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("listing nodeclaims, %w", err)
+	}
+	if err := c.annotateTerminationGracePeriodByDefualt(ctx, nodeClaims[0]); err != nil {
+		return reconcile.Result{}, fmt.Errorf("annotated termination grace peirod on nodeclaim, %w", err)
+	}
+
+	// 3. Otherwise, if the Node is unhealthy we can forcefully remove the node (by deleting it)
+	if err := c.kubeClient.Delete(ctx, node); err != nil {
+		return reconcile.Result{}, err
+	}
+	// 4. The deletion timestamp has successfully been set for the Node, update relevant metrics.
+	log.FromContext(ctx).V(1).Info("deleting unhealthy node")
+	metrics.NodeClaimsDisruptedTotal.With(prometheus.Labels{
+		metrics.ReasonLabel:       metrics.UnhealthyReason,
+		metrics.NodePoolLabel:     nodeClaims[0].Labels[v1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel: nodeClaims[0].Labels[v1.CapacityTypeLabelKey],
+	}).Inc()
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) annotateTerminationGracePeriodByDefualt(ctx context.Context, nodeClaim *v1.NodeClaim) error {
+	if _, ok := nodeClaim.ObjectMeta.Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]; ok {
+		return nil
+	}
+
+	stored := nodeClaim.DeepCopy()
+	terminationTime := c.clock.Now().Format(time.RFC3339)
+	nodeClaim.ObjectMeta.Annotations = lo.Assign(nodeClaim.ObjectMeta.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: terminationTime})
+
+	if err := c.kubeClient.Patch(ctx, nodeClaim, client.MergeFrom(stored)); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	return nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("node.health").
+		For(&corev1.Node{}).
+		WithOptions(
+			controller.Options{
+				RateLimiter: workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
+					workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](100*time.Millisecond, 10*time.Second),
+					// 10 qps, 100 bucket size
+					&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+				),
+				MaxConcurrentReconciles: 100,
+			},
+		).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clock "k8s.io/utils/clock/testing"
+
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
@@ -47,7 +48,6 @@ var fakeClock *clock.FakeClock
 var cloudProvider *fake.CloudProvider
 var recorder *test.EventRecorder
 var queue *terminator.Queue
-var defaultOwnerRefs = []metav1.OwnerReference{{Kind: "ReplicaSet", APIVersion: "appsv1", Name: "rs", UID: "1234567890"}}
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -94,7 +94,7 @@ var _ = Describe("Health", func() {
 		metrics.NodeClaimsDisruptedTotal.Reset()
 	})
 
-	Context("Reconcilation", func() {
+	Context("Reconciliation", func() {
 		It("should delete nodes that are unhealthy by the cloud proivder", func() {
 			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
 				Type:               "HealthyNode",

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/karpenter/pkg/apis"
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/node/health"
+	"sigs.k8s.io/karpenter/pkg/controllers/node/termination"
+	"sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator"
+	"sigs.k8s.io/karpenter/pkg/metrics"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var ctx context.Context
+var healthController *health.Controller
+var terminationController *termination.Controller
+var env *test.Environment
+var fakeClock *clock.FakeClock
+var cloudProvider *fake.CloudProvider
+var recorder *test.EventRecorder
+var queue *terminator.Queue
+var defaultOwnerRefs = []metav1.OwnerReference{{Kind: "ReplicaSet", APIVersion: "appsv1", Name: "rs", UID: "1234567890"}}
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Termination")
+}
+
+var _ = BeforeSuite(func() {
+	fakeClock = clock.NewFakeClock(time.Now())
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...), test.WithFieldIndexers(test.NodeClaimFieldIndexer(ctx), test.VolumeAttachmentFieldIndexer(ctx)))
+
+	cloudProvider = fake.NewCloudProvider()
+	cloudProvider = fake.NewCloudProvider()
+	recorder = test.NewEventRecorder()
+	queue = terminator.NewTestingQueue(env.Client, recorder)
+	healthController = health.NewController(env.Client, cloudProvider, fakeClock)
+	terminationController = termination.NewController(fakeClock, env.Client, cloudProvider, terminator.NewTerminator(fakeClock, env.Client, queue, recorder), recorder)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("Health", func() {
+	var node *corev1.Node
+	var nodeClaim *v1.NodeClaim
+	var nodePool *v1.NodePool
+
+	BeforeEach(func() {
+		fakeClock.SetTime(time.Now())
+		cloudProvider.Reset()
+
+		nodePool = test.NodePool()
+		nodeClaim, node = test.NodeClaimAndNode(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{v1.TerminationFinalizer}}})
+		node.Labels[v1.NodePoolLabelKey] = nodePool.Name
+		nodeClaim.Labels[v1.NodePoolLabelKey] = nodePool.Name
+		cloudProvider.CreatedNodeClaims[node.Spec.ProviderID] = nodeClaim
+	})
+
+	AfterEach(func() {
+		ExpectCleanedUp(ctx, env.Client)
+
+		// Reset the metrics collectors
+		metrics.NodeClaimsDisruptedTotal.Reset()
+	})
+
+	Context("Reconcilation", func() {
+		It("should delete nodes that are unhealthy by the cloud proivder", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               "HealthyNode",
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectNotFound(ctx, env.Client, node)
+		})
+		It("should not reconcile when a node has delation timestamp set", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               "HealthyNode",
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectDeletionTimestampSet(ctx, env.Client, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectExists(ctx, env.Client, node)
+		})
+		It("should not delete node when unhealthy type does not match cloudprovider passed in value", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               "FakeHealthyNode",
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectExists(ctx, env.Client, node)
+		})
+		It("should not delete node when health status does not match cloudprovider passed in value", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               "HealthyNode",
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectExists(ctx, env.Client, node)
+		})
+		It("should not delete node when health duration is not reached", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:   "HealthyNode",
+				Status: corev1.ConditionFalse,
+				// We expect the last transition for HealthyNode condition to wait 30 minites
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			fakeClock.Step(20 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectExists(ctx, env.Client, node)
+		})
+		It("should set termination grace period to now when not defined ", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:   "HealthyNode",
+				Status: corev1.ConditionFalse,
+				// We expect the last transition for HealthyNode condition to wait 30 minites
+				LastTransitionTime: metav1.Time{Time: time.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1.NodeClaimTerminationTimestampAnnotationKey, fakeClock.Now().Format(time.RFC3339)))
+		})
+		It("should respect termination grace period if set on the nodepool", func() {
+			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Minute}
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:   "HealthyNode",
+				Status: corev1.ConditionFalse,
+				// We expect the last transition for HealthyNode condition to wait 30 minites
+				LastTransitionTime: metav1.Time{Time: time.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1.NodeClaimTerminationTimestampAnnotationKey, fakeClock.Now().Format(time.RFC3339)))
+		})
+	})
+
+	Context("Forceful termination", func() {
+		It("should not respect node disruption budgets ", func() {
+			// Blocking disruption budgets
+			nodePool.Spec.Disruption = v1.Disruption{
+				Budgets: []v1.Budget{
+					{
+						Nodes: "0",
+					},
+				},
+			}
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               "HealthyNode",
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectNotFound(ctx, env.Client, node)
+		})
+		It("should not respect do-not-disrupt on node ", func() {
+			node.Annotations = map[string]string{v1.DoNotDisruptAnnotationKey: "true"}
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               "HealthyNode",
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			// Determine to delete unhealthy nodes
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectNotFound(ctx, env.Client, node)
+		})
+	})
+	Context("Metrics", func() {
+		It("should fire a karpenter_nodeclaims_disrupted_total metric when unhealthy", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               "HealthyNode",
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			fakeClock.Step(60 * time.Minute)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+			// Let the termination controller terminate the node
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectNotFound(ctx, env.Client, node)
+
+			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
+				metrics.ReasonLabel:   metrics.UnhealthyReason,
+				metrics.NodePoolLabel: nodePool.Name,
+			})
+		})
+	})
+})

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -33,7 +33,6 @@ const (
 	// Reasons for CREATE/DELETE shared metrics
 	ProvisionedReason = "provisioned"
 	ExpiredReason     = "expired"
-	UnhealthyReason   = "unhealthy"
 )
 
 // DurationBuckets returns a []float64 of default threshold values for duration histograms.

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -33,6 +33,7 @@ const (
 	// Reasons for CREATE/DELETE shared metrics
 	ProvisionedReason = "provisioned"
 	ExpiredReason     = "expired"
+	UnhealthyReason   = "unhealthy"
 )
 
 // DurationBuckets returns a []float64 of default threshold values for duration histograms.

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -42,6 +42,7 @@ type FeatureGates struct {
 	inputStr string
 
 	SpotToSpotConsolidation bool
+	NodeRepair              bool
 }
 
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
@@ -97,7 +98,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.LogErrorOutputPaths, "log-error-output-paths", env.WithDefaultString("LOG_ERROR_OUTPUT_PATHS", "stderr"), "Optional comma separated paths for logging error output")
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
-	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "SpotToSpotConsolidation=false"), "Optional features can be enabled / disabled using feature gates. Current options are: SpotToSpotConsolidation")
+	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,SpotToSpotConsolidation=false"), "Optional features can be enabled / disabled using feature gates. Current options are: SpotToSpotConsolidation")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {
@@ -131,6 +132,9 @@ func ParseFeatureGates(gateStr string) (FeatureGates, error) {
 	// simple merging with environment vars.
 	if err := cliflag.NewMapStringBool(&gateMap).Set(gateStr); err != nil {
 		return gates, err
+	}
+	if val, ok := gateMap["NodeRepair"]; ok {
+		gates.NodeRepair = val
 	}
 	if val, ok := gateMap["SpotToSpotConsolidation"]; ok {
 		gates.SpotToSpotConsolidation = val

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -111,6 +111,7 @@ var _ = Describe("Options", func() {
 				BatchMaxDuration:        lo.ToPtr(10 * time.Second),
 				BatchIdleDuration:       lo.ToPtr(time.Second),
 				FeatureGates: test.FeatureGates{
+					NodeRepair:              lo.ToPtr(false),
 					SpotToSpotConsolidation: lo.ToPtr(false),
 				},
 			}))
@@ -136,7 +137,7 @@ var _ = Describe("Options", func() {
 				"--log-error-output-paths", "/etc/k8s/testerror",
 				"--batch-max-duration", "5s",
 				"--batch-idle-duration", "5s",
-				"--feature-gates", "SpotToSpotConsolidation=true",
+				"--feature-gates", "SpotToSpotConsolidation=true,NodeRepair=true",
 			)
 			Expect(err).To(BeNil())
 			expectOptionsMatch(opts, test.Options(test.OptionsFields{
@@ -156,6 +157,7 @@ var _ = Describe("Options", func() {
 				BatchMaxDuration:        lo.ToPtr(5 * time.Second),
 				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
 				FeatureGates: test.FeatureGates{
+					NodeRepair:              lo.ToPtr(true),
 					SpotToSpotConsolidation: lo.ToPtr(true),
 				},
 			}))
@@ -177,7 +179,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("LOG_ERROR_OUTPUT_PATHS", "/etc/k8s/testerror")
 			os.Setenv("BATCH_MAX_DURATION", "5s")
 			os.Setenv("BATCH_IDLE_DURATION", "5s")
-			os.Setenv("FEATURE_GATES", "SpotToSpotConsolidation=true")
+			os.Setenv("FEATURE_GATES", "SpotToSpotConsolidation=true,NodeRepair=true")
 			fs = &options.FlagSet{
 				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
 			}
@@ -201,6 +203,7 @@ var _ = Describe("Options", func() {
 				BatchMaxDuration:        lo.ToPtr(5 * time.Second),
 				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
 				FeatureGates: test.FeatureGates{
+					NodeRepair:              lo.ToPtr(true),
 					SpotToSpotConsolidation: lo.ToPtr(true),
 				},
 			}))
@@ -217,7 +220,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("LOG_LEVEL", "debug")
 			os.Setenv("BATCH_MAX_DURATION", "5s")
 			os.Setenv("BATCH_IDLE_DURATION", "5s")
-			os.Setenv("FEATURE_GATES", "SpotToSpotConsolidation=true")
+			os.Setenv("FEATURE_GATES", "SpotToSpotConsolidation=true,NodeRepair=true")
 			fs = &options.FlagSet{
 				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
 			}
@@ -246,6 +249,7 @@ var _ = Describe("Options", func() {
 				BatchMaxDuration:        lo.ToPtr(5 * time.Second),
 				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
 				FeatureGates: test.FeatureGates{
+					NodeRepair:              lo.ToPtr(true),
 					SpotToSpotConsolidation: lo.ToPtr(true),
 				},
 			}))

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -47,6 +47,7 @@ type OptionsFields struct {
 }
 
 type FeatureGates struct {
+	NodeRepair              *bool
 	SpotToSpotConsolidation *bool
 }
 
@@ -73,6 +74,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		BatchMaxDuration:      lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
 		BatchIdleDuration:     lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
 		FeatureGates: options.FeatureGates{
+			NodeRepair:              lo.FromPtrOr(opts.FeatureGates.NodeRepair, false),
 			SpotToSpotConsolidation: lo.FromPtrOr(opts.FeatureGates.SpotToSpotConsolidation, false),
 		},
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- RFC: https://github.com/kubernetes-sigs/karpenter/pull/1768
- This PR is the implementation of the recommend solution defined in the node repair RFC 
- Defining a cloud provider interface `RepairPolicy` that will support node conditions that Karpenter will forcefully terminate nodes. The cloud provider policies will be unhealthy conditions a node can enter and the duration for Karpenter to react. 

**How was this change tested?**
- `make resubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
