### PR TITLE
BREAKING: Allow custom condition reasons to be returned from Create

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -388,12 +388,14 @@ func IsNodeClassNotReadyError(err error) bool {
 // CreateError is an error type returned by CloudProviders when instance creation fails
 type CreateError struct {
 	error
+	ConditionReason  string
 	ConditionMessage string
 }
 
-func NewCreateError(err error, message string) *CreateError {
+func NewCreateError(err error, reason, message string) *CreateError {
 	return &CreateError{
 		error:            err,
+		ConditionReason:  reason,
 		ConditionMessage: message,
 	}
 }

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -103,7 +103,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 		default:
 			var createError *cloudprovider.CreateError
 			if errors.As(err, &createError) {
-				nodeClaim.StatusConditions().SetUnknownWithReason(v1.ConditionTypeLaunched, "LaunchFailed", createError.ConditionMessage)
+				nodeClaim.StatusConditions().SetUnknownWithReason(v1.ConditionTypeLaunched, createError.ConditionReason, createError.ConditionMessage)
 			} else {
 				nodeClaim.StatusConditions().SetUnknownWithReason(v1.ConditionTypeLaunched, "LaunchFailed", truncateMessage(err.Error()))
 			}

--- a/pkg/controllers/nodeclaim/lifecycle/launch_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch_test.go
@@ -103,14 +103,16 @@ var _ = Describe("Launch", func() {
 		ExpectNotFound(ctx, env.Client, nodeClaim)
 	})
 	It("should set nodeClaim status condition from the condition message received if error returned is CreateError", func() {
+		conditionReason := "CustomReason"
 		conditionMessage := "instance creation failed"
-		cloudProvider.NextCreateErr = cloudprovider.NewCreateError(fmt.Errorf("error launching instance"), conditionMessage)
+		cloudProvider.NextCreateErr = cloudprovider.NewCreateError(fmt.Errorf("error launching instance"), conditionReason, conditionMessage)
 		nodeClaim := test.NodeClaim()
 		ExpectApplied(ctx, env.Client, nodeClaim)
 		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 		condition := ExpectStatusConditionExists(nodeClaim, v1.ConditionTypeLaunched)
 		Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
+		Expect(condition.Reason).To(Equal(conditionReason))
 		Expect(condition.Message).To(Equal(conditionMessage))
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change allows CloudProviders to not just affect the condition message when the Create returns an error but also to affect the condition reason. 

This change is a breaking change since any CloudProvider that uses the CreateError type now needs to specify a "reason" value with the CreateError or will get errors when trying to assign the reason to the Launched status condition.

### Motivation

We were already supporting adding a custom error message but we'd like to start allowing classification of "error codes" back from CloudProviders but specifying well-structured custom reasons. We may be able to build on this for metrics and when considering things like #1910 which may propagate similar information down into the degraded condition based on the failure code that NodeClaims are indicating (and whether they succeeded/failed to launch or not -- imagine differentiating a user-induced error vs. something that failed on the service-side)

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
