### PR TITLE
chore: Ensure that we implement `Unwrap` to support `errors.As`

### DIFF
--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+)
+
+func TestCloudProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CloudProvider Suite")
+}
+
+var _ = Describe("CloudProvider", func() {
+	It("should support unwrapping for NodeClaimNotFound", func() {
+		err := cloudprovider.NewNodeClaimNotFoundError(&BaseError{})
+		_, ok := lo.ErrorsAs[*BaseError](err)
+		Expect(ok).To(BeTrue())
+	})
+	It("should support unwrapping for InsufficientCapacity", func() {
+		err := cloudprovider.NewInsufficientCapacityError(&BaseError{})
+		_, ok := lo.ErrorsAs[*BaseError](err)
+		Expect(ok).To(BeTrue())
+	})
+	It("should support unwrapping for NodeClassNotReady", func() {
+		err := cloudprovider.NewNodeClassNotReadyError(&BaseError{})
+		_, ok := lo.ErrorsAs[*BaseError](err)
+		Expect(ok).To(BeTrue())
+	})
+	It("should support unwrapping for CreateError", func() {
+		err := cloudprovider.NewCreateError(&BaseError{}, "", "")
+		_, ok := lo.ErrorsAs[*BaseError](err)
+		Expect(ok).To(BeTrue())
+	})
+})
+
+type BaseError struct {
+	error
+}

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -326,6 +326,10 @@ func (e *NodeClaimNotFoundError) Error() string {
 	return fmt.Sprintf("nodeclaim not found, %s", e.error)
 }
 
+func (e *NodeClaimNotFoundError) Unwrap() error {
+	return e.error
+}
+
 func IsNodeClaimNotFoundError(err error) bool {
 	if err == nil {
 		return false
@@ -356,6 +360,10 @@ func (e *InsufficientCapacityError) Error() string {
 	return fmt.Sprintf("insufficient capacity, %s", e.error)
 }
 
+func (e *InsufficientCapacityError) Unwrap() error {
+	return e.error
+}
+
 func IsInsufficientCapacityError(err error) bool {
 	if err == nil {
 		return false
@@ -379,6 +387,10 @@ func (e *NodeClassNotReadyError) Error() string {
 	return fmt.Sprintf("NodeClassRef not ready, %s", e.error)
 }
 
+func (e *NodeClassNotReadyError) Unwrap() error {
+	return e.error
+}
+
 func IsNodeClassNotReadyError(err error) bool {
 	if err == nil {
 		return false
@@ -400,4 +412,12 @@ func NewCreateError(err error, reason, message string) *CreateError {
 		ConditionReason:  reason,
 		ConditionMessage: message,
 	}
+}
+
+func (e *CreateError) Error() string {
+	return fmt.Sprintf("creating nodeclaim, %s", e.error)
+}
+
+func (e *CreateError) Unwrap() error {
+	return e.error
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Support error unwrapping with our custom error types -- our current error types wouldn't recognize the inner error types because they didn't implement `Unwrap()`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
