### PR TITLE
feat(nodepool): add statuses for nodepool drift

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -141,7 +141,7 @@ spec:
                       maxItems: 50
                       type: array
                       x-kubernetes-validations:
-                        - message: "'schedule' must be set with 'duration'"
+                        - message: '''schedule'' must be set with ''duration'''
                           rule: self.all(x, has(x.schedule) == has(x.duration))
                     consolidateAfter:
                       description: |-
@@ -243,7 +243,7 @@ spec:
                                 - message: kind may not be empty
                                   rule: self != ''
                             name:
-                              description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                               type: string
                               x-kubernetes-validations:
                                 - message: name may not be empty
@@ -323,11 +323,11 @@ spec:
                           type: array
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined
-                              rule: "self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
                             - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
-                              rule: "self.all(x, (x.operator == 'Gt' || x.operator == 'Lt') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
                             - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
-                              rule: "self.all(x, (x.operator == 'In' && has(x.minValues)) ? x.values.size() >= x.minValues : true)"
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
                         startupTaints:
                           description: |-
                             StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -498,6 +498,9 @@ spec:
                       - type
                     type: object
                   type: array
+                driftedNodeClaimCount:
+                  description: DriftedNodeClaimCount represents the count of NodeClaims that have drifted from the NodePool/NodeClass configuration
+                  type: integer
                 nodeClassObservedGeneration:
                   description: |-
                     NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -41,6 +41,10 @@ spec:
           name: Memory
           priority: 1
           type: string
+        - jsonPath: .status.driftedNodeClaimCount
+          name: DriftedNodeClaims
+          type: integer
+          priority: 1
       name: v1
       schema:
         openAPIV3Schema:
@@ -137,7 +141,7 @@ spec:
                       maxItems: 50
                       type: array
                       x-kubernetes-validations:
-                        - message: '''schedule'' must be set with ''duration'''
+                        - message: "'schedule' must be set with 'duration'"
                           rule: self.all(x, has(x.schedule) == has(x.duration))
                     consolidateAfter:
                       description: |-
@@ -239,7 +243,7 @@ spec:
                                 - message: kind may not be empty
                                   rule: self != ''
                             name:
-                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
                               type: string
                               x-kubernetes-validations:
                                 - message: name may not be empty
@@ -319,11 +323,11 @@ spec:
                           type: array
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined
-                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                              rule: "self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
                             - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
-                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                              rule: "self.all(x, (x.operator == 'Gt' || x.operator == 'Lt') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
                             - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
-                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                              rule: "self.all(x, (x.operator == 'In' && has(x.minValues)) ? x.values.size() >= x.minValues : true)"
                         startupTaints:
                           description: |-
                             StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -496,6 +496,9 @@ spec:
                       - type
                     type: object
                   type: array
+                driftedNodeClaimCount:
+                  description: DriftedNodeClaimCount represents the count of NodeClaims that have drifted from the NodePool/NodeClass configuration
+                  type: integer
                 nodeClassObservedGeneration:
                   description: |-
                     NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -141,7 +141,7 @@ spec:
                       maxItems: 50
                       type: array
                       x-kubernetes-validations:
-                        - message: "'schedule' must be set with 'duration'"
+                        - message: '''schedule'' must be set with ''duration'''
                           rule: self.all(x, has(x.schedule) == has(x.duration))
                     consolidateAfter:
                       description: |-
@@ -243,7 +243,7 @@ spec:
                                 - message: kind may not be empty
                                   rule: self != ''
                             name:
-                              description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                               type: string
                               x-kubernetes-validations:
                                 - message: name may not be empty
@@ -321,11 +321,11 @@ spec:
                           type: array
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined
-                              rule: "self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
                             - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
-                              rule: "self.all(x, (x.operator == 'Gt' || x.operator == 'Lt') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
                             - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
-                              rule: "self.all(x, (x.operator == 'In' && has(x.minValues)) ? x.values.size() >= x.minValues : true)"
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
                         startupTaints:
                           description: |-
                             StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -41,6 +41,10 @@ spec:
           name: Memory
           priority: 1
           type: string
+        - jsonPath: .status.driftedNodeClaimCount
+          name: DriftedNodeClaims
+          type: integer
+          priority: 1
       name: v1
       schema:
         openAPIV3Schema:
@@ -137,7 +141,7 @@ spec:
                       maxItems: 50
                       type: array
                       x-kubernetes-validations:
-                        - message: '''schedule'' must be set with ''duration'''
+                        - message: "'schedule' must be set with 'duration'"
                           rule: self.all(x, has(x.schedule) == has(x.duration))
                     consolidateAfter:
                       description: |-
@@ -239,7 +243,7 @@ spec:
                                 - message: kind may not be empty
                                   rule: self != ''
                             name:
-                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
                               type: string
                               x-kubernetes-validations:
                                 - message: name may not be empty
@@ -317,11 +321,11 @@ spec:
                           type: array
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined
-                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                              rule: "self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
                             - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
-                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                              rule: "self.all(x, (x.operator == 'Gt' || x.operator == 'Lt') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
                             - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
-                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                              rule: "self.all(x, (x.operator == 'In' && has(x.minValues)) ? x.values.size() >= x.minValues : true)"
                         startupTaints:
                           description: |-
                             StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically

--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	ConditionTypeLaunched             = "Launched"
-	ConditionTypeRegistered           = "Registered"
-	ConditionTypeInitialized          = "Initialized"
-	ConditionTypeConsolidatable       = "Consolidatable"
+	ConditionTypeLaunched       = "Launched"
+	ConditionTypeRegistered     = "Registered"
+	ConditionTypeInitialized    = "Initialized"
+	ConditionTypeConsolidatable = "Consolidatable"
+	// There is another condition for NodePool with same name.
 	ConditionTypeDrifted              = "Drifted"
 	ConditionTypeInstanceTerminating  = "InstanceTerminating"
 	ConditionTypeConsistentStateFound = "ConsistentStateFound"

--- a/pkg/apis/v1/nodepool_status.go
+++ b/pkg/apis/v1/nodepool_status.go
@@ -29,6 +29,10 @@ const (
 	ConditionTypeNodeClassReady = "NodeClassReady"
 	// ConditionTypeNodeRegistrationHealthy = "NodeRegistrationHealthy" condition indicates if a misconfiguration exists that is preventing successful node launch/registrations that requires manual investigation
 	ConditionTypeNodeRegistrationHealthy = "NodeRegistrationHealthy"
+	// ConditionTypeNodeClaimsDrifted = "Drifted" condition indicates if any NodeClaims belonging to the NodePool have drifted
+	// from their expected configuration based on the NodePool and/or NodeClass hash
+	// Just named with the prefix NodeClaims to avoid a duplication with the NodeClaim's condition
+	ConditionTypeNodeClaimsDrifted = "Drifted"
 )
 
 // NodePoolStatus defines the observed state of NodePool
@@ -40,6 +44,9 @@ type NodePoolStatus struct {
 	// the actual NodeClass Generation, NodeRegistrationHealthy status condition on the NodePool will be reset
 	// +optional
 	NodeClassObservedGeneration int64 `json:"nodeClassObservedGeneration,omitempty"`
+	// DriftedNodeClaimCount represents the count of NodeClaims that have drifted from the NodePool/NodeClass configuration
+	// +optional
+	DriftedNodeClaimCount int `json:"driftedNodeClaimCount,omitempty"`
 	// Conditions contains signals for health and readiness
 	// +optional
 	Conditions []status.Condition `json:"conditions,omitempty"`

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -48,6 +48,7 @@ import (
 	nodeclaimlifecycle "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
 	"sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/podevents"
 	nodepoolcounter "sigs.k8s.io/karpenter/pkg/controllers/nodepool/counter"
+	nodepooldrift "sigs.k8s.io/karpenter/pkg/controllers/nodepool/drift"
 	nodepoolhash "sigs.k8s.io/karpenter/pkg/controllers/nodepool/hash"
 	nodepoolreadiness "sigs.k8s.io/karpenter/pkg/controllers/nodepool/readiness"
 	nodepoolregistrationhealth "sigs.k8s.io/karpenter/pkg/controllers/nodepool/registrationhealth"
@@ -92,6 +93,7 @@ func NewControllers(
 		nodepoolregistrationhealth.NewController(kubeClient, cloudProvider),
 		nodepoolcounter.NewController(kubeClient, cloudProvider, cluster),
 		nodepoolvalidation.NewController(kubeClient, cloudProvider),
+		nodepooldrift.NewController(kubeClient, cloudProvider),
 		podevents.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimconsistency.NewController(clock, kubeClient, cloudProvider, recorder),
 		nodeclaimlifecycle.NewController(clock, kubeClient, cloudProvider, recorder),

--- a/pkg/controllers/nodepool/drift/controller.go
+++ b/pkg/controllers/nodepool/drift/controller.go
@@ -1,0 +1,157 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drift
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
+	nodepoolutils "sigs.k8s.io/karpenter/pkg/utils/nodepool"
+)
+
+// Controller for tracking drift on NodePools
+type Controller struct {
+	kubeClient    client.Client
+	cloudProvider cloudprovider.CloudProvider
+}
+
+// NewController is a constructor
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) *Controller {
+	return &Controller{
+		kubeClient:    kubeClient,
+		cloudProvider: cloudProvider,
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, nodePool *v1.NodePool) (reconcile.Result, error) {
+	ctx = injection.WithControllerName(ctx, "nodepool.drift")
+	stored := nodePool.DeepCopy()
+
+	if !nodepoolutils.IsManaged(nodePool, c.cloudProvider) {
+		return reconcile.Result{}, nil
+	}
+
+	// Get all NodeClaims managed by this NodePool
+	nodeClaims, err := nodeclaimutils.ListManaged(ctx, c.kubeClient, c.cloudProvider, nodeclaimutils.ForNodePool(nodePool.Name))
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("listing nodeclaims: %w", err)
+	}
+
+	// Check and count drifted NodeClaims
+	driftedNodeClaimCount := lo.CountBy(nodeClaims, func(nodeClaim *v1.NodeClaim) bool {
+		driftedCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)
+		return driftedCondition != nil && driftedCondition.IsTrue()
+	})
+
+	// Update the Drifted condition on the NodePool
+	hasDriftedNodeClaims := driftedNodeClaimCount > 0
+	if hasDriftedNodeClaims {
+		nodePool.StatusConditions().SetTrueWithReason(
+			v1.ConditionTypeNodeClaimsDrifted,
+			"NodeClaimsDriftedExist",
+			fmt.Sprintf("%d NodeClaim(s) managed by this NodePool have drifted", driftedNodeClaimCount),
+		)
+		// All the other cases, No managed NodeClaims or all NodeClaim with Drifted condition as false, unknown even nil
+	} else {
+		nodePool.StatusConditions().SetFalse(
+			v1.ConditionTypeNodeClaimsDrifted,
+			"ZeroNodeClaimsDrifted",
+			"All NodeClaims are in sync with the NodePool configuration",
+		)
+	}
+
+	nodePool.Status.DriftedNodeClaimCount = driftedNodeClaimCount
+	if !equality.Semantic.DeepEqual(stored, nodePool) {
+		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
+		// can cause races due to the fact that it fully replaces the list on a change
+		// Here, we are updating the status condition list
+		if err = c.kubeClient.Status().Patch(ctx, nodePool, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
+			if errors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	// Create a NodeClaim predicate that only triggers reconciliation when the Drifted condition changes
+	driftedStatusChangePredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNodeClaim, ok := e.ObjectOld.(*v1.NodeClaim)
+			if !ok {
+				return false
+			}
+			newNodeClaim, ok := e.ObjectNew.(*v1.NodeClaim)
+			if !ok {
+				return false
+			}
+
+			oldDrifted := oldNodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)
+			newDrifted := newNodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)
+
+			// If both are nil or both have the same status, don't trigger
+			if (oldDrifted == nil && newDrifted == nil) ||
+				(oldDrifted != nil && newDrifted != nil && oldDrifted.Status == newDrifted.Status) {
+				return false
+			}
+
+			return true
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			nodeClaim, ok := e.Object.(*v1.NodeClaim)
+			if !ok {
+				return false
+			}
+			// Only reconcile if the nodeclaim is created with a drifted condition
+			return nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted) != nil
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// Always reconcile on deletion to recalculate drift nodeclaims count
+			return true
+		},
+	}
+
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("nodepool.drift").
+		For(&v1.NodePool{}, builder.WithPredicates(nodepoolutils.IsManagedPredicateFuncs(c.cloudProvider))).
+		Watches(
+			&v1.NodeClaim{},
+			nodepoolutils.NodeClaimEventHandler(),
+			builder.WithPredicates(driftedStatusChangePredicate),
+		).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}

--- a/pkg/controllers/nodepool/drift/suite_test.go
+++ b/pkg/controllers/nodepool/drift/suite_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drift_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awslabs/operatorpkg/object"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/nodepool/drift"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var (
+	controller    *drift.Controller
+	ctx           context.Context
+	env           *test.Environment
+	cloudProvider *fake.CloudProvider
+	nodePool      *v1.NodePool
+	nodeClass     *v1alpha1.TestNodeClass
+)
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Drift")
+}
+
+var _ = BeforeSuite(func() {
+	cloudProvider = fake.NewCloudProvider()
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
+	controller = drift.NewController(env.Client, cloudProvider)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("Drift", func() {
+	BeforeEach(func() {
+		nodePool = test.NodePool()
+		nodeClass = test.NodeClass(v1alpha1.TestNodeClass{
+			ObjectMeta: metav1.ObjectMeta{Name: nodePool.Spec.Template.Spec.NodeClassRef.Name},
+		})
+		nodePool.Spec.Template.Spec.NodeClassRef.Group = object.GVK(nodeClass).Group
+		nodePool.Spec.Template.Spec.NodeClassRef.Kind = object.GVK(nodeClass).Kind
+		_ = nodePool.StatusConditions().Clear(v1.ConditionTypeNodeClaimsDrifted)
+	})
+
+	It("should not set Drifted if there are no managed nodeclaims", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeClaimsDrifted).IsFalse()).To(BeTrue())
+	})
+
+	It("should not set Drifted if the drifted condition of nodeclaim is nil ", func() {
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1.NodePoolLabelKey: nodePool.Name,
+			}},
+		})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)).To(BeNil())
+
+		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeClaimsDrifted).IsFalse()).To(BeTrue())
+		Expect(nodePool.Status.DriftedNodeClaimCount).To(BeZero())
+	})
+
+	It("should set Drifted to false if all NodeClaims are not drifted", func() {
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1.NodePoolLabelKey: nodePool.Name,
+			}},
+		})
+		nodeClaim.StatusConditions().SetFalse(v1.ConditionTypeDrifted, "NotDrifted", "NotDrifted")
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted).IsFalse()).To(BeTrue())
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+
+		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeClaimsDrifted).IsFalse()).To(BeTrue())
+		Expect(nodePool.Status.DriftedNodeClaimCount).To(BeZero())
+	})
+
+	It("should set Drifted to true if there are drifted NodeClaims", func() {
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1.NodePoolLabelKey: nodePool.Name,
+			}},
+		})
+		unknownNodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1.NodePoolLabelKey: nodePool.Name,
+			}},
+		})
+		unknownNodeClaim.StatusConditions().SetUnknown(v1.ConditionTypeDrifted)
+		notDriftedNodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1.NodePoolLabelKey: nodePool.Name,
+			}},
+		})
+		notDriftedNodeClaim.StatusConditions().SetFalse(v1.ConditionTypeDrifted, "NotDrifted", "NotDrifted")
+		driftedNodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1.NodePoolLabelKey: nodePool.Name,
+			}},
+		})
+		driftedNodeClaim.StatusConditions().SetTrue(v1.ConditionTypeDrifted)
+
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)).To(BeNil())
+		Expect(unknownNodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted).IsUnknown()).To(BeTrue())
+		Expect(notDriftedNodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted).IsFalse()).To(BeTrue())
+		Expect(driftedNodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted).IsTrue()).To(BeTrue())
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass, nodeClaim, unknownNodeClaim, driftedNodeClaim, notDriftedNodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+
+		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeClaimsDrifted).IsTrue()).To(BeTrue())
+		Expect(nodePool.Status.DriftedNodeClaimCount).To(Equal(1))
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1785

**Description**

add two statuses of NodePool about drifts:
- Drifted, as one of conditions, indicates if any NodeClaims belonging to the NodePool have drifted
- DriftedNodeClaimCount, as a numeric field, represents the number of NodeClaims that have drifted

print the DriftedNodeClaimCount as a column of result of kubectl get nodepool

**How was this change tested?**

unit tests are added, `make presubmit`, `kubectl get nodepool -owide` on my local k3s

```sh
❯ k get nodepool -owide
NAME      NODECLASS   NODES   READY   AGE   WEIGHT   CPU   MEMORY   DRIFTEDNODECLAIMS
default   default                     10m                           
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
