### PR TITLE
ci: fix flaky test for stale instance type drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,14 @@ uninstall-kwok: ## Uninstall kwok provider
 build-with-kind: # build with kind assumes the image will be uploaded directly onto the kind control plane, without an image repository
 	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) KO_DOCKER_REPO="$(KWOK_REPO)" ko build sigs.k8s.io/karpenter/kwok))
 	$(eval IMG_REPOSITORY=$(shell echo $(CONTROLLER_IMG) | cut -d ":" -f 1))
-	$(eval IMG_TAG=latest) 
+	$(eval IMG_TAG=latest)
 
 build: ## Build the Karpenter KWOK controller images using ko build
 	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) KO_DOCKER_REPO="$(KWOK_REPO)" ko build -B sigs.k8s.io/karpenter/kwok))
 	$(eval IMG_REPOSITORY=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 1))
 	$(eval IMG_TAG=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 2 -s))
 	$(eval IMG_DIGEST=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 2))
-	
+
 apply-with-kind: verify build-with-kind ## Deploy the kwok controller from the current state of your git repository into your ~/.kube/config cluster
 	kubectl apply -f kwok/charts/crds
 	helm upgrade --install karpenter kwok/charts --namespace $(KARPENTER_NAMESPACE) --skip-crds \
@@ -38,7 +38,7 @@ apply-with-kind: verify build-with-kind ## Deploy the kwok controller from the c
 		--set controller.image.tag=$(IMG_TAG) \
 		--set serviceMonitor.enabled=true \
 		--set-string controller.env[0].name=ENABLE_PROFILING \
-		--set-string controller.env[0].value=true 
+		--set-string controller.env[0].value=true
 
 e2etests: ## Run the e2e suite against your local cluster
 	cd test && go test \

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -115,7 +115,6 @@ var _ = Describe("Drift", func() {
 				for i := range it.Offerings {
 					it.Offerings[i].Requirements = scheduling.NewLabelRequirements(map[string]string{
 						corev1.LabelTopologyZone: test.RandomName(),
-						// v1.CapacityTypeLabelKey:  test.RandomName(),
 					})
 				}
 			}

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -112,8 +112,12 @@ var _ = Describe("Drift", func() {
 	It("should detect stale instance type drift if the instance type offerings aren't compatible with the nodeclaim", func() {
 		cp.InstanceTypes = lo.Map(cp.InstanceTypes, func(it *cloudprovider.InstanceType, _ int) *cloudprovider.InstanceType {
 			if it.Name == nodeClaim.Labels[corev1.LabelInstanceTypeStable] {
-				newLabels := lo.Keys(nodeClaim.Labels)
-				it.Requirements = scheduling.NewLabelRequirements(map[string]string{newLabels[0]: test.RandomName()})
+				for i := range it.Offerings {
+					it.Offerings[i].Requirements = scheduling.NewLabelRequirements(map[string]string{
+						corev1.LabelTopologyZone: test.RandomName(),
+						// v1.CapacityTypeLabelKey:  test.RandomName(),
+					})
+				}
 			}
 			return it
 		})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1986 

**Description**

1. change Offering.Requirements of InstanceType over Requirements for setup test; ofs.HasCompatible compare Offering.Requirements with the argument(NodeClaim.Labels in this case) -> so i don't know how the test was passed sometimes
2. fix the key for changing value to Offering.Requirements concerns since a return of lo.Keys is not sorted, the previous key was random.
  a. just one changing is enough so commented another  

chore: remove trailing whitespaces in Makefile

**How was this change tested?**

check the test case is passed on make deflake FOCUS="should detect stale instance type drift if the instance type offerings aren't compatible with the nodeclaim"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
