### PR TITLE
perf: Improve consolidation performance by adding a scheduling simulation cache

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -130,10 +130,10 @@ func (c *consolidation) sortCandidates(candidates []*Candidate) []*Candidate {
 // computeConsolidation computes a consolidation action to take
 //
 // nolint:gocyclo
-func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...*Candidate) (Command, pscheduling.Results, error) {
+func (c *consolidation) computeConsolidation(ctx context.Context, cache *pscheduling.SimulationCache, candidates ...*Candidate) (Command, pscheduling.Results, error) {
 	var err error
 	// Run scheduling simulation to compute consolidation option
-	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, candidates...)
+	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, cache, candidates...)
 	if err != nil {
 		// if a candidate node is now deleting, just retry
 		if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -84,6 +84,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[
 		}, scheduling.Results{}, nil
 	}
 
+	cache := scheduling.NewSimulationCache()
 	for _, candidate := range candidates {
 		// If the disruption budget doesn't allow this candidate to be disrupted,
 		// continue to the next candidate. We don't need to decrement any budget
@@ -92,7 +93,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[
 			continue
 		}
 		// Check if we need to create any NodeClaims.
-		results, err := SimulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, candidate)
+		results, err := SimulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, cache, candidate)
 		if err != nil {
 			// if a candidate is now deleting, just retry
 			if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption/orchestration"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
-	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
@@ -48,7 +47,7 @@ var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 
 //nolint:gocyclo
 func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *state.Cluster, provisioner *provisioning.Provisioner,
-	cache *pscheduling.SimulationCache, candidates ...*Candidate,
+	cache *scheduling.SimulationCache, candidates ...*Candidate,
 ) (scheduling.Results, error) {
 	candidateNames := sets.NewString(lo.Map(candidates, func(t *Candidate, i int) string { return t.Name() })...)
 	nodes := cluster.Nodes()

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption/orchestration"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
+	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
@@ -47,7 +48,7 @@ var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 
 //nolint:gocyclo
 func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *state.Cluster, provisioner *provisioning.Provisioner,
-	candidates ...*Candidate,
+	cache *pscheduling.SimulationCache, candidates ...*Candidate,
 ) (scheduling.Results, error) {
 	candidateNames := sets.NewString(lo.Map(candidates, func(t *Candidate, i int) string { return t.Name() })...)
 	nodes := cluster.Nodes()
@@ -79,7 +80,7 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 		pods = append(pods, n.reschedulablePods...)
 	}
 	pods = append(pods, deletingNodePods...)
-	scheduler, err := provisioner.NewScheduler(log.IntoContext(ctx, operatorlogging.NopLogger), pods, stateNodes)
+	scheduler, err := provisioner.NewScheduler(log.IntoContext(ctx, operatorlogging.NopLogger), pods, stateNodes, cache)
 	if err != nil {
 		return scheduling.Results{}, fmt.Errorf("creating scheduler, %w", err)
 	}

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -124,12 +124,13 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 	// Set a timeout
 	timeoutCtx, cancel := context.WithTimeout(ctx, MultiNodeConsolidationTimeoutDuration)
 	defer cancel()
+	cache := scheduling.NewSimulationCache()
 	for min <= max {
 		mid := (min + max) / 2
 		candidatesToConsolidate := candidates[0 : mid+1]
 
 		// Pass the timeout context to ensure sub-operations can be canceled
-		cmd, results, err := m.computeConsolidation(timeoutCtx, candidatesToConsolidate...)
+		cmd, results, err := m.computeConsolidation(timeoutCtx, cache, candidatesToConsolidate...)
 		// context deadline exceeded will return to the top of the loop and either return nothing or the last saved command
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -64,6 +64,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 
 	unseenNodePools := sets.New(lo.Map(candidates, func(c *Candidate, _ int) string { return c.NodePool.Name })...)
 
+	cache := scheduling.NewSimulationCache()
 	for i, candidate := range candidates {
 		// If the disruption budget doesn't allow this candidate to be disrupted,
 		// continue to the next candidate. We don't need to decrement any budget
@@ -91,7 +92,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, disruption
 		unseenNodePools.Delete(candidate.NodePool.Name)
 
 		// compute a possible consolidation option
-		cmd, results, err := s.computeConsolidation(ctx, candidate)
+		cmd, results, err := s.computeConsolidation(ctx, cache, candidate)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "failed computing consolidation")
 			continue

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, stateNode, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(Succeed())
 
-		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, candidate)
+		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, nil, candidate)
 		Expect(err).To(Succeed())
 		Expect(results.PodErrors[pod]).To(BeNil())
 	})

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -158,7 +158,7 @@ func (v *Validation) ValidateCommand(ctx context.Context, cmd Command, candidate
 	if len(candidates) == 0 {
 		return NewValidationError(fmt.Errorf("no candidates"))
 	}
-	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, candidates...)
+	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, nil, candidates...)
 	if err != nil {
 		return fmt.Errorf("simluating scheduling, %w", err)
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -157,7 +157,7 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 	cluster = state.NewCluster(clock, client, cloudProvider)
 	topology, err := scheduling.NewTopology(ctx, client, cluster, nil, []*v1.NodePool{nodePool}, map[string][]*cloudprovider.InstanceType{
 		nodePool.Name: instanceTypes,
-	}, pods)
+	}, pods, nil)
 	if err != nil {
 		b.Fatalf("creating topology, %s", err)
 	}
@@ -173,6 +173,7 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 		nil,
 		events.NewRecorder(&record.FakeRecorder{}),
 		clock,
+		nil,
 		scheduling.DisableReservedCapacityFallback,
 	)
 

--- a/pkg/controllers/provisioning/scheduling/simulationcache.go
+++ b/pkg/controllers/provisioning/scheduling/simulationcache.go
@@ -1,0 +1,31 @@
+package scheduling
+
+import (
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+)
+
+// SimulationCache is used specifically for consolidation as a method to cache
+// expensive calculations across simulation runs. The methods are written so that they
+// perform correctly (though without caching), if the cache object is nil.
+type SimulationCache struct {
+	stateNodeLabelRequirements *scheduling.RequirementsReadOnly
+}
+
+func NewSimulationCache() *SimulationCache {
+	return &SimulationCache{}
+}
+
+// StateNodeLabelRequirements returns the scheduling requirements for the state nodes labels. This is safe to cache
+// as we don't modify these requirements and the state nodes won't change during a consolidation pass.
+func (c *SimulationCache) StateNodeLabelRequirements(n *state.StateNode) scheduling.RequirementsReadOnly {
+	if c == nil {
+		return scheduling.NewLabelRequirements(n.Node.Labels)
+	}
+	if c.stateNodeLabelRequirements != nil {
+		return *c.stateNodeLabelRequirements
+	}
+	reqs := scheduling.RequirementsReadOnly(scheduling.NewLabelRequirements(n.Node.Labels))
+	c.stateNodeLabelRequirements = &reqs
+	return reqs
+}

--- a/pkg/controllers/provisioning/scheduling/simulationcache.go
+++ b/pkg/controllers/provisioning/scheduling/simulationcache.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package scheduling
 
 import (

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -3668,7 +3668,7 @@ var _ = Context("Scheduling", func() {
 					},
 				},
 			}) // Create 1000 pods which should take long enough to schedule that we should be able to read the queueDepth metric with a value
-			s, err := prov.NewScheduler(ctx, pods, nil, scheduling.DisableReservedCapacityFallback)
+			s, err := prov.NewScheduler(ctx, pods, nil, nil, scheduling.DisableReservedCapacityFallback)
 			Expect(err).To(BeNil())
 
 			var wg sync.WaitGroup
@@ -3742,7 +3742,7 @@ var _ = Context("Scheduling", func() {
 					},
 				},
 			}) // Create 1000 pods which should take long enough to schedule that we should be able to read the queueDepth metric with a value
-			s, err := prov.NewScheduler(ctx, pods, nil, scheduling.DisableReservedCapacityFallback)
+			s, err := prov.NewScheduler(ctx, pods, nil, nil, scheduling.DisableReservedCapacityFallback)
 			Expect(err).To(BeNil())
 			_, err = s.Solve(injection.WithControllerName(ctx, "provisioner"), pods)
 			Expect(err).To(BeNil())

--- a/pkg/controllers/provisioning/scheduling/topologynodefilter.go
+++ b/pkg/controllers/provisioning/scheduling/topologynodefilter.go
@@ -65,7 +65,7 @@ func MakeTopologyNodeFilter(p *corev1.Pod, taintPolicy corev1.NodeInclusionPolic
 }
 
 // Matches returns true if the TopologyNodeFilter doesn't prohibit node from the participating in the topology
-func (t TopologyNodeFilter) Matches(taints []corev1.Taint, requirements scheduling.Requirements, compatibilityOptions ...option.Function[scheduling.CompatibilityOptions]) bool {
+func (t TopologyNodeFilter) Matches(taints []corev1.Taint, requirements scheduling.RequirementsReadOnly, compatibilityOptions ...option.Function[scheduling.CompatibilityOptions]) bool {
 	matchesAffinity := true
 	if t.AffinityPolicy == corev1.NodeInclusionPolicyHonor {
 		matchesAffinity = t.matchesRequirements(requirements)
@@ -82,7 +82,7 @@ func (t TopologyNodeFilter) Matches(taints []corev1.Taint, requirements scheduli
 // MatchesRequirements returns true if the TopologyNodeFilter doesn't prohibit a node with the requirements from
 // participating in the topology. This method allows checking the requirements from a scheduling.NodeClaim to see if the
 // node we will soon create participates in this topology.
-func (t TopologyNodeFilter) matchesRequirements(requirements scheduling.Requirements, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) bool {
+func (t TopologyNodeFilter) matchesRequirements(requirements scheduling.RequirementsReadOnly, compatabilityOptions ...option.Function[scheduling.CompatibilityOptions]) bool {
 	// no requirements, so it always matches
 	if len(t.Requirements) == 0 || t.AffinityPolicy == corev1.NodeInclusionPolicyIgnore {
 		return true

--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -35,6 +35,12 @@ import (
 // types are slices and maps, this type should not be used as a pointer.
 type Requirements map[string]*Requirement
 
+// RequirementsReadOnly is an interface that should be accepted by consumers that only need to evaluate requirements and
+// will not be changing them. This allows reuse of requirements safely.
+type RequirementsReadOnly interface {
+	Compatible(requirements Requirements, options ...option.Function[CompatibilityOptions]) (errs error)
+}
+
 func NewRequirements(requirements ...*Requirement) Requirements {
 	r := Requirements{}
 	for _, requirement := range requirements {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Improve the performance of single-node consolidation by caching requirements.


**How was this change tested?**
Two deployments were applied to a cluster with pod anti-affinity rules selecting for self and topology key: hostname. The deployments also had requests that would fit two pods per node and after scaling to 1000 replicas, the result is 1000 dataplane nodes. These are the results of how many candidates can be considered for multi- and single-node consolidations.

All other consolidation methods disabled except for the one being tested:

In single-node consolidation by ~44% averaged across three runs:
before
```
{"level":"DEBUG","time":"2025-03-24T19:45:31.992Z","logger":"controller","caller":"disruption/controller.go:184","message":"abandoning single-node consolidation due to timeout after evaluating 37 candidates",
{"level":"DEBUG","time":"2025-03-24T19:46:44.164Z","logger":"controller","caller":"disruption/controller.go:184","message":"abandoning single-node consolidation due to timeout after evaluating 47 candidates",
{"level":"DEBUG","time":"2025-03-24T19:47:58.551Z","logger":"controller","caller":"disruption/controller.go:184","message":"abandoning single-node consolidation due to timeout after evaluating 49 candidates",
```
after
```
{"level":"DEBUG","time":"2025-03-24T19:51:21.959Z","logger":"controller","caller":"disruption/controller.go:184","message":"abandoning single-node consolidation due to timeout after evaluating 55 candidates",
{"level":"DEBUG","time":"2025-03-24T19:52:34.378Z","logger":"controller","caller":"disruption/controller.go:184","message":"abandoning single-node consolidation due to timeout after evaluating 71 candidates",
{"level":"DEBUG","time":"2025-03-24T19:53:46.266Z","logger":"controller","caller":"disruption/controller.go:184","message":"abandoning single-node consolidation due to timeout after evaluating 66 candidates",
```

In multi-node consolidation, no significant improvement averaged across five runs:
before
```
{"level":"DEBUG","time":"2025-03-24T20:53:43.043Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 33 seconds, returning last valid command"
{"level":"DEBUG","time":"2025-03-24T20:54:19.267Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 7 seconds, returning last valid command",
{"level":"DEBUG","time":"2025-03-24T20:54:51.270Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 42 seconds, returning last valid command",
{"level":"DEBUG","time":"2025-03-24T20:55:23.761Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 14 seconds, returning last valid command",
{"level":"DEBUG","time":"2025-03-24T20:55:53.896Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 46 seconds, returning last valid command",
```
after
```
{"level":"DEBUG","time":"2025-03-24T20:57:43.205Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 34 seconds, returning last valid command",
{"level":"DEBUG","time":"2025-03-24T20:58:13.913Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 7 seconds, returning last valid command",
{"level":"DEBUG","time":"2025-03-24T20:58:53.230Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 48 seconds, returning last valid command",
{"level":"DEBUG","time":"2025-03-24T20:59:36.101Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 27 seconds, returning last valid command",
{"level":"DEBUG","time":"2025-03-24T21:00:05.943Z","logger":"controller","caller":"disruption/multinodeconsolidation.go:84","message":"exiting multi-node consolidation after considerating 100 candidates over 59 seconds, returning last valid command",
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
