### PR TITLE
remove unschedulable_pods_count metric in disruption loop

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -275,7 +275,9 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) Results {
 	// We need to schedule them alternating, A, B, A, B, .... and this solution also solves that as well.
 	errors := map[*corev1.Pod]error{}
 	// Reset the metric for the controller, so we don't keep old ids around
-	UnschedulablePodsCount.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
+	if injection.GetControllerName(ctx) == "provisioner" {
+		UnschedulablePodsCount.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
+	}
 	QueueDepth.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
 	for _, p := range pods {
 		s.updateCachedPodData(p)


### PR DESCRIPTION
Fixes #1993 https://github.com/kubernetes-sigs/karpenter/issues/1993
**Description**
remove the unschedulable_pods_count metric if the controller is not `provisioner`

**How was this change tested?**
make presubmit
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
