### PR TITLE
chore: Add pod scheduled prometheus label

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -52,6 +52,7 @@ const (
 	podHostCapacityType = "capacity_type"
 	podHostInstanceType = "instance_type"
 	podPhase            = "phase"
+	podScheduled        = "scheduled"
 )
 
 var (
@@ -182,6 +183,7 @@ func labelNames() []string {
 		podNamespace,
 		ownerSelfLink,
 		podHostName,
+		podScheduled,
 		podNodePool,
 		podHostZone,
 		podHostArchitecture,
@@ -383,6 +385,7 @@ func (c *Controller) makeLabels(ctx context.Context, pod *corev1.Pod) (prometheu
 	}
 	metricLabels[ownerSelfLink] = selflink
 	metricLabels[podHostName] = pod.Spec.NodeName
+	metricLabels[podScheduled] = lo.Ternary(pod.Spec.NodeName != "", "true", "false")
 	metricLabels[podPhase] = string(pod.Status.Phase)
 
 	node := &corev1.Node{}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add `scheduled` prometheus label for the `pod_state` metrics

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
