### PR TITLE
feat: Expose drifted nodeclaim condition status to printer column output

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -51,6 +51,10 @@ spec:
           name: NodeClass
           priority: 1
           type: string
+        - jsonPath: .status.conditions[?(@.type=="Drifted")].status
+          name: Drifted
+          priority: 1
+          type: string
       name: v1
       schema:
         openAPIV3Schema:

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -51,6 +51,10 @@ spec:
           name: NodeClass
           priority: 1
           type: string
+        - jsonPath: .status.conditions[?(@.type=="Drifted")].status
+          name: Drifted
+          priority: 1
+          type: string
       name: v1
       schema:
         openAPIV3Schema:

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -137,6 +137,7 @@ type Provider = runtime.RawExtension
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.providerID",priority=1,description=""
 // +kubebuilder:printcolumn:name="NodePool",type="string",JSONPath=".metadata.labels.karpenter\\.sh/nodepool",priority=1,description=""
 // +kubebuilder:printcolumn:name="NodeClass",type="string",JSONPath=".spec.nodeClassRef.name",priority=1,description=""
+// +kubebuilder:printcolumn:name="Drifted",type="string",JSONPath=".status.conditions[?(@.type==\"Drifted\")].status",priority=1,description=""
 type NodeClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1464

**Description**
feat: Expose drifted nodeclaim condition status to printer column output. Updates the nodeclaim reconcile to not clear the condition, but set the drifted condition state to false. Tests were similarly updated for this change in behavior.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
