### PR TITLE
fix: move pod ack to when pod is first seen by Karpenter

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -74,7 +74,7 @@ func NewControllers(
 	controllers := []controller.Controller{
 		p, evictionQueue, disruptionQueue,
 		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue),
-		provisioning.NewPodController(kubeClient, p),
+		provisioning.NewPodController(kubeClient, p, cluster),
 		provisioning.NewNodeController(kubeClient, p),
 		nodepoolhash.NewController(kubeClient, cloudProvider),
 		expiration.NewController(clock, kubeClient, cloudProvider),

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 )
@@ -37,13 +38,15 @@ import (
 type PodController struct {
 	kubeClient  client.Client
 	provisioner *Provisioner
+	cluster     *state.Cluster
 }
 
 // NewPodController constructs a controller instance
-func NewPodController(kubeClient client.Client, provisioner *Provisioner) *PodController {
+func NewPodController(kubeClient client.Client, provisioner *Provisioner, cluster *state.Cluster) *PodController {
 	return &PodController{
 		kubeClient:  kubeClient,
 		provisioner: provisioner,
+		cluster:     cluster,
 	}
 }
 
@@ -55,6 +58,8 @@ func (c *PodController) Reconcile(ctx context.Context, p *corev1.Pod) (reconcile
 		return reconcile.Result{}, nil
 	}
 	c.provisioner.Trigger()
+	// ACK the pending pod at the start of the scheduling loop so that we can emit metrics on when we actually first try to schedule it.
+	c.cluster.AckPods(p)
 	// Continue to requeue until the pod is no longer provisionable. Pods may
 	// not be scheduled as expected if new pods are created while nodes are
 	// coming online. Even if a provisioning loop is successful, the pod may

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -58,7 +58,7 @@ func (c *PodController) Reconcile(ctx context.Context, p *corev1.Pod) (reconcile
 		return reconcile.Result{}, nil
 	}
 	c.provisioner.Trigger()
-	// ACK the pending pod at the start of the scheduling loop so that we can emit metrics on when we actually first try to schedule it.
+	// ACK the pending pod when first observed so that total time spent pending due to Karpenter is tracked.
 	c.cluster.AckPods(p)
 	// Continue to requeue until the pod is no longer provisionable. Pods may
 	// not be scheduled as expected if new pods are created while nodes are

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -340,8 +340,6 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 		}
 		return scheduler.Results{}, fmt.Errorf("creating scheduler, %w", err)
 	}
-	// ACK the pending pods at the start of the scheduling loop so that we can emit metrics on when we actually first try to schedule it.
-	p.cluster.AckPods(pendingPods...)
 	results := s.Solve(ctx, pods).TruncateInstanceTypes(scheduler.MaxInstanceTypes)
 	scheduler.UnschedulablePodsCount.Set(float64(len(results.PodErrors)), map[string]string{scheduler.ControllerLabel: injection.GetControllerName(ctx)})
 	if len(results.NewNodeClaims) > 0 {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This change includes the time a pod spent waiting for batching in pod scheduling duration.

**How was this change tested?**
Unit test.

Example in metrics change for single pod:
```
before moving ackPods
karpenter_pods_scheduling_decision_duration_seconds_bucket{le="0.05"} 0
karpenter_pods_scheduling_decision_duration_seconds_bucket{le="0.1"} 1

after moving ackPods

karpenter_pods_scheduling_decision_duration_seconds_bucket{le="1"} 0
karpenter_pods_scheduling_decision_duration_seconds_bucket{le="1.25"} 1
```
Moving `ackPods` has added the 1 second coming from `maxIdleBatching` to the total time it takes to schedule.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
