### PR TITLE
chore: Make nodeclaimlifecycle.Controller.Name() method private in lifecycle controller code

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -211,7 +211,7 @@ func filterVolumeAttachments(ctx context.Context, kubeClient client.Client, node
 		return pod.IsDrainable(p, clk)
 	})
 	// Filter out VolumeAttachments associated with non-drain-able Pods
-	// Match on Pod -> PersistentVolumeClaim -> PersistentVolume Name <- VolumeAttachment
+	// Match on Pod -> PersistentVolumeClaim -> PersistentVolume name <- VolumeAttachment
 	shouldFilterOutVolume := sets.New[string]()
 	for _, p := range unDrainablePods {
 		for _, v := range p.Spec.Volumes {

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -458,7 +458,7 @@ var _ = Describe("Drift", func() {
 			Entry("Taints", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{Taints: []corev1.Taint{{Key: "keytest2taint", Effect: corev1.TaintEffectNoExecute}}}}}}),
 			Entry("StartupTaints", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{StartupTaints: []corev1.Taint{{Key: "keytest2taint", Effect: corev1.TaintEffectNoExecute}}}}}}),
 			Entry("NodeClassRef APIVersion", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{NodeClassRef: &v1.NodeClassReference{Group: "testVersion"}}}}}),
-			Entry("NodeClassRef Name", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{NodeClassRef: &v1.NodeClassReference{Name: "testName"}}}}}),
+			Entry("NodeClassRef name", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{NodeClassRef: &v1.NodeClassReference{Name: "testName"}}}}}),
 			Entry("NodeClassRef Kind", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{NodeClassRef: &v1.NodeClassReference{Kind: "testKind"}}}}}),
 			Entry("ExpireAfter", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{ExpireAfter: v1.MustParseNillableDuration("100m")}}}}),
 			Entry("TerminationGracePeriod", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{TerminationGracePeriod: &metav1.Duration{Duration: 100 * time.Minute}}}}}),

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -85,7 +85,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider clou
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(m).
-		Named(c.Name()).
+		Named(c.name()).
 		For(&v1.NodeClaim{}).
 		Watches(
 			&corev1.Node{},
@@ -103,12 +103,12 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 		Complete(reconcile.AsReconciler(m.GetClient(), c))
 }
 
-func (c *Controller) Name() string {
+func (c *Controller) name() string {
 	return "nodeclaim.lifecycle"
 }
 
 func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
-	ctx = injection.WithControllerName(ctx, c.Name())
+	ctx = injection.WithControllerName(ctx, c.name())
 
 	if !nodeClaim.DeletionTimestamp.IsZero() {
 		return c.finalize(ctx, nodeClaim)

--- a/pkg/scheduling/requirements_test.go
+++ b/pkg/scheduling/requirements_test.go
@@ -549,7 +549,7 @@ var _ = Describe("Requirements", func() {
 		},
 			Entry("Zone Label", "zone", `label "zone" does not have known values (typo of "topology.kubernetes.io/zone"?)`),
 			Entry("Region Label", "region", `label "region" does not have known values (typo of "topology.kubernetes.io/region"?)`),
-			Entry("NodePool Name Label", "nodepool", `label "nodepool" does not have known values (typo of "karpenter.sh/nodepool"?)`),
+			Entry("NodePool name Label", "nodepool", `label "nodepool" does not have known values (typo of "karpenter.sh/nodepool"?)`),
 			Entry("Instance Type Label", "instance-type", `label "instance-type" does not have known values (typo of "node.kubernetes.io/instance-type"?)`),
 			Entry("Architecture Label", "arch", `label "arch" does not have known values (typo of "kubernetes.io/arch"?)`),
 			Entry("Capacity Type Label", "capacity-type", `label "capacity-type" does not have known values (typo of "karpenter.sh/capacity-type"?)`),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
The original public method `c.Name()` caused IntelliJ to spit out errors for not matching the `ObjectReconciler` interface.
This method won't be used outside of struct `nodeclaimlifecycle.Controller`, so I privatized this method to resolve the object infer errors.

<img width="1898" alt="image" src="https://github.com/user-attachments/assets/7c8f43b9-bf79-49ea-b3c5-0d1103cbac56">


**How was this change tested?**
ran `make presubmit`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
