### PR TITLE
feat(nodeclaim): use PodScheduled's status for lastPodEventTime

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/consolidation.go
+++ b/pkg/controllers/nodeclaim/disruption/consolidation.go
@@ -60,6 +60,7 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	timeToCheck := lo.Ternary(!nodeClaim.Status.LastPodEventTime.IsZero(), nodeClaim.Status.LastPodEventTime.Time, initialized.LastTransitionTime.Time)
 
 	// Consider a node consolidatable by looking at the lastPodEvent status field on the nodeclaim.
+	// This time is now based on the PodScheduled condition's lastTransitionTime or pod is being removed(terminal or terminating)
 	if c.clock.Since(timeToCheck) < lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration) {
 		if hasConsolidatableCondition {
 			_ = nodeClaim.StatusConditions().Clear(v1.ConditionTypeConsolidatable)

--- a/pkg/controllers/nodeclaim/hydration/suite_test.go
+++ b/pkg/controllers/nodeclaim/hydration/suite_test.go
@@ -35,10 +35,12 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 )
 
-var ctx context.Context
-var hydrationController *hydration.Controller
-var env *test.Environment
-var cloudProvider *fake.CloudProvider
+var (
+	ctx                 context.Context
+	hydrationController *hydration.Controller
+	env                 *test.Environment
+	cloudProvider       *fake.CloudProvider
+)
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)

--- a/pkg/controllers/nodeclaim/podevents/controller.go
+++ b/pkg/controllers/nodeclaim/podevents/controller.go
@@ -32,18 +32,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/samber/lo"
+
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
-// dedupeTimeout is 10 seconds to reduce the number of writes to the APIServer, since pod scheduling and deletion events are very frequent.
-// The smaller this value is, the more writes Karpenter will make in a busy cluster. This timeout is intentionally smaller than the consolidation
-// 15 second validation period, so that we can ensure that we invalidate consolidation commands that are decided while we're de-duping pod events.
-const dedupeTimeout = 10 * time.Second
-
-// Podevents is a nodeclaim controller that deletes adds the lastPodEvent status onto the nodeclaim
+// Podevents is a nodeclaim controller that updates the lastPodEvent status based on PodScheduled condition
 type Controller struct {
 	clock         clock.Clock
 	kubeClient    client.Client
@@ -82,12 +79,28 @@ func (c *Controller) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.
 	}
 
 	stored := nc.DeepCopy()
-	// If we've set the lastPodEvent before and it hasn't been before the timeout, don't do anything
-	if !nc.Status.LastPodEventTime.Time.IsZero() && c.clock.Since(nc.Status.LastPodEventTime.Time) < dedupeTimeout {
+
+	var eventTime time.Time
+
+	// If pod is being removed (terminal or terminating), use current time
+	if podutils.IsTerminal(pod) || podutils.IsTerminating(pod) {
+		eventTime = c.clock.Now()
+	} else {
+		// Otherwise check for PodScheduled condition
+		if cond, ok := lo.Find(pod.Status.Conditions, func(c corev1.PodCondition) bool {
+			return c.Type == corev1.PodScheduled && c.Status == corev1.ConditionTrue
+		}); ok {
+			eventTime = cond.LastTransitionTime.Time
+		}
+	}
+
+	// If we don't have a valid time, skip
+	if eventTime.IsZero() {
 		return reconcile.Result{}, nil
 	}
-	// otherwise, set the pod event time to now
-	nc.Status.LastPodEventTime.Time = c.clock.Now()
+
+	// Update the lastPodEvent time
+	nc.Status.LastPodEventTime.Time = eventTime
 	if !equality.Semantic.DeepEqual(stored, nc) {
 		if err = c.kubeClient.Status().Patch(ctx, nc, client.MergeFrom(stored)); err != nil {
 			return reconcile.Result{}, client.IgnoreNotFound(err)
@@ -101,18 +114,32 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 		Named("nodeclaim.podevents").
 		For(&corev1.Pod{}).
 		WithEventFilter(predicate.TypedFuncs[client.Object]{
-			// If a pod is bound to a node or goes terminal
 			UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
 				oldPod := (e.ObjectOld).(*corev1.Pod)
 				newPod := (e.ObjectNew).(*corev1.Pod)
-				// if this is a newly bound pod
-				bound := oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != ""
-				// if this is a newly terminal pod
-				terminal := (newPod.Spec.NodeName != "" && !podutils.IsTerminal(oldPod) && podutils.IsTerminal(newPod))
-				// if this is a newly terminating pod
-				terminating := (newPod.Spec.NodeName != "" && !podutils.IsTerminating(oldPod) && podutils.IsTerminating(newPod))
-				// return true if it was bound to a node, went terminal, or went terminating
-				return bound || terminal || terminating
+
+				// Check for pod scheduling changes
+				oldCond, oldOk := lo.Find(oldPod.Status.Conditions, func(c corev1.PodCondition) bool {
+					return c.Type == corev1.PodScheduled
+				})
+				newCond, newOk := lo.Find(newPod.Status.Conditions, func(c corev1.PodCondition) bool {
+					return c.Type == corev1.PodScheduled
+				})
+
+				// Trigger on PodScheduled condition changes
+				if (!oldOk && newOk) || (oldOk && newOk && (oldCond.Status != newCond.Status || !oldCond.LastTransitionTime.Equal(&newCond.LastTransitionTime))) {
+					return true
+				}
+
+				// Trigger on pod removal (terminal or terminating)
+				if !podutils.IsTerminal(oldPod) && podutils.IsTerminal(newPod) {
+					return true
+				}
+				if !podutils.IsTerminating(oldPod) && podutils.IsTerminating(newPod) {
+					return true
+				}
+
+				return false
 			},
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1965 

**Description**

use PodScheduled's lastTransitionTime for NodeClaim.LastPodEventTime
actually, only for the pod is bound to node so it still has same timestamp value for terminal and terminating
(should we follow deletionTimestamp or some risks are if then?)
the mitigations by dedupeTimestamp are removed
filter for registering more precise only for the PodScheduled has changed 

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
