### PR TITLE
test: increase Eventually timeout in e2e tests

### DIFF
--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -91,7 +91,7 @@ func NewEnvironment(t *testing.T) *Environment {
 	// Get the output dir if it's set
 	outputDir, _ := os.LookupEnv("OUTPUT_DIR")
 
-	gomega.SetDefaultEventuallyTimeout(5 * time.Minute)
+	gomega.SetDefaultEventuallyTimeout(10 * time.Minute)
 	gomega.SetDefaultEventuallyPollingInterval(1 * time.Second)
 	return &Environment{
 		Context:               ctx,


### PR DESCRIPTION
Fixes #2007

**Description**
For now, this PR bumps up the default `Eventually` timeout to 10 minutes. E2E tests may fail if the cloud provider cannot finish provisioning an instance within the previous low 5 minute default.

**How was this change tested?**
Running the e2e tests in a local kind cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
