### PR TITLE
chore: Add logging for `ConsolidationState` test flake

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -426,12 +426,17 @@ func (c *Cluster) ConsolidationState() time.Time {
 func (c *Cluster) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.clusterState = time.Time{}
+	c.unsyncedStartTime = time.Time{}
 	c.nodes = map[string]*StateNode{}
 	c.nodeNameToProviderID = map[string]string{}
 	c.nodeClaimNameToProviderID = map[string]string{}
 	c.bindings = map[types.NamespacedName]string{}
 	c.antiAffinityPods = sync.Map{}
 	c.daemonSetPods = sync.Map{}
+	c.podAcks = sync.Map{}
+	c.podsSchedulingAttempted = sync.Map{}
+	c.podsSchedulableTimes = sync.Map{}
 }
 
 func (c *Cluster) GetDaemonSetPod(daemonset *appsv1.DaemonSet) *corev1.Pod {

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1474,17 +1474,26 @@ var _ = Describe("Consolidated State", func() {
 		cluster.MarkUnconsolidated()
 		Expect(cluster.ConsolidationState()).ToNot(Equal(state))
 	})
-	It("should update the consolidated value when consolidation timeout (5m) has passed and state hasn't changed", func() {
+	It("should update the consolidated value when state timeout (5m) has passed and state hasn't changed", func() {
+		// TODO: Remove these print logs in the future once we track down the flake
+		fmt.Printf("Current time: %v\n", fakeClock.Now())
 		state := cluster.ConsolidationState()
+		fmt.Printf("Initial state: %v\n", state)
 
 		fakeClock.Step(time.Minute)
-		Expect(cluster.ConsolidationState()).To(Equal(state))
+		initial := cluster.ConsolidationState()
+		fmt.Printf("After moving a minute: %v\n", initial)
+		Expect(initial).To(Equal(state))
 
 		fakeClock.Step(time.Minute * 2)
-		Expect(cluster.ConsolidationState()).To(Equal(state))
+		initial2 := cluster.ConsolidationState()
+		fmt.Printf("After moving two minutes: %v\n", initial2)
+		Expect(initial2).To(Equal(state))
 
 		fakeClock.Step(time.Minute * 2)
-		Expect(cluster.ConsolidationState()).ToNot(Equal(state))
+		initial3 := cluster.ConsolidationState()
+		fmt.Printf("After moving two more minutes: %v\n", initial3)
+		Expect(initial3).ToNot(Equal(state))
 	})
 	It("should cause consolidation state to change when a NodePool is updated", func() {
 		cluster.MarkUnconsolidated()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds logging for `ConsolidationState` testing. This helps us figure out why this test is flaking.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
