### PR TITLE
chore: Update issue stale-out to use triage flow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,29 +3,48 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * *'
-permissions:
-  contents: read
 jobs:
   StaleBot:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      discussions: write
-      pull-requests: write
+      issues: write # actions/stale@v8.0.0
+      pull-requests: write # actions/stale@v8.0.0
     if: github.repository == 'kubernetes-sigs/karpenter'
     name: Stale issue bot
     steps:
+      # PR stale-out
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue has been inactive for 14 days. StaleBot will close this stale issue after 14 more days of inactivity.'
-          exempt-issue-labels: 'kind/cleanup,kind/testing,kind/documentation,kind/regression,kind/flake,kind/bug,kind/deprecation,kind/feature,kind/failing-test,kind/api-change,kind/automation'
-          stale-issue-label: 'lifecycle/stale'
-          close-issue-label: 'lifecycle/closed'
+          only-issue-labels: 'ignore' # Ignore this step for Issues
           stale-pr-message: 'This PR has been inactive for 14 days. StaleBot will close this stale PR after 14 more days of inactivity.'
           exempt-pr-labels: 'blocked,needs-review,needs-design'
           stale-pr-label: 'lifecycle/stale'
           close-pr-label: 'lifecycle/closed'
           days-before-stale: 14
           days-before-close: 14
+          operations-per-run: 300
+      # Issue stale-out for "triage/needs-information"
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been inactive for 14 days. StaleBot will close this stale issue after 14 more days of inactivity.'
+          only-issue-labels: 'triage/needs-information'
+          stale-issue-label: 'lifecycle/stale'
+          close-issue-label: 'lifecycle/closed'
+          only-pr-labels: 'ignore' # Ignore this step for PRs
+          days-before-stale: 14
+          days-before-close: 14
+          operations-per-run: 300
+      # Issue stale-out for "triage/solved"
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been inactive for 7 days and is marked as "triage/solved". StaleBot will close this stale issue after 7 more days of inactivity.'
+          only-issue-labels: 'triage/solved'
+          stale-issue-label: 'lifecycle/stale'
+          close-issue-label: 'lifecycle/closed'
+          only-pr-labels: 'ignore' # Ignore this step for PRs
+          days-before-stale: 7
+          days-before-close: 7
           operations-per-run: 300


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the issue stale-bot to change our triage flow so that we have the following flow for removing issues quicker with the bot:
1. Issues that are marked as `triage/needs-information` but are not updated within 14d are automatically staled. These are then automatically closed within 14d.
2. Issues that are marked as `triage/solved` but are not updated within 7d are automatically staled. These are then automatically closed within 7d.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
