### PR TITLE
fix: ensure node leases aren't leaked

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -45,10 +45,10 @@ type Initialization struct {
 // c) all extended resources have been registered
 // This method handles both nil nodepools and nodes without extended resources gracefully.
 func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
-	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue() {
+	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsUnknown() {
 		return reconcile.Result{}, nil
 	}
-	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsUnknown() {
+	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue() {
 		return reconcile.Result{}, nil
 	}
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("provider-id", nodeClaim.Status.ProviderID))

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -45,6 +45,9 @@ type Initialization struct {
 // c) all extended resources have been registered
 // This method handles both nil nodepools and nodes without extended resources gracefully.
 func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
+	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue() {
+		return reconcile.Result{}, nil
+	}
 	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsUnknown() {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Initialization", func() {
 		})
 		ExpectApplied(ctx, env.Client, node)
 
-		ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
 		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR makes two changes to the NodeClaim lifecycle controller to ensure node leases aren't leaked:
- The NodeClaim must be registered before being initialized. This ensures NodeClaims aren't candidates for voluntary disruption mechanisms if the Node hasn't had the termination finalizer added by the registration sub-reconciler.
- When terminating a NodeClaim, only delete the associated Nodes if the NodeClaim is registered. Similar to the first change, this ensures we don't delete Nodes which don't have Karpenter's termination finalizer. These Nodes should be removed out-of-band by CCM once the underlying instance has terminated.

**How was this change tested?**
`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
