### PR TITLE
chore: fix nodeclaim going unknown during instance termination

### DIFF
--- a/pkg/utils/termination/termination.go
+++ b/pkg/utils/termination/termination.go
@@ -37,7 +37,7 @@ func EnsureTerminated(ctx context.Context, c client.Client, nodeClaim *v1.NodeCl
 		if err = cloudProvider.Delete(ctx, nodeClaim); err != nil {
 			if cloudprovider.IsNodeClaimNotFoundError(err) {
 				stored := nodeClaim.DeepCopy()
-				nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeInstanceTerminating)
+				updateStatusConditionsForDeleting(nodeClaim)
 				// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 				// can cause races due to the fact that it fully replaces the list on a change
 				// Here, we are updating the status condition list
@@ -51,7 +51,7 @@ func EnsureTerminated(ctx context.Context, c client.Client, nodeClaim *v1.NodeCl
 		}
 
 		stored := nodeClaim.DeepCopy()
-		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeInstanceTerminating)
+		updateStatusConditionsForDeleting(nodeClaim)
 		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 		// can cause races due to the fact that it fully replaces the list on a change
 		// Here, we are updating the status condition list
@@ -68,4 +68,11 @@ func EnsureTerminated(ctx context.Context, c client.Client, nodeClaim *v1.NodeCl
 		return false, fmt.Errorf("getting cloudprovider instance, %w", err)
 	}
 	return false, nil
+}
+
+func updateStatusConditionsForDeleting(nc *v1.NodeClaim) {
+	for _, condition := range nc.Status.Conditions {
+		nc.StatusConditions().Set(condition)
+	}
+	nc.StatusConditions().SetTrue(v1.ConditionTypeInstanceTerminating)
 }

--- a/pkg/utils/termination/termination.go
+++ b/pkg/utils/termination/termination.go
@@ -71,6 +71,9 @@ func EnsureTerminated(ctx context.Context, c client.Client, nodeClaim *v1.NodeCl
 }
 
 func updateStatusConditionsForDeleting(nc *v1.NodeClaim) {
+	// perform a no-op for whatever the status condition is currently set to
+	// so that we bump the observed generation to the latest and prevent the nodeclaim
+	// root status from entering an `Unknown` state
 	for _, condition := range nc.Status.Conditions {
 		nc.StatusConditions().Set(condition)
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This fixes an issue where during deletion, the generation of an object is incremented and then the status condition controller we use transitions the root condition of the object to `Unknown` due to a mismatch in `lastSeenGeneration` and `currentGeneration` for other status conditions.

**How was this change tested?**
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
