### PR TITLE
chore: Fix make apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build: ## Build the Karpenter KWOK controller images using ko build
 	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) KO_DOCKER_REPO="$(KWOK_REPO)" ko build -B sigs.k8s.io/karpenter/kwok))
 	$(eval IMG_REPOSITORY=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 1))
 	$(eval IMG_TAG=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 2 -s))
-	$(eval IMG_DIGEST=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 2))
+	$(eval IMG_DIGEST=$(shell echo $(CONTROLLER_IMG) | grep -q "@" && echo $(CONTROLLER_IMG) | cut -d "@" -f 2 || echo ""))
 	
 apply-with-kind: verify build-with-kind ## Deploy the kwok controller from the current state of your git repository into your ~/.kube/config cluster
 	kubectl apply -f kwok/charts/crds


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

**Description**

Can not get the right image digest when applying this guide: https://github.com/kubernetes-sigs/karpenter/tree/main/kwok

```
(base) ➜  karpenter git:(main) ✗ export KIND_CLUSTER_NAME=kind
(base) ➜  karpenter git:(main) ✗ KO_DOCKER_REPO="kind.local"
(base) ➜  karpenter git:(main) ✗ make apply
...
helm upgrade --install karpenter kwok/charts --namespace kube-system --skip-crds \
		--set logLevel=debug --set controller.resources.requests.cpu=1 --set controller.resources.requests.memory=1Gi --set controller.resources.limits.cpu=1 --set controller.resources.limits.memory=1Gi \
		--set controller.image.repository=kind.local/kwok \
		--set controller.image.tag=e01ee363f7007f73a4966469b6a5e7dfac32350c97bfab0085c2af648c529153 \
		--set controller.image.digest=kind.local/kwok:e01ee363f7007f73a4966469b6a5e7dfac32350c97bfab0085c2af648c529153 \
...
(base) ➜  karpenter git:(main) ✗ kubectl get  po -n kube-system karpenter-6496969887-hw2hj
NAME                         READY   STATUS             RESTARTS   AGE
karpenter-6496969887-hw2hj   0/1     InvalidImageName   0          73s
(base) ➜  karpenter git:(main) ✗ kubectl get po -n kube-system karpenter-6496969887-hw2hj -oyaml | grep image
    image: kind.local/kwok:e01ee363f7007f73a4966469b6a5e7dfac32350c97bfab0085c2af648c529153@kind.local/kwok:e01ee363f7007f73a4966469b6a5e7dfac32350c97bfab0085c2af648c529153
...
```

/hold
for https://github.com/ko-build/ko/issues/1475

**How was this change tested?**
```
(base) ➜  karpenter git:(main) ✗ export KIND_CLUSTER_NAME=kind
(base) ➜  karpenter git:(main) ✗ KO_DOCKER_REPO="kind.local"
(base) ➜  karpenter git:(main) ✗ make apply
...
helm upgrade --install karpenter kwok/charts --namespace kube-system --skip-crds \
		--set logLevel=debug --set controller.resources.requests.cpu=1 --set controller.resources.requests.memory=1Gi --set controller.resources.limits.cpu=1 --set controller.resources.limits.memory=1Gi \
		--set controller.image.repository=kind.local/kwok \
		--set controller.image.tag=e01ee363f7007f73a4966469b6a5e7dfac32350c97bfab0085c2af648c529153 \
		--set controller.image.digest= \
...
(base) ➜  karpenter git:(main) ✗ kubectl get po -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS       AGE
kube-system          coredns-668d6bf9bc-6mws9                     1/1     Running   3 (4d4h ago)   10d
kube-system          coredns-668d6bf9bc-9bhxr                     1/1     Running   3 (4d4h ago)   10d
kube-system          etcd-kind-control-plane                      1/1     Running   0              4d4h
kube-system          karpenter-74995c6d54-lgbd4                   1/1     Running   0              16s
kube-system          kindnet-ggv2b                                1/1     Running   3 (4d4h ago)   10d
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0              4d4h
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   3 (4d4h ago)   10d
kube-system          kube-proxy-bpcn7                             1/1     Running   3 (4d4h ago)   10d
kube-system          kube-scheduler-kind-control-plane            1/1     Running   3 (4d4h ago)   10d
kube-system          kwok-controller-a-788697bc98-2p2bm           1/1     Running   6 (4d4h ago)   10d
local-path-storage   local-path-provisioner-58cc7856b6-d4k9k      1/1     Running   6 (4d4h ago)   10d
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
