### PR TITLE
perf: Unregister the topology domain when failing NodeClaim creation

### DIFF
--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -39,6 +39,7 @@ type NodeClaim struct {
 	topology        *Topology
 	hostPortUsage   *scheduling.HostPortUsage
 	daemonResources v1.ResourceList
+	hostname        string
 }
 
 var nodeID int64
@@ -59,6 +60,7 @@ func NewNodeClaim(nodeClaimTemplate *NodeClaimTemplate, topology *Topology, daem
 		hostPortUsage:     scheduling.NewHostPortUsage(),
 		topology:          topology,
 		daemonResources:   daemonResources,
+		hostname:          hostname,
 	}
 }
 
@@ -117,6 +119,10 @@ func (n *NodeClaim) Add(pod *v1.Pod) error {
 	n.topology.Record(pod, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
 	n.hostPortUsage.Add(pod, hostPorts)
 	return nil
+}
+
+func (n *NodeClaim) Destroy() {
+	n.topology.Unregister(v1.LabelHostname, n.hostname)
 }
 
 // FinalizeScheduling is called once all scheduling has completed and allows the node to perform any cleanup

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -289,6 +289,7 @@ func (s *Scheduler) add(ctx context.Context, pod *corev1.Pod) error {
 		}
 		nodeClaim := NewNodeClaim(nodeClaimTemplate, s.topology, s.daemonOverhead[nodeClaimTemplate], instanceTypes)
 		if err := nodeClaim.Add(pod); err != nil {
+			nodeClaim.Destroy() // Ensure we cleanup any changes that we made while mocking out a NodeClaim
 			errs = multierr.Append(errs, fmt.Errorf("incompatible with nodepool %q, daemonset overhead=%s, %w",
 				nodeClaimTemplate.NodePoolName,
 				resources.String(s.daemonOverhead[nodeClaimTemplate]),

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -201,6 +201,20 @@ func (t *Topology) Register(topologyKey string, domain string) {
 	}
 }
 
+// Unregister is used to unregister a domain as available across topologies for the given topology key.
+func (t *Topology) Unregister(topologyKey string, domain string) {
+	for _, topology := range t.topologies {
+		if topology.Key == topologyKey {
+			topology.Unregister(domain)
+		}
+	}
+	for _, topology := range t.inverseTopologies {
+		if topology.Key == topologyKey {
+			topology.Unregister(domain)
+		}
+	}
+}
+
 // updateInverseAffinities is used to identify pods with anti-affinity terms so we can track those topologies.  We
 // have to look at every pod in the cluster as there is no way to query for a pod with anti-affinity terms.
 func (t *Topology) updateInverseAffinities(ctx context.Context) error {

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -128,6 +128,14 @@ func (t *TopologyGroup) Register(domains ...string) {
 	}
 }
 
+// Unregister removes the topology group from being aware of the domain
+func (t *TopologyGroup) Unregister(domains ...string) {
+	for _, domain := range domains {
+		delete(t.domains, domain)
+		t.emptyDomains.Delete(domain)
+	}
+}
+
 func (t *TopologyGroup) AddOwner(key types.UID) {
 	t.owners[key] = struct{}{}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Unregister the topology domain when failing to create a NodeClaim so that we don't hold topology domains around for hostname. Prior to this change, we weren't removing a mock domain that we would create for a topology on NewNodeClaim(). As a result, we would continually expand the number of hostname domains, making hostnmae topology spread and hostname anti-affinity way more inefficient than it should have.

### Before

__Example: Debug Image showing ~53,000 domains after only a few seconds iterating in the scheduling loop__

<img width="534" alt="Screenshot 2024-11-16 at 5 12 51 PM" src="https://github.com/user-attachments/assets/269fdfec-6a62-4bc5-902e-26c154a9d40f">

### After

__Example: Debug Image showing only a single domain after only a few seconds iterating in the scheduling loop__

<img width="721" alt="Screenshot 2024-11-16 at 5 17 01 PM" src="https://github.com/user-attachments/assets/d6ef2229-9215-46cd-95e8-bc049359a3b8">

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
