### PR TITLE
fix: nodeclass label validation for kwok CRDs

### DIFF
--- a/hack/kwok/requirements.sh
+++ b/hack/kwok/requirements.sh
@@ -4,8 +4,8 @@
 ## checking for restricted labels while filtering out well-known labels
 # NodeClaim Validation:
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations += [
-    {"message": "label domain \"karpenter.kwok.sh\" is restricted", "rule": "self in [\"karpenter.kwok.sh/instance-cpu\", \"karpenter.kwok.sh/instance-memory\", \"karpenter.kwok.sh/instance-family\", \"karpenter.kwok.sh/instance-size\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.kwok.sh\")"}]' -i kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+    {"message": "label domain \"karpenter.kwok.sh\" is restricted", "rule": "self in [\"karpenter.kwok.sh/kwoknodeclass\", \"karpenter.kwok.sh/instance-cpu\", \"karpenter.kwok.sh/instance-memory\", \"karpenter.kwok.sh/instance-family\", \"karpenter.kwok.sh/instance-size\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.kwok.sh\")"}]' -i kwok/charts/crds/karpenter.sh_nodeclaims.yaml
 
 # NodePool Validation:
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations  += [
-    {"message": "label domain \"karpenter.kwok.sh\" is restricted", "rule": "self in [\"karpenter.kwok.sh/instance-cpu\", \"karpenter.kwok.sh/instance-memory\", \"karpenter.kwok.sh/instance-family\", \"karpenter.kwok.sh/instance-size\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.kwok.sh\")"}]' -i kwok/charts/crds/karpenter.sh_nodepools.yaml
+    {"message": "label domain \"karpenter.kwok.sh\" is restricted", "rule": "self in [\"karpenter.kwok.sh/kwoknodeclass\", \"karpenter.kwok.sh/instance-cpu\", \"karpenter.kwok.sh/instance-memory\", \"karpenter.kwok.sh/instance-family\", \"karpenter.kwok.sh/instance-size\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.kwok.sh\")"}]' -i kwok/charts/crds/karpenter.sh_nodepools.yaml

--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -130,7 +130,7 @@ spec:
                           - message: label "kubernetes.io/hostname" is restricted
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.kwok.sh" is restricted
-                            rule: self in ["karpenter.kwok.sh/instance-cpu", "karpenter.kwok.sh/instance-memory", "karpenter.kwok.sh/instance-family", "karpenter.kwok.sh/instance-size"] || !self.find("^([^/]+)").endsWith("karpenter.kwok.sh")
+                            rule: self in ["karpenter.kwok.sh/kwoknodeclass", "karpenter.kwok.sh/instance-cpu", "karpenter.kwok.sh/instance-memory", "karpenter.kwok.sh/instance-family", "karpenter.kwok.sh/instance-size"] || !self.find("^([^/]+)").endsWith("karpenter.kwok.sh")
                       minValues:
                         description: |-
                           This field is ALPHA and can be dropped or replaced at any time

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -278,7 +278,7 @@ spec:
                                   - message: label "kubernetes.io/hostname" is restricted
                                     rule: self != "kubernetes.io/hostname"
                                   - message: label domain "karpenter.kwok.sh" is restricted
-                                    rule: self in ["karpenter.kwok.sh/instance-cpu", "karpenter.kwok.sh/instance-memory", "karpenter.kwok.sh/instance-family", "karpenter.kwok.sh/instance-size"] || !self.find("^([^/]+)").endsWith("karpenter.kwok.sh")
+                                    rule: self in ["karpenter.kwok.sh/kwoknodeclass", "karpenter.kwok.sh/instance-cpu", "karpenter.kwok.sh/instance-memory", "karpenter.kwok.sh/instance-family", "karpenter.kwok.sh/instance-size"] || !self.find("^([^/]+)").endsWith("karpenter.kwok.sh")
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updates the validation logic for the kwok CRDs to allow the `karpenter.kwok.sh/kwoknodeclass` label.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
