### PR TITLE
feat: drain and volume detachment status conditions

### DIFF
--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -28,6 +28,8 @@ const (
 	ConditionTypeInitialized          = "Initialized"
 	ConditionTypeConsolidatable       = "Consolidatable"
 	ConditionTypeDrifted              = "Drifted"
+	ConditionTypeDrained              = "Drained"
+	ConditionTypeVolumesDetached      = "VolumesDetached"
 	ConditionTypeInstanceTerminating  = "InstanceTerminating"
 	ConditionTypeConsistentStateFound = "ConsistentStateFound"
 	ConditionTypeDisruptionReason     = "DisruptionReason"

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -160,6 +160,7 @@ func (c *Controller) finalize(ctx context.Context, node *corev1.Node) (reconcile
 	}
 	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsTrue() {
 		stored := nodeClaim.DeepCopy()
+		// No need to check for modification since we've already verifyied it wasn't set to true
 		_ = nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeDrained)
 		if err := c.kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
 			if errors.IsConflict(err) {

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -549,7 +549,7 @@ var _ = Describe("Termination", func() {
 			ExpectSingletonReconciled(ctx, queue)
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsFalse()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsUnknown()).To(BeTrue())
 			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).Reason).To(Equal("Draining"))
 
 			// Expect the pods to be evicted
@@ -560,7 +560,7 @@ var _ = Describe("Termination", func() {
 			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainValidation
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsFalse()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsUnknown()).To(BeTrue())
 			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).Reason).To(Equal("Draining"))
 
 			ExpectDeleted(ctx, env.Client, pods[1])
@@ -795,7 +795,7 @@ var _ = Describe("Termination", func() {
 				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachmentInitiation
 				ExpectExists(ctx, env.Client, node)
 				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsFalse()).To(BeTrue())
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsUnknown()).To(BeTrue())
 				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).Reason).To(Equal("AwaitingVolumeDetachment"))
 
 				ExpectDeleted(ctx, env.Client, va)
@@ -837,7 +837,7 @@ var _ = Describe("Termination", func() {
 				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachment
 				ExpectExists(ctx, env.Client, node)
 				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsFalse()).To(BeTrue())
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsUnknown()).To(BeTrue())
 				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).Reason).To(Equal("AwaitingVolumeDetachment"))
 
 				ExpectDeleted(ctx, env.Client, vaDrainable)
@@ -865,7 +865,8 @@ var _ = Describe("Termination", func() {
 				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachment
 				ExpectExists(ctx, env.Client, node)
 				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsFalse()).To(BeTrue())
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsUnknown()).To(BeTrue())
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).Reason).To(Equal("AwaitingVolumeDetachment"))
 
 				fakeClock.Step(5 * time.Minute)
 				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachment

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -107,9 +108,10 @@ var _ = Describe("Termination", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim)
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // Drain
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should ignore nodes not managed by this Karpenter instance", func() {
@@ -118,10 +120,7 @@ var _ = Describe("Termination", func() {
 			ExpectApplied(ctx, env.Client, node)
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
 			ExpectExists(ctx, env.Client, node)
 		})
 		It("should delete nodeclaims associated with nodes", func() {
@@ -129,15 +128,16 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 
-			// The first reconciliation should trigger the Delete, and set the terminating status condition
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // Drain
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationInitiation
 			nc := ExpectExists(ctx, env.Client, nodeClaim)
 			Expect(nc.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue()).To(BeTrue())
 			ExpectNodeExists(ctx, env.Client, node.Name)
 
-			// The second reconciliation should call get, see the "instance" is terminated, and remove the node.
+			// The final reconciliation should call get, see the "instance" is terminated, and remove the node.
 			// We should have deleted the NodeClaim from the node termination controller, so removing it's finalizer should result in it being removed.
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
 			ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
 			ExpectNotFound(ctx, env.Client, node, nodeClaim)
 		})
@@ -151,8 +151,9 @@ var _ = Describe("Termination", func() {
 				*node = *ExpectNodeExists(ctx, env.Client, node.Name)
 			}
 
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			for range 2 {
+			// Reconcile four times for each stage: drain, volume detachment, instance termination initiation, and
+			// instance termination verification.
+			for range 4 {
 				var wg sync.WaitGroup
 				// this is enough to trip the race detector
 				for i := range nodes {
@@ -186,7 +187,8 @@ var _ = Describe("Termination", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim, pod, pdb)
 			ExpectManualBinding(ctx, env.Client, pod, node)
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			// We only reconcile once since this label should be applied before draining the node
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			Expect(node.Labels[corev1.LabelNodeExcludeBalancers]).Should(Equal("karpenter"))
 		})
@@ -202,7 +204,7 @@ var _ = Describe("Termination", func() {
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			Expect(queue.Has(node, podSkip)).To(BeFalse())
 			ExpectSingletonReconciled(ctx, queue)
 
@@ -215,9 +217,10 @@ var _ = Describe("Termination", func() {
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should not evict pods that tolerate karpenter disruption taint with exists operator", func() {
@@ -232,7 +235,7 @@ var _ = Describe("Termination", func() {
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			Expect(queue.Has(node, podSkip)).To(BeFalse())
 			ExpectSingletonReconciled(ctx, queue)
 
@@ -247,9 +250,10 @@ var _ = Describe("Termination", func() {
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should evict pods that tolerate the node.kubernetes.io/unschedulable taint", func() {
@@ -263,7 +267,7 @@ var _ = Describe("Termination", func() {
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Expect node to exist and be draining
@@ -275,9 +279,10 @@ var _ = Describe("Termination", func() {
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should delete nodes that have pods without an ownerRef", func() {
@@ -291,7 +296,7 @@ var _ = Describe("Termination", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim, pod)
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Expect pod with no owner ref to be enqueued for eviction
@@ -305,9 +310,10 @@ var _ = Describe("Termination", func() {
 
 			// Reconcile node to evict pod and delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should delete nodes with terminal pods", func() {
@@ -324,9 +330,10 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			// Trigger Termination Controller, which should ignore these pods and delete the node
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // Drain
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should fail to evict pods that violate a PDB", func() {
@@ -351,7 +358,7 @@ var _ = Describe("Termination", func() {
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 
 			// Expect node to exist and be draining
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
@@ -371,9 +378,10 @@ var _ = Describe("Termination", func() {
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should evict pods in order and wait until pods are fully deleted", func() {
@@ -421,7 +429,7 @@ var _ = Describe("Termination", func() {
 				for _, p := range podGroup {
 					ExpectPodExists(ctx, env.Client, p.Name, p.Namespace)
 				}
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
 				ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 				for range podGroup {
 					ExpectSingletonReconciled(ctx, queue)
@@ -442,9 +450,10 @@ var _ = Describe("Termination", func() {
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should evict non-critical pods first", func() {
@@ -457,7 +466,7 @@ var _ = Describe("Termination", func() {
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation (non-critical)
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Expect node to exist and be draining
@@ -469,7 +478,7 @@ var _ = Describe("Termination", func() {
 
 			// Expect the critical pods to be evicted and deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation (critical)
 			ExpectSingletonReconciled(ctx, queue)
 			ExpectSingletonReconciled(ctx, queue)
 
@@ -479,9 +488,10 @@ var _ = Describe("Termination", func() {
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should not evict static pods", func() {
@@ -503,7 +513,7 @@ var _ = Describe("Termination", func() {
 
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectSingletonReconciled(ctx, queue)
 
 			// Expect mirror pod to not be queued for eviction
@@ -515,54 +525,62 @@ var _ = Describe("Termination", func() {
 			// Expect node to exist and be draining
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
-			// Reconcile node to evict pod
-			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-
 			// Delete pod to simulate successful eviction
 			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should not delete nodes until all pods are deleted", func() {
 			pods := test.Pods(2, test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})
 			ExpectApplied(ctx, env.Client, node, nodeClaim, pods[0], pods[1])
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsUnknown()).To(BeTrue())
 
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectSingletonReconciled(ctx, queue)
 			ExpectSingletonReconciled(ctx, queue)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsFalse()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).Reason).To(Equal("Draining"))
 
 			// Expect the pods to be evicted
 			EventuallyExpectTerminating(ctx, env.Client, pods[0], pods[1])
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainValidation
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsFalse()).To(BeTrue())
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).Reason).To(Equal("Draining"))
 
 			ExpectDeleted(ctx, env.Client, pods[1])
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // Drain Validation
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			ExpectDeleted(ctx, env.Client, pods[0])
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsTrue()).To(BeTrue())
 		})
 		It("should delete nodes with no underlying instance even if not fully drained", func() {
 			pods := test.Pods(2, test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})
@@ -574,7 +592,7 @@ var _ = Describe("Termination", func() {
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectSingletonReconciled(ctx, queue)
 			ExpectSingletonReconciled(ctx, queue)
 
@@ -583,7 +601,7 @@ var _ = Describe("Termination", func() {
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainValidation
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// After this, the node still has one pod that is evicting.
@@ -594,9 +612,7 @@ var _ = Describe("Termination", func() {
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should not delete nodes with no underlying instance if the node is still Ready", func() {
@@ -606,7 +622,7 @@ var _ = Describe("Termination", func() {
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectSingletonReconciled(ctx, queue)
 			ExpectSingletonReconciled(ctx, queue)
 
@@ -615,7 +631,7 @@ var _ = Describe("Termination", func() {
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainValidation
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 
 			// After this, the node still has one pod that is evicting.
@@ -627,19 +643,17 @@ var _ = Describe("Termination", func() {
 			// Reconcile to try to delete the node, but don't succeed because the readiness condition
 			// of the node still won't let us delete it
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
 			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
 			ExpectExists(ctx, env.Client, node)
 		})
-		It("should wait for pods to terminate", func() {
+		It("should bypass pods which are stuck terminating past their grace period", func() {
 			pod := test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})
 			fakeClock.SetTime(time.Now()) // make our fake clock match the pod creation time
 			ExpectApplied(ctx, env.Client, node, nodeClaim, pod)
 
 			// Before grace period, node should not delete
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectSingletonReconciled(ctx, queue)
 			ExpectNodeExists(ctx, env.Client, node.Name)
 			EventuallyExpectTerminating(ctx, env.Client, pod)
@@ -648,9 +662,10 @@ var _ = Describe("Termination", func() {
 			// to eliminate test-flakiness we reset the time to current time + 90 seconds instead of just advancing
 			// the clock by 90 seconds.
 			fakeClock.SetTime(time.Now().Add(90 * time.Second))
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should not evict a new pod with the same name using the old pod's eviction queue key", func() {
@@ -666,7 +681,7 @@ var _ = Describe("Termination", func() {
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 
 			// Don't trigger a call into the queue to make sure that we effectively aren't triggering eviction
 			// We'll use this to try to leave pods in the queue
@@ -677,8 +692,11 @@ var _ = Describe("Termination", func() {
 			// Delete the pod directly to act like something else is doing the pod termination
 			ExpectDeleted(ctx, env.Client, pod)
 
-			// Requeue the termination controller to completely delete the node
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // DrainValidation
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationValidation
+			ExpectNotFound(ctx, env.Client, node)
 
 			// Expect that the old pod's key still exists in the queue
 			Expect(queue.Has(node, pod)).To(BeTrue())
@@ -724,10 +742,10 @@ var _ = Describe("Termination", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim, nodePool, pod)
 
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectSingletonReconciled(ctx, queue)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectDeleted(ctx, env.Client, pod)
+			pod = ExpectExists(ctx, env.Client, pod)
+			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 		})
 		It("should only delete pods when their terminationGracePeriodSeconds is less than the the node's remaining terminationGracePeriod", func() {
 			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
@@ -750,16 +768,17 @@ var _ = Describe("Termination", func() {
 
 			// expect pod still exists
 			fakeClock.Step(90 * time.Second)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 			ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectPodExists(ctx, env.Client, pod.Name, pod.Namespace)
+			pod = ExpectExists(ctx, env.Client, pod)
+			Expect(pod.DeletionTimestamp.IsZero()).To(BeTrue())
 
-			// expect pod is now deleted
+			// The pod should be deleted 60 seconds before the node's TGP expires
 			fakeClock.Step(175 * time.Second)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectSingletonReconciled(ctx, queue)
-			ExpectDeleted(ctx, env.Client, pod)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+			pod = ExpectExists(ctx, env.Client, pod)
+			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 		})
 		Context("VolumeAttachments", func() {
 			It("should wait for volume attachments", func() {
@@ -769,15 +788,24 @@ var _ = Describe("Termination", func() {
 				})
 				ExpectApplied(ctx, env.Client, node, nodeClaim, nodePool, va)
 				Expect(env.Client.Delete(ctx, node)).To(Succeed())
+				ExpectExists(ctx, env.Client, nodeClaim)
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsUnknown()).To(BeTrue())
 
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // Drain
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachmentInitiation
 				ExpectExists(ctx, env.Client, node)
+				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsFalse()).To(BeTrue())
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).Reason).To(Equal("AwaitingVolumeDetachment"))
 
 				ExpectDeleted(ctx, env.Client, va)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachmentFinalization
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+				ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationFinalization
 				ExpectNotFound(ctx, env.Client, node)
+
+				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsTrue()).To(BeTrue())
 			})
 			It("should only wait for volume attachments associated with drainable pods", func() {
 				vaDrainable := test.VolumeAttachment(test.VolumeAttachmentOptions{
@@ -805,13 +833,21 @@ var _ = Describe("Termination", func() {
 				ExpectManualBinding(ctx, env.Client, pod, node)
 				Expect(env.Client.Delete(ctx, node)).To(Succeed())
 
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // Drain
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachment
 				ExpectExists(ctx, env.Client, node)
+				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsFalse()).To(BeTrue())
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).Reason).To(Equal("AwaitingVolumeDetachment"))
 
 				ExpectDeleted(ctx, env.Client, vaDrainable)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachment
+				ExpectExists(ctx, env.Client, node)
+				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsTrue()).To(BeTrue())
+
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitiation
+				ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationFinalization
 				ExpectNotFound(ctx, env.Client, node)
 			})
 			It("should wait for volume attachments until the nodeclaim's termination grace period expires", func() {
@@ -825,13 +861,21 @@ var _ = Describe("Termination", func() {
 				ExpectApplied(ctx, env.Client, node, nodeClaim, nodePool, va)
 				Expect(env.Client.Delete(ctx, node)).To(Succeed())
 
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // Drain
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachment
 				ExpectExists(ctx, env.Client, node)
+				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsFalse()).To(BeTrue())
 
 				fakeClock.Step(5 * time.Minute)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-				ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // VolumeDetachment
+				ExpectExists(ctx, env.Client, node)
+				nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).IsFalse()).To(BeTrue())
+				Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeVolumesDetached).Reason).To(Equal("TerminationGracePeriodElapsed"))
+
+				ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitation
+				ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationFinalization
 				ExpectNotFound(ctx, env.Client, node)
 			})
 		})
@@ -842,8 +886,10 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // Drain
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationFinalization
 
 			m, ok := FindMetricWithLabelValues("karpenter_nodes_termination_duration_seconds", map[string]string{"nodepool": node.Labels[v1.NodePoolLabelKey]})
 			Expect(ok).To(BeTrue())
@@ -853,10 +899,11 @@ var _ = Describe("Termination", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim)
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // Drain
 			ExpectMetricCounterValue(termination.NodesDrainedTotal, 1, map[string]string{"nodepool": node.Labels[v1.NodePoolLabelKey]})
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationFinalization
 
 			m, ok := FindMetricWithLabelValues("karpenter_nodes_terminated_total", map[string]string{"nodepool": node.Labels[v1.NodePoolLabelKey]})
 			Expect(ok).To(BeTrue())
@@ -866,9 +913,10 @@ var _ = Describe("Termination", func() {
 			ExpectApplied(ctx, env.Client, node, nodeClaim)
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			// Reconcile twice, once to set the NodeClaim to terminating, another to check the instance termination status (and delete the node).
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // Drain
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // VolumeDetachment
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))    // InstanceTerminationInitation
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // InstanceTerminationFinalization
 
 			m, ok := FindMetricWithLabelValues("karpenter_nodes_lifetime_duration_seconds", map[string]string{"nodepool": node.Labels[v1.NodePoolLabelKey]})
 			Expect(ok).To(BeTrue())
@@ -882,7 +930,7 @@ var _ = Describe("Termination", func() {
 				// Don't let any pod evict
 				MinAvailable: &minAvailable,
 			})
-			ExpectApplied(ctx, env.Client, pdb, node)
+			ExpectApplied(ctx, env.Client, pdb, node, nodeClaim)
 			pods := test.Pods(5, test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{
 				OwnerReferences: defaultOwnerRefs,
 				Labels:          labelSelector,
@@ -892,7 +940,7 @@ var _ = Describe("Termination", func() {
 			wqDepthBefore, _ := FindMetricWithLabelValues("workqueue_adds_total", map[string]string{"name": "eviction.workqueue"})
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			ExpectObjectReconciled(ctx, env.Client, terminationController, node)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // Drain
 			wqDepthAfter, ok := FindMetricWithLabelValues("workqueue_adds_total", map[string]string{"name": "eviction.workqueue"})
 			Expect(ok).To(BeTrue())
 			Expect(lo.FromPtr(wqDepthAfter.GetCounter().Value) - lo.FromPtr(wqDepthBefore.GetCounter().Value)).To(BeNumerically("==", 5))
@@ -907,4 +955,14 @@ func ExpectNodeWithNodeClaimDraining(c client.Client, nodeName string) *corev1.N
 	Expect(lo.Contains(node.Finalizers, v1.TerminationFinalizer)).To(BeTrue())
 	Expect(node.DeletionTimestamp).ToNot(BeNil())
 	return node
+}
+
+func ExpectNotRequeued(result reconcile.Result) {
+	GinkgoHelper()
+	Expect(result.Requeue == false && result.RequeueAfter == time.Duration(0)).To(BeTrue())
+}
+
+func ExpectRequeued(result reconcile.Result) {
+	GinkgoHelper()
+	Expect(result.Requeue || result.RequeueAfter != time.Duration(0)).To(BeTrue())
 }

--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -108,12 +108,12 @@ func DuplicateNodeClaimsFound(node *corev1.Node, nodeClaims ...*v1.NodeClaim) ev
 	}
 }
 
-func NodeClaimNotFound(node *corev1.Node, nodeClaims ...*v1.NodeClaim) events.Event {
+func NodeClaimNotFound(node *corev1.Node) events.Event {
 	return events.Event{
 		InvolvedObject: node,
 		Type:           corev1.EventTypeWarning,
 		Reason:         events.TerminationFailed,
-		Message:        "Failed to terminate node, nodeclaims not found",
+		Message:        "Failed to terminate node, nodeclaim not found",
 		DedupeValues:   []string{node.Name},
 	}
 }

--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -66,7 +66,7 @@ func NodeAwaitingVolumeDetachmentEvent(node *corev1.Node, volumeAttachments ...*
 		Type:           corev1.EventTypeNormal,
 		Reason:         "AwaitingVolumeDetachment",
 		Message: fmt.Sprintf(
-			"Awaiting deletion of bound VolumeAttachments (%s)",
+			"Awaiting deletion of bound volumeattachments (%s)",
 			pretty.Slice(lo.Map(volumeAttachments, func(va *storagev1.VolumeAttachment, _ int) string {
 				return va.Name
 			}), 5),
@@ -92,5 +92,28 @@ func NodeClaimTerminationGracePeriodExpiring(nodeClaim *v1.NodeClaim, terminatio
 		Reason:         events.TerminationGracePeriodExpiring,
 		Message:        fmt.Sprintf("All pods will be deleted by %s", terminationTime),
 		DedupeValues:   []string{nodeClaim.Name},
+	}
+}
+
+func DuplicateNodeClaimsFound(node *corev1.Node, nodeClaims ...*v1.NodeClaim) events.Event {
+	return events.Event{
+		InvolvedObject: node,
+		Type:           corev1.EventTypeWarning,
+		Reason:         events.TerminationFailed,
+		Message: fmt.Sprintf(
+			"Failed to terminate node, bound to duplicate nodeclaims (%s)",
+			pretty.Slice(lo.Map(nodeClaims, func(nc *v1.NodeClaim, _ int) string { return nc.Name }), 5),
+		),
+		DedupeValues: []string{node.Name},
+	}
+}
+
+func NodeClaimNotFound(node *corev1.Node, nodeClaims ...*v1.NodeClaim) events.Event {
+	return events.Event{
+		InvolvedObject: node,
+		Type:           corev1.EventTypeWarning,
+		Reason:         events.TerminationFailed,
+		Message:        "Failed to terminate node, nodeclaims not found",
+		DedupeValues:   []string{node.Name},
 	}
 }

--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -94,26 +94,3 @@ func NodeClaimTerminationGracePeriodExpiring(nodeClaim *v1.NodeClaim, terminatio
 		DedupeValues:   []string{nodeClaim.Name},
 	}
 }
-
-func DuplicateNodeClaimsFound(node *corev1.Node, nodeClaims ...*v1.NodeClaim) events.Event {
-	return events.Event{
-		InvolvedObject: node,
-		Type:           corev1.EventTypeWarning,
-		Reason:         events.TerminationFailed,
-		Message: fmt.Sprintf(
-			"Failed to terminate node, bound to duplicate nodeclaims (%s)",
-			pretty.Slice(lo.Map(nodeClaims, func(nc *v1.NodeClaim, _ int) string { return nc.Name }), 5),
-		),
-		DedupeValues: []string{node.Name},
-	}
-}
-
-func NodeClaimNotFound(node *corev1.Node) events.Event {
-	return events.Event{
-		InvolvedObject: node,
-		Type:           corev1.EventTypeWarning,
-		Reason:         events.TerminationFailed,
-		Message:        "Failed to terminate node, nodeclaim not found",
-		DedupeValues:   []string{node.Name},
-	}
-}

--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -57,6 +57,16 @@ func NodeFailedToDrain(node *corev1.Node, err error) events.Event {
 	}
 }
 
+func NodeAwaitingVolumeDetachmentEvent(node *corev1.Node) events.Event {
+	return events.Event{
+		InvolvedObject: node,
+		Type:           corev1.EventTypeNormal,
+		Reason:         "AwaitingVolumeDetachment",
+		Message:        "Awaiting deletion VolumeAttachments bound to node",
+		DedupeValues:   []string{node.Name},
+	}
+}
+
 func NodeTerminationGracePeriodExpiring(node *corev1.Node, terminationTime string) events.Event {
 	return events.Event{
 		InvolvedObject: node,

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -62,6 +62,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	fakeClock = clock.NewFakeClock(time.Now())
 	env = test.NewEnvironment(
 		test.WithCRDs(apis.CRDs...),
 		test.WithCRDs(v1alpha1.CRDs...),

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -141,7 +141,7 @@ func (t *Terminator) DeleteExpiringPods(ctx context.Context, pods []*corev1.Pod,
 	for _, pod := range pods {
 		// check if the node has an expiration time and the pod needs to be deleted
 		deleteTime := t.podDeleteTimeWithGracePeriod(nodeGracePeriodTerminationTime, pod)
-		if deleteTime != nil && time.Now().After(*deleteTime) {
+		if deleteTime != nil && t.clock.Now().After(*deleteTime) {
 			// delete pod proactively to give as much of its terminationGracePeriodSeconds as possible for deletion
 			// ensure that we clamp the maximum pod terminationGracePeriodSeconds to the node's remaining expiration time in the delete command
 			gracePeriodSeconds := lo.ToPtr(int64(time.Until(*nodeGracePeriodTerminationTime).Seconds()))

--- a/pkg/events/reason.go
+++ b/pkg/events/reason.go
@@ -38,6 +38,7 @@ const (
 	Evicted                        = "Evicted"
 	FailedDraining                 = "FailedDraining"
 	TerminationGracePeriodExpiring = "TerminationGracePeriodExpiring"
+	TerminationFailed              = "FailedTermination"
 
 	// nodeclaim/consistency
 	FailedConsistencyCheck = "FailedConsistencyCheck"

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -72,7 +72,6 @@ func IgnoreNodeClaimNotFoundError(err error) error {
 // DuplicateNodeClaimError is an error returned when multiple v1.NodeClaims are found matching the passed providerID
 type DuplicateNodeClaimError struct {
 	error
-	nodeClaims []*v1.NodeClaim
 }
 
 func NewDuplicateNodeClaimError(providerID string, nodeClaims ...*v1.NodeClaim) DuplicateNodeClaimError {
@@ -83,10 +82,6 @@ func NewDuplicateNodeClaimError(providerID string, nodeClaims ...*v1.NodeClaim) 
 			"NodeClaims", lo.Map(nodeClaims, func(nc *v1.NodeClaim, _ int) klog.ObjectRef { return klog.KObj(nc) }),
 		),
 	}
-}
-
-func (e DuplicateNodeClaimError) NodeClaims() []*v1.NodeClaim {
-	return e.nodeClaims
 }
 
 func IsDuplicateNodeClaimError(err error) bool {

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -65,6 +65,7 @@ func IgnoreNodeClaimNotFoundError(err error) error {
 // DuplicateNodeClaimError is an error returned when multiple v1.NodeClaims are found matching the passed providerID
 type DuplicateNodeClaimError struct {
 	ProviderID string
+	NodeClaims []string
 }
 
 func (e *DuplicateNodeClaimError) Error() string {
@@ -120,7 +121,12 @@ func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (
 		return nil, err
 	}
 	if len(nodeClaims) > 1 {
-		return nil, &DuplicateNodeClaimError{ProviderID: node.Spec.ProviderID}
+		return nil, &DuplicateNodeClaimError{
+			ProviderID: node.Spec.ProviderID,
+			NodeClaims: lo.Map(nodeClaims, func(nc *v1.NodeClaim, _ int) string {
+				return nc.Name
+			}),
+		}
 	}
 	if len(nodeClaims) == 0 {
 		return nil, &NodeClaimNotFoundError{ProviderID: node.Spec.ProviderID}

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -64,8 +64,8 @@ func IgnoreNodeClaimNotFoundError(err error) error {
 
 // DuplicateNodeClaimError is an error returned when multiple v1.NodeClaims are found matching the passed providerID
 type DuplicateNodeClaimError struct {
-	ProviderID string
-	NodeClaims []string
+	ProviderID     string
+	NodeClaimNames []string
 }
 
 func (e *DuplicateNodeClaimError) Error() string {
@@ -123,7 +123,7 @@ func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (
 	if len(nodeClaims) > 1 {
 		return nil, &DuplicateNodeClaimError{
 			ProviderID: node.Spec.ProviderID,
-			NodeClaims: lo.Map(nodeClaims, func(nc *v1.NodeClaim, _ int) string {
+			NodeClaimNames: lo.Map(nodeClaims, func(nc *v1.NodeClaim, _ int) string {
 				return nc.Name
 			}),
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds status conditions for node drain and volume detachment to improve observability for the individual termination stages. This is a scoped down version of #1837, which takes these changes along with splitting each termination stage into a separate controller. I will continue to work on that refactor, but I'm decoupling to work on higher priority work.

**Status Conditions:**
|Condition|Unknown|False|True|
|-|-|-|-|
|`Drained`|Karpenter hasn't attempted to drain the Node yet **or** the node is currently draining (marked with reason)|N/A|Karpenter has successfully drained the node and will proceed with the termination flow.|
|`VolumesDetached`|Karpenter hasn't checked for volume attachments yet or there are volume attachments which are currently blocking termination. This won't transition out of unknown until `Drained` transitions to true.|There are blocking volume attachments, but the nodeclaim's TerminationGracePeriod has elapsed. This state is **only** possible if TGP is configured.|All blocking volume attachment objects have been deleted.|

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
