### PR TITLE
fix: update CEL validation for expireAfter and consolidateAfter fields to block invalid values like 1hr

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -83,7 +83,7 @@ spec:
                     before terminating a node, measured from when the node is created. This
                     is useful to implement features like eventually consistent node upgrade,
                     memory leak protection, and disruption testing.
-                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  pattern: ^(([0-9]+(s|m|h))+|Never)$
                   type: string
                 nodeClassRef:
                   description: NodeClassRef is a reference to an object that defines provider specific configuration

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -144,7 +144,7 @@ spec:
                         ConsolidateAfter is the duration the controller will wait
                         before attempting to terminate nodes that are underutilized.
                         Refer to ConsolidationPolicy for how underutilization is considered.
-                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      pattern: ^(([0-9]+(s|m|h))+|Never)$
                       type: string
                     consolidationPolicy:
                       default: WhenEmptyOrUnderutilized
@@ -220,7 +220,7 @@ spec:
                             before terminating a node, measured from when the node is created. This
                             is useful to implement features like eventually consistent node upgrade,
                             memory leak protection, and disruption testing.
-                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          pattern: ^(([0-9]+(s|m|h))+|Never)$
                           type: string
                         nodeClassRef:
                           description: NodeClassRef is a reference to an object that defines provider specific configuration

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -83,7 +83,7 @@ spec:
                     before terminating a node, measured from when the node is created. This
                     is useful to implement features like eventually consistent node upgrade,
                     memory leak protection, and disruption testing.
-                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  pattern: ^(([0-9]+(s|m|h))+|Never)$
                   type: string
                 nodeClassRef:
                   description: NodeClassRef is a reference to an object that defines provider specific configuration

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -144,7 +144,7 @@ spec:
                         ConsolidateAfter is the duration the controller will wait
                         before attempting to terminate nodes that are underutilized.
                         Refer to ConsolidationPolicy for how underutilization is considered.
-                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      pattern: ^(([0-9]+(s|m|h))+|Never)$
                       type: string
                     consolidationPolicy:
                       default: WhenEmptyOrUnderutilized
@@ -220,7 +220,7 @@ spec:
                             before terminating a node, measured from when the node is created. This
                             is useful to implement features like eventually consistent node upgrade,
                             memory leak protection, and disruption testing.
-                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          pattern: ^(([0-9]+(s|m|h))+|Never)$
                           type: string
                         nodeClassRef:
                           description: NodeClassRef is a reference to an object that defines provider specific configuration

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -69,7 +69,7 @@ type NodeClaimSpec struct {
 	// is useful to implement features like eventually consistent node upgrade,
 	// memory leak protection, and disruption testing.
 	// +kubebuilder:default:="720h"
-	// +kubebuilder:validation:Pattern=`^(([0-9]+(s|m|h))+)|(Never)$`
+	// +kubebuilder:validation:Pattern=`^(([0-9]+(s|m|h))+|Never)$`
 	// +kubebuilder:validation:Type="string"
 	// +kubebuilder:validation:Schemaless
 	// +optional

--- a/pkg/apis/v1/nodeclaim_validation_cel_test.go
+++ b/pkg/apis/v1/nodeclaim_validation_cel_test.go
@@ -19,7 +19,6 @@ package v1_test
 import (
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/awslabs/operatorpkg/object"
@@ -28,6 +27,8 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	. "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -60,6 +61,7 @@ var _ = Describe("Validation", func() {
 				},
 			},
 		}
+		nodeClaim.SetGroupVersionKind(object.GVK(nodeClaim)) // This is needed so that the GVK is set on the unstructured object
 	})
 
 	Context("Taints", func() {
@@ -244,13 +246,55 @@ var _ = Describe("Validation", func() {
 		})
 	})
 	Context("TerminationGracePeriod", func() {
-		It("should succeed on a positive terminationGracePeriod duration", func() {
-			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
-			Expect(env.Client.Create(ctx, nodeClaim)).To(Succeed())
-		})
-		It("should fail on a negative terminationGracePeriod duration", func() {
-			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * -30}
-			Expect(env.Client.Create(ctx, nodeClaim)).ToNot(Succeed())
-		})
+		DescribeTable("should succeed on a valid terminationGracePeriod", func(value string) {
+			u := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodeClaim))
+			lo.Must0(unstructured.SetNestedField(u, value, "spec", "terminationGracePeriod"))
+			obj := &unstructured.Unstructured{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj))
+
+			Expect(env.Client.Create(ctx, obj)).To(Succeed())
+		},
+			Entry("single unit", "30s"),
+			Entry("multiple units", "1h30m5s"),
+		)
+		DescribeTable("should fail on an invalid terminationGracePeriod", func(value string) {
+			u := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodeClaim))
+			lo.Must0(unstructured.SetNestedField(u, value, "spec", "terminationGracePeriod"))
+			obj := &unstructured.Unstructured{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj))
+
+			Expect(env.Client.Create(ctx, obj)).To(Not(Succeed()))
+		},
+			Entry("negative", "-1s"),
+			Entry("invalid unit", "1hr"),
+			Entry("never", "Never"),
+			Entry("partial match", "FooNever"),
+		)
+	})
+	Context("ExpireAfter", func() {
+		DescribeTable("should succeed on a valid expireAfter", func(value string) {
+			u := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodeClaim))
+			lo.Must0(unstructured.SetNestedField(u, value, "spec", "expireAfter"))
+			obj := &unstructured.Unstructured{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj))
+
+			Expect(env.Client.Create(ctx, obj)).To(Succeed())
+		},
+			Entry("single unit", "30s"),
+			Entry("multiple units", "1h30m5s"),
+			Entry("never", "Never"),
+		)
+		DescribeTable("should fail on an invalid expireAfter", func(value string) {
+			u := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodeClaim))
+			lo.Must0(unstructured.SetNestedField(u, value, "spec", "expireAfter"))
+			obj := &unstructured.Unstructured{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj))
+
+			Expect(env.Client.Create(ctx, obj)).To(Not(Succeed()))
+		},
+			Entry("negative", "-1s"),
+			Entry("invalid unit", "1hr"),
+			Entry("partial match", "FooNever"),
+		)
 	})
 })

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -61,7 +61,7 @@ type Disruption struct {
 	// ConsolidateAfter is the duration the controller will wait
 	// before attempting to terminate nodes that are underutilized.
 	// Refer to ConsolidationPolicy for how underutilization is considered.
-	// +kubebuilder:validation:Pattern=`^(([0-9]+(s|m|h))+)|(Never)$`
+	// +kubebuilder:validation:Pattern=`^(([0-9]+(s|m|h))+|Never)$`
 	// +kubebuilder:validation:Type="string"
 	// +kubebuilder:validation:Schemaless
 	// +required
@@ -206,7 +206,7 @@ type NodeClaimTemplateSpec struct {
 	// is useful to implement features like eventually consistent node upgrade,
 	// memory leak protection, and disruption testing.
 	// +kubebuilder:default:="720h"
-	// +kubebuilder:validation:Pattern=`^(([0-9]+(s|m|h))+)|(Never)$`
+	// +kubebuilder:validation:Pattern=`^(([0-9]+(s|m|h))+|Never)$`
 	// +kubebuilder:validation:Type="string"
 	// +kubebuilder:validation:Schemaless
 	// +optional


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Current CEL validation allows values like `1hr` to be set in the spec which causes the resources to be stuck in a weird state.

**How was this change tested?**

Used this spec for nodepool:
```
apiVersion: karpenter.sh/v1
kind: NodePool
metadata:
  name: malformed
spec:
  disruption:
    budgets:
    - nodes: 10%
    consolidateAfter: 1hr
    consolidationPolicy: WhenEmpty
  template:
    spec:
      expireAfter: 12h
      nodeClassRef:
        group: karpenter.k8s.aws
        kind: EC2NodeClass
        name: default
      requirements:
      - key: karpenter.sh/capacity-type
        operator: In
        values:
        - on-demand
      terminationGracePeriod: 24h0m0s
```

**Before the change:** 
```
~ k apply -f malformed-nodepool.yaml
nodepool.karpenter.sh/malformed created
```

```
~ k get nodepool
NAME        NODECLASS   NODES   READY   AGE
default     default     0       True    8d
malformed   default                     89s
```

In the logs:
```
{"level":"INFO","time":"2025-03-06T18:14:19.413Z","logger":"controller","caller":"cache/reflector.go:370","message":"k8s.io/client-go@v0.32.2/tools/cache/reflector.go:251: failed to list *v1.NodePool: time: unknown unit \"hr\" in duration \"1hr\"","commit":"974a323-dirty"}
```

**After the change:** 
```
 ~ k apply -f malformed-nodepool.yaml
The NodePool "malformed" is invalid: spec.disruption.consolidateAfter: Invalid value: "1hr": spec.disruption.consolidateAfter in body should match '^(([0-9]+(s|m|h))+|Never)$'
```

I can't replicate this in the unit tests since the tests parse the duration so testing that kind of makes it pointless since what we really want to test is CEL server-side validation catching it like it did above. I've added other unit tests to ensure that there's no regression.

**Regex testing:**

Before: https://regex101.com/r/C8F0Wf/1
After: https://regex101.com/r/nHnhl2/1


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
