### PR TITLE
fix: BREAKING put karpenter_ignored_pod_count metric under scheduler subsystem

### DIFF
--- a/pkg/controllers/provisioning/scheduling/metrics.go
+++ b/pkg/controllers/provisioning/scheduling/metrics.go
@@ -74,6 +74,7 @@ var (
 		crmetrics.Registry,
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
+			Subsystem: schedulerSubsystem,
 			Name:      "ignored_pod_count",
 			Help:      "Number of pods ignored during scheduling by Karpenter",
 		},

--- a/pkg/controllers/provisioning/scheduling/metrics.go
+++ b/pkg/controllers/provisioning/scheduling/metrics.go
@@ -75,7 +75,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: schedulerSubsystem,
-			Name:      "ignored_pod_count",
+			Name:      "ignored_pods_count",
 			Help:      "Number of pods ignored during scheduling by Karpenter",
 		},
 		[]string{},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1992

**Description**
Put `karpenter_ignored_pod_count` metric under `scheduler` subsystem, new metric name is: `karpenter_scheduler_ignored_pod_count`.

**How was this change tested?**
1 . Made temporary changes:
```diff
diff --git a/Makefile b/Makefile
index 3029f80..ffe428d 100644
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,11 @@ delete: ## Delete the controller from your ~/.kube/config cluster
 	helm uninstall karpenter --namespace $(KARPENTER_NAMESPACE)
 
 test: ## Run tests
-	go test ./pkg/... \
+	go test ./pkg/controllers/provisioning \
 		-race \
 		-timeout 20m \
-		--ginkgo.focus="${FOCUS}" \
 		--ginkgo.randomize-all \
-		--ginkgo.v \
-		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
+		--ginkgo.v
 
 deflake: ## Run randomized, racing tests until the test fails to catch flakes
 	ginkgo \
diff --git a/pkg/controllers/provisioning/suite_test.go b/pkg/controllers/provisioning/suite_test.go
index 1174ef9..46d34a7 100644
--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -1631,7 +1631,7 @@ var _ = Describe("Provisioning", func() {
 		BeforeEach(func() {
 			storageClass = test.StorageClass(test.StorageClassOptions{Zones: []string{"test-zone-2", "test-zone-3"}})
 		})
-		It("should not schedule if invalid pvc", func() {
+		FIt("should not schedule if invalid pvc", func() {
 			ExpectApplied(ctx, env.Client, test.NodePool())
 			pod := test.UnschedulablePod(test.PodOptions{
 				PersistentVolumeClaims: []string{"invalid"},
diff --git a/pkg/test/expectations/expectations.go b/pkg/test/expectations/expectations.go
index 060ec78..b459422 100644
--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -567,6 +567,7 @@ func FindMetricWithLabelValues(name string, labelValues map[string]string) (*pro
 func ExpectMetricGaugeValue(collector opmetrics.GaugeMetric, expectedValue float64, labels map[string]string) {
 	GinkgoHelper()
 	metricName := ExpectMetricName(collector.(*opmetrics.PrometheusGauge))
+	fmt.Println("metricName is:", metricName)
 	metric, ok := FindMetricWithLabelValues(metricName, labels)
 	Expect(ok).To(BeTrue(), "Metric "+metricName+" should be available")
 	Expect(lo.FromPtr(metric.Gauge.Value)).To(Equal(expectedValue), "Metric "+metricName+" should have the expected value")

```


2. Executed:
```
make test
```

3. Result (truncated):
```
metricName is: karpenter_scheduler_ignored_pod_count
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
