### PR TITLE
chore: Update the scheduling metric name to be `karpenter_pods_provisioning_scheduling_undecided_time_seconds`

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -160,7 +160,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: metrics.PodSubsystem,
-			Name:      "scheduling_undecided_time_seconds",
+			Name:      "provisioning_scheduling_undecided_time_seconds",
 			Help:      "The time from when Karpenter has seen a pod without making a scheduling decision for the pod. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 		},
 		[]string{podName, podNamespace},

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Pod Metrics", func() {
 
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		fakeClock.Step(1 * time.Hour)
-		_, found := FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
+		_, found := FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -265,7 +265,7 @@ var _ = Describe("Pod Metrics", func() {
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		fakeClock.Step(1 * time.Hour)
 
-		_, found = FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -274,7 +274,7 @@ var _ = Describe("Pod Metrics", func() {
 		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, p)
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 
-		_, found = FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -287,7 +287,7 @@ var _ = Describe("Pod Metrics", func() {
 
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		fakeClock.Step(1 * time.Hour)
-		_, found := FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
+		_, found := FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -298,7 +298,7 @@ var _ = Describe("Pod Metrics", func() {
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		fakeClock.Step(1 * time.Hour)
 
-		_, found = FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})
@@ -307,7 +307,7 @@ var _ = Describe("Pod Metrics", func() {
 		ExpectDeleted(ctx, env.Client, p)
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 
-		_, found = FindMetricWithLabelValues("karpenter_pods_scheduling_undecided_time_seconds", map[string]string{
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
 		})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Update metric from `karpenter_pods_scheduling_undecided_time_seconds` to be `karpenter_pods_provisioning_scheduling_undecided_time_seconds`

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
