### PR TITLE
perf: Don't create new sets when checking compatibility

### DIFF
--- a/pkg/scheduling/requirement.go
+++ b/pkg/scheduling/requirement.go
@@ -187,6 +187,46 @@ func (r *Requirement) Intersection(requirement *Requirement) *Requirement {
 	return &Requirement{Key: r.Key, values: values, complement: complement, greaterThan: greaterThan, lessThan: lessThan, MinValues: minValues}
 }
 
+// nolint:gocyclo
+// HasIntersection is a more efficient implementation of Intersection
+// It validates whether there is an intersection between the two requirements without actually creating the sets
+// This prevents the garbage collector from having to spend cycles cleaning up all of these created set objects
+func (r *Requirement) HasIntersection(requirement *Requirement) bool {
+	greaterThan := maxIntPtr(r.greaterThan, requirement.greaterThan)
+	lessThan := minIntPtr(r.lessThan, requirement.lessThan)
+	if greaterThan != nil && lessThan != nil && *greaterThan >= *lessThan {
+		return false
+	}
+	// Both requirements have a complement
+	if r.complement && requirement.complement {
+		return true
+	}
+	// Only one requirement has a complement
+	if r.complement && !requirement.complement {
+		for value := range requirement.values {
+			if !r.values.Has(value) && withinIntPtrs(value, greaterThan, lessThan) {
+				return true
+			}
+		}
+		return false
+	}
+	if !r.complement && requirement.complement {
+		for value := range r.values {
+			if !requirement.values.Has(value) && withinIntPtrs(value, greaterThan, lessThan) {
+				return true
+			}
+		}
+		return false
+	}
+	// Both requirements are non-complement requirements
+	for value := range r.values {
+		if requirement.values.Has(value) && withinIntPtrs(value, greaterThan, lessThan) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Requirement) Any() string {
 	switch r.Operator() {
 	case corev1.NodeSelectorOpIn:

--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -284,8 +284,7 @@ func (r Requirements) Intersects(requirements Requirements) (errs error) {
 	for key := range r.intersectKeys(requirements) {
 		existing := r.Get(key)
 		incoming := requirements.Get(key)
-		// There must be some value, except
-		if existing.Intersection(incoming).Len() == 0 {
+		if !existing.HasIntersection(incoming) {
 			// where the incoming requirement has operator { NotIn, DoesNotExist }
 			if operator := incoming.Operator(); operator == corev1.NodeSelectorOpNotIn || operator == corev1.NodeSelectorOpDoesNotExist {
 				// and the existing requirement has operator { NotIn, DoesNotExist }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds the `HasIntersection` method which allows the `Intersects` check to validate whether two keys have an intersection with their values without creating new sets under the hood -- greatly reducing the number of allocations that we do for sets and reducing the amount of time that the garbage collector needs to spend cleaning them up.

These changes were executed against the scheduling benchmark (which showed negligible performance changes) and a live test that deploys 20,000 pods to the cluster and generates 10,000 nodes (with two pods per node constrained by the size of the instance types on NodePools). Prior to the change, this test took __27m17s__. After the change, the same test case takes __21m36s__ (a 5m41s improvement).

### Before PR

#### Scheduling Benchmark

```
=== RUN   TestSchedulingProfile
scheduled 40151 against 8031 nodes in total in 51.37107493s 781.5876941393798 pods/sec
400 instances 1 pods      1 nodes     119.528µs per scheduling      119.528µs per pod
400 instances 50 pods     10 nodes    36.164402ms per scheduling    723.288µs per pod
400 instances 100 pods    20 nodes    93.232259ms per scheduling    932.322µs per pod
400 instances 500 pods    100 nodes   363.313687ms per scheduling   726.627µs per pod
400 instances 1000 pods   200 nodes   660.635666ms per scheduling   660.635µs per pod
400 instances 1500 pods   300 nodes   1.071160167s per scheduling   714.106µs per pod
400 instances 2000 pods   400 nodes   1.600917583s per scheduling   800.458µs per pod
400 instances 5000 pods   1000 nodes  4.364474833s per scheduling   872.894µs per pod
400 instances 10000 pods  2000 nodes  10.308064042s per scheduling  1.030806ms per pod
400 instances 20000 pods  4000 nodes  31.277778625s per scheduling  1.563888ms per pod
--- PASS: TestSchedulingProfile (59.83s)
PASS
```

#### CPU Flamegraph

![flame_requirements_improvement](https://github.com/user-attachments/assets/3b1b230d-7b0f-44f0-bd28-e622b7f872b4)

#### Heap Profile

![requirements_improvement](https://github.com/user-attachments/assets/edaa5460-5218-4c9b-98c7-83aa546b6eea)

#### Live Test

__Scheduling Time: 27m17s__

```
{"level":"INFO","time":"2025-02-03T00:28:12.643Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":3877,"pods-remaining":16123,"duration":"1m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:29:12.709Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":5465,"pods-remaining":14535,"duration":"2m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:30:12.804Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":6691,"pods-remaining":13309,"duration":"3m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:31:12.920Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":7715,"pods-remaining":12285,"duration":"4m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:32:12.935Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":8621,"pods-remaining":11379,"duration":"5m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:33:12.965Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":9439,"pods-remaining":10561,"duration":"6m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:34:12.990Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":10189,"pods-remaining":9811,"duration":"7m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:35:13.012Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":10891,"pods-remaining":9109,"duration":"8m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:36:13.073Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":11551,"pods-remaining":8449,"duration":"9m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:37:13.233Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":12179,"pods-remaining":7821,"duration":"10m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:38:13.419Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":12777,"pods-remaining":7223,"duration":"11m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:39:13.467Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":13349,"pods-remaining":6651,"duration":"12m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:40:13.603Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":13897,"pods-remaining":6103,"duration":"13m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:41:13.613Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":14423,"pods-remaining":5577,"duration":"14m0s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:42:13.735Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":14927,"pods-remaining":5073,"duration":"15m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:43:13.772Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":15411,"pods-remaining":4589,"duration":"16m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:44:13.849Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":15877,"pods-remaining":4123,"duration":"17m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:45:13.930Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":16329,"pods-remaining":3671,"duration":"18m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:46:13.948Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":16761,"pods-remaining":3239,"duration":"19m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:47:14.036Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":17187,"pods-remaining":2813,"duration":"20m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:48:14.240Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":17601,"pods-remaining":2399,"duration":"21m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:49:14.313Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":18007,"pods-remaining":1993,"duration":"22m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:50:14.475Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":18403,"pods-remaining":1597,"duration":"23m1s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:51:14.623Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":18795,"pods-remaining":1205,"duration":"24m2s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:52:14.962Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":19175,"pods-remaining":825,"duration":"25m2s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:53:15.127Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":19549,"pods-remaining":451,"duration":"26m2s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:54:15.345Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","pods-scheduled":19917,"pods-remaining":83,"duration":"27m2s","scheduling-id":"2684e073-ce3f-410c-84aa-a6375ddcade6"}
{"level":"INFO","time":"2025-02-03T00:54:29.289Z","logger":"controller","caller":"provisioning/provisioner.go:129","message":"found provisionable pod(s)","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","Pods":"default/test-51, default/test-123, default/test-31, default/test-181, default/test-19 and 19995 other(s)","duration":"27m17.609613827s"}
{"level":"INFO","time":"2025-02-03T00:54:29.321Z","logger":"controller","caller":"provisioning/provisioner.go:350","message":"computed new nodeclaim(s) to fit pod(s)","commit":"16dfcb0-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0500d28b-8738-4b34-a9a7-1a80bfe4b184","nodeclaims":10000,"pods":20000}
```

### After PR

#### Scheduling Benchmark

```
=== RUN   TestSchedulingProfile
scheduled 40151 against 8031 nodes in total in 43.928768734s 914.0023988180646 pods/sec
400 instances 1 pods      1 nodes     115.139µs per scheduling      115.139µs per pod
400 instances 50 pods     10 nodes    38.590847ms per scheduling    771.816µs per pod
400 instances 100 pods    20 nodes    67.372103ms per scheduling    673.721µs per pod
400 instances 500 pods    100 nodes   282.340958ms per scheduling   564.681µs per pod
400 instances 1000 pods   200 nodes   569.778687ms per scheduling   569.778µs per pod
400 instances 1500 pods   300 nodes   858.480083ms per scheduling   572.32µs per pod
400 instances 2000 pods   400 nodes   1.144083s per scheduling      572.041µs per pod
400 instances 5000 pods   1000 nodes  3.677685959s per scheduling   735.537µs per pod
400 instances 10000 pods  2000 nodes  8.664178458s per scheduling   866.417µs per pod
400 instances 20000 pods  4000 nodes  26.991566916s per scheduling  1.349578ms per pod
--- PASS: TestSchedulingProfile (52.09s)
PASS
```

#### CPU Flamegraph

![flame_requirements_improvement](https://github.com/user-attachments/assets/d55f47b4-bdc5-4a58-b183-6d41886fd8fd)

#### Heap Profile

![requirements_improvement](https://github.com/user-attachments/assets/e0debd6f-be3e-444e-9373-72e104d13cad)

#### Live Test

__Scheduling Time: 21m36s__

```
{"level":"INFO","time":"2025-02-03T06:00:40.597Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":4425,"pods-remaining":15575,"duration":"1m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:01:40.614Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":6243,"pods-remaining":13757,"duration":"2m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:02:40.662Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":7631,"pods-remaining":12369,"duration":"3m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:03:40.715Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":8795,"pods-remaining":11205,"duration":"4m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:04:40.855Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":9807,"pods-remaining":10193,"duration":"5m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:05:40.910Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":10715,"pods-remaining":9285,"duration":"6m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:06:41.040Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":11541,"pods-remaining":8459,"duration":"7m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:07:41.183Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":12309,"pods-remaining":7691,"duration":"8m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:08:41.268Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":13029,"pods-remaining":6971,"duration":"9m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:09:41.416Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":13713,"pods-remaining":6287,"duration":"10m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:10:41.449Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":14367,"pods-remaining":5633,"duration":"11m0s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:11:41.586Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":14989,"pods-remaining":5011,"duration":"12m1s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:12:41.619Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":15587,"pods-remaining":4413,"duration":"13m1s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:13:41.774Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":16163,"pods-remaining":3837,"duration":"14m1s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:14:42.072Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":16719,"pods-remaining":3281,"duration":"15m1s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:15:42.291Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":17259,"pods-remaining":2741,"duration":"16m1s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:16:42.464Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":17783,"pods-remaining":2217,"duration":"17m1s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:17:42.514Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":18293,"pods-remaining":1707,"duration":"18m1s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:18:42.663Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":18787,"pods-remaining":1213,"duration":"19m2s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:19:42.839Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":19275,"pods-remaining":725,"duration":"20m2s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:20:42.999Z","logger":"controller","caller":"provisioning/provisioner.go:343","message":"computing pod scheduling...","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","pods-scheduled":19747,"pods-remaining":253,"duration":"21m2s","scheduling-id":"f1ef8173-7e95-4c4c-a773-61cb806aded8"}
{"level":"INFO","time":"2025-02-03T06:21:16.112Z","logger":"controller","caller":"provisioning/provisioner.go:129","message":"found provisionable pod(s)","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","Pods":"default/test-51, default/test-123, default/test-31, default/test-181, default/test-19 and 19995 other(s)","duration":"21m36.366916445s"}
{"level":"INFO","time":"2025-02-03T06:21:16.143Z","logger":"controller","caller":"provisioning/provisioner.go:350","message":"computed new nodeclaim(s) to fit pod(s)","commit":"c2dfcaf-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0fd888df-cc29-4182-ada0-f0456ee6824f","nodeclaims":10000,"pods":20000}
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
