### PR TITLE
deps: bump operatorpkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.2
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/awslabs/operatorpkg v0.0.0-20241115011931-885371bcf05d
+	github.com/awslabs/operatorpkg v0.0.0-20241125173122-bef8fba1bdf6
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/go-logr/logr v1.4.2
 	github.com/imdario/mergo v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/awslabs/operatorpkg v0.0.0-20241115011931-885371bcf05d h1:u0ftwckbIE7A3Ph4dtQI+VwmVXok8hen+H0kUi6AQR4=
-github.com/awslabs/operatorpkg v0.0.0-20241115011931-885371bcf05d/go.mod h1:jina2fQk+b3oa9r5bRuMDbpy6mfhTGuruh05oVVWwnk=
+github.com/awslabs/operatorpkg v0.0.0-20241125173122-bef8fba1bdf6 h1:O32mqYd4TFNsiZP93RSPfkAKaskV0vP8pBcwTkR9p2M=
+github.com/awslabs/operatorpkg v0.0.0-20241125173122-bef8fba1bdf6/go.mod h1:jina2fQk+b3oa9r5bRuMDbpy6mfhTGuruh05oVVWwnk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/test/metadata.go
+++ b/pkg/test/metadata.go
@@ -52,10 +52,13 @@ func NamespacedObjectMeta(overrides ...metav1.ObjectMeta) metav1.ObjectMeta {
 }
 
 func ObjectMeta(overrides ...metav1.ObjectMeta) metav1.ObjectMeta {
-	return MustMerge(metav1.ObjectMeta{
+	om := MustMerge(metav1.ObjectMeta{
 		Name:   RandomName(),
 		Labels: map[string]string{DiscoveryLabel: "unspecified"}, // For cleanup discovery
 	}, overrides...)
+	om.CreationTimestamp = metav1.Now()
+	om.Generation = 1
+	return om
 }
 
 func TemplateObjectMeta(overrides ...v1.ObjectMeta) v1.ObjectMeta {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Bumps operatorpkg to include https://github.com/awslabs/operatorpkg/pull/106. This improves the metrics produced by the status controller by setting the LastTransitionTime to the creation timestamp (if it was previously unset, transitioning to unknown).

**How was this change tested?**
Tested in operatorpkg

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
