### PR TITLE
feat: Add Global Default Termination Grace Period Variable 

### DIFF
--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -30,6 +30,11 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
+// DefaultTerminationGracePeriod is used as runtime defaulting for TerminationGracePeriod on the NodeClaim
+// This would be a mechanism to allow cloud providers to enforce a TerminationGracePeriod on all node
+// provisioned by Karpenter
+var DefaultTerminationGracePeriod *metav1.Duration = nil
+
 // MaxInstanceTypes is a constant that restricts the number of instance types to be sent for launch. Note that this
 // is intentionally changed to var just to help in testing the code.
 var MaxInstanceTypes = 60
@@ -93,5 +98,9 @@ func (i *NodeClaimTemplate) ToNodeClaim() *v1.NodeClaim {
 		Spec: i.Spec,
 	}
 	nc.Spec.Requirements = i.Requirements.NodeSelectorRequirements()
+	if nc.Spec.TerminationGracePeriod == nil {
+		nc.Spec.TerminationGracePeriod = DefaultTerminationGracePeriod
+	}
+
 	return nc
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Adding a global termination grace period to set on all NodeClaims that are owned by NodePools that don't add contain a termination grace period.
- This would be a mechanisms for cloud provider to enforce a termination grace period on all nodeClaims provided by Karpenter
- This would allow CloudProvider to avoid manipulating the nodeClaim validation rules prior to setting termination grace period 

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
