### PR TITLE
perf: Improve TopologyGroup node domain iteration

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -268,9 +268,8 @@ func (t *TopologyGroup) nextDomainAffinity(pod *v1.Pod, podDomains *scheduling.R
 		return options
 	}
 
-	// If pod is self-selecting and no pod has been scheduled yet OR there is another pod that has scheduled but it's
-	// incompatible with our podDomains, we can pick a domain at random to bootstrap scheduling
-	// This also requires that there not already be some other domain where this a pod in this topology has scheduled
+	// If pod is self-selecting and no pod has been scheduled yet OR the pods that have scheduled are
+	// incompatible with our podDomains, we can pick a domain at random to bootstrap scheduling.
 	if t.selects(pod) && (len(t.domains) == len(t.emptyDomains) || !t.anyCompatiblePodDomain(podDomains)) {
 		// First try to find a domain that is within the intersection of pod/node domains. In the case of an in-flight node
 		// this causes us to pick the domain that the existing in-flight node is already in if possible instead of picking

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -99,7 +99,7 @@ func (t *TopologyGroup) Get(pod *v1.Pod, podDomains, nodeDomains *scheduling.Req
 	case TopologyTypePodAffinity:
 		return t.nextDomainAffinity(pod, podDomains, nodeDomains)
 	case TopologyTypePodAntiAffinity:
-		return t.nextDomainAntiAffinity(podDomains)
+		return t.nextDomainAntiAffinity(podDomains, nodeDomains)
 	default:
 		panic(fmt.Sprintf("Unrecognized topology group type: %s", t.Type))
 	}
@@ -128,7 +128,6 @@ func (t *TopologyGroup) Register(domains ...string) {
 	}
 }
 
-// Unregister removes the topology group from being aware of the domain
 func (t *TopologyGroup) Unregister(domains ...string) {
 	for _, domain := range domains {
 		delete(t.domains, domain)
@@ -172,6 +171,7 @@ func (t *TopologyGroup) Hash() uint64 {
 // nextDomainTopologySpread returns a scheduling.Requirement that includes a node domain that a pod should be scheduled to.
 // If there are multiple eligible domains, we return any random domain that satisfies the `maxSkew` configuration.
 // If there are no eligible domains, we return a `DoesNotExist` requirement, implying that we could not satisfy the topologySpread requirement.
+// nolint:gocyclo
 func (t *TopologyGroup) nextDomainTopologySpread(pod *v1.Pod, podDomains, nodeDomains *scheduling.Requirement) *scheduling.Requirement {
 	// min count is calculated across all domains
 	min := t.domainMinCount(podDomains)
@@ -179,18 +179,37 @@ func (t *TopologyGroup) nextDomainTopologySpread(pod *v1.Pod, podDomains, nodeDo
 
 	minDomain := ""
 	minCount := int32(math.MaxInt32)
-	for domain := range t.domains {
-		// but we can only choose from the node domains
-		if nodeDomains.Has(domain) {
-			// comment from kube-scheduler regarding the viable choices to schedule to based on skew is:
-			// 'existing matching num' + 'if self-match (1 or 0)' - 'global min matching num' <= 'maxSkew'
-			count := t.domains[domain]
-			if selfSelecting {
-				count++
+
+	// If we are explicitly selecting on specific node domains ("In" requirement),
+	// this is going to be more efficient to iterate through
+	// This is particularly useful when considering the hostname topology key that can have a
+	// lot of t.domains but only a single nodeDomain
+	if nodeDomains.Operator() == v1.NodeSelectorOpIn {
+		for _, domain := range nodeDomains.Values() {
+			if count, ok := t.domains[domain]; ok {
+				if selfSelecting {
+					count++
+				}
+				if count-min <= t.maxSkew && count < minCount {
+					minDomain = domain
+					minCount = count
+				}
 			}
-			if count-min <= t.maxSkew && count < minCount {
-				minDomain = domain
-				minCount = count
+		}
+	} else {
+		for domain := range t.domains {
+			// but we can only choose from the node domains
+			if nodeDomains.Has(domain) {
+				// comment from kube-scheduler regarding the viable choices to schedule to based on skew is:
+				// 'existing matching num' + 'if self-match (1 or 0)' - 'global min matching num' <= 'maxSkew'
+				count := t.domains[domain]
+				if selfSelecting {
+					count++
+				}
+				if count-min <= t.maxSkew && count < minCount {
+					minDomain = domain
+					minCount = count
+				}
 			}
 		}
 	}
@@ -224,17 +243,35 @@ func (t *TopologyGroup) domainMinCount(domains *scheduling.Requirement) int32 {
 	return min
 }
 
+// nolint:gocyclo
 func (t *TopologyGroup) nextDomainAffinity(pod *v1.Pod, podDomains *scheduling.Requirement, nodeDomains *scheduling.Requirement) *scheduling.Requirement {
 	options := scheduling.NewRequirement(podDomains.Key, v1.NodeSelectorOpDoesNotExist)
-	for domain := range t.domains {
-		if podDomains.Has(domain) && t.domains[domain] > 0 {
-			options.Insert(domain)
+
+	// If we are explicitly selecting on specific node domains ("In" requirement),
+	// this is going to be more efficient to iterate through
+	// This is particularly useful when considering the hostname topology key that can have a
+	// lot of t.domains but only a single nodeDomain
+	if nodeDomains.Operator() == v1.NodeSelectorOpIn {
+		for _, domain := range nodeDomains.Values() {
+			if count, ok := t.domains[domain]; podDomains.Has(domain) && ok && count > 0 {
+				options.Insert(domain)
+			}
+		}
+	} else {
+		for domain := range t.domains {
+			if podDomains.Has(domain) && t.domains[domain] > 0 && nodeDomains.Has(domain) {
+				options.Insert(domain)
+			}
 		}
 	}
+	if options.Len() != 0 {
+		return options
+	}
 
-	// If pod is self selecting and no pod has been scheduled yet, we can pick a domain at random to bootstrap scheduling
-
-	if options.Len() == 0 && t.selects(pod) {
+	// If pod is self-selecting and no pod has been scheduled yet OR there is another pod that has scheduled but it's
+	// incompatible with our podDomains, we can pick a domain at random to bootstrap scheduling
+	// This also requires that there not already be some other domain where this a pod in this topology has scheduled
+	if t.selects(pod) && (len(t.domains) == len(t.emptyDomains) || !t.anyCompatiblePodDomain(podDomains)) {
 		// First try to find a domain that is within the intersection of pod/node domains. In the case of an in-flight node
 		// this causes us to pick the domain that the existing in-flight node is already in if possible instead of picking
 		// a random viable domain.
@@ -257,16 +294,43 @@ func (t *TopologyGroup) nextDomainAffinity(pod *v1.Pod, podDomains *scheduling.R
 	return options
 }
 
-func (t *TopologyGroup) nextDomainAntiAffinity(domains *scheduling.Requirement) *scheduling.Requirement {
-	options := scheduling.NewRequirement(domains.Key, v1.NodeSelectorOpDoesNotExist)
+// anyCompatiblePodDomain validates whether any t.domain is compatible with our podDomains
+// This is only useful in affinity checking because it tells us whether we can schedule the pod
+// to the current node since it is the first pod that exists in the TopologyGroup OR all other domains
+// in the TopologyGroup are incompatible with the podDomains
+func (t *TopologyGroup) anyCompatiblePodDomain(podDomains *scheduling.Requirement) bool {
+	for domain := range t.domains {
+		if podDomains.Has(domain) && t.domains[domain] > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// nolint:gocyclo
+func (t *TopologyGroup) nextDomainAntiAffinity(podDomains, nodeDomains *scheduling.Requirement) *scheduling.Requirement {
+	options := scheduling.NewRequirement(podDomains.Key, v1.NodeSelectorOpDoesNotExist)
 	// pods with anti-affinity must schedule to a domain where there are currently none of those pods (an empty
 	// domain). If there are none of those domains, then the pod can't schedule and we don't need to walk this
 	// list of domains.  The use case where this optimization is really great is when we are launching nodes for
 	// a deployment of pods with self anti-affinity.  The domains map here continues to grow, and we continue to
 	// fully scan it each iteration.
-	for domain := range t.emptyDomains {
-		if domains.Has(domain) && t.domains[domain] == 0 {
-			options.Insert(domain)
+
+	// If we are explicitly selecting on specific node domains ("In" requirement) and the number of node domains
+	// is less than our empty domains, this is going to be more efficient to iterate through
+	// This is particularly useful when considering the hostname topology key that can have a
+	// lot of t.domains but only a single nodeDomain
+	if nodeDomains.Operator() == v1.NodeSelectorOpIn && nodeDomains.Len() < len(t.emptyDomains) {
+		for _, domain := range nodeDomains.Values() {
+			if t.emptyDomains.Has(domain) && podDomains.Has(domain) {
+				options.Insert(domain)
+			}
+		}
+	} else {
+		for domain := range t.emptyDomains {
+			if nodeDomains.Has(domain) && podDomains.Has(domain) {
+				options.Insert(domain)
+			}
 		}
 	}
 	return options


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates our iteration over domains for TSC, affinity, and anti-affinity. Often, we have cases where we have available domains across the cluster, but those domains aren't available for the node we are currently on. This is specifically true with hostname requirements where there is only one option that the node can carry. 

Rather than looping through all domain options and adding those as possibilities when they were never really possible because the node doesn't support it, this change adds an optimization to only loop through the available node domains if it's shorter than all available domains. 

For hostname, this turns our O(node) operation into an O(1) operation to validate whether the pod can fit on the node. 

### Before

<img width="1442" alt="Screenshot 2024-11-16 at 11 05 06 PM" src="https://github.com/user-attachments/assets/cb10f460-73dd-498e-8714-6e4e9692c1b1">

### After

<img width="1435" alt="Screenshot 2024-11-17 at 12 38 48 AM" src="https://github.com/user-attachments/assets/d24faf4b-94e3-4176-9db7-2316cc8eeef6">

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
