### PR TITLE
chore: move event reasons to the package and as constants

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectSingletonReconciled(ctx, disruptionController)
 			wg.Wait()
 
-			Expect(recorder.Calls("Unconsolidatable")).To(Equal(0))
+			Expect(recorder.Calls(events.Unconsolidatable)).To(Equal(0))
 		})
 		It("should fire an event for ConsolidationDisabled when the NodePool has consolidation set to WhenEmpty", func() {
 			pod := test.Pod()
@@ -123,7 +123,7 @@ var _ = Describe("Consolidation", func() {
 
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 			ExpectSingletonReconciled(ctx, disruptionController)
-			Expect(recorder.Calls("Unconsolidatable")).To(Equal(4))
+			Expect(recorder.Calls(events.Unconsolidatable)).To(Equal(4))
 		})
 		It("should fire an event for ConsolidationDisabled when the NodePool has consolidateAfter set to 'Never'", func() {
 			pod := test.Pod()
@@ -135,7 +135,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectSingletonReconciled(ctx, disruptionController)
 			// We get six calls here because we have Nodes and NodeClaims that fired for this event
 			// and each of the consolidation mechanisms specifies that this event should be fired
-			Expect(recorder.Calls("Unconsolidatable")).To(Equal(6))
+			Expect(recorder.Calls(events.Unconsolidatable)).To(Equal(6))
 		})
 		It("should fire an event when a candidate does not have a resolvable instance type", func() {
 			pod := test.Pod()
@@ -148,7 +148,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 			ExpectSingletonReconciled(ctx, disruptionController)
 			// We get four calls since we only care about this since we don't emit for empty node consolidation
-			Expect(recorder.Calls("Unconsolidatable")).To(Equal(4))
+			Expect(recorder.Calls(events.Unconsolidatable)).To(Equal(4))
 		})
 		It("should fire an event when a candidate does not have the capacity type label", func() {
 			pod := test.Pod()
@@ -161,7 +161,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 			ExpectSingletonReconciled(ctx, disruptionController)
 			// We get four calls since we only care about this since we don't emit for empty node consolidation
-			Expect(recorder.Calls("Unconsolidatable")).To(Equal(4))
+			Expect(recorder.Calls(events.Unconsolidatable)).To(Equal(4))
 		})
 		It("should fire an event when a candidate does not have the zone label", func() {
 			pod := test.Pod()
@@ -174,7 +174,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 			ExpectSingletonReconciled(ctx, disruptionController)
 			// We get four calls since we only care about this since we don't emit for empty node consolidation
-			Expect(recorder.Calls("Unconsolidatable")).To(Equal(4))
+			Expect(recorder.Calls(events.Unconsolidatable)).To(Equal(4))
 		})
 	})
 	Context("Metrics", func() {

--- a/pkg/controllers/disruption/events/events.go
+++ b/pkg/controllers/disruption/events/events.go
@@ -32,7 +32,7 @@ func Launching(nodeClaim *v1.NodeClaim, reason string) events.Event {
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeNormal,
-		Reason:         "DisruptionLaunching",
+		Reason:         events.DisruptionLaunching,
 		Message:        fmt.Sprintf("Launching NodeClaim: %s", cases.Title(language.Und, cases.NoLower).String(reason)),
 		DedupeValues:   []string{string(nodeClaim.UID), reason},
 	}
@@ -42,7 +42,7 @@ func WaitingOnReadiness(nodeClaim *v1.NodeClaim) events.Event {
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeNormal,
-		Reason:         "DisruptionWaitingReadiness",
+		Reason:         events.DisruptionWaitingReadiness,
 		Message:        "Waiting on readiness to continue disruption",
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}
@@ -53,14 +53,14 @@ func Terminating(node *corev1.Node, nodeClaim *v1.NodeClaim, reason string) []ev
 		{
 			InvolvedObject: node,
 			Type:           corev1.EventTypeNormal,
-			Reason:         "DisruptionTerminating",
+			Reason:         events.DisruptionTerminating,
 			Message:        fmt.Sprintf("Disrupting Node: %s", cases.Title(language.Und, cases.NoLower).String(reason)),
 			DedupeValues:   []string{string(node.UID), reason},
 		},
 		{
 			InvolvedObject: nodeClaim,
 			Type:           corev1.EventTypeNormal,
-			Reason:         "DisruptionTerminating",
+			Reason:         events.DisruptionTerminating,
 			Message:        fmt.Sprintf("Disrupting NodeClaim: %s", cases.Title(language.Und, cases.NoLower).String(reason)),
 			DedupeValues:   []string{string(nodeClaim.UID), reason},
 		},
@@ -74,7 +74,7 @@ func Unconsolidatable(node *corev1.Node, nodeClaim *v1.NodeClaim, msg string) []
 		{
 			InvolvedObject: node,
 			Type:           corev1.EventTypeNormal,
-			Reason:         "Unconsolidatable",
+			Reason:         events.Unconsolidatable,
 			Message:        msg,
 			DedupeValues:   []string{string(node.UID)},
 			DedupeTimeout:  time.Minute * 15,
@@ -82,7 +82,7 @@ func Unconsolidatable(node *corev1.Node, nodeClaim *v1.NodeClaim, msg string) []
 		{
 			InvolvedObject: nodeClaim,
 			Type:           corev1.EventTypeNormal,
-			Reason:         "Unconsolidatable",
+			Reason:         events.Unconsolidatable,
 			Message:        msg,
 			DedupeValues:   []string{string(nodeClaim.UID)},
 			DedupeTimeout:  time.Minute * 15,
@@ -97,7 +97,7 @@ func Blocked(node *corev1.Node, nodeClaim *v1.NodeClaim, msg string) (evs []even
 		evs = append(evs, events.Event{
 			InvolvedObject: node,
 			Type:           corev1.EventTypeNormal,
-			Reason:         "DisruptionBlocked",
+			Reason:         events.DisruptionBlocked,
 			Message:        msg,
 			DedupeValues:   []string{string(node.UID)},
 		})
@@ -106,7 +106,7 @@ func Blocked(node *corev1.Node, nodeClaim *v1.NodeClaim, msg string) (evs []even
 		evs = append(evs, events.Event{
 			InvolvedObject: nodeClaim,
 			Type:           corev1.EventTypeNormal,
-			Reason:         "DisruptionBlocked",
+			Reason:         events.DisruptionBlocked,
 			Message:        msg,
 			DedupeValues:   []string{string(nodeClaim.UID)},
 		})
@@ -118,7 +118,7 @@ func NodePoolBlockedForDisruptionReason(nodePool *v1.NodePool, reason v1.Disrupt
 	return events.Event{
 		InvolvedObject: nodePool,
 		Type:           corev1.EventTypeNormal,
-		Reason:         "DisruptionBlocked",
+		Reason:         events.DisruptionBlocked,
 		Message:        fmt.Sprintf("No allowed disruptions for disruption reason %s due to blocking budget", reason),
 		DedupeValues:   []string{string(nodePool.UID), string(reason)},
 		DedupeTimeout:  1 * time.Minute,
@@ -129,7 +129,7 @@ func NodePoolBlocked(nodePool *v1.NodePool) events.Event {
 	return events.Event{
 		InvolvedObject: nodePool,
 		Type:           corev1.EventTypeNormal,
-		Reason:         "DisruptionBlocked",
+		Reason:         events.DisruptionBlocked,
 		Message:        "No allowed disruptions due to blocking budget",
 		DedupeValues:   []string{string(nodePool.UID)},
 		// Set a small timeout as a NodePool's disruption budget can change every minute.

--- a/pkg/controllers/node/health/events.go
+++ b/pkg/controllers/node/health/events.go
@@ -30,7 +30,7 @@ func NodeRepairBlocked(node *corev1.Node, nodeClaim *v1.NodeClaim, nodePool *v1.
 		{
 			InvolvedObject: node,
 			Type:           corev1.EventTypeWarning,
-			Reason:         "NodeRepairBlocked",
+			Reason:         events.NodeRepairBlocked,
 			Message:        reason,
 			DedupeValues:   []string{string(node.UID)},
 			DedupeTimeout:  time.Minute * 15,
@@ -38,7 +38,7 @@ func NodeRepairBlocked(node *corev1.Node, nodeClaim *v1.NodeClaim, nodePool *v1.
 		{
 			InvolvedObject: node,
 			Type:           corev1.EventTypeWarning,
-			Reason:         "NodeRepairBlocked",
+			Reason:         events.NodeRepairBlocked,
 			Message:        reason,
 			DedupeValues:   []string{string(nodeClaim.UID)},
 			DedupeTimeout:  time.Minute * 15,
@@ -46,7 +46,7 @@ func NodeRepairBlocked(node *corev1.Node, nodeClaim *v1.NodeClaim, nodePool *v1.
 		{
 			InvolvedObject: node,
 			Type:           corev1.EventTypeWarning,
-			Reason:         "NodeRepairBlocked",
+			Reason:         events.NodeRepairBlocked,
 			Message:        reason,
 			DedupeValues:   []string{string(nodePool.UID)},
 			DedupeTimeout:  time.Minute * 15,
@@ -59,7 +59,7 @@ func NodeRepairBlockedUnmanagedNodeClaim(node *corev1.Node, nodeClaim *v1.NodeCl
 		{
 			InvolvedObject: node,
 			Type:           corev1.EventTypeWarning,
-			Reason:         "NodeRepairBlocked",
+			Reason:         events.NodeRepairBlocked,
 			Message:        reason,
 			DedupeValues:   []string{string(node.UID)},
 			DedupeTimeout:  time.Minute * 15,
@@ -67,7 +67,7 @@ func NodeRepairBlockedUnmanagedNodeClaim(node *corev1.Node, nodeClaim *v1.NodeCl
 		{
 			InvolvedObject: node,
 			Type:           corev1.EventTypeWarning,
-			Reason:         "NodeRepairBlocked",
+			Reason:         events.NodeRepairBlocked,
 			Message:        reason,
 			DedupeValues:   []string{string(nodeClaim.UID)},
 			DedupeTimeout:  time.Minute * 15,

--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -30,7 +30,7 @@ func EvictPod(pod *corev1.Pod, message string) events.Event {
 	return events.Event{
 		InvolvedObject: pod,
 		Type:           corev1.EventTypeNormal,
-		Reason:         "Evicted",
+		Reason:         events.Evicted,
 		Message:        "Evicted pod: " + message,
 		DedupeValues:   []string{pod.Name},
 	}
@@ -40,7 +40,7 @@ func DisruptPodDelete(pod *corev1.Pod, gracePeriodSeconds *int64, nodeGracePerio
 	return events.Event{
 		InvolvedObject: pod,
 		Type:           corev1.EventTypeNormal,
-		Reason:         "Disrupted",
+		Reason:         events.Disrupted,
 		Message:        fmt.Sprintf("Deleting the pod to accommodate the terminationTime %v of the node. The pod was granted %v seconds of grace-period of its %v terminationGracePeriodSeconds. This bypasses the PDB of the pod and the do-not-disrupt annotation.", *nodeGracePeriodTerminationTime, *gracePeriodSeconds, pod.Spec.TerminationGracePeriodSeconds),
 		DedupeValues:   []string{pod.Name},
 	}
@@ -50,7 +50,7 @@ func NodeFailedToDrain(node *corev1.Node, err error) events.Event {
 	return events.Event{
 		InvolvedObject: node,
 		Type:           corev1.EventTypeWarning,
-		Reason:         "FailedDraining",
+		Reason:         events.FailedDraining,
 		Message:        fmt.Sprintf("Failed to drain node, %s", err),
 		DedupeValues:   []string{node.Name},
 	}
@@ -60,7 +60,7 @@ func NodeTerminationGracePeriodExpiring(node *corev1.Node, terminationTime strin
 	return events.Event{
 		InvolvedObject: node,
 		Type:           corev1.EventTypeWarning,
-		Reason:         "TerminationGracePeriodExpiring",
+		Reason:         events.TerminationGracePeriodExpiring,
 		Message:        fmt.Sprintf("All pods will be deleted by %s", terminationTime),
 		DedupeValues:   []string{node.Name},
 	}
@@ -70,7 +70,7 @@ func NodeClaimTerminationGracePeriodExpiring(nodeClaim *v1.NodeClaim, terminatio
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
-		Reason:         "TerminationGracePeriodExpiring",
+		Reason:         events.TerminationGracePeriodExpiring,
 		Message:        fmt.Sprintf("All pods will be deleted by %s", terminationTime),
 		DedupeValues:   []string{nodeClaim.Name},
 	}

--- a/pkg/controllers/nodeclaim/consistency/events.go
+++ b/pkg/controllers/nodeclaim/consistency/events.go
@@ -27,7 +27,7 @@ func FailedConsistencyCheckEvent(nodeClaim *v1.NodeClaim, message string) events
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
-		Reason:         "FailedConsistencyCheck",
+		Reason:         events.FailedConsistencyCheck,
 		Message:        message,
 		DedupeValues:   []string{string(nodeClaim.UID), message},
 	}

--- a/pkg/controllers/nodeclaim/lifecycle/events.go
+++ b/pkg/controllers/nodeclaim/lifecycle/events.go
@@ -29,7 +29,7 @@ func InsufficientCapacityErrorEvent(nodeClaim *v1.NodeClaim, err error) events.E
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
-		Reason:         "InsufficientCapacityError",
+		Reason:         events.InsufficientCapacityError,
 		Message:        fmt.Sprintf("NodeClaim %s event: %s", nodeClaim.Name, truncateMessage(err.Error())),
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}
@@ -39,7 +39,7 @@ func NodeClassNotReadyEvent(nodeClaim *v1.NodeClaim, err error) events.Event {
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
-		Reason:         "NodeClassNotReady",
+		Reason:         events.NodeClassNotReady,
 		Message:        fmt.Sprintf("NodeClaim %s event: %s", nodeClaim.Name, truncateMessage(err.Error())),
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}

--- a/pkg/controllers/provisioning/scheduling/events.go
+++ b/pkg/controllers/provisioning/scheduling/events.go
@@ -42,7 +42,7 @@ func NominatePodEvent(pod *corev1.Pod, node *corev1.Node, nodeClaim *v1.NodeClai
 	return events.Event{
 		InvolvedObject: pod,
 		Type:           corev1.EventTypeNormal,
-		Reason:         "Nominated",
+		Reason:         events.Nominated,
 		Message:        fmt.Sprintf("Pod should schedule on: %s", strings.Join(info, ", ")),
 		DedupeValues:   []string{string(pod.UID)},
 		RateLimiter:    PodNominationRateLimiter,
@@ -53,7 +53,7 @@ func NoCompatibleInstanceTypes(np *v1.NodePool) events.Event {
 	return events.Event{
 		InvolvedObject: np,
 		Type:           corev1.EventTypeWarning,
-		Reason:         "NoCompatibleInstanceTypes",
+		Reason:         events.NoCompatibleInstanceTypes,
 		Message:        "NodePool requirements filtered out all compatible available instance types",
 		DedupeValues:   []string{string(np.UID)},
 		DedupeTimeout:  1 * time.Minute,
@@ -64,7 +64,7 @@ func PodFailedToScheduleEvent(pod *corev1.Pod, err error) events.Event {
 	return events.Event{
 		InvolvedObject: pod,
 		Type:           corev1.EventTypeWarning,
-		Reason:         "FailedScheduling",
+		Reason:         events.FailedScheduling,
 		Message:        fmt.Sprintf("Failed to schedule pod, %s", err),
 		DedupeValues:   []string{string(pod.UID)},
 		DedupeTimeout:  5 * time.Minute,

--- a/pkg/events/reason.go
+++ b/pkg/events/reason.go
@@ -1,0 +1,48 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+// Reasons of events controllers emit
+const (
+	// disruption
+	DisruptionBlocked          = "DisruptionBlocked"
+	DisruptionLaunching        = "DisruptionLaunching"
+	DisruptionTerminating      = "DisruptionTerminating"
+	DisruptionWaitingReadiness = "DisruptionWaitingReadiness"
+	Unconsolidatable           = "Unconsolidatable"
+
+	// provisioning/scheduling
+	FailedScheduling          = "FailedScheduling"
+	NoCompatibleInstanceTypes = "NoCompatibleInstanceTypes"
+	Nominated                 = "Nominated"
+
+	// node/health
+	NodeRepairBlocked = "NodeRepairBlocked"
+
+	// node/termination/terminator
+	Disrupted                      = "Disrupted"
+	Evicted                        = "Evicted"
+	FailedDraining                 = "FailedDraining"
+	TerminationGracePeriodExpiring = "TerminationGracePeriodExpiring"
+
+	// nodeclaim/consistency
+	FailedConsistencyCheck = "FailedConsistencyCheck"
+
+	// nodeclaim/lifecycle
+	InsufficientCapacityError = "InsufficientCapacityError"
+	NodeClassNotReady         = "NodeClassNotReady"
+)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1897  <!-- issue number -->

**Description**

1. converts string literals as reasons of event to constant
2. pull up them to the package `events`
- i think `events` is enough over `apis` or under that 

**How was this change tested?**

- test or e2etest not yet, cannot run tests and more details would be written in a thread.
- when finding double quoted strings, they are only exist in the `events` package.
  -  except, `"InsufficientCapacityError"` which also is in `cloudprovider/metrics` package.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
