### PR TITLE
Fix pod metrics that don't get deleted when the pod is deleted

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -147,7 +147,17 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, pod); err != nil {
 		if errors.IsNotFound(err) {
 			c.pendingPods.Delete(req.NamespacedName.String())
+			// Delete the unstarted metric since the pod is deleted
+			podUnstartedTimeSeconds.Delete(map[string]string{
+				podName:      req.Name,
+				podNamespace: req.Namespace,
+			})
 			c.unscheduledPods.Delete(req.NamespacedName.String())
+			// Delete the unbound metric since the pod is deleted
+			podCurrentUnboundTimeSeconds.Delete(map[string]string{
+				podName:      req.Name,
+				podNamespace: req.Namespace,
+			})
 			c.metricStore.Delete(req.NamespacedName.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
When a pod gets deleted, `karpenter_pods_current_unbound_time_seconds` and `karpenter_pods_unstarted_time_seconds` should also get deleted.

**How was this change tested?**
`manually tested`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
