### PR TITLE
chore: Use non-deprecated TypedRateLimitingQueue

### DIFF
--- a/pkg/controllers/disruption/orchestration/suite_test.go
+++ b/pkg/controllers/disruption/orchestration/suite_test.go
@@ -355,6 +355,6 @@ func NewTestingQueue(kubeClient client.Client, recorder events.Recorder, cluster
 	q := orchestration.NewQueue(kubeClient, recorder, cluster, clock, provisioner)
 	// nolint:staticcheck
 	// We need to implement a deprecated interface since Command currently doesn't implement "comparable"
-	q.RateLimitingInterface = test.NewRateLimitingInterface(workqueue.QueueConfig{Name: "disruption.workqueue"})
+	q.TypedRateLimitingInterface = test.NewTypedRateLimitingInterface[*orchestration.Command](workqueue.TypedQueueConfig[*orchestration.Command]{Name: "disruption.workqueue"})
 	return q
 }

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -2151,8 +2151,6 @@ func NewTestingQueue(kubeClient client.Client, recorder events.Recorder, cluster
 	provisioner *provisioning.Provisioner) *orchestration.Queue {
 
 	q := orchestration.NewQueue(kubeClient, recorder, cluster, clock, provisioner)
-	// nolint:staticcheck
-	// We need to implement a deprecated interface since Command currently doesn't implement "comparable"
-	q.RateLimitingInterface = test.NewRateLimitingInterface(workqueue.QueueConfig{Name: "disruption.workqueue"})
+	q.TypedRateLimitingInterface = test.NewTypedRateLimitingInterface[*orchestration.Command](workqueue.TypedQueueConfig[*orchestration.Command]{Name: "disruption.workqueue"})
 	return q
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Use the `TypedRateLimitingQueue` and other Typed structs/interfaces as opposed to their non-typed deprecated forms

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
