### PR TITLE
perf: Capture InstanceTypeFilterErrors in error structs and don't print them until the end

### DIFF
--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -103,17 +103,16 @@ func (n *NodeClaim) Add(pod *v1.Pod, podRequests v1.ResourceList) error {
 	// Check instance type combinations
 	requests := resources.Merge(n.Spec.Resources.Requests, podRequests)
 
-	filtered := filterInstanceTypesByRequirements(n.InstanceTypeOptions, nodeClaimRequirements, requests)
-
-	if len(filtered.remaining) == 0 {
-		// log the total resources being requested (daemonset + the pod)
-		cumulativeResources := resources.Merge(n.daemonResources, podRequests)
-		return fmt.Errorf("no instance type satisfied resources %s and requirements %s (%s)", resources.String(cumulativeResources), nodeClaimRequirements, filtered.FailureReason())
+	remaining, err := filterInstanceTypesByRequirements(n.InstanceTypeOptions, nodeClaimRequirements, podRequests, n.daemonResources, requests)
+	if err != nil {
+		// We avoid wrapping this err because calling String() on InstanceTypeFilterError is an expensive operation
+		// due to calls to resources.Merge and stringifying the nodeClaimRequirements
+		return err
 	}
 
 	// Update node
 	n.Pods = append(n.Pods, pod)
-	n.InstanceTypeOptions = filtered.remaining
+	n.InstanceTypeOptions = remaining
 	n.Spec.Resources.Requests = requests
 	n.Requirements = nodeClaimRequirements
 	n.topology.Record(pod, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
@@ -159,8 +158,7 @@ func InstanceTypeList(instanceTypeOptions []*cloudprovider.InstanceType) string 
 	return itSb.String()
 }
 
-type filterResults struct {
-	remaining cloudprovider.InstanceTypes
+type InstanceTypeFilterError struct {
 	// Each of these three flags indicates if that particular criteria was met by at least one instance type
 	requirementsMet bool
 	fits            bool
@@ -173,81 +171,74 @@ type filterResults struct {
 	// fitsAndOffering indicates if a single instance type had enough resources and was a required offering
 	fitsAndOffering          bool
 	minValuesIncompatibleErr error
-	requests                 v1.ResourceList
+
+	// We capture requirements so that we can know what the requirements were when evaluating instance type compatibility
+	requirements scheduling.Requirements
+	// We capture podRequests here since when a pod can't schedule due to requests, it's because the pod
+	// was on its own on the simulated Node and exceeded the available resources for any instance type for this NodePool
+	podRequests v1.ResourceList
+	// We capture daemonRequests since this contributes to the resources that are required to schedule to this NodePool
+	daemonRequests v1.ResourceList
 }
 
-// FailureReason returns a presentable string explaining why all instance types were filtered out
-//
 //nolint:gocyclo
-func (r filterResults) FailureReason() string {
-	if len(r.remaining) > 0 {
-		return ""
-	}
-
+func (e InstanceTypeFilterError) Error() string {
 	// minValues is specified in the requirements and is not met
-	if r.minValuesIncompatibleErr != nil {
-		return r.minValuesIncompatibleErr.Error()
+	if e.minValuesIncompatibleErr != nil {
+		return fmt.Sprintf("%s, requirements=%s, resources=%s", e.minValuesIncompatibleErr.Error(), e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-
 	// no instance type met any of the three criteria, meaning each criteria was enough to completely prevent
 	// this pod from scheduling
-	if !r.requirementsMet && !r.fits && !r.hasOffering {
-		return "no instance type met the scheduling requirements or had enough resources or had a required offering"
+	if !e.requirementsMet && !e.fits && !e.hasOffering {
+		return fmt.Sprintf("no instance type met the scheduling requirements or had enough resources or had a required offering, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-
 	// check the other pairwise criteria
-	if !r.requirementsMet && !r.fits {
-		return "no instance type met the scheduling requirements or had enough resources"
+	if !e.requirementsMet && !e.fits {
+		return fmt.Sprintf("no instance type met the scheduling requirements or had enough resources, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-
-	if !r.requirementsMet && !r.hasOffering {
-		return "no instance type met the scheduling requirements or had a required offering"
+	if !e.requirementsMet && !e.hasOffering {
+		return fmt.Sprintf("no instance type met the scheduling requirements or had a required offering, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-
-	if !r.fits && !r.hasOffering {
-		return "no instance type had enough resources or had a required offering"
+	if !e.fits && !e.hasOffering {
+		return fmt.Sprintf("no instance type had enough resources or had a required offering, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-
 	// and then each individual criteria. These are sort of the same as above in that each one indicates that no
 	// instance type matched that criteria at all, so it was enough to exclude all instance types.  I think it's
 	// helpful to have these separate, since we can report the multiple excluding criteria above.
-	if !r.requirementsMet {
-		return "no instance type met all requirements"
+	if !e.requirementsMet {
+		return fmt.Sprintf("no instance type met all requirements, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-
-	if !r.fits {
-		msg := "no instance type has enough resources"
+	if !e.fits {
+		msg := fmt.Sprintf("no instance type has enough resources, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 		// special case for a user typo I saw reported once
-		if r.requests.Cpu().Cmp(resource.MustParse("1M")) >= 0 {
+		if e.podRequests.Cpu().Cmp(resource.MustParse("1M")) >= 0 {
 			msg += " (CPU request >= 1 Million, m vs M typo?)"
 		}
 		return msg
 	}
-
-	if !r.hasOffering {
-		return "no instance type has the required offering"
+	if !e.hasOffering {
+		return fmt.Sprintf("no instance type has the required offering, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-
 	// see if any pair of criteria was enough to exclude all instances
-	if r.requirementsAndFits {
-		return "no instance type which met the scheduling requirements and had enough resources, had a required offering"
+	if e.requirementsAndFits {
+		return fmt.Sprintf("no instance type which met the scheduling requirements and had enough resources, had a required offering, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-	if r.fitsAndOffering {
-		return "no instance type which had enough resources and the required offering met the scheduling requirements"
+	if e.fitsAndOffering {
+		return fmt.Sprintf("no instance type which had enough resources and the required offering met the scheduling requirements, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-	if r.requirementsAndOffering {
-		return "no instance type which met the scheduling requirements and the required offering had the required resources"
+	if e.requirementsAndOffering {
+		return fmt.Sprintf("no instance type which met the scheduling requirements and the required offering had the required resources, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 	}
-
 	// finally all instances were filtered out, but we had at least one instance that met each criteria, and met each
 	// pairwise set of criteria, so the only thing that remains is no instance which met all three criteria simultaneously
-	return "no instance type met the requirements/resources/offering tuple"
+	return fmt.Sprintf("no instance type met the requirements/resources/offering tuple, requirements=%s, resources=%s", e.requirements, resources.String(resources.Merge(e.daemonRequests, e.podRequests)))
 }
 
 //nolint:gocyclo
-func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceType, requirements scheduling.Requirements, requests v1.ResourceList) filterResults {
-	results := filterResults{
-		requests:        requests,
+func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceType, requirements scheduling.Requirements, podRequests, daemonRequests, totalRequests v1.ResourceList) (cloudprovider.InstanceTypes, error) {
+	// We hold the results of our scheduling simulation inside of this InstanceTypeFilterError struct
+	// to reduce the CPU load of having to generate the error string for a failed scheduling simulation
+	err := InstanceTypeFilterError{
 		requirementsMet: false,
 		fits:            false,
 		hasOffering:     false,
@@ -255,13 +246,17 @@ func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceTy
 		requirementsAndFits:     false,
 		requirementsAndOffering: false,
 		fitsAndOffering:         false,
+
+		podRequests:    podRequests,
+		daemonRequests: daemonRequests,
 	}
+	remaining := cloudprovider.InstanceTypes{}
 
 	for _, it := range instanceTypes {
-		// the tradeoff to not short circuiting on the filtering is that we can report much better error messages
+		// the tradeoff to not short-circuiting on the filtering is that we can report much better error messages
 		// about why scheduling failed
 		itCompat := compatible(it, requirements)
-		itFits := fits(it, requests)
+		itFits := fits(it, totalRequests)
 
 		// By using this iterative approach vs. the Available() function it prevents allocations
 		// which have to be garbage collected and slow down Karpenter's scheduling algorithm
@@ -274,31 +269,34 @@ func filterInstanceTypesByRequirements(instanceTypes []*cloudprovider.InstanceTy
 		}
 
 		// track if any single instance type met a single criteria
-		results.requirementsMet = results.requirementsMet || itCompat
-		results.fits = results.fits || itFits
-		results.hasOffering = results.hasOffering || itHasOffering
+		err.requirementsMet = err.requirementsMet || itCompat
+		err.fits = err.fits || itFits
+		err.hasOffering = err.hasOffering || itHasOffering
 
 		// track if any single instance type met the three pairs of criteria
-		results.requirementsAndFits = results.requirementsAndFits || (itCompat && itFits && !itHasOffering)
-		results.requirementsAndOffering = results.requirementsAndOffering || (itCompat && itHasOffering && !itFits)
-		results.fitsAndOffering = results.fitsAndOffering || (itFits && itHasOffering && !itCompat)
+		err.requirementsAndFits = err.requirementsAndFits || (itCompat && itFits && !itHasOffering)
+		err.requirementsAndOffering = err.requirementsAndOffering || (itCompat && itHasOffering && !itFits)
+		err.fitsAndOffering = err.fitsAndOffering || (itFits && itHasOffering && !itCompat)
 
 		// and if it met all criteria, we keep the instance type and continue filtering.  We now won't be reporting
 		// any errors.
 		if itCompat && itFits && itHasOffering {
-			results.remaining = append(results.remaining, it)
+			remaining = append(remaining, it)
 		}
 	}
 
 	if requirements.HasMinValues() {
 		// We don't care about the minimum number of instance types that meet our requirements here, we only care if they meet our requirements.
-		_, results.minValuesIncompatibleErr = results.remaining.SatisfiesMinValues(requirements)
-		if results.minValuesIncompatibleErr != nil {
+		_, err.minValuesIncompatibleErr = remaining.SatisfiesMinValues(requirements)
+		if err.minValuesIncompatibleErr != nil {
 			// If minValues is NOT met for any of the requirement across InstanceTypes, then return empty InstanceTypeOptions as we cannot launch with the remaining InstanceTypes.
-			results.remaining = nil
+			remaining = nil
 		}
 	}
-	return results
+	if len(remaining) == 0 {
+		return nil, err
+	}
+	return remaining, nil
 }
 
 func compatible(instanceType *cloudprovider.InstanceType, requirements scheduling.Requirements) bool {

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -62,7 +62,7 @@ func NewScheduler(ctx context.Context, kubeClient client.Client, nodePools []*v1
 	// Pre-filter instance types eligible for NodePools to reduce work done during scheduling loops for pods
 	templates := lo.FilterMap(nodePools, func(np *v1.NodePool, _ int) (*NodeClaimTemplate, bool) {
 		nct := NewNodeClaimTemplate(np)
-		nct.InstanceTypeOptions = filterInstanceTypesByRequirements(instanceTypes[np.Name], nct.Requirements, corev1.ResourceList{}).remaining
+		nct.InstanceTypeOptions, _ = filterInstanceTypesByRequirements(instanceTypes[np.Name], nct.Requirements, corev1.ResourceList{}, corev1.ResourceList{}, corev1.ResourceList{})
 		if len(nct.InstanceTypeOptions) == 0 {
 			recorder.Publish(NoCompatibleInstanceTypes(np))
 			log.FromContext(ctx).WithValues("NodePool", klog.KRef("", np.Name)).Info("skipping, nodepool requirements filtered out all instance types")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change ensures that we don't perform expensive operations that show-up in the CPU profile and show-up in our heap analysis to print the nodeClaimRequirements and performing resources.Merge. 

These changes were executed against the scheduling benchmark (which showed negligible performance changes) and a live test that deploys 20,000 pods to the cluster and generates 10,000 nodes (with two pods per node constrained by the size of the instance types on NodePools). Prior to the change, this test took __31m49s__. After the change, the same test case takes __26m34s__ (a 5m15s improvement).

![flame_requirements_improvement](https://github.com/user-attachments/assets/3b1b230d-7b0f-44f0-bd28-e622b7f872b4)

### Before PR

#### Scheduling Benchmark

```
=== RUN   TestSchedulingProfile
scheduled 40151 against 8031 nodes in total in 59.198867831s 678.2393223232317 pods/sec
400 instances 1 pods      1 nodes     183.666µs per scheduling      183.666µs per pod
400 instances 50 pods     10 nodes    42.342407ms per scheduling    846.848µs per pod
400 instances 100 pods    20 nodes    86.044652ms per scheduling    860.446µs per pod
400 instances 500 pods    100 nodes   408.015194ms per scheduling   816.03µs per pod
400 instances 1000 pods   200 nodes   803.296687ms per scheduling   803.296µs per pod
400 instances 1500 pods   300 nodes   1.23015975s per scheduling    820.106µs per pod
400 instances 2000 pods   400 nodes   1.744999875s per scheduling   872.499µs per pod
400 instances 5000 pods   1000 nodes  5.008729875s per scheduling   1.001745ms per pod
400 instances 10000 pods  2000 nodes  12.685723333s per scheduling  1.268572ms per pod
400 instances 20000 pods  4000 nodes  35.421737833s per scheduling  1.771086ms per pod
--- PASS: TestSchedulingProfile (67.02s)
PASS
```

#### Live Test 

__Scheduling Time: 31m49s__

```
{"level":"INFO","time":"2025-02-02T06:45:17.502Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":3563,"pods-remaining":16437,"duration":"1m0s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:46:17.563Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":5017,"pods-remaining":14983,"duration":"2m0s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:47:17.663Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":6127,"pods-remaining":13873,"duration":"3m0s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:48:17.718Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":7071,"pods-remaining":12929,"duration":"4m0s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:49:17.873Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":7911,"pods-remaining":12089,"duration":"5m0s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:50:18.015Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":8671,"pods-remaining":11329,"duration":"6m0s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:51:18.075Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":9367,"pods-remaining":10633,"duration":"7m0s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:52:18.319Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":10017,"pods-remaining":9983,"duration":"8m0s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:53:18.497Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":10627,"pods-remaining":9373,"duration":"9m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:54:18.551Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":11205,"pods-remaining":8795,"duration":"10m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:55:18.745Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":11755,"pods-remaining":8245,"duration":"11m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:56:18.965Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":12283,"pods-remaining":7717,"duration":"12m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:57:19.157Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":12787,"pods-remaining":7213,"duration":"13m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:58:19.252Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":13273,"pods-remaining":6727,"duration":"14m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T06:59:19.280Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":13743,"pods-remaining":6257,"duration":"15m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:00:19.325Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":14195,"pods-remaining":5805,"duration":"16m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:01:19.376Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":14635,"pods-remaining":5365,"duration":"17m1s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:02:19.579Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":15063,"pods-remaining":4937,"duration":"18m2s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:03:19.664Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":15479,"pods-remaining":4521,"duration":"19m2s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:04:19.813Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":15885,"pods-remaining":4115,"duration":"20m2s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:05:20.038Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":16281,"pods-remaining":3719,"duration":"21m2s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:06:20.256Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":16663,"pods-remaining":3337,"duration":"22m2s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:07:20.293Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":17035,"pods-remaining":2965,"duration":"23m2s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:08:20.542Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":17407,"pods-remaining":2593,"duration":"24m3s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:09:20.691Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":17763,"pods-remaining":2237,"duration":"25m3s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:10:20.868Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":18117,"pods-remaining":1883,"duration":"26m3s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:11:20.904Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":18463,"pods-remaining":1537,"duration":"27m3s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:12:21.082Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":18795,"pods-remaining":1205,"duration":"28m3s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:13:21.410Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":19123,"pods-remaining":877,"duration":"29m3s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:14:21.578Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":19447,"pods-remaining":553,"duration":"30m4s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:15:21.892Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","pods-scheduled":19767,"pods-remaining":233,"duration":"31m4s","scheduling-id":"cbdf5dcc-94c3-4371-b0a6-f8574137b2af"}
{"level":"INFO","time":"2025-02-02T07:16:06.064Z","logger":"controller","caller":"provisioning/provisioner.go:129","message":"found provisionable pod(s)","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","Pods":"default/test-51, default/test-123, default/test-31, default/test-181, default/test-19 and 19995 other(s)","duration":"31m49.389166009s"}
{"level":"INFO","time":"2025-02-02T07:16:06.094Z","logger":"controller","caller":"provisioning/provisioner.go:350","message":"computed new nodeclaim(s) to fit pod(s)","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"c3bd7c1f-4074-4d75-83e3-22c046e7efe6","nodeclaims":10000,"pods":20000}
```

#### Heap Profile

![requirements_improvement](https://github.com/user-attachments/assets/edaa5460-5218-4c9b-98c7-83aa546b6eea)

### After PR

#### Scheduling Benchmark

```
=== RUN   TestSchedulingProfile
scheduled 40151 against 8031 nodes in total in 59.329537061s 676.7455468044276 pods/sec
400 instances 1 pods      1 nodes     199.111µs per scheduling      199.111µs per pod
400 instances 50 pods     10 nodes    42.671329ms per scheduling    853.426µs per pod
400 instances 100 pods    20 nodes    110.710599ms per scheduling   1.107105ms per pod
400 instances 500 pods    100 nodes   432.48425ms per scheduling    864.968µs per pod
400 instances 1000 pods   200 nodes   1.021048083s per scheduling   1.021048ms per pod
400 instances 1500 pods   300 nodes   1.41967825s per scheduling    946.452µs per pod
400 instances 2000 pods   400 nodes   1.755113042s per scheduling   877.556µs per pod
400 instances 5000 pods   1000 nodes  5.021272375s per scheduling   1.004254ms per pod
400 instances 10000 pods  2000 nodes  12.540354458s per scheduling  1.254035ms per pod
400 instances 20000 pods  4000 nodes  35.597483625s per scheduling  1.779874ms per pod
--- PASS: TestSchedulingProfile (66.63s)
PASS
```

#### Live Test

__Scheduling Time: 26m34s__

```
{"level":"INFO","time":"2025-02-02T06:14:35.499Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":3993,"pods-remaining":16007,"duration":"1m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:15:35.613Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":5631,"pods-remaining":14369,"duration":"2m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:16:35.706Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":6837,"pods-remaining":13163,"duration":"3m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:17:35.835Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":7859,"pods-remaining":12141,"duration":"4m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:18:35.920Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":8763,"pods-remaining":11237,"duration":"5m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:19:36.030Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":9581,"pods-remaining":10419,"duration":"6m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:20:36.137Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":10337,"pods-remaining":9663,"duration":"7m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:21:36.266Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":11037,"pods-remaining":8963,"duration":"8m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:22:36.288Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":11685,"pods-remaining":8315,"duration":"9m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:23:36.336Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":12307,"pods-remaining":7693,"duration":"10m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:24:36.356Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":12901,"pods-remaining":7099,"duration":"11m0s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:25:36.485Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":13467,"pods-remaining":6533,"duration":"12m1s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:26:36.632Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":14011,"pods-remaining":5989,"duration":"13m1s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:27:36.802Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":14539,"pods-remaining":5461,"duration":"14m1s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:28:37.000Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":15051,"pods-remaining":4949,"duration":"15m1s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:29:37.161Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":15545,"pods-remaining":4455,"duration":"16m1s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:30:37.245Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":16023,"pods-remaining":3977,"duration":"17m1s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:31:37.392Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":16485,"pods-remaining":3515,"duration":"18m1s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:32:37.534Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":16935,"pods-remaining":3065,"duration":"19m2s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:33:37.625Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":17375,"pods-remaining":2625,"duration":"20m2s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:34:37.690Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":17803,"pods-remaining":2197,"duration":"21m2s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:35:37.839Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":18217,"pods-remaining":1783,"duration":"22m2s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:36:37.930Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":18623,"pods-remaining":1377,"duration":"23m2s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:37:38.041Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":19023,"pods-remaining":977,"duration":"24m2s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:38:38.068Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":19415,"pods-remaining":585,"duration":"25m2s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:39:38.221Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","pods-scheduled":19801,"pods-remaining":199,"duration":"26m2s","scheduling-id":"7045ca91-106e-453a-8921-3cd9b2719ba1"}
{"level":"INFO","time":"2025-02-02T06:40:09.404Z","logger":"controller","caller":"provisioning/provisioner.go:129","message":"found provisionable pod(s)","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","Pods":"default/test-51, default/test-123, default/test-31, default/test-181, default/test-19 and 19995 other(s)","duration":"26m34.756538567s"}
{"level":"INFO","time":"2025-02-02T06:40:09.435Z","logger":"controller","caller":"provisioning/provisioner.go:350","message":"computed new nodeclaim(s) to fit pod(s)","commit":"0edfada-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aea398a8-2f52-4a1d-9250-70b4a268231e","nodeclaims":10000,"pods":20000}
```

#### Heap Profile 

![requirements_improvement2](https://github.com/user-attachments/assets/00374b07-72ac-4477-9f33-9dd60ccfc97f)

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
