### PR TITLE
Abstract prometheus metrics into interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.2
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/awslabs/operatorpkg v0.0.0-20240920182301-771460b3160b
+	github.com/awslabs/operatorpkg v0.0.0-20241108183842-a2ebef231d52
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/go-logr/logr v1.4.2
 	github.com/imdario/mergo v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/awslabs/operatorpkg v0.0.0-20240920182301-771460b3160b h1:aG1+YRmKIf5nLTZJNhw1NmuxvjUprWYyluqJ2jmVqiU=
-github.com/awslabs/operatorpkg v0.0.0-20240920182301-771460b3160b/go.mod h1:RI+iNDn57c3WX0tsZg4rvkmM58lWsEC5cc6E4vJJld8=
+github.com/awslabs/operatorpkg v0.0.0-20241108183842-a2ebef231d52 h1:k8f1ukVs49+nC6JbN8r8bxs8g1TPE3Iki/dK/LGwf3A=
+github.com/awslabs/operatorpkg v0.0.0-20241108183842-a2ebef231d52/go.mod h1:nq1PLBLCojzjfqSK8SG3ymxqwW6e/cHLJvddKOSFkfw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -234,9 +234,9 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 		allowedDisruptions := nodePool.MustGetAllowedDisruptions(clk, numNodes[nodePool.Name], reason)
 		disruptionBudgetMapping[nodePool.Name] = lo.Max([]int{allowedDisruptions - disrupting[nodePool.Name], 0})
 
-		NodePoolAllowedDisruptions.With(map[string]string{
+		NodePoolAllowedDisruptions.Set(float64(allowedDisruptions), map[string]string{
 			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
-		}).Set(float64(allowedDisruptions))
+		})
 		if allowedDisruptions == 0 {
 			recorder.Publish(disruptionevents.NodePoolBlockedForDisruptionReason(lo.ToPtr(nodePool), reason))
 		}

--- a/pkg/controllers/disruption/metrics.go
+++ b/pkg/controllers/disruption/metrics.go
@@ -17,21 +17,12 @@ limitations under the License.
 package disruption
 
 import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/karpenter/pkg/metrics"
 )
-
-func init() {
-	crmetrics.Registry.MustRegister(
-		EvaluationDurationSeconds,
-		DecisionsPerformedTotal,
-		EligibleNodes,
-		ConsolidationTimeoutsTotal,
-		NodePoolAllowedDisruptions,
-	)
-}
 
 const (
 	voluntaryDisruptionSubsystem = "voluntary_disruption"
@@ -40,7 +31,8 @@ const (
 )
 
 var (
-	EvaluationDurationSeconds = prometheus.NewHistogramVec(
+	EvaluationDurationSeconds = opmetrics.NewPrometheusHistogram(
+		crmetrics.Registry,
 		prometheus.HistogramOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: voluntaryDisruptionSubsystem,
@@ -50,7 +42,8 @@ var (
 		},
 		[]string{metrics.ReasonLabel, consolidationTypeLabel},
 	)
-	DecisionsPerformedTotal = prometheus.NewCounterVec(
+	DecisionsPerformedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: voluntaryDisruptionSubsystem,
@@ -59,7 +52,8 @@ var (
 		},
 		[]string{decisionLabel, metrics.ReasonLabel, consolidationTypeLabel},
 	)
-	EligibleNodes = prometheus.NewGaugeVec(
+	EligibleNodes = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: voluntaryDisruptionSubsystem,
@@ -68,7 +62,8 @@ var (
 		},
 		[]string{metrics.ReasonLabel},
 	)
-	ConsolidationTimeoutsTotal = prometheus.NewCounterVec(
+	ConsolidationTimeoutsTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: voluntaryDisruptionSubsystem,
@@ -77,7 +72,8 @@ var (
 		},
 		[]string{consolidationTypeLabel},
 	)
-	NodePoolAllowedDisruptions = prometheus.NewGaugeVec(
+	NodePoolAllowedDisruptions = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: metrics.NodePoolSubsystem,

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -123,7 +123,7 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 	// binary search to find the maximum number of NodeClaims we can terminate
 	for min <= max {
 		if m.clock.Now().After(timeout) {
-			ConsolidationTimeoutsTotal.WithLabelValues(m.ConsolidationType()).Inc()
+			ConsolidationTimeoutsTotal.Inc(map[string]string{consolidationTypeLabel: m.ConsolidationType()})
 			if lastSavedCommand.candidates == nil {
 				log.FromContext(ctx).V(1).Info(fmt.Sprintf("failed to find a multi-node consolidation after timeout, last considered batch had %d", (min+max)/2))
 			} else {

--- a/pkg/controllers/disruption/orchestration/metrics.go
+++ b/pkg/controllers/disruption/orchestration/metrics.go
@@ -17,15 +17,12 @@ limitations under the License.
 package orchestration
 
 import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/karpenter/pkg/metrics"
 )
-
-func init() {
-	crmetrics.Registry.MustRegister(disruptionQueueFailuresTotal)
-}
 
 const (
 	voluntaryDisruptionSubsystem = "voluntary_disruption"
@@ -34,7 +31,8 @@ const (
 )
 
 var (
-	disruptionQueueFailuresTotal = prometheus.NewCounterVec(
+	DisruptionQueueFailuresTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: voluntaryDisruptionSubsystem,

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -68,7 +68,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 			continue
 		}
 		if s.clock.Now().After(timeout) {
-			ConsolidationTimeoutsTotal.WithLabelValues(s.ConsolidationType()).Inc()
+			ConsolidationTimeoutsTotal.Inc(map[string]string{consolidationTypeLabel: s.ConsolidationType()})
 			log.FromContext(ctx).V(1).Info(fmt.Sprintf("abandoning single-node consolidation due to timeout after evaluating %d candidates", i))
 			return Command{}, scheduling.Results{}, nil
 		}

--- a/pkg/controllers/node/termination/metrics.go
+++ b/pkg/controllers/node/termination/metrics.go
@@ -19,23 +19,18 @@ package termination
 import (
 	"time"
 
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
-func init() {
-	crmetrics.Registry.MustRegister(
-		TerminationDurationSeconds,
-		NodeLifetimeDurationSeconds,
-		NodesDrainedTotal)
-}
-
 const dayDuration = time.Hour * 24
 
 var (
-	TerminationDurationSeconds = prometheus.NewSummaryVec(
+	DurationSeconds = opmetrics.NewPrometheusSummary(
+		crmetrics.Registry,
 		prometheus.SummaryOpts{
 			Namespace:  metrics.Namespace,
 			Subsystem:  metrics.NodeSubsystem,
@@ -45,7 +40,8 @@ var (
 		},
 		[]string{metrics.NodePoolLabel},
 	)
-	NodesDrainedTotal = prometheus.NewCounterVec(
+	NodesDrainedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: metrics.NodeSubsystem,
@@ -54,7 +50,8 @@ var (
 		},
 		[]string{metrics.NodePoolLabel},
 	)
-	NodeLifetimeDurationSeconds = prometheus.NewHistogramVec(
+	NodeLifetimeDurationSeconds = opmetrics.NewPrometheusHistogram(
+		crmetrics.Registry,
 		prometheus.HistogramOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: metrics.NodeSubsystem,

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Termination", func() {
 
 		// Reset the metrics collectors
 		metrics.NodesTerminatedTotal.Reset()
-		termination.TerminationDurationSeconds.Reset()
+		termination.DurationSeconds.Reset()
 		termination.NodeLifetimeDurationSeconds.Reset()
 		termination.NodesDrainedTotal.Reset()
 	})

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -183,7 +183,7 @@ func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
 		var apiStatus apierrors.APIStatus
 		if errors.As(err, &apiStatus) {
 			code := apiStatus.Status().Code
-			NodesEvictionRequestsTotal.With(map[string]string{CodeLabel: fmt.Sprint(code)}).Inc()
+			NodesEvictionRequestsTotal.Inc(map[string]string{CodeLabel: fmt.Sprint(code)})
 		}
 		// status codes for the eviction API are defined here:
 		// https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/#how-api-initiated-eviction-works
@@ -204,7 +204,7 @@ func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
 		log.FromContext(ctx).Error(err, "failed evicting pod")
 		return false
 	}
-	NodesEvictionRequestsTotal.With(map[string]string{CodeLabel: "200"}).Inc()
+	NodesEvictionRequestsTotal.Inc(map[string]string{CodeLabel: "200"})
 	q.recorder.Publish(terminatorevents.EvictPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}))
 	return true
 }

--- a/pkg/controllers/node/termination/terminator/metrics.go
+++ b/pkg/controllers/node/termination/terminator/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package terminator
 
 import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -28,7 +29,8 @@ const (
 	CodeLabel = "code"
 )
 
-var NodesEvictionRequestsTotal = prometheus.NewCounterVec(
+var NodesEvictionRequestsTotal = opmetrics.NewPrometheusCounter(
+	crmetrics.Registry,
 	prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
 		Subsystem: metrics.NodeSubsystem,
@@ -37,7 +39,3 @@ var NodesEvictionRequestsTotal = prometheus.NewCounterVec(
 	},
 	[]string{CodeLabel},
 )
-
-func init() {
-	crmetrics.Registry.MustRegister(NodesEvictionRequestsTotal)
-}

--- a/pkg/controllers/nodeclaim/expiration/controller.go
+++ b/pkg/controllers/nodeclaim/expiration/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,11 +66,11 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 	}
 	// 4. The deletion timestamp has successfully been set for the NodeClaim, update relevant metrics.
 	log.FromContext(ctx).V(1).Info("deleting expired nodeclaim")
-	metrics.NodeClaimsDisruptedTotal.With(prometheus.Labels{
+	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
 		metrics.ReasonLabel:       metrics.ExpiredReason,
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
-	}).Inc()
+	})
 	// We sleep here after the delete operation since we want to ensure that we are able to read our own writes so that
 	// we avoid duplicating metrics and log lines due to quick re-queues.
 	// USE CAUTION when determining whether to increase this timeout or remove this line

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/awslabs/operatorpkg/singleton"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
@@ -105,11 +104,11 @@ func (c *Controller) Reconcile(ctx context.Context) (reconcile.Result, error) {
 			"provider-id", nodeClaims[i].Status.ProviderID,
 			"nodepool", nodeClaims[i].Labels[v1.NodePoolLabelKey],
 		).V(1).Info("garbage collecting nodeclaim with no cloudprovider representation")
-		metrics.NodeClaimsDisruptedTotal.With(prometheus.Labels{
+		metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
 			metrics.ReasonLabel:       "garbage_collected",
 			metrics.NodePoolLabel:     nodeClaims[i].Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel: nodeClaims[i].Labels[v1.CapacityTypeLabelKey],
-		}).Inc()
+		})
 	})
 	if err = multierr.Combine(errs...); err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -57,11 +56,11 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 	log.FromContext(ctx).V(1).WithValues("ttl", registrationTTL).Info("terminating due to registration ttl")
-	metrics.NodeClaimsDisruptedTotal.With(prometheus.Labels{
+	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
 		metrics.ReasonLabel:       "liveness",
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
-	}).Inc()
+	})
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclaim/lifecycle/metrics.go
+++ b/pkg/controllers/nodeclaim/lifecycle/metrics.go
@@ -17,17 +17,15 @@ limitations under the License.
 package lifecycle
 
 import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
-func init() {
-	crmetrics.Registry.MustRegister(InstanceTerminationDurationSeconds, NodeClaimTerminationDurationSeconds)
-}
-
-var InstanceTerminationDurationSeconds = prometheus.NewHistogramVec(
+var InstanceTerminationDurationSeconds = opmetrics.NewPrometheusHistogram(
+	crmetrics.Registry,
 	prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
 		Subsystem: metrics.NodeClaimSubsystem,
@@ -38,7 +36,8 @@ var InstanceTerminationDurationSeconds = prometheus.NewHistogramVec(
 	[]string{metrics.NodePoolLabel},
 )
 
-var NodeClaimTerminationDurationSeconds = prometheus.NewHistogramVec(
+var NodeClaimTerminationDurationSeconds = opmetrics.NewPrometheusHistogram(
+	crmetrics.Registry,
 	prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
 		Subsystem: metrics.NodeClaimSubsystem,

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -78,9 +77,9 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (
 	nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeRegistered)
 	nodeClaim.Status.NodeName = node.Name
 
-	metrics.NodesCreatedTotal.With(prometheus.Labels{
+	metrics.NodesCreatedTotal.Inc(map[string]string{
 		metrics.NodePoolLabel: nodeClaim.Labels[v1.NodePoolLabelKey],
-	}).Inc()
+	})
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controllers/provisioning/scheduling/metrics.go
+++ b/pkg/controllers/provisioning/scheduling/metrics.go
@@ -17,15 +17,12 @@ limitations under the License.
 package scheduling
 
 import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/karpenter/pkg/metrics"
 )
-
-func init() {
-	crmetrics.Registry.MustRegister(SchedulingDurationSeconds, QueueDepth, IgnoredPodCount, UnschedulablePodsCount)
-}
 
 const (
 	ControllerLabel    = "controller"
@@ -34,7 +31,8 @@ const (
 )
 
 var (
-	SchedulingDurationSeconds = prometheus.NewHistogramVec(
+	DurationSeconds = opmetrics.NewPrometheusHistogram(
+		crmetrics.Registry,
 		prometheus.HistogramOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: schedulerSubsystem,
@@ -46,7 +44,8 @@ var (
 			ControllerLabel,
 		},
 	)
-	QueueDepth = prometheus.NewGaugeVec(
+	QueueDepth = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: schedulerSubsystem,
@@ -58,14 +57,17 @@ var (
 			schedulingIDLabel,
 		},
 	)
-	IgnoredPodCount = prometheus.NewGauge(
+	IgnoredPodCount = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Name:      "ignored_pod_count",
 			Help:      "Number of pods ignored during scheduling by Karpenter",
 		},
+		[]string{},
 	)
-	UnschedulablePodsCount = prometheus.NewGaugeVec(
+	UnschedulablePodsCount = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: schedulerSubsystem,

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -111,7 +111,7 @@ var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
 	cluster.Reset()
 	scheduling.QueueDepth.Reset()
-	scheduling.SchedulingDurationSeconds.Reset()
+	scheduling.DurationSeconds.Reset()
 	scheduling.UnschedulablePodsCount.Reset()
 })
 

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -100,7 +100,7 @@ var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
 	cloudProvider.Reset()
 	cluster.Reset()
-	pscheduling.IgnoredPodCount.Set(0)
+	pscheduling.IgnoredPodCount.Set(0, nil)
 })
 
 var _ = Describe("Provisioning", func() {

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package state
 
 import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -28,24 +29,29 @@ const (
 )
 
 var (
-	ClusterStateNodesCount = prometheus.NewGauge(
+	ClusterStateNodesCount = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "node_count",
 			Help:      "Current count of nodes in cluster state",
 		},
+		[]string{},
 	)
 
-	ClusterStateSynced = prometheus.NewGauge(
+	ClusterStateSynced = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
 			Name:      "synced",
 			Help:      "Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state",
 		},
+		[]string{},
 	)
-	ClusterStateUnsyncedTimeSeconds = prometheus.NewGaugeVec(
+	ClusterStateUnsyncedTimeSeconds = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: stateSubsystem,
@@ -55,7 +61,3 @@ var (
 		[]string{},
 	)
 )
-
-func init() {
-	crmetrics.Registry.MustRegister(ClusterStateNodesCount, ClusterStateSynced, ClusterStateUnsyncedTimeSeconds)
-}

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -19,7 +19,7 @@ package metrics
 import (
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 )
 
 const (
@@ -58,7 +58,7 @@ func SummaryObjectives() map[float64]float64 {
 
 // Measure returns a deferrable function that observes the duration between the
 // defer statement and the end of the function.
-func Measure(observer prometheus.Observer) func() {
+func Measure(observer opmetrics.ObservationMetric, labels map[string]string) func() {
 	start := time.Now()
-	return func() { observer.Observe(time.Since(start).Seconds()) }
+	return func() { observer.Observe(time.Since(start).Seconds(), labels) }
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -29,7 +30,8 @@ const (
 )
 
 var (
-	NodeClaimsCreatedTotal = prometheus.NewCounterVec(
+	NodeClaimsCreatedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: NodeClaimSubsystem,
@@ -42,7 +44,8 @@ var (
 			CapacityTypeLabel,
 		},
 	)
-	NodeClaimsTerminatedTotal = prometheus.NewCounterVec(
+	NodeClaimsTerminatedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: NodeClaimSubsystem,
@@ -54,7 +57,8 @@ var (
 			CapacityTypeLabel,
 		},
 	)
-	NodeClaimsDisruptedTotal = prometheus.NewCounterVec(
+	NodeClaimsDisruptedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: NodeClaimSubsystem,
@@ -67,7 +71,8 @@ var (
 			CapacityTypeLabel,
 		},
 	)
-	NodesCreatedTotal = prometheus.NewCounterVec(
+	NodesCreatedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: NodeSubsystem,
@@ -78,7 +83,8 @@ var (
 			NodePoolLabel,
 		},
 	)
-	NodesTerminatedTotal = prometheus.NewCounterVec(
+	NodesTerminatedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: NodeSubsystem,
@@ -90,8 +96,3 @@ var (
 		},
 	)
 )
-
-func init() {
-	crmetrics.Registry.MustRegister(NodeClaimsCreatedTotal, NodeClaimsTerminatedTotal, NodeClaimsDisruptedTotal,
-		NodesCreatedTotal, NodesTerminatedTotal)
-}

--- a/pkg/metrics/suite_test.go
+++ b/pkg/metrics/suite_test.go
@@ -19,6 +19,7 @@ package metrics_test
 import (
 	"testing"
 
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
@@ -30,7 +31,7 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
 
-var testGauge1, testGauge2 *prometheus.GaugeVec
+var testGauge1, testGauge2 opmetrics.GaugeMetric
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -38,9 +39,8 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testGauge1 = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_gauge_1"}, []string{"label_1", "label_2"})
-	testGauge2 = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_gauge_2"}, []string{"label_1", "label_2"})
-	crmetrics.Registry.MustRegister(testGauge1, testGauge2)
+	testGauge1 = opmetrics.NewPrometheusGauge(crmetrics.Registry, prometheus.GaugeOpts{Name: "test_gauge_1"}, []string{"label_1", "label_2"})
+	testGauge2 = opmetrics.NewPrometheusGauge(crmetrics.Registry, prometheus.GaugeOpts{Name: "test_gauge_2"}, []string{"label_1", "label_2"})
 })
 
 var _ = Describe("Store", func() {
@@ -55,17 +55,17 @@ var _ = Describe("Store", func() {
 		It("should create metrics when calling update", func() {
 			storeMetrics := []*metrics.StoreMetric{
 				{
-					GaugeVec: testGauge1,
-					Value:    3.65,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge1,
+					Value:       3.65,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
 				},
 				{
-					GaugeVec: testGauge2,
-					Value:    5.3,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge2,
+					Value:       5.3,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
@@ -86,17 +86,17 @@ var _ = Describe("Store", func() {
 		It("should delete metrics when calling update", func() {
 			storeMetrics := []*metrics.StoreMetric{
 				{
-					GaugeVec: testGauge1,
-					Value:    3.65,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge1,
+					Value:       3.65,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
 				},
 				{
-					GaugeVec: testGauge2,
-					Value:    5.3,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge2,
+					Value:       5.3,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
@@ -106,17 +106,17 @@ var _ = Describe("Store", func() {
 
 			newStoreMetrics := []*metrics.StoreMetric{
 				{
-					GaugeVec: testGauge1,
-					Value:    3.65,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge1,
+					Value:       3.65,
+					Labels: map[string]string{
 						"label_1": "test_2",
 						"label_2": "test_2",
 					},
 				},
 				{
-					GaugeVec: testGauge2,
-					Value:    5.3,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge2,
+					Value:       5.3,
+					Labels: map[string]string{
 						"label_1": "test_2",
 						"label_2": "test_2",
 					},
@@ -141,17 +141,17 @@ var _ = Describe("Store", func() {
 		It("should consider metrics equal with the same labels", func() {
 			storeMetrics := []*metrics.StoreMetric{
 				{
-					GaugeVec: testGauge1,
-					Value:    3.65,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge1,
+					Value:       3.65,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
 				},
 				{
-					GaugeVec: testGauge2,
-					Value:    5.3,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge2,
+					Value:       5.3,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
@@ -171,17 +171,17 @@ var _ = Describe("Store", func() {
 			// Flip around the labels in the map
 			newStoreMetrics := []*metrics.StoreMetric{
 				{
-					GaugeVec: testGauge1,
-					Value:    4.5,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge1,
+					Value:       4.5,
+					Labels: map[string]string{
 						"label_2": "test",
 						"label_1": "test",
 					},
 				},
 				{
-					GaugeVec: testGauge2,
-					Value:    6.9,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge2,
+					Value:       6.9,
+					Labels: map[string]string{
 						"label_2": "test",
 						"label_1": "test",
 					},
@@ -203,17 +203,17 @@ var _ = Describe("Store", func() {
 		It("should delete metrics by key", func() {
 			storeMetrics := []*metrics.StoreMetric{
 				{
-					GaugeVec: testGauge1,
-					Value:    3.65,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge1,
+					Value:       3.65,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
 				},
 				{
-					GaugeVec: testGauge2,
-					Value:    5.3,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge2,
+					Value:       5.3,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
@@ -243,17 +243,17 @@ var _ = Describe("Store", func() {
 		It("should replace all metrics", func() {
 			storeMetrics := []*metrics.StoreMetric{
 				{
-					GaugeVec: testGauge1,
-					Value:    3.65,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge1,
+					Value:       3.65,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
 				},
 				{
-					GaugeVec: testGauge2,
-					Value:    5.3,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge2,
+					Value:       5.3,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
@@ -273,17 +273,17 @@ var _ = Describe("Store", func() {
 			newStore := map[string][]*metrics.StoreMetric{
 				key2.String(): {
 					{
-						GaugeVec: testGauge1,
-						Value:    3.65,
-						Labels: prometheus.Labels{
+						GaugeMetric: testGauge1,
+						Value:       3.65,
+						Labels: map[string]string{
 							"label_1": "test2",
 							"label_2": "test2",
 						},
 					},
 					{
-						GaugeVec: testGauge2,
-						Value:    4.3,
-						Labels: prometheus.Labels{
+						GaugeMetric: testGauge2,
+						Value:       4.3,
+						Labels: map[string]string{
 							"label_1": "test2",
 							"label_2": "test2",
 						},
@@ -291,17 +291,17 @@ var _ = Describe("Store", func() {
 				},
 				key3.String(): {
 					{
-						GaugeVec: testGauge1,
-						Value:    2.1,
-						Labels: prometheus.Labels{
+						GaugeMetric: testGauge1,
+						Value:       2.1,
+						Labels: map[string]string{
 							"label_1": "test3",
 							"label_2": "test3",
 						},
 					},
 					{
-						GaugeVec: testGauge2,
-						Value:    8.9,
-						Labels: prometheus.Labels{
+						GaugeMetric: testGauge2,
+						Value:       8.9,
+						Labels: map[string]string{
 							"label_1": "test3",
 							"label_2": "test3",
 						},
@@ -331,17 +331,17 @@ var _ = Describe("Store", func() {
 		It("should replace with an empty store", func() {
 			storeMetrics := []*metrics.StoreMetric{
 				{
-					GaugeVec: testGauge1,
-					Value:    3.65,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge1,
+					Value:       3.65,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},
 				},
 				{
-					GaugeVec: testGauge2,
-					Value:    5.3,
-					Labels: prometheus.Labels{
+					GaugeMetric: testGauge2,
+					Value:       5.3,
+					Labels: map[string]string{
 						"label_1": "test",
 						"label_2": "test",
 					},

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -67,7 +67,8 @@ const (
 )
 
 var (
-	BuildInfo = prometheus.NewGaugeVec(
+	BuildInfo = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Name:      "build_info",
@@ -82,10 +83,14 @@ var (
 var Version = "unspecified"
 
 func init() {
-	crmetrics.Registry.MustRegister(BuildInfo)
 	opmetrics.RegisterClientMetrics(crmetrics.Registry)
 
-	BuildInfo.WithLabelValues(Version, runtime.Version(), runtime.GOARCH, env.GetRevision()).Set(1)
+	BuildInfo.Set(1, map[string]string{
+		"version":   Version,
+		"goversion": runtime.Version(),
+		"goarch":    runtime.GOARCH,
+		"commit":    env.GetRevision(),
+	})
 }
 
 type Operator struct {

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/awslabs/operatorpkg/singleton"
 	"github.com/awslabs/operatorpkg/status"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,stylecheck
@@ -543,17 +544,17 @@ func FindMetricWithLabelValues(name string, labelValues map[string]string) (*pro
 	return nil, false
 }
 
-func ExpectMetricGaugeValue(collector prometheus.Collector, expectedValue float64, labels map[string]string) {
+func ExpectMetricGaugeValue(collector opmetrics.GaugeMetric, expectedValue float64, labels map[string]string) {
 	GinkgoHelper()
-	metricName := ExpectMetricName(collector)
+	metricName := ExpectMetricName(collector.(*opmetrics.PrometheusGauge))
 	metric, ok := FindMetricWithLabelValues(metricName, labels)
 	Expect(ok).To(BeTrue(), "Metric "+metricName+" should be available")
 	Expect(lo.FromPtr(metric.Gauge.Value)).To(Equal(expectedValue), "Metric "+metricName+" should have the expected value")
 }
 
-func ExpectMetricCounterValue(collector prometheus.Collector, expectedValue float64, labels map[string]string) {
+func ExpectMetricCounterValue(collector opmetrics.CounterMetric, expectedValue float64, labels map[string]string) {
 	GinkgoHelper()
-	metricName := ExpectMetricName(collector)
+	metricName := ExpectMetricName(collector.(*opmetrics.PrometheusCounter))
 	metric, ok := FindMetricWithLabelValues(metricName, labels)
 	Expect(ok).To(BeTrue(), "Metric "+metricName+" should be available")
 	Expect(lo.FromPtr(metric.Counter.Value)).To(Equal(expectedValue), "Metric "+metricName+" should have the expected value")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This leverages https://github.com/awslabs/operatorpkg/pull/92 to create abstract metrics so that you can create an arbitrary pipeline for routing metrics beyond prometheus

For instance,
```
status.TerminationDuration = pmetrics.NewMultiObservation(
	status.TerminationDuration,
	pmetrics.NewEMFObservation(writer, "operatorpkg", "operator_termination_duration_seconds", []string{"group", "kind", "namespace"}),
)
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
