### PR TITLE
feat: Expose kubelet version on nodeclaim status and printer output

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -35,6 +35,9 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+        - jsonPath: .status.kubeletVersion
+          name: Version
+          type: string
         - jsonPath: .status.providerID
           name: ID
           priority: 1
@@ -367,6 +370,9 @@ spec:
                   type: array
                 imageID:
                   description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                kubeletVersion:
+                  description: KubeletVersion is the version of kubelet on the node
                   type: string
                 lastPodEventTime:
                   description: |-

--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -249,10 +249,11 @@ func (c CloudProvider) toNodeClaim(node *corev1.Node) (*v1.NodeClaim, error) {
 			NodeClassRef:  nil,
 		},
 		Status: v1.NodeClaimStatus{
-			NodeName:    node.Name,
-			ProviderID:  node.Spec.ProviderID,
-			Capacity:    node.Status.Capacity,
-			Allocatable: node.Status.Allocatable,
+			NodeName:       node.Name,
+			ProviderID:     node.Spec.ProviderID,
+			KubeletVersion: node.Status.NodeInfo.KubeletVersion,
+			Capacity:       node.Status.Capacity,
+			Allocatable:    node.Status.Allocatable,
 		},
 	}, nil
 }

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -35,6 +35,9 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+        - jsonPath: .status.kubeletVersion
+          name: Version
+          type: string
         - jsonPath: .status.providerID
           name: ID
           priority: 1
@@ -365,6 +368,9 @@ spec:
                   type: array
                 imageID:
                   description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                kubeletVersion:
+                  description: KubeletVersion is the version of kubelet on the node
                   type: string
                 lastPodEventTime:
                   description: |-

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -133,6 +133,7 @@ type Provider = runtime.RawExtension
 // +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.nodeName",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.kubeletVersion",description=""
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".status.providerID",priority=1,description=""
 // +kubebuilder:printcolumn:name="NodePool",type="string",JSONPath=".metadata.labels.karpenter\\.sh/nodepool",priority=1,description=""
 // +kubebuilder:printcolumn:name="NodeClass",type="string",JSONPath=".spec.nodeClassRef.name",priority=1,description=""

--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -43,6 +43,9 @@ type NodeClaimStatus struct {
 	// ImageID is an identifier for the image that runs on the node
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
+	// KubeletVersion is the version of kubelet on the node
+	// +optional
+	KubeletVersion string `json:"kubeletVersion,omitempty"`
 	// Capacity is the estimated full capacity of the node
 	// +optional
 	Capacity v1.ResourceList `json:"capacity,omitempty"`

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -81,7 +81,8 @@ func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim)
 			return reconcile.Result{}, err
 		}
 	}
-	log.FromContext(ctx).WithValues("allocatable", node.Status.Allocatable).Info("initialized nodeclaim")
+	log.FromContext(ctx).WithValues("allocatable", node.Status.Allocatable).Info("initialized nodeclaim, kubelet version: " + node.Status.NodeInfo.KubeletVersion)
+	nodeClaim.Status.KubeletVersion = node.Status.NodeInfo.KubeletVersion
 	nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeInitialized)
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1463

**Description**
Adds a new field `kubeletVersion` to the nodeclaim status, and exposes it in the nodeclaim column printer.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
