### PR TITLE
feat: add karpenter_pods_drained_total metric to track pod draining by reason

### DIFF
--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -209,7 +209,9 @@ func (q *Queue) Evict(ctx context.Context, key QueueKey) bool {
 		return false
 	}
 	NodesEvictionRequestsTotal.Inc(map[string]string{CodeLabel: "200"})
-	q.recorder.Publish(terminatorevents.EvictPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}, evictionReason(ctx, key, q.kubeClient)))
+	reason := evictionReason(ctx, key, q.kubeClient)
+	q.recorder.Publish(terminatorevents.EvictPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}, reason))
+	PodsDrainedTotal.Inc(map[string]string{ReasonLabel: reason})
 	return true
 }
 

--- a/pkg/controllers/node/termination/terminator/metrics.go
+++ b/pkg/controllers/node/termination/terminator/metrics.go
@@ -27,6 +27,8 @@ import (
 const (
 	// CodeLabel for eviction request
 	CodeLabel = "code"
+	// ReasonLabel for pod draining
+	ReasonLabel = "reason"
 )
 
 var NodesEvictionRequestsTotal = opmetrics.NewPrometheusCounter(
@@ -38,4 +40,15 @@ var NodesEvictionRequestsTotal = opmetrics.NewPrometheusCounter(
 		Help:      "The total number of eviction requests made by Karpenter",
 	},
 	[]string{CodeLabel},
+)
+
+var PodsDrainedTotal = opmetrics.NewPrometheusCounter(
+	crmetrics.Registry,
+	prometheus.CounterOpts{
+		Namespace: metrics.Namespace,
+		Subsystem: metrics.PodSubsystem,
+		Name:      "pods_drained_total",
+		Help:      "The total number of pods drained during node termination by Karpenter, labeled by reason",
+	},
+	[]string{ReasonLabel},
 )


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2021

**Description**
Implements a new Prometheus metric to count pods drained during node termination, labeled by the reason for draining. This provides visibility into the number of pods affected by different termination scenarios.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
