### PR TITLE
fix: Fix heap profile benchmarking

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -114,7 +114,7 @@ func TestSchedulingProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating heap profile: %s", err)
 	}
-	defer lo.Must0(pprof.WriteHeapProfile(heapf))
+	defer func() { lo.Must0(pprof.WriteHeapProfile(heapf)) }()
 
 	totalPods := 0
 	totalNodes := 0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The heap profile wasn't actually capturing the full run on the scheduling benchmark 

### Before PR

![heap](https://github.com/user-attachments/assets/d2a7c618-84d4-41af-a606-8feb30b55785)

### After PR

![heap](https://github.com/user-attachments/assets/ca4e6900-7cfa-4d2b-901a-83315902b6fe)

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
