### PR TITLE
test: Ensure that we don't step the idle duration since this can cause the batcher to exit

### DIFF
--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -151,6 +151,9 @@ var _ = Describe("Provisioning", func() {
 				// We expect to have waiters on the fakeClock since this is still within the batch idle duration of 5s.
 				Eventually(func() bool { return fakeClock.HasWaiters() }, time.Second).Should(BeTrue())
 				prov.Trigger(pod.UID)
+
+				time.Sleep(time.Second) // give the process time to iterate on the batching section
+
 				// Step the clock again by 3s to just cross the batch idle duration. We should be able to get out of the
 				// provisioning loop because the same pod will not cause the idle duration to reset.
 				fakeClock.Step(3 * time.Second)
@@ -191,12 +194,15 @@ var _ = Describe("Provisioning", func() {
 				// We expect to have waiters on the fakeClock since this is still within the batch idle duration of 5s.
 				Eventually(func() bool { return fakeClock.HasWaiters() }, time.Second).Should(BeTrue())
 				prov.Trigger(pod2.UID)
-				// Step the clock by 5s as we expect provisioning to not happen until another 5s because the
+
+				time.Sleep(time.Second) // give the process time to iterate on the batching section
+
+				// Step the clock by 3s as we expect provisioning to not happen until another 5s because the
 				// batch idle duration was reset due to a new pod being added.
-				fakeClock.Step(5 * time.Second)
+				fakeClock.Step(3 * time.Second)
 				Consistently(func() bool { return fakeClock.HasWaiters() }, time.Second).Should(BeTrue())
-				// Stepping the clock again by 2s. We should be able to get out of the
-				// provisioning loop at this point
+				// Stepping the clock again by 3s. We should be able to get out of the
+				// provisioning loop at this point (since we have exceeded the idle duration)
 				fakeClock.Step(3 * time.Second)
 				Eventually(func() bool { return fakeClock.HasWaiters() }, time.Second).Should(BeFalse())
 			}()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This ensures that we don't trigger a 5s move on the batcher during testing since this is exactly the same as the idle duration and was causing flakes in testing like in https://github.com/kubernetes-sigs/karpenter/actions/runs/13143439974/attempts/1?pr=1950

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
