### PR TITLE
perf: Cache requirements for pods alongside requests

### DIFF
--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -65,7 +65,7 @@ func NewExistingNode(n *state.StateNode, topology *Topology, taints []v1.Taint, 
 	return node
 }
 
-func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v1.Pod, podRequests v1.ResourceList) error {
+func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v1.Pod, podData *PodData) error {
 	// Check Taints
 	if err := scheduling.Taints(n.cachedTaints).Tolerates(pod); err != nil {
 		return err
@@ -86,29 +86,21 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 
 	// check resource requests first since that's a pretty likely reason the pod won't schedule on an in-flight
 	// node, which at this point can't be increased in size
-	requests := resources.Merge(n.requests, podRequests)
+	requests := resources.Merge(n.requests, podData.Requests)
 
 	if !resources.Fits(requests, n.cachedAvailable) {
 		return fmt.Errorf("exceeds node resources")
 	}
 
 	nodeRequirements := scheduling.NewRequirements(n.requirements.Values()...)
-	podRequirements := scheduling.NewPodRequirements(pod)
 	// Check NodeClaim Affinity Requirements
-	if err = nodeRequirements.Compatible(podRequirements); err != nil {
+	if err = nodeRequirements.Compatible(podData.Requirements); err != nil {
 		return err
 	}
-	nodeRequirements.Add(podRequirements.Values()...)
-
-	strictPodRequirements := podRequirements
-	if scheduling.HasPreferredNodeAffinity(pod) {
-		// strictPodRequirements is important as it ensures we don't inadvertently restrict the possible pod domains by a
-		// preferred node affinity.  Only required node affinities can actually reduce pod domains.
-		strictPodRequirements = scheduling.NewStrictPodRequirements(pod)
-	}
+	nodeRequirements.Add(podData.Requirements.Values()...)
 
 	// Check Topology Requirements
-	topologyRequirements, err := n.topology.AddRequirements(strictPodRequirements, nodeRequirements, pod)
+	topologyRequirements, err := n.topology.AddRequirements(podData.StrictRequirements, nodeRequirements, pod)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/provisioning/scheduling/queue.go
+++ b/pkg/controllers/provisioning/scheduling/queue.go
@@ -34,8 +34,8 @@ type Queue struct {
 }
 
 // NewQueue constructs a new queue given the input pods, sorting them to optimize for bin-packing into nodes.
-func NewQueue(pods []*v1.Pod, podRequests map[types.UID]v1.ResourceList) *Queue {
-	sort.Slice(pods, byCPUAndMemoryDescending(pods, podRequests))
+func NewQueue(pods []*v1.Pod, podData map[types.UID]*PodData) *Queue {
+	sort.Slice(pods, byCPUAndMemoryDescending(pods, podData))
 	return &Queue{
 		pods:    pods,
 		lastLen: map[types.UID]int{},
@@ -73,13 +73,13 @@ func (q *Queue) List() []*v1.Pod {
 	return q.pods
 }
 
-func byCPUAndMemoryDescending(pods []*v1.Pod, podRequests map[types.UID]v1.ResourceList) func(i int, j int) bool {
+func byCPUAndMemoryDescending(pods []*v1.Pod, podData map[types.UID]*PodData) func(i int, j int) bool {
 	return func(i, j int) bool {
 		lhsPod := pods[i]
 		rhsPod := pods[j]
 
-		lhs := podRequests[lhsPod.UID]
-		rhs := podRequests[rhsPod.UID]
+		lhs := podData[lhsPod.UID].Requests
+		rhs := podData[rhsPod.UID].Requests
 
 		cpuCmp := resources.Cmp(lhs[v1.ResourceCPU], rhs[v1.ResourceCPU])
 		if cpuCmp < 0 {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Cache requirements for pods alongside requests so we don't have to spend memory continually re-creating the pod requirements when we are iterating through the pods in our scheduling loops. This also prevents the garbage collector from having to run as frequently since there will be more live memory that is being used in the scheduling loop

These changes were executed against the scheduling benchmark (which showed negligible performance changes) and a live test that deploys 20,000 pods to the cluster and generates 10,000 nodes (with two pods per node constrained by the size of the instance types on NodePools). Prior to the change, this test took __27m17s__. After the change, the same test case takes __25m24s__ (a 1m53s improvement).

### Before PR

#### Scheduling Benchmark

```
=== RUN   TestSchedulingProfile
scheduled 40151 against 8031 nodes in total in 51.37107493s 781.5876941393798 pods/sec
400 instances 1 pods      1 nodes     119.528µs per scheduling      119.528µs per pod
400 instances 50 pods     10 nodes    36.164402ms per scheduling    723.288µs per pod
400 instances 100 pods    20 nodes    93.232259ms per scheduling    932.322µs per pod
400 instances 500 pods    100 nodes   363.313687ms per scheduling   726.627µs per pod
400 instances 1000 pods   200 nodes   660.635666ms per scheduling   660.635µs per pod
400 instances 1500 pods   300 nodes   1.071160167s per scheduling   714.106µs per pod
400 instances 2000 pods   400 nodes   1.600917583s per scheduling   800.458µs per pod
400 instances 5000 pods   1000 nodes  4.364474833s per scheduling   872.894µs per pod
400 instances 10000 pods  2000 nodes  10.308064042s per scheduling  1.030806ms per pod
400 instances 20000 pods  4000 nodes  31.277778625s per scheduling  1.563888ms per pod
--- PASS: TestSchedulingProfile (59.83s)
PASS
```

#### Heap Profiles

##### Alloc Space

![heap](https://github.com/user-attachments/assets/8722366c-a7df-46ea-9d35-6b302cfd6da6)

##### Inuse Space

![requirements_improvement_inuse](https://github.com/user-attachments/assets/c0bd061b-efec-437e-bc0d-ef0d863e0cf5)

#### Live Test

__Scheduling Time: 27m17s__

```
{"level":"INFO","time":"2025-02-03T00:28:12.643Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":3877,"pods-remaining":16123,"duration":"1m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:29:12.709Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":5465,"pods-remaining":14535,"duration":"2m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:30:12.804Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":6691,"pods-remaining":13309,"duration":"3m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:31:12.920Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":7715,"pods-remaining":12285,"duration":"4m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:32:12.935Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":8621,"pods-remaining":11379,"duration":"5m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:33:12.965Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":9439,"pods-remaining":10561,"duration":"6m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:34:12.990Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":10189,"pods-remaining":9811,"duration":"7m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:35:13.012Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":10891,"pods-remaining":9109,"duration":"8m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:36:13.073Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":11551,"pods-remaining":8449,"duration":"9m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:37:13.233Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":12179,"pods-remaining":7821,"duration":"10m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:38:13.419Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":12777,"pods-remaining":7223,"duration":"11m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:39:13.467Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":13349,"pods-remaining":6651,"duration":"12m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:40:13.603Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":13897,"pods-remaining":6103,"duration":"13m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:41:13.613Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":14423,"pods-remaining":5577,"duration":"14m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:42:13.735Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":14927,"pods-remaining":5073,"duration":"15m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:43:13.772Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":15411,"pods-remaining":4589,"duration":"16m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:44:13.849Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":15877,"pods-remaining":4123,"duration":"17m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:45:13.930Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":16329,"pods-remaining":3671,"duration":"18m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:46:13.948Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":16761,"pods-remaining":3239,"duration":"19m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:47:14.036Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":17187,"pods-remaining":2813,"duration":"20m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:48:14.240Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":17601,"pods-remaining":2399,"duration":"21m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:49:14.313Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":18007,"pods-remaining":1993,"duration":"22m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:50:14.475Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":18403,"pods-remaining":1597,"duration":"23m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:51:14.623Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":18795,"pods-remaining":1205,"duration":"24m2s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:52:14.962Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":19175,"pods-remaining":825,"duration":"25m2s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:53:15.127Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":19549,"pods-remaining":451,"duration":"26m2s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:54:15.345Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":19917,"pods-remaining":83,"duration":"27m2s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:54:29.289Z","logger":"controller","caller":"provisioning/provisioner.go:129","message":"found provisionable pod(s)","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","Pods":"default/test-51, default/test-123, default/test-31, default/test-181, default/test-19 and 19995 other(s)","duration":"27m17.609613827s"}
{"level":"INFO","time":"2025-02-03T00:54:29.321Z","logger":"controller","caller":"provisioning/provisioner.go:350","message":"computed new nodeclaim(s) to fit pod(s)","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","nodeclaims":10000,"pods":20000}
```

### After PR

#### Scheduling Benchmark

```
=== RUN   TestSchedulingProfile
scheduled 40151 against 8031 nodes in total in 51.561393638s 778.7027690114508 pods/sec
400 instances 1 pods      1 nodes     116.978µs per scheduling      116.978µs per pod
400 instances 50 pods     10 nodes    37.567928ms per scheduling    751.358µs per pod
400 instances 100 pods    20 nodes    92.407481ms per scheduling    924.074µs per pod
400 instances 500 pods    100 nodes   337.864222ms per scheduling   675.728µs per pod
400 instances 1000 pods   200 nodes   723.253291ms per scheduling   723.253µs per pod
400 instances 1500 pods   300 nodes   1.074757042s per scheduling   716.504µs per pod
400 instances 2000 pods   400 nodes   1.322436833s per scheduling   661.218µs per pod
400 instances 5000 pods   1000 nodes  4.027264875s per scheduling   805.452µs per pod
400 instances 10000 pods  2000 nodes  10.799694167s per scheduling  1.079969ms per pod
400 instances 20000 pods  4000 nodes  31.691078833s per scheduling  1.584553ms per pod
--- PASS: TestSchedulingProfile (59.63s)
PASS
```

#### Heap Profiles

##### Alloc Space

![heap](https://github.com/user-attachments/assets/b68abc1f-b814-4ba7-8ccc-f117e4eb6574)

##### Inuse Space

![requirements_improvement_inuse](https://github.com/user-attachments/assets/b8fc5583-abee-476c-8fbf-13832e6c21a1)

#### Live Test

__Scheduling Time: 25m24s__

```
{"level":"INFO","time":"2025-02-02T23:16:38.191Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":4041,"pods-remaining":15959,"duration":"1m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:17:38.209Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":5661,"pods-remaining":14339,"duration":"2m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:18:38.377Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":6917,"pods-remaining":13083,"duration":"3m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:19:38.436Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":7973,"pods-remaining":12027,"duration":"4m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:20:38.510Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":8911,"pods-remaining":11089,"duration":"5m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:21:38.621Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":9759,"pods-remaining":10241,"duration":"6m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:22:38.756Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":10541,"pods-remaining":9459,"duration":"7m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:23:38.763Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":11271,"pods-remaining":8729,"duration":"8m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:24:38.869Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":11957,"pods-remaining":8043,"duration":"9m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:25:39.009Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":12599,"pods-remaining":7401,"duration":"10m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:26:39.021Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":13211,"pods-remaining":6789,"duration":"11m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:27:39.038Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":13801,"pods-remaining":6199,"duration":"12m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:28:39.066Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":14365,"pods-remaining":5635,"duration":"13m0s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:29:39.218Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":14913,"pods-remaining":5087,"duration":"14m1s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:30:39.401Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":15443,"pods-remaining":4557,"duration":"15m1s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:31:39.404Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":15951,"pods-remaining":4049,"duration":"16m1s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:32:39.608Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":16441,"pods-remaining":3559,"duration":"17m1s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:33:39.727Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":16911,"pods-remaining":3089,"duration":"18m1s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:34:39.926Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":17371,"pods-remaining":2629,"duration":"19m1s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:35:40.158Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":17809,"pods-remaining":2191,"duration":"20m1s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:36:40.307Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":18235,"pods-remaining":1765,"duration":"21m2s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:37:40.513Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":18655,"pods-remaining":1345,"duration":"22m2s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:38:40.690Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":19063,"pods-remaining":937,"duration":"23m2s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:39:40.755Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":19467,"pods-remaining":533,"duration":"24m2s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:40:40.995Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","pods-scheduled":19867,"pods-remaining":133,"duration":"25m2s","scheduling-id":"73859a87-7d14-4257-9b2d-653293a4e7c8"}
{"level":"INFO","time":"2025-02-02T23:41:01.653Z","logger":"controller","caller":"provisioning/provisioner.go:129","message":"found provisionable pod(s)","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","Pods":"default/test-51, default/test-123, default/test-31, default/test-181, default/test-19 and 19995 other(s)","duration":"25m24.402803933s"}
{"level":"INFO","time":"2025-02-02T23:41:01.684Z","logger":"controller","caller":"provisioning/provisioner.go:350","message":"computed new nodeclaim(s) to fit pod(s)","commit":"2c2a16c-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"5caeb05a-29a6-4266-987c-5175156ae675","nodeclaims":10000,"pods":20000}
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
