### PR TITLE
perf: trade off less verbose errors for faster execution

### DIFF
--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -172,7 +172,7 @@ func (r Requirements) IsCompatible(requirements Requirements, options ...option.
 }
 
 // Compatible ensures the provided requirements can loosely be met.
-func (r Requirements) Compatible(requirements Requirements, options ...option.Function[CompatibilityOptions]) (errs error) {
+func (r Requirements) Compatible(requirements Requirements, options ...option.Function[CompatibilityOptions]) error {
 	opts := option.Resolve(options...)
 
 	// Custom Labels must intersect, but if not defined are denied.
@@ -183,10 +183,11 @@ func (r Requirements) Compatible(requirements Requirements, options ...option.Fu
 		if operator := requirements.Get(key).Operator(); r.Has(key) || operator == corev1.NodeSelectorOpNotIn || operator == corev1.NodeSelectorOpDoesNotExist {
 			continue
 		}
-		errs = multierr.Append(errs, fmt.Errorf("label %q does not have known values%s", key, labelHint(r, key, opts.AllowUndefined)))
+		// break early so we only report the first error
+		return fmt.Errorf("label %q does not have known values%s", key, labelHint(r, key, opts.AllowUndefined))
 	}
 	// Well Known Labels must intersect, but if not defined, are allowed.
-	return multierr.Append(errs, r.Intersects(requirements))
+	return r.Intersects(requirements)
 }
 
 // editDistance is an implementation of edit distance from Algorithms/DPV


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**

Returning the first error we find is both faster and allocates less. There is a tradeoff here in that we'll only report one of the reasons that a Pod won't schedule, but I think the tradeoff for faster speed & fewer allocations is worth it.


**How was this change tested?**

Unit testing & deployed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
