### PR TITLE
fix: Ensure we keep observedGeneration up-to-date even when resource has completed

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -45,7 +45,9 @@ type Initialization struct {
 // c) all extended resources have been registered
 // This method handles both nil nodepools and nodes without extended resources gracefully.
 func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
-	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsUnknown() {
+	if cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized); !cond.IsUnknown() {
+		// Ensure that we always set the status condition to the latest generation
+		nodeClaim.StatusConditions().Set(*cond)
 		return reconcile.Result{}, nil
 	}
 	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue() {

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -43,7 +43,9 @@ type Launch struct {
 }
 
 func (l *Launch) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
-	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched).IsUnknown() {
+	if cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched); !cond.IsUnknown() {
+		// Ensure that we always set the status condition to the latest generation
+		nodeClaim.StatusConditions().Set(*cond)
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -41,7 +41,9 @@ type Registration struct {
 }
 
 func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
-	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsUnknown() {
+	if cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered); !cond.IsUnknown() {
+		// Ensure that we always set the status condition to the latest generation
+		nodeClaim.StatusConditions().Set(*cond)
 		return reconcile.Result{}, nil
 	}
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("provider-id", nodeClaim.Status.ProviderID))

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -21,9 +21,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/awslabs/operatorpkg/status"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
@@ -52,9 +56,21 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Lifecycle")
 }
 
+func removeNodeClaimImmutabilityValidation(crds ...*apiextensionsv1.CustomResourceDefinition) []*apiextensionsv1.CustomResourceDefinition {
+	for _, crd := range crds {
+		if crd.Name != "nodeclaims.karpenter.sh" {
+			continue
+		}
+		overrideProperties := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"]
+		overrideProperties.XValidations = []apiextensionsv1.ValidationRule{}
+		crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"] = overrideProperties
+	}
+	return crds
+}
+
 var _ = BeforeSuite(func() {
 	fakeClock = clock.NewFakeClock(time.Now())
-	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...), test.WithFieldIndexers(test.NodeProviderIDFieldIndexer(ctx)))
+	env = test.NewEnvironment(test.WithCRDs(removeNodeClaimImmutabilityValidation(apis.CRDs...)...), test.WithCRDs(v1alpha1.CRDs...), test.WithFieldIndexers(test.NodeProviderIDFieldIndexer(ctx)))
 	ctx = options.ToContext(ctx, test.Options())
 
 	cloudProvider = fake.NewCloudProvider()
@@ -119,5 +135,75 @@ var _ = Describe("Finalizer", func() {
 			})
 			Expect(ok).To(BeFalse())
 		})
+	})
+	It("should update observedGeneration if generation increases after all conditions are marked True", func() {
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey: nodePool.Name,
+				},
+			},
+			Spec: v1.NodeClaimSpec{
+				Resources: v1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
+						corev1.ResourcePods:   resource.MustParse("5"),
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+
+		node := test.Node(test.NodeOptions{
+			ProviderID: nodeClaim.Status.ProviderID,
+			Taints:     []corev1.Taint{v1.UnregisteredNoExecuteTaint},
+		})
+		ExpectApplied(ctx, env.Client, node)
+
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsUnknown()).To(BeTrue())
+
+		node = ExpectExists(ctx, env.Client, node)
+		node.Status.Capacity = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+			corev1.ResourcePods:   resource.MustParse("110"),
+		}
+		node.Status.Allocatable = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("8"),
+			corev1.ResourceMemory: resource.MustParse("80Mi"),
+			corev1.ResourcePods:   resource.MustParse("110"),
+		}
+		ExpectApplied(ctx, env.Client, node)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
+
+		// Change a field to increase the generation
+		nodeClaim.Spec.Taints = append(nodeClaim.Spec.Taints, corev1.Taint{Key: "test", Value: "value", Effect: corev1.TaintEffectNoSchedule})
+		ExpectApplied(ctx, env.Client, nodeClaim)
+
+		// Expect that when the object re-reconciles, all of the observedGenerations across all status condition match
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched).ObservedGeneration).To(Equal(nodeClaim.Generation))
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).ObservedGeneration).To(Equal(nodeClaim.Generation))
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).ObservedGeneration).To(Equal(nodeClaim.Generation))
+
+		Expect(nodeClaim.StatusConditions().Get(status.ConditionReady).IsTrue()).To(BeTrue())
+		Expect(nodeClaim.StatusConditions().Get(status.ConditionReady).ObservedGeneration).To(Equal(nodeClaim.Generation))
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter-provider-aws/issues/7494

**Description**

This ensures that we always set the `observedGeneration` for the status condition to the latest generation even for status conditions on NodeClaims that have already been marked as `True`.

### NodeClaims with v1.0.8 Installed

```
➜  karpenter-provider-aws git:(main) k get nodeclaims
NAME            TYPE         CAPACITY    ZONE         NODE                                            READY   AGE
default-5x87w   c6gd.large   on-demand   us-west-2d   ip-192-168-98-14.us-west-2.compute.internal     True    83s
default-cmsrt   c6gd.large   on-demand   us-west-2a   ip-192-168-55-87.us-west-2.compute.internal     True    83s
default-hl8xp   c6gd.large   on-demand   us-west-2a   ip-192-168-142-174.us-west-2.compute.internal   True    83s
default-mfkxj   c6gd.large   on-demand   us-west-2b   ip-192-168-66-198.us-west-2.compute.internal    True    83s
default-w25n4   c6gd.large   on-demand   us-west-2d   ip-192-168-6-65.us-west-2.compute.internal      True    83s
```

### NodeClaims after upgrade to v1.1.0

```
➜  karpenter-provider-aws git:(main) k get nodeclaims
NAME            TYPE         CAPACITY    ZONE         NODE                                            READY     AGE
default-5x87w   c6gd.large   on-demand   us-west-2d   ip-192-168-98-14.us-west-2.compute.internal     Unknown   3m31s
default-cmsrt   c6gd.large   on-demand   us-west-2a   ip-192-168-55-87.us-west-2.compute.internal     Unknown   3m31s
default-hl8xp   c6gd.large   on-demand   us-west-2a   ip-192-168-142-174.us-west-2.compute.internal   Unknown   3m31s
default-mfkxj   c6gd.large   on-demand   us-west-2b   ip-192-168-66-198.us-west-2.compute.internal    Unknown   3m31s
default-w25n4   c6gd.large   on-demand   us-west-2d   ip-192-168-6-65.us-west-2.compute.internal      Unknown   3m31s
```

### NodeClaims after upgrading to this bugfix

```
➜  karpenter-provider-aws git:(main) k get nodeclaims
NAME            TYPE         CAPACITY    ZONE         NODE                                            READY   AGE
default-5x87w   c6gd.large   on-demand   us-west-2d   ip-192-168-98-14.us-west-2.compute.internal     True    6m14s
default-cmsrt   c6gd.large   on-demand   us-west-2a   ip-192-168-55-87.us-west-2.compute.internal     True    6m14s
default-hl8xp   c6gd.large   on-demand   us-west-2a   ip-192-168-142-174.us-west-2.compute.internal   True    6m14s
default-mfkxj   c6gd.large   on-demand   us-west-2b   ip-192-168-66-198.us-west-2.compute.internal    True    6m14s
default-w25n4   c6gd.large   on-demand   us-west-2d   ip-192-168-6-65.us-west-2.compute.internal      True    6m14s
```

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
