### PR TITLE
chore: Fix undecided time naming

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -154,12 +154,12 @@ var (
 		[]string{podName, podNamespace},
 	)
 	// Stage: alpha
-	PodProvisioningSchedulingUndecidedTimeSeconds = opmetrics.NewPrometheusGauge(
+	PodSchedulingUndecidedTimeSeconds = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: metrics.PodSubsystem,
-			Name:      "provisioning_scheduling_undecided_time_seconds",
+			Name:      "scheduling_undecided_time_seconds",
 			Help:      "The time from when Karpenter has seen a pod without making a scheduling decision for the pod. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 		},
 		[]string{podName, podNamespace},
@@ -229,7 +229,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				podName:      req.Name,
 				podNamespace: req.Namespace,
 			})
-			PodProvisioningSchedulingUndecidedTimeSeconds.Delete(map[string]string{
+			PodSchedulingUndecidedTimeSeconds.Delete(map[string]string{
 				podName:      req.Name,
 				podNamespace: req.Namespace,
 			})
@@ -261,7 +261,7 @@ func (c *Controller) recordPodSchedulingUndecidedMetric(pod *corev1.Pod) {
 	nn := client.ObjectKeyFromObject(pod)
 	// If we've made a decision on this pod, delete the metric idempotently and return
 	if decisionTime := c.cluster.PodSchedulingDecisionTime(nn); !decisionTime.IsZero() {
-		PodProvisioningSchedulingUndecidedTimeSeconds.Delete(map[string]string{
+		PodSchedulingUndecidedTimeSeconds.Delete(map[string]string{
 			podName:      pod.Name,
 			podNamespace: pod.Namespace,
 		})
@@ -269,7 +269,7 @@ func (c *Controller) recordPodSchedulingUndecidedMetric(pod *corev1.Pod) {
 	}
 	// If we haven't made a decision, get the time that we ACK'd the pod and emit the metric based on that
 	if podAckTime := c.cluster.PodAckTime(nn); !podAckTime.IsZero() {
-		PodProvisioningSchedulingUndecidedTimeSeconds.Set(time.Since(podAckTime).Seconds(), map[string]string{
+		PodSchedulingUndecidedTimeSeconds.Set(time.Since(podAckTime).Seconds(), map[string]string{
 			podName:      pod.Name,
 			podNamespace: pod.Namespace,
 		})

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Pod Metrics", func() {
 
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		fakeClock.Step(1 * time.Hour)
-		_, found := FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
+		_, found := FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -262,7 +262,7 @@ var _ = Describe("Pod Metrics", func() {
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		fakeClock.Step(1 * time.Hour)
 
-		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
+		_, found = FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -271,7 +271,7 @@ var _ = Describe("Pod Metrics", func() {
 		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, p)
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 
-		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
+		_, found = FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -284,7 +284,7 @@ var _ = Describe("Pod Metrics", func() {
 
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		fakeClock.Step(1 * time.Hour)
-		_, found := FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
+		_, found := FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -295,7 +295,7 @@ var _ = Describe("Pod Metrics", func() {
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		fakeClock.Step(1 * time.Hour)
 
-		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
+		_, found = FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -304,7 +304,7 @@ var _ = Describe("Pod Metrics", func() {
 		ExpectDeleted(ctx, env.Client, p)
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 
-		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
+		_, found = FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fix changing name from `karpenter_provisioning_scheduling_undecided_time_seconds` to `karpenter_scheduling_undecided_time_seconds` 

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
