### PR TITLE
Use Expectations from awslabs/operatorpkg and remove duplicate expect…

### DIFF
--- a/pkg/apis/v1/suite_test.go
+++ b/pkg/apis/v1/suite_test.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"testing"
 
+	. "github.com/awslabs/operatorpkg/test/expectations"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	"sigs.k8s.io/karpenter/pkg/test"
-	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 )


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes 1348 <!-- issue number -->

**Description**
- Using expectations from `operatorpkg` so that we can avoid duplication at multiple places.
- Changing only one expectation `ExpectCleanedUp` from `pkg/controllers/disruption/suite_test.go` as part of this PR to align the overall change with reviewers before creating a bigger PR. 


**Issue tracker**
- https://github.com/kubernetes-sigs/karpenter/issues/1348

**How was this change tested?** 
- Ran tests from VS code and it passed
