### PR TITLE
chore: Bump operatorpkg with adding additional labels to status condition controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.2
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/awslabs/operatorpkg v0.0.0-20241125173122-bef8fba1bdf6
+	github.com/awslabs/operatorpkg v0.0.0-20241130063505-5dacc78b698c
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/go-logr/logr v1.4.2
 	github.com/imdario/mergo v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/awslabs/operatorpkg v0.0.0-20241125173122-bef8fba1bdf6 h1:O32mqYd4TFNsiZP93RSPfkAKaskV0vP8pBcwTkR9p2M=
-github.com/awslabs/operatorpkg v0.0.0-20241125173122-bef8fba1bdf6/go.mod h1:jina2fQk+b3oa9r5bRuMDbpy6mfhTGuruh05oVVWwnk=
+github.com/awslabs/operatorpkg v0.0.0-20241130063505-5dacc78b698c h1:29AoLPWYyGjg66kuL94RPJBsyfkOlQ1YT3At9aT+hHg=
+github.com/awslabs/operatorpkg v0.0.0-20241130063505-5dacc78b698c/go.mod h1:/d+XFCUzpwskkp4FyeftGMESTG+BitZ+OLugaCrKxuQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This bumps operatorpkg to the latest which allows us to inject additional labels into status condition metrics

```
➜  karpenter-provider-aws git:(main) curl localhost:8080/metrics | grep operator_nodeclaim
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  858k    0  858k    0     0   936k      0 --:--:-- --:--:-- --:--:--  935k# HELP operator_nodeclaim_status_condition_count The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0
# TYPE operator_nodeclaim_status_condition_count gauge
operator_nodeclaim_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-2d4jt",namespace="",reason="AwaitingReconciliation",status="Unknown",type="Initialized"} 1
operator_nodeclaim_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-2d4jt",namespace="",reason="AwaitingReconciliation",status="Unknown",type="Launched"} 1
operator_nodeclaim_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-9jczn",namespace="",reason="AwaitingReconciliation",status="Unknown",type="Initialized"} 1
operator_nodeclaim_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-9jczn",namespace="",reason="AwaitingReconciliation",status="Unknown",type="Launched"} 1
operator_nodeclaim_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-f755c",namespace="",reason="AwaitingReconciliation",status="Unknown",type="Initialized"} 1


➜  karpenter-provider-aws git:(main) curl localhost:8080/metrics | grep operator_node_status_condition_count
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  910k    0  910k    0     0   904k      0 --:--:--  0:00:01 --:--:--  904k# HELP operator_node_status_condition_count The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0
# TYPE operator_node_status_condition_count gauge
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="",karpenter_sh_nodepool="",name="fargate-ip-192-168-107-123.us-west-2.compute.internal",namespace="",reason="KubeletHasNoDiskPressure",status="False",type="DiskPressure"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="",karpenter_sh_nodepool="",name="fargate-ip-192-168-107-123.us-west-2.compute.internal",namespace="",reason="KubeletHasSufficientMemory",status="False",type="MemoryPressure"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-42-26.us-west-2.compute.internal",namespace="",reason="KubeletReady",status="True",type="Ready"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-45-170.us-west-2.compute.internal",namespace="",reason="KubeletHasNoDiskPressure",status="False",type="DiskPressure"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-45-170.us-west-2.compute.internal",namespace="",reason="KubeletHasSufficientMemory",status="False",type="MemoryPressure"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-45-170.us-west-2.compute.internal",namespace="",reason="KubeletHasSufficientPID",status="False",type="PIDPressure"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-45-170.us-west-2.compute.internal",namespace="",reason="KubeletReady",status="True",type="Ready"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-53-168.us-west-2.compute.internal",namespace="",reason="KubeletHasNoDiskPressure",status="False",type="DiskPressure"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-53-168.us-west-2.compute.internal",namespace="",reason="KubeletHasSufficientMemory",status="False",type="MemoryPressure"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-53-168.us-west-2.compute.internal",namespace="",reason="KubeletHasSufficientPID",status="False",type="PIDPressure"} 1
operator_node_status_condition_count{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="ip-192-168-53-168.us-west-2.compute.internal",namespace="",reason="KubeletReady",status="True",type="Ready"} 1
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
