### PR TITLE
perf: Remove deep-copying the allocatable resource list

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -111,7 +111,7 @@ func (i *InstanceType) precompute() {
 
 func (i *InstanceType) Allocatable() corev1.ResourceList {
 	i.once.Do(i.precompute)
-	return i.allocatable.DeepCopy()
+	return i.allocatable
 }
 
 func (its InstanceTypes) OrderByPrice(reqs scheduling.Requirements) InstanceTypes {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

DeepCopying this field wasn't necessary and was resulting in the garbage collector having to do more work than necessary to clean-up the copying

### Before PR

```
=== RUN   TestSchedulingProfile
scheduled 40151 against 8031 nodes in total in 53.357417524s 752.4914409873793 pods/sec
400 instances 1 pods      1 nodes     128.608µs per scheduling      128.608µs per pod
400 instances 50 pods     10 nodes    43.255586ms per scheduling    865.111µs per pod
400 instances 100 pods    20 nodes    88.47598ms per scheduling     884.759µs per pod
400 instances 500 pods    100 nodes   347.842527ms per scheduling   695.685µs per pod
400 instances 1000 pods   200 nodes   701.784041ms per scheduling   701.784µs per pod
400 instances 1500 pods   300 nodes   1.212005917s per scheduling   808.003µs per pod
400 instances 2000 pods   400 nodes   1.394536s per scheduling      697.268µs per pod
400 instances 5000 pods   1000 nodes  4.270449833s per scheduling   854.089µs per pod
400 instances 10000 pods  2000 nodes  10.723536792s per scheduling  1.072353ms per pod
400 instances 20000 pods  4000 nodes  32.865441875s per scheduling  1.643272ms per pod
--- PASS: TestSchedulingProfile (61.36s)
PASS
```

![heap](https://github.com/user-attachments/assets/2aaf33cd-f63d-4e94-a75f-8a6bbf22bf93)

### After PR


```
=== RUN   TestSchedulingProfile
scheduled 40151 against 8031 nodes in total in 53.541851009s 749.8993636445424 pods/sec
400 instances 1 pods      1 nodes     132.724µs per scheduling      132.724µs per pod
400 instances 50 pods     10 nodes    36.135768ms per scheduling    722.715µs per pod
400 instances 100 pods    20 nodes    81.514936ms per scheduling    815.149µs per pod
400 instances 500 pods    100 nodes   400.986277ms per scheduling   801.972µs per pod
400 instances 1000 pods   200 nodes   764.866291ms per scheduling   764.866µs per pod
400 instances 1500 pods   300 nodes   1.071175958s per scheduling   714.117µs per pod
400 instances 2000 pods   400 nodes   1.602387292s per scheduling   801.193µs per pod
400 instances 5000 pods   1000 nodes  4.361053208s per scheduling   872.21µs per pod
400 instances 10000 pods  2000 nodes  11.422063667s per scheduling  1.142206ms per pod
400 instances 20000 pods  4000 nodes  32.138826542s per scheduling  1.606941ms per pod
--- PASS: TestSchedulingProfile (60.86s)
PASS
```

![heap](https://github.com/user-attachments/assets/03161749-a810-47a7-9787-7fd7077bcab8)


**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
