### PR TITLE
fix: Modify conversion webhook check to check for v1 version existence

### DIFF
--- a/kwok/apis/crds/kwok.karpenter.sh_kwoknodeclasses.yaml
+++ b/kwok/apis/crds/kwok.karpenter.sh_kwoknodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: kwoknodeclasses.kwok.karpenter.sh
 spec:
   group: kwok.karpenter.sh

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -274,7 +274,8 @@ func (o *Operator) Start(ctx context.Context, cp cloudprovider.CloudProvider) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			webhooks.ValidateConversionEnabled(ctx, o.GetClient())
+			// Create a direct kubernetes API client so that we don't hit the read cache on subsequent reads during this check
+			webhooks.ValidateConversionEnabled(ctx, lo.Must(client.New(o.GetConfig(), client.Options{Scheme: o.GetScheme()})))
 		}()
 	}
 	wg.Wait()

--- a/pkg/test/v1alpha1/crds/karpenter.test.sh_testnodeclasses.yaml
+++ b/pkg/test/v1alpha1/crds/karpenter.test.sh_testnodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: testnodeclasses.karpenter.test.sh
 spec:
   group: karpenter.test.sh


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the conversion webhook check that we added to the latest pre-v1.0 patch versions so that we crash when we have an issue calling the v1 conversion endpoint converting from v1beta1, not when we get any error -- this allows the v1 CRD to be deployed after the application is deployed.

This also logs errors if we get any unknown errors when calling this API just in case there are errors that we are getting in this health check that are unexpected and we don't see.

This also ensures that this health check will continually fire throughout the lifetime of the process so that if the CRD is updated and deployed later after the application is deployed or if the NodePools aren't deployed until after the process is started, the check continues to be executed.

We also need to ensure that we don't fail immediately when we restart the container so that we give an unhealthy container a chance to become healthy again -- if a Karpenter container was crahsing with a blocked network path to the conversion webhook and that network path has now opened back up again -- we need to allow for that container to go back to ready -- we can make that happen by ensuring that we don't crash on the first failure but checking that we have consecutive failures.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
