### PR TITLE
feat: add event for prefiltered instance types

### DIFF
--- a/pkg/controllers/provisioning/scheduling/events.go
+++ b/pkg/controllers/provisioning/scheduling/events.go
@@ -49,6 +49,17 @@ func NominatePodEvent(pod *corev1.Pod, node *corev1.Node, nodeClaim *v1.NodeClai
 	}
 }
 
+func NoCompatibleInstanceTypes(np *v1.NodePool) events.Event {
+	return events.Event{
+		InvolvedObject: np,
+		Type:           corev1.EventTypeWarning,
+		Reason:         "NoCompatibleInstanceTypes",
+		Message:        fmt.Sprintf("NodePool requirements filtered out all compatible instance types"),
+		DedupeValues:   []string{string(np.UID)},
+		DedupeTimeout:  1 * time.Minute,
+	}
+}
+
 func PodFailedToScheduleEvent(pod *corev1.Pod, err error) events.Event {
 	return events.Event{
 		InvolvedObject: pod,

--- a/pkg/controllers/provisioning/scheduling/events.go
+++ b/pkg/controllers/provisioning/scheduling/events.go
@@ -54,7 +54,7 @@ func NoCompatibleInstanceTypes(np *v1.NodePool) events.Event {
 		InvolvedObject: np,
 		Type:           corev1.EventTypeWarning,
 		Reason:         "NoCompatibleInstanceTypes",
-		Message:        "NodePool requirements filtered out all compatible instance types",
+		Message:        "NodePool requirements filtered out all compatible available instance types",
 		DedupeValues:   []string{string(np.UID)},
 		DedupeTimeout:  1 * time.Minute,
 	}

--- a/pkg/controllers/provisioning/scheduling/events.go
+++ b/pkg/controllers/provisioning/scheduling/events.go
@@ -54,7 +54,7 @@ func NoCompatibleInstanceTypes(np *v1.NodePool) events.Event {
 		InvolvedObject: np,
 		Type:           corev1.EventTypeWarning,
 		Reason:         "NoCompatibleInstanceTypes",
-		Message:        fmt.Sprintf("NodePool requirements filtered out all compatible instance types"),
+		Message:        "NodePool requirements filtered out all compatible instance types",
 		DedupeValues:   []string{string(np.UID)},
 		DedupeTimeout:  1 * time.Minute,
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -64,6 +64,7 @@ func NewScheduler(ctx context.Context, kubeClient client.Client, nodePools []*v1
 		nct := NewNodeClaimTemplate(np)
 		nct.InstanceTypeOptions = filterInstanceTypesByRequirements(instanceTypes[np.Name], nct.Requirements, corev1.ResourceList{}).remaining
 		if len(nct.InstanceTypeOptions) == 0 {
+			recorder.Publish(NoCompatibleInstanceTypes(np))
 			log.FromContext(ctx).WithValues("NodePool", klog.KRef("", np.Name)).Info("skipping, nodepool requirements filtered out all instance types")
 			return nil, false
 		}

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1480,7 +1480,7 @@ var _ = Describe("Consolidated State", func() {
 		fakeClock.Step(time.Minute)
 		Expect(cluster.ConsolidationState()).To(Equal(state))
 
-		fakeClock.Step(time.Minute * 3)
+		fakeClock.Step(time.Minute * 2)
 		Expect(cluster.ConsolidationState()).To(Equal(state))
 
 		fakeClock.Step(time.Minute * 2)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Creates an event any time a nodepool isn't considered because it has no instance types at the time of provisioning that can be used

**How was this change tested?**
make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
