### PR TITLE
perf: Remove using `Difference()` from set creation

### DIFF
--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -176,7 +176,10 @@ func (r Requirements) Compatible(requirements Requirements, options ...option.Fu
 	opts := option.Resolve(options...)
 
 	// Custom Labels must intersect, but if not defined are denied.
-	for key := range requirements.Keys().Difference(opts.AllowUndefined) {
+	for key := range requirements {
+		if opts.AllowUndefined.Has(key) {
+			continue
+		}
 		if operator := requirements.Get(key).Operator(); r.Has(key) || operator == corev1.NodeSelectorOpNotIn || operator == corev1.NodeSelectorOpDoesNotExist {
 			continue
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Using the `Difference` function results in us creating a new set when we could have just iterated through the map and read the existing values

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
