### PR TITLE
test: Remove drifted reason on Reset() for `fake.CloudProvider`

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -87,7 +87,7 @@ func (c *CloudProvider) Reset() {
 	c.NextGetErr = nil
 	c.DeleteCalls = []*v1.NodeClaim{}
 	c.GetCalls = nil
-	c.Drifted = "drifted"
+	c.Drifted = ""
 	c.NodeClassGroupVersionKind = []schema.GroupVersionKind{
 		{
 			Group:   "",

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -193,7 +193,6 @@ var _ = Describe("Drift", func() {
 		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)).To(BeNil())
 	})
 	It("should remove the status condition from the nodeClaim if the nodeClaim is no longer drifted", func() {
-		cp.Drifted = ""
 		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeDrifted)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
@@ -205,8 +204,6 @@ var _ = Describe("Drift", func() {
 	Context("NodeRequirement Drift", func() {
 		DescribeTable("",
 			func(oldNodePoolReq []v1.NodeSelectorRequirementWithMinValues, newNodePoolReq []v1.NodeSelectorRequirementWithMinValues, labels map[string]string, drifted bool) {
-				cp.Drifted = ""
-
 				nodePool.Spec.Template.Spec.Requirements = oldNodePoolReq
 				nodeClaim.Labels = lo.Assign(nodeClaim.Labels, labels)
 
@@ -356,7 +353,6 @@ var _ = Describe("Drift", func() {
 			),
 		)
 		It("should return drifted only on NodeClaims that are drifted from an updated nodePool", func() {
-			cp.Drifted = ""
 			nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirementWithMinValues{
 				{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: v1.CapacityTypeLabelKey, Operator: corev1.NodeSelectorOpIn, Values: []string{v1.CapacityTypeOnDemand}}},
 				{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelOSStable, Operator: corev1.NodeSelectorOpIn, Values: []string{string(corev1.Linux), string(corev1.Windows)}}},
@@ -411,7 +407,6 @@ var _ = Describe("Drift", func() {
 	Context("NodePool Static Drift", func() {
 		var nodePoolController *hash.Controller
 		BeforeEach(func() {
-			cp.Drifted = ""
 			nodePoolController = hash.NewController(env.Client, cp)
 			nodePool = &v1.NodePool{
 				ObjectMeta: nodePool.ObjectMeta,

--- a/pkg/controllers/nodeclaim/disruption/suite_test.go
+++ b/pkg/controllers/nodeclaim/disruption/suite_test.go
@@ -142,7 +142,6 @@ var _ = Describe("Disruption", func() {
 		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeConsolidatable).IsTrue()).To(BeTrue())
 	})
 	It("should remove multiple disruption conditions simultaneously", func() {
-		cp.Drifted = ""
 		nodePool.Spec.Disruption.ConsolidateAfter = v1.MustParseNillableDuration("Never")
 
 		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeDrifted)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change ensures that the `Reset()` call doesn't set the Drifted reason each time to remove test flakes

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
