### PR TITLE
Update karpenter_scheduler_unschedulable_pods_count

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -219,9 +219,6 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) Results {
 	// had 5xA pods and 5xB pods were they have a zonal topology spread, but A can only go in one zone and B in another.
 	// We need to schedule them alternating, A, B, A, B, .... and this solution also solves that as well.
 	errors := map[*corev1.Pod]error{}
-	// Reset the metric for the controller, so we don't keep old ids around
-	UnschedulablePodsCount.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
-	QueueDepth.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
 	for _, p := range pods {
 		s.updateCachedPodData(p)
 	}

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -3717,7 +3717,7 @@ var _ = Context("Scheduling", func() {
 				ExpectApplied(ctx, env.Client, i)
 			}
 			_, err := prov.Schedule(injection.WithControllerName(ctx, "provisioner"))
-			m, ok := FindMetricWithLabelValues("karpenter_scheduler_unschedulable_pods_count", map[string]string{"controller": "provisioner"})
+			m, ok := FindMetricWithLabelValues("karpenter_scheduler_unschedulable_pods_count", map[string]string{})
 			Expect(ok).To(BeTrue())
 			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", 10))
 			Expect(err).To(BeNil())


### PR DESCRIPTION
karpenter_scheduler_unschedulable_pods_count has unnecessary DeletePartialMatch in the scheduler

Fixes #1993 

**Description**
karpenter_scheduler_unschedulable_pods_count is set at the top of every provisioning loop -- realistically, this value is continually set as provisioning loops are run and we shouldn't need this metric in the disruption loops (because we expect that there are going to be cases with consolidation where pods won't schedule) -- we should remove the DeletePartialMatch as well as the controller label on the metric since it's unneccesary


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
