### PR TITLE
fix: Create a separate leader config for different QPS/Burst

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -38,8 +38,8 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -123,7 +123,15 @@ func NewOperator() (context.Context, *Operator) {
 
 	// Client Config
 	config := ctrl.GetConfigOrDie()
-	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(float32(options.FromContext(ctx).KubeClientQPS), options.FromContext(ctx).KubeClientBurst)
+	// Copy the leader config for lower QPS/Burst
+	// We changed this from explicitly setting the RateLimiter on the config and not creating
+	// a separate leaderConfig ourselves because this caused a subtle bug when copying the leaderConfig
+	// for the leader election client. The leaderConfig would use the same RateLimiter, so client-side rate
+	// limiting on the regular config would also cause client-side rate limiting on the leader election client,
+	// often leading to leader loss during large scale-ups or periods of high churn
+	leaderConfig := rest.CopyConfig(config)
+	config.QPS = float32(options.FromContext(ctx).KubeClientQPS)
+	config.Burst = options.FromContext(ctx).KubeClientBurst
 	config.UserAgent = fmt.Sprintf("%s/%s", appName, Version)
 
 	// Client
@@ -139,6 +147,7 @@ func NewOperator() (context.Context, *Operator) {
 		LeaderElectionNamespace:       options.FromContext(ctx).LeaderElectionNamespace,
 		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
 		LeaderElectionReleaseOnCancel: true,
+		LeaderElectionConfig:          leaderConfig,
 		Metrics: server.Options{
 			BindAddress: fmt.Sprintf(":%d", options.FromContext(ctx).MetricsPort),
 		},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change fixes a bug in Karpenter where the leaderConfig and the regular config were sharing a token bucket for client-side rate limiting. This meant that in large scale-ups you would see logs like the log below which showed that the leader election client was getting client-side rate-limited by other requests that were made to the apiserver. This would result in leader election being lost and Karpenter would restart.

This was particularly annoying because often Karpenter was getting client-side rate limited after making a large scheduling decision, meaning that the scheduler would then have to re-calculate the decision again from the start (although it might have been able to launch some number of NodeClaims before leader election was lost).

```
{"level":"ERROR","time":"2025-01-29T05:26:25.921Z","logger":"controller","caller":"leaderelection/leaderelection.go:285","message":"Failed to update lock optimistically: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline, falling back to slow path","commit":"2a09110-dirty"}
{"level":"ERROR","time":"2025-01-29T05:26:25.921Z","logger":"controller","caller":"leaderelection/leaderelection.go:285","message":"error retrieving resource lock kube-system/karpenter-leader-election: client rate limiter Wait returned an error: context deadline exceeded","commit":"2a09110-dirty"}
{"level":"INFO","time":"2025-01-29T05:26:25.921Z","logger":"controller","caller":"wait/backoff.go:226","message":"failed to renew lease kube-system/karpenter-leader-election: context deadline exceeded","commit":"2a09110-dirty"}
{"level":"ERROR","time":"2025-01-29T05:26:25.921Z","logger":"controller","caller":"leaderelection/leaderelection.go:303","message":"Failed to release lock: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline","commit":"2a09110-dirty"}
panic: leader election lost

goroutine 96 [running]:
github.com/samber/lo.must({0x1cecc40, 0xc7c3b19730}, {0x0, 0x0, 0x0})
        github.com/samber/lo@v1.49.1/errors.go:53 +0x1df
github.com/samber/lo.Must0(...)
        github.com/samber/lo@v1.49.1/errors.go:72
sigs.k8s.io/karpenter/pkg/operator.(*Operator).Start.func1()
        sigs.k8s.io/karpenter/pkg/operator/operator.go:220 +0x75
created by sigs.k8s.io/karpenter/pkg/operator.(*Operator).Start in goroutine 1
        sigs.k8s.io/karpenter/pkg/operator/operator.go:218 +0xa5
```

After the change, I no longer see any crashing during a 7000 NodeClaim scale-up

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
