### PR TITLE
feat: Create Unhealthy Disrupted Nodeclaim Metric

### DIFF
--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -136,9 +136,15 @@ func (c *Controller) deleteNodeClaim(ctx context.Context, nodeClaim *v1.NodeClai
 	// The deletion timestamp has successfully been set for the Node, update relevant metrics.
 	log.FromContext(ctx).V(1).Info("deleting unhealthy node")
 	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-		metrics.ReasonLabel:       pretty.ToSnakeCase(string(unhealthyNodeCondition.Type)),
+		metrics.ReasonLabel:       metrics.UnhealthyReason,
 		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: node.Labels[v1.CapacityTypeLabelKey],
+	})
+	NodeClaimsUnhealthyDisruptedTotal.Inc(map[string]string{
+		Condition:                 pretty.ToSnakeCase(string(unhealthyNodeCondition.Type)),
+		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel: node.Labels[v1.CapacityTypeLabelKey],
+		ImageID:                   nodeClaim.Status.ImageID,
 	})
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/node/health/metrics.go
+++ b/pkg/controllers/node/health/metrics.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/karpenter/pkg/metrics"
+)
+
+const (
+	ImageID   = "image_id"
+	Condition = "condition"
+)
+
+var NodeClaimsUnhealthyDisruptedTotal = opmetrics.NewPrometheusCounter(
+	crmetrics.Registry,
+	prometheus.CounterOpts{
+		Namespace: metrics.Namespace,
+		Subsystem: metrics.NodeClaimSubsystem,
+		Name:      "unhealthy_disrupted_total",
+		Help:      "Number of unhealthy nodeclaims disrupted in total by Karpenter. Labeled by condition on the node was disrupted, the owning nodepool, and the image ID.",
+	},
+	[]string{
+		Condition,
+		metrics.NodePoolLabel,
+		metrics.CapacityTypeLabel,
+		ImageID,
+	},
+)

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -360,7 +360,11 @@ var _ = Describe("Node Health", func() {
 			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
 
 			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
-				metrics.ReasonLabel:   pretty.ToSnakeCase(string(cloudProvider.RepairPolicies()[0].ConditionType)),
+				metrics.ReasonLabel:   metrics.UnhealthyReason,
+				metrics.NodePoolLabel: nodePool.Name,
+			})
+			ExpectMetricCounterValue(health.NodeClaimsUnhealthyDisruptedTotal, 1, map[string]string{
+				health.Condition:      pretty.ToSnakeCase(string(cloudProvider.RepairPolicies()[0].ConditionType)),
 				metrics.NodePoolLabel: nodePool.Name,
 			})
 		})

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -33,6 +33,7 @@ const (
 	// Reasons for CREATE/DELETE shared metrics
 	ProvisionedReason = "provisioned"
 	ExpiredReason     = "expired"
+	UnhealthyReason   = "unhealthy"
 )
 
 // DurationBuckets returns a []float64 of default threshold values for duration histograms.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Add dedicated metrics for tracking unhealthy disrupted nodeclaims

This PR introduces a new of metric specifically for tracking nodeclaims that were disrupted due to unhealthy states, separate from other disruption types. This separation enables:

- More precise monitoring of repair-related disruptions
- Better alerting capabilities for node health issues
- Distinct label sets optimized for repaired node scenarios

This change improves observability by distinguishing between health-related node disruptions and other forms of disruption 

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
