### PR TITLE
test: Fix `ConsolidationState()` test failure in state testing

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -426,12 +426,17 @@ func (c *Cluster) ConsolidationState() time.Time {
 func (c *Cluster) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.clusterState = time.Time{}
+	c.unsyncedStartTime = time.Time{}
 	c.nodes = map[string]*StateNode{}
 	c.nodeNameToProviderID = map[string]string{}
 	c.nodeClaimNameToProviderID = map[string]string{}
 	c.bindings = map[types.NamespacedName]string{}
 	c.antiAffinityPods = sync.Map{}
 	c.daemonSetPods = sync.Map{}
+	c.podAcks = sync.Map{}
+	c.podsSchedulingAttempted = sync.Map{}
+	c.podsSchedulableTimes = sync.Map{}
 }
 
 func (c *Cluster) GetDaemonSetPod(daemonset *appsv1.DaemonSet) *corev1.Pod {

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -1474,7 +1475,7 @@ var _ = Describe("Consolidated State", func() {
 		cluster.MarkUnconsolidated()
 		Expect(cluster.ConsolidationState()).ToNot(Equal(state))
 	})
-	It("should update the consolidated value when consolidation timeout (5m) has passed and state hasn't changed", func() {
+	It("should update the consolidated value when state timeout (5m) has passed and state hasn't changed", func() {
 		state := cluster.ConsolidationState()
 
 		fakeClock.Step(time.Minute)
@@ -1499,12 +1500,16 @@ var _ = Describe("Consolidated State", func() {
 var _ = Describe("Data Races", func() {
 	It("should ensure that calling Synced() is valid while making updates to Nodes", func() {
 		cancelCtx, cancel := context.WithCancel(ctx)
+		var wg sync.WaitGroup
 		DeferCleanup(func() {
 			cancel()
+			wg.Wait()
 		})
 
 		// Keep calling Synced for the entirety of this test
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for {
 				_ = cluster.Synced(ctx)
 				if cancelCtx.Err() != nil {
@@ -1524,12 +1529,16 @@ var _ = Describe("Data Races", func() {
 	})
 	It("should ensure that calling Synced() is valid while making updates to NodeClaims", func() {
 		cancelCtx, cancel := context.WithCancel(ctx)
+		var wg sync.WaitGroup
 		DeferCleanup(func() {
 			cancel()
+			wg.Wait()
 		})
 
 		// Keep calling Synced for the entirety of this test
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for {
 				_ = cluster.Synced(ctx)
 				if cancelCtx.Err() != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fix test flakes coming from the `ConsolidationState()` and DataRace checks inside of the test suite. Resetting the cluster state without using a wait group to complete the goroutine was causing the data race during the Data Race test and not properly resetting all of the details inside of cluster state was causing the `ConsolidationState()` test to fail.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
