### PR TITLE
test: allow kwok provider deletion to terminate instance

### DIFF
--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -70,7 +70,7 @@ func (c CloudProvider) Delete(ctx context.Context, nodeClaim *v1.NodeClaim) erro
 		}
 		return fmt.Errorf("deleting node, %w", err)
 	}
-	return nil
+	return cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("instance terminated"))
 }
 
 func (c CloudProvider) Get(ctx context.Context, providerID string) (*v1.NodeClaim, error) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A

**Description**
In order to delete a Node or NodeClaim by termination, the current behaviour is that Karpenter calls [`EnsureTerminated`](https://github.com/kubernetes-sigs/karpenter/blob/main/pkg/utils/termination/termination.go#L34) which calls the cloudProvider's implementation of `Delete` in order to "ensure" the underlying instance is actually deleted from the infra before removing the k8s resources. Using KWOK, there is no real backing infra, but the KWOK provider `Delete` implementation currently tries to delete the actual NodeClaim from the kubernetes api. So this becomes a chicken and egg problem because `EnsureTerminated` is expecting an `NodeClaimNotFound` error to be returned in order to proceed with the deletion (removing finalizers), but the KWOK provider cannot actually delete the Kubernetes resource and eventually return that error since it is blocking itself from doing so.

This change just changes the KWOK provider implementation of delete to initiate a delete, and if there is no immediate error, instantly return a `NodeClaimNotFoundError` in order to simulate the underlying cloud provider instance being "deleted". 

**How was this change tested?**
By running a kind cluster and applying this script to initiated e2e tests:
```bash
#!/usr/bin/env bash
# kind create cluster

export KWOK_REPO=kind.local
export KIND_CLUSTER_NAME=kind
./hack/install-prometheus.sh
make install-kwok
make apply-with-kind
kubectl taint node kind-control-plane CriticalAddonsOnly:NoSchedule
sleep 10

make e2etests
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
