### PR TITLE
feat: scale disruption cost by the node utilization

### DIFF
--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -112,7 +112,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 		zone:              node.Labels()[corev1.LabelTopologyZone],
 		reschedulablePods: lo.Filter(pods, func(p *corev1.Pod, _ int) bool { return pod.IsReschedulable(p) }),
 		// We get the disruption cost from all pods in the candidate, not just the reschedulable pods
-		DisruptionCost: disruptionutils.ReschedulingCost(ctx, pods) * disruptionutils.LifetimeRemaining(clk, nodePool, node.NodeClaim),
+		DisruptionCost: disruptionutils.ReschedulingCost(ctx, pods) * disruptionutils.LifetimeRemaining(clk, nodePool, node.NodeClaim) * node.Utilization(),
 	}, nil
 }
 

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -365,6 +365,21 @@ func (in *StateNode) Available() corev1.ResourceList {
 	return resources.Subtract(in.Allocatable(), in.PodRequests())
 }
 
+// Utilization is the ratio of requested resources to allocatable resources
+func (in *StateNode) Utilization() float64 {
+	requested := in.PodRequests()
+	if len(requested) == 0 {
+		return 0
+	}
+	alloc := in.Allocatable()
+	utilization := 0.0
+	for resource, request := range requested {
+		allocResource := alloc[resource]
+		utilization += float64(request.MilliValue()) / float64(allocResource.MilliValue())
+	}
+	return utilization / float64(len(requested))
+}
+
 func (in *StateNode) DaemonSetRequests() corev1.ResourceList {
 	return resources.Merge(lo.Values(in.daemonSetRequests)...)
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Scales the disruption cost of nodes by their utilization of pod resources. A node with 1 pod and 99% utilization should have a higher disruption cost than a node with 1 pod and 10% utilization. 

**How was this change tested?**
We've been looking at improving utilization of resources in our clusters, and noticed that Karpenter tends to prefer consolidating underutilized nodes with fewer pods rather than nodes with the most wasted resources. It seems like this can happen because the `disruptionutils.ReschedulingCost(ctx, pods)` produces a value that is roughly equivalent to the pod count (scaled by pod priority class). So nodes with fewer pods and higher utilization will be candidates for consolidation, while underutilized nodes with many smaller pods are not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
