### PR TITLE
test: Fix DataRace test cleanup ordering

### DIFF
--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1498,14 +1498,17 @@ var _ = Describe("Consolidated State", func() {
 })
 
 var _ = Describe("Data Races", func() {
+	var wg sync.WaitGroup
+	var cancelCtx context.Context
+	var cancel context.CancelFunc
+	BeforeEach(func() {
+		cancelCtx, cancel = context.WithCancel(ctx)
+	})
+	AfterEach(func() {
+		cancel()
+		wg.Wait()
+	})
 	It("should ensure that calling Synced() is valid while making updates to Nodes", func() {
-		cancelCtx, cancel := context.WithCancel(ctx)
-		var wg sync.WaitGroup
-		DeferCleanup(func() {
-			cancel()
-			wg.Wait()
-		})
-
 		// Keep calling Synced for the entirety of this test
 		wg.Add(1)
 		go func() {
@@ -1528,13 +1531,6 @@ var _ = Describe("Data Races", func() {
 		}
 	})
 	It("should ensure that calling Synced() is valid while making updates to NodeClaims", func() {
-		cancelCtx, cancel := context.WithCancel(ctx)
-		var wg sync.WaitGroup
-		DeferCleanup(func() {
-			cancel()
-			wg.Wait()
-		})
-
 		// Keep calling Synced for the entirety of this test
 		wg.Add(1)
 		go func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

`DeferCleanup` blocks run after all `AfterEach` blocks as described in https://github.com/onsi/ginkgo/issues/1360. As a result, we need to create a seprate `AfterEach` node which will be run from inner-most nested block to outer-most nested block to ensure that the WaitGroup finishes before we reset the cluster state to avoid DATA RACES

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
