### PR TITLE
perf: Drop unneeded recalculation for resources and available

### DIFF
--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -30,6 +30,7 @@ import (
 
 type ExistingNode struct {
 	*state.StateNode
+	cachedAvailable v1.ResourceList // Cache so we don't have to re-subtract resources on the StateNode every time
 
 	Pods         []*v1.Pod
 	topology     *Topology
@@ -51,10 +52,11 @@ func NewExistingNode(n *state.StateNode, topology *Topology, daemonResources v1.
 		}
 	}
 	node := &ExistingNode{
-		StateNode:    n,
-		topology:     topology,
-		requests:     remainingDaemonResources,
-		requirements: scheduling.NewLabelRequirements(n.Labels()),
+		StateNode:       n,
+		cachedAvailable: n.Available(),
+		topology:        topology,
+		requests:        remainingDaemonResources,
+		requirements:    scheduling.NewLabelRequirements(n.Labels()),
 	}
 	node.requirements.Add(scheduling.NewRequirement(v1.LabelHostname, v1.NodeSelectorOpIn, n.HostName()))
 	topology.Register(v1.LabelHostname, n.HostName())
@@ -84,7 +86,7 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 	// node, which at this point can't be increased in size
 	requests := resources.Merge(n.requests, resources.RequestsForPods(pod))
 
-	if !resources.Fits(requests, n.Available()) {
+	if !resources.Fits(requests, n.cachedAvailable) {
 		return fmt.Errorf("exceeds node resources")
 	}
 

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -183,19 +183,18 @@ func MaxResources(resources ...v1.ResourceList) v1.ResourceList {
 
 // MergeResourceLimitsIntoRequests merges resource limits into requests if no request exists for the given resource
 func MergeResourceLimitsIntoRequests(container v1.Container) v1.ResourceList {
-	resources := container.Resources.DeepCopy()
-	if resources.Requests == nil {
-		resources.Requests = v1.ResourceList{}
+	ret := v1.ResourceList{}
+	for resourceName, quantity := range container.Resources.Requests {
+		ret[resourceName] = quantity
 	}
-
-	if resources.Limits != nil {
-		for resourceName, quantity := range resources.Limits {
-			if _, ok := resources.Requests[resourceName]; !ok {
-				resources.Requests[resourceName] = quantity
+	if container.Resources.Limits != nil {
+		for resourceName, quantity := range container.Resources.Limits {
+			if _, ok := container.Resources.Requests[resourceName]; !ok {
+				ret[resourceName] = quantity
 			}
 		}
 	}
-	return resources.Requests
+	return ret
 }
 
 // Quantity parses the string value into a *Quantity


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

We were recalculating `n.Available()` every time we were running through a scheduling loop which didn't end up being a cheap check when we were calculating pods for existing nodes

### Flame Graph

<img width="1201" alt="Screenshot 2024-11-17 at 12 32 08 AM" src="https://github.com/user-attachments/assets/c951bfc3-5207-49fa-8a07-48ee37768c26">

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
