### PR TITLE
chore: Update the README with update community meetings times

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,23 @@ Karpenter is a multi-cloud project with implementations by the following cloud p
 If you have any questions or want to get the latest project news, you can connect with us in the following ways:
 - __Using and Deploying Karpenter?__ Reach out in the [#karpenter](https://kubernetes.slack.com/archives/C02SFFZSA2K) channel in the [Kubernetes slack](https://slack.k8s.io/) to ask questions about configuring or troubleshooting Karpenter.
 - __Contributing to or Developing with Karpenter?__ Join the [#karpenter-dev](https://kubernetes.slack.com/archives/C04JW2J5J5P) channel in the [Kubernetes slack](https://slack.k8s.io/) to ask in-depth questions about contribution or to get involved in design discussions.
-- Join our alternating working group meetings where we share the latest project updates, answer questions, and triage issues:
-  - Bi-weekly meetings alternating between Mondays @ 9:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=Seattle)) and Thursdays @ 14:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=Seattle)) on [Zoom](https://zoom.us/j/95618088729) - the password is 77777.
-  - Invites are managed through our [Calendar](https://calendar.google.com/calendar/u/0?cid=N3FmZGVvZjVoZWJkZjZpMnJrMmplZzVqYmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
-  - Add future questions or read past discussions in our [Working Group Log](https://docs.google.com/document/d/18BT0AIMugpNpiSPJNlcAL2rv69yAE6Z06gUVj7v_clg/edit?usp=sharing)
+
+### Working Group Meetings
+Bi-weekly meetings alternating between Thursdays @ 9:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=Seattle)) and Thursdays @ 15:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=Seattle))
+
+### Issue Triage Meetings
+Weekly meetings alternating between repositories and time slots. Please check the calendar invite for specific dates:
+
+**kubernetes-sigs/karpenter**:
+- Alternating Mondays @ 9:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=Seattle)) and @ 15:00 PT [convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=Seattle) bi-weekly
+
+**aws/karpenter-provider-aws**:
+- Alternating Mondays @ 9:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=Seattle)) and @ 15:00 PT [convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=Seattle) bi-weekly
+
+#### Meeting Resources
+- **Zoom Link**: [Join Meeting](https://zoom.us/j/95618088729) (password: 77777)
+- **Calendar**: Subscribe to our [Google Calendar](https://calendar.google.com/calendar/u/0?cid=N3FmZGVvZjVoZWJkZjZpMnJrMmplZzVqYmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
+- **Meeting Notes**: View our [Working Group Log](https://docs.google.com/document/d/18BT0AIMugpNpiSPJNlcAL2rv69yAE6Z06gUVj7v_clg/edit?usp=sharing)
 
 Pull Requests and feedback on issues are very welcome!
 See the [issue tracker](https://github.com/aws/karpenter-core/issues) if you're unsure where to start, especially the [Good first issue](https://github.com/aws/karpenter-core/issues?q=is%3Aopen+is%3Aissue+label%3Agood-first-issue) and [Help wanted](https://github.com/aws/karpenter-core/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted) tags, and


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updates the README to include both Working Group and Issue Triage meeting information. This change:
- Adds the new Issue Triage meeting schedule
- Reorganizes the community meeting section for better clarity
- Maintains existing Working Group meeting information
- Consolidates meeting resources and links

**How was this change tested?**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
