### PR TITLE
feat: add requirement keys of KWOK instance offerings to well-known labels

### DIFF
--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -222,8 +222,6 @@ func addInstanceLabels(labels map[string]string, instanceType *cloudprovider.Ins
 	// Randomly add each new node to one of the pre-created kwokPartitions.
 
 	ret[v1alpha1.KwokPartitionLabelKey] = lo.Sample(kwokPartitions)
-	ret[v1.CapacityTypeLabelKey] = offering.Requirements.Get(v1.CapacityTypeLabelKey).Any()
-	ret[corev1.LabelTopologyZone] = offering.Requirements.Get(corev1.LabelTopologyZone).Any()
 	ret[corev1.LabelHostname] = nodeClaim.Name
 
 	ret[v1alpha1.KwokLabelKey] = v1alpha1.KwokLabelValue

--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -211,6 +211,11 @@ func addInstanceLabels(labels map[string]string, instanceType *cloudprovider.Ins
 			ret[r.Key] = r.Values()[0]
 		}
 	}
+	for _, r := range offering.Requirements {
+		if r.Len() == 1 && r.Operator() == corev1.NodeSelectorOpIn {
+			ret[r.Key] = r.Values()[0]
+		}
+	}
 	// add in github.com/awslabs/eks-node-viewer label so that it shows up.
 	ret[v1alpha1.NodeViewerLabelKey] = fmt.Sprintf("%f", offering.Price)
 	// Kwok has some scalability limitations.

--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -139,6 +139,13 @@ func setDefaultOptions(opts InstanceTypeOptions) InstanceTypeOptions {
 		v1alpha1.InstanceCPULabelKey:    cpu,
 		v1alpha1.InstanceMemoryLabelKey: memory,
 	}
+	for _, offering := range opts.Offerings {
+		for _, req := range offering.Requirements {
+			if _, exists := opts.instanceTypeLabels[req.Key]; !exists {
+				opts.instanceTypeLabels[req.Key] = req.Values[0]
+			}
+		}
+	}
 
 	// if the user specified a different pod limit, override the default
 	opts.Resources = lo.Assign(corev1.ResourceList{
@@ -168,6 +175,12 @@ func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 		})
 		return req.Values
 	})))
+
+	for _, offering := range options.Offerings {
+		for _, requirement := range offering.Requirements {
+			v1.WellKnownLabels = v1.WellKnownLabels.Insert(requirement.Key)
+		}
+	}
 
 	requirements := scheduling.NewRequirements(
 		scheduling.NewRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, options.Name),

--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -139,13 +139,6 @@ func setDefaultOptions(opts InstanceTypeOptions) InstanceTypeOptions {
 		v1alpha1.InstanceCPULabelKey:    cpu,
 		v1alpha1.InstanceMemoryLabelKey: memory,
 	}
-	for _, offering := range opts.Offerings {
-		for _, req := range offering.Requirements {
-			if _, exists := opts.instanceTypeLabels[req.Key]; !exists {
-				opts.instanceTypeLabels[req.Key] = req.Values[0]
-			}
-		}
-	}
 
 	// if the user specified a different pod limit, override the default
 	opts.Resources = lo.Assign(corev1.ResourceList{
@@ -178,6 +171,9 @@ func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 
 	for _, offering := range options.Offerings {
 		for _, requirement := range offering.Requirements {
+			v1.WellKnownLabels = v1.WellKnownLabels.Insert(requirement.Key)
+		}
+		for _, requirement := range offering.Offering.Requirements {
 			v1.WellKnownLabels = v1.WellKnownLabels.Insert(requirement.Key)
 		}
 	}


### PR DESCRIPTION
**Description**

Adds the keys of all requirements for each instance-type offering to the list of Well Known Labels. 

This makes it easier to run simulations with non-KWOK NodePools (e.g. using KWOK to simulate how Karpenter would autoscale under certain circumstances in an AWS environment).

Issue: https://github.com/kubernetes-sigs/karpenter/issues/2045

**How was this change tested?**

Tested by running locally against a [KWOK all-in-one](https://kwok.sigs.k8s.io/docs/user/all-in-one-image) environment (pod). 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
