### PR TITLE
ci: add a workflow semantic-pr

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -8,6 +8,7 @@ on:
       - synchronize
 
 permissions:
+  # write permission is required for the wip feature to update PR status to pending when [WIP] is in the title
   pull-requests: write
 
 jobs:

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,22 @@
+name: "Semantic Pull Request"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: Validate a PR title is following the conventional commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          wip: true

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+      - reopened
 
 permissions:
   # write permission is required for the wip feature to update PR status to pending when [WIP] is in the title

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Validate a PR title is following the conventional commits
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3, to avoid Unpinned tag for 3rd party Action in workflow from CodeQL
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -9,8 +9,7 @@ on:
       - reopened
 
 permissions:
-  # write permission is required for the wip feature to update PR status to pending when [WIP] is in the title
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   main:
@@ -20,5 +19,3 @@ jobs:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3, to avoid Unpinned tag for 3rd party Action in workflow from CodeQL
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          wip: true


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1978 

**Description**

add a workflow [sematic-pull-request](https://github.com/marketplace/actions/semantic-pull-request) to validate for each pr title would follow the conventional commits -- most of default value of parameters of the action are for this.
a write permission is required to use `wip` option, skip PRs the title is started with `[WIP]`.

**How was this change tested?**

no, [the limitation of trigger `pull_request_target`](https://github.com/marketplace/actions/semantic-pull-request#event-triggers)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
