### PR TITLE
ci: Automating scheduling benchmarking testing for PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -61,3 +61,11 @@ updates:
       action-deps:
         patterns:
           - '*'
+  - package-ecosystem: github-actions
+    directory: .github/actions/run-bench-test
+    schedule:
+      interval: weekly
+    groups:
+      action-deps:
+        patterns:
+          - '*'

--- a/.github/workflows/run-bench-test.yaml
+++ b/.github/workflows/run-bench-test.yaml
@@ -1,0 +1,53 @@
+name: "Run Bench Test"
+
+on:
+  workflow_call:
+    inputs:
+      path:
+        description: Path to the performance test
+        required: true
+        type: string
+      runName:
+        description: Name of the run, for the purpose of file naming and github comments
+        required: true
+        type: string
+      githubSha:
+        description: Sha of the github commit to check out
+        required: true
+        type: string
+jobs:
+  run-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.githubSha }}
+      - name: Run Test
+        id: test-run
+        shell: bash
+        run: |
+          {
+            cd ${{ inputs.path }}
+            mkdir output
+            go test -tags=test_performance -run=1 -bench=. -count=1 -cpuprofile output/cpu.out -memprofile output/mem.out > output/results.txt
+            echo 'OUTPUT<<EOF'
+            cat output/results.txt
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        id: artifact-upload
+        with:
+          name: ${{ inputs.runName }}
+          path: ${{ inputs.path }}/output
+      - uses: actions/github-script@v7
+        env:
+          RESULTS: ${{ steps.test-run.outputs.OUTPUT }}
+          UPLOAD: ${{ steps.artifact-upload.outputs.artifact-url }}
+        with:
+          script: |
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `# :mag: ${{ inputs.runName }} :mag:\nResults of benchmarking testing in \`${{ inputs.path }}\`: \n\`\`\`${process.env.RESULTS}\n\`\`\`\n${process.env.UPLOAD}`
+              })

--- a/.github/workflows/scheduling-benchmarking.yaml
+++ b/.github/workflows/scheduling-benchmarking.yaml
@@ -1,0 +1,38 @@
+name: "Scheduling Benchmarking"
+
+on:
+  pull_request:
+    paths:
+      - "**.go"
+    branches:
+      - main
+
+jobs:
+  before:
+    name: Before PR
+    permissions:
+        pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        path: ["pkg/controllers/provisioning/scheduling"]
+    uses: ./.github/workflows/run-bench-test.yaml
+    secrets: inherit
+    with:
+      path: ${{ matrix.path }}
+      runName: before-${{ strategy.job-index }}
+      githubSha: ${{ github.event.pull_request.base.sha }}
+  after:
+    name: After PR
+    permissions:
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        path: ["pkg/controllers/provisioning/scheduling"]
+    uses: ./.github/workflows/run-bench-test.yaml
+    secrets: inherit
+    with:
+      path: ${{ matrix.path }}
+      runName: after-${{ strategy.job-index }}  
+      githubSha: ${{ github.sha }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

New CI to automatically run scheduling benchmark tests for both the existing code and proposed changes whenever a PR modifies a `.go` file. The new workflow will comment results into PR comments, and also store CPU and MEM profiles into a downloadable artifacts that reviewers and approvers can use to analyze any performance improvements or regressions. The current setup leverages the `matrix` functionality to make setting up new benchmark CI tests simple in the future. 

This is a first iteration of a CI suite for performance testing. There are a couple, sometimes contradictory natural extensions for the future:
* Automatically fail the test if performance regresses and remove performance results from PR comments
* Add Consolidation performance benchmark tests
* Parameterize more components of the `go test` call
* Refactor the approach to run a single bench test per GitHub action for cleaner replication

CI testing will always be a moving target as the needs of the community develop, this is intended to be a quick and dirty approach to gather feedback and allow the CI performance testing to adapt to the needs of developers.

**How was this change tested?**

Simulated PRs in my own fork to demonstrate the functionality.

PR that shows benchmarking in action:

* https://github.com/DerekFrank/karpenter-testing-fork/pull/13

PR that shows how doc and other non `.go` functionality changes won't get tested:
* https://github.com/DerekFrank/karpenter-testing-fork/pull/12


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
