### PR TITLE
test: Including test options into the scheduling benchmark context

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
 	fakecr "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -45,7 +44,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
-	operatorlogging "sigs.k8s.io/karpenter/pkg/operator/logging"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/test"
 )
 
@@ -135,8 +134,9 @@ func TestSchedulingProfile(t *testing.T) {
 
 // nolint:gocyclo
 func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
-	// disable logging
-	ctx = ctrl.IntoContext(context.Background(), operatorlogging.NopLogger)
+	// create context from background with test options
+	// test options disable logging by default
+	ctx = options.ToContext(context.Background(), test.Options())
 	nodePool := test.NodePool(v1.NodePool{
 		Spec: v1.NodePoolSpec{
 			Limits: v1.Limits{


### PR DESCRIPTION
Fixes #N/A

**Description**

The recent ODCR PR [#1911](https://github.com/kubernetes-sigs/karpenter/pull/1911) broke the scheduling benchmarking test by adding a requirement for scheduling to have options in its context. 

This change introduces the standard `test.Options()` into the context prior to the benchmarking test,

**How was this change tested?**

 I ran both `make test` and the actual scheduling test and both passed:

```
go test -tags=test_performance -run=SchedulingProfile
scheduled 40151 against 8031 nodes in total in 40.306934825s 996.1313152270939 pods/sec
400 instances 1 pods      1 nodes     96.906µs per scheduling      96.906µs per pod
400 instances 50 pods     10 nodes    27.13001ms per scheduling    542.6µs per pod
400 instances 100 pods    20 nodes    60.294949ms per scheduling   602.949µs per pod
400 instances 500 pods    100 nodes   257.862183ms per scheduling  515.724µs per pod
400 instances 1000 pods   200 nodes   621.7505ms per scheduling    621.75µs per pod
400 instances 1500 pods   300 nodes   784.344291ms per scheduling  522.896µs per pod
400 instances 2000 pods   400 nodes   1.013751666s per scheduling  506.875µs per pod
400 instances 5000 pods   1000 nodes  3.449692875s per scheduling  689.938µs per pod
400 instances 10000 pods  2000 nodes  8.076069042s per scheduling  807.606µs per pod
400 instances 20000 pods  4000 nodes  24.2633625s per scheduling   1.213168ms per pod
PASS
ok  	sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling	50.701s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
