### PR TITLE
perf: check validity before constructing a new set of requirements

### DIFF
--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -92,11 +92,13 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 		return fmt.Errorf("exceeds node resources")
 	}
 
-	nodeRequirements := scheduling.NewRequirements(n.requirements.Values()...)
 	// Check NodeClaim Affinity Requirements
-	if err = nodeRequirements.Compatible(podData.Requirements); err != nil {
+	if err = n.requirements.Compatible(podData.Requirements); err != nil {
 		return err
 	}
+	// avoid creating our temp set of requirements until after we've ensured that at least
+	// the pod is compatible
+	nodeRequirements := scheduling.NewRequirements(n.requirements.Values()...)
 	nodeRequirements.Add(podData.Requirements.Values()...)
 
 	// Check Topology Requirements


### PR DESCRIPTION
**Description**
When checking if a Pod will work on an existing Node, we validate in several ways including
checking the Pods requirements vs the Node's requirements. If it fails at any step, 
we need to leave the Node's requirements unchanged. Previously we were:

1) Creating set of temporary requirements from the current node's requirements
2) Check if the Pod is compatible with them
3) Assigning those back to the Node if all compatibility checks passed

This changes the order so that we check for compatibility with the Pod first so that 
in the case of a Pod not being compatible, we can avoid the allocation that occurs when
creating the temporary set of requirements.

**How was this change tested?**

Unit testing & deployed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
