### PR TITLE
perf: Reduce the memory overhead on cluster state `Synced()`

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -378,7 +378,7 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
 	})
-	// Update the nodeclaim manually in state to avoid evenutal consistency delay races with our watcher.
+	// Update the nodeclaim manually in state to avoid eventual consistency delay races with our watcher.
 	// This is essential to avoiding races where disruption can create a replacement node, then immediately
 	// requeue. This can race with controller-runtime's internal cache as it watches events on the cluster
 	// to then trigger cluster state updates. Triggering it manually ensures that Karpenter waits for the


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates our cluster state `Synced()` logic so that we only wait for the Nodes and NodeClaims to match at the controller startup and then only check the providerID after that point.

This allows us to save on allocations that we were spending on DeepCopying NodeClaims and Nodes as well as saving CPU time on checking this

### Before PR 

<img width="1195" alt="Screenshot 2025-02-05 at 11 57 27 AM" src="https://github.com/user-attachments/assets/bf64e80d-15ea-4b48-9bac-05a3c53ce613" />

<img width="1194" alt="Screenshot 2025-02-05 at 11 58 36 AM" src="https://github.com/user-attachments/assets/7b10b59c-075e-46b7-8981-5449f571bbc1" />

![alloc_space_before](https://github.com/user-attachments/assets/dd6bfd3c-1fcc-4420-b640-1eeb06e35deb)

(Note the portions of the heap that are used by the NodeClaim and Node deep copies)

### After PR

<img width="1198" alt="Screenshot 2025-02-05 at 11 57 20 AM" src="https://github.com/user-attachments/assets/7031d92a-5304-4023-9880-8c5ceca4a3a9" />

<img width="1192" alt="Screenshot 2025-02-05 at 11 59 44 AM" src="https://github.com/user-attachments/assets/40962dbd-7674-40f0-9061-68c03e7dbaa1" />

![alloc_space_after](https://github.com/user-attachments/assets/16f13b05-c3fb-4af3-b2bf-46c6f26841b7)

(Note how there are no longer any nodes in the heap that are dedicated toward the Node and NodeClaim deep copies)

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
