### PR TITLE
fix: address nodeclaims being repeatedly created when host ports for a pending pod would conflict with daemons

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -181,7 +181,7 @@ func (c *Controller) finalize(ctx context.Context, nodeClaim *v1.NodeClaim) (rec
 		return reconcile.Result{}, fmt.Errorf("adding nodeclaim terminationGracePeriod annotation, %w", err)
 	}
 
-	// Only delete Nodes if the NodeClaim has not been registered. Deleting Node's without the termination finalizer
+	// Only delete Nodes if the NodeClaim has been registered. Deleting Nodes without the termination finalizer
 	// may result in leaked leases due to a kubelet bug until k8s 1.29. The Node should be garbage collected after the
 	// instance is terminated by CCM.
 	// Upstream Kubelet Fix: https://github.com/kubernetes/kubernetes/pull/119661

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -84,6 +84,7 @@ func NewNodeClaim(
 	nodeClaimTemplate *NodeClaimTemplate,
 	topology *Topology,
 	daemonResources corev1.ResourceList,
+	hostPortUsage *scheduling.HostPortUsage,
 	instanceTypes []*cloudprovider.InstanceType,
 	reservationManager *ReservationManager,
 	reservedOfferingMode ReservedOfferingMode,
@@ -98,7 +99,7 @@ func NewNodeClaim(
 	template.Spec.Resources.Requests = daemonResources
 	return &NodeClaim{
 		NodeClaimTemplate:    template,
-		hostPortUsage:        scheduling.NewHostPortUsage(),
+		hostPortUsage:        hostPortUsage,
 		topology:             topology,
 		daemonResources:      daemonResources,
 		hostname:             hostname,

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -471,12 +471,12 @@ func getDaemonOverhead(nodeClaimTemplates []*NodeClaimTemplate, daemonSetPods []
 	})
 }
 
-// getDaemonHostPortUsage tracks requested host ports for daemonsets, given a nodeclaimtemplate
+// getDaemonHostPortUsage determines requested host ports for DaemonSet pods, given a NodeClaimTemplate
 func getDaemonHostPortUsage(nodeClaimTemplates []*NodeClaimTemplate, daemonSetPods []*corev1.Pod) map[*NodeClaimTemplate]*scheduling.HostPortUsage {
 	nctToOccupiedPorts := map[*NodeClaimTemplate]*scheduling.HostPortUsage{}
 	for _, nct := range nodeClaimTemplates {
 		hostPortUsage := scheduling.NewHostPortUsage()
-		// gather compatible daemon sets for the NodeClaimTemplate of a NodePool
+		// gather compatible DaemonSet pods for the NodeClaimTemplate
 		for _, pod := range lo.Filter(daemonSetPods, func(p *corev1.Pod, _ int) bool { return isDaemonPodCompatible(nct, p) }) {
 			hostPortUsage.Add(pod, scheduling.GetHostPorts(pod))
 		}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -480,9 +480,7 @@ func getDaemonHostPortUsage(nodeClaimTemplates []*NodeClaimTemplate, daemonSetPo
 		for _, pod := range lo.Filter(daemonSetPods, func(p *corev1.Pod, _ int) bool { return isDaemonPodCompatible(nct, p) }) {
 			hostPortUsage.Add(pod, scheduling.GetHostPorts(pod))
 		}
-		if _, ok := nctToOccupiedPorts[nct]; !ok {
-			nctToOccupiedPorts[nct] = hostPortUsage
-		}
+		nctToOccupiedPorts[nct] = hostPortUsage
 	}
 	return nctToOccupiedPorts
 }

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -826,6 +826,24 @@ var _ = Describe("Provisioning", func() {
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("4")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
 		})
+		FIt("should account for daemonset hostports", func() {
+			ExpectApplied(ctx, env.Client, test.NodePool(), test.DaemonSet(
+				test.DaemonSetOptions{PodOptions: test.PodOptions{
+					ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("2Gi")}},
+					HostPorts:            []int32{8080},
+				}},
+			))
+			pod := test.UnschedulablePod(
+				test.PodOptions{
+					ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourceMemory: resource.MustParse("1Gi")}},
+					HostPorts:            []int32{8080},
+				},
+			)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			// Expect that the host port will be blocked by a compatible daemonset
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
+		})
 		It("should account for daemonsets (with startup taint)", func() {
 			nodePool := test.NodePool(v1.NodePool{
 				Spec: v1.NodePoolSpec{

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -826,7 +826,7 @@ var _ = Describe("Provisioning", func() {
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("4")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
 		})
-		FIt("should account for daemonset hostports", func() {
+		It("should account for daemonset hostports", func() {
 			ExpectApplied(ctx, env.Client, test.NodePool(), test.DaemonSet(
 				test.DaemonSetOptions{PodOptions: test.PodOptions{
 					ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("2Gi")}},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2083
Fixes #2093 <!-- issue number -->

**Description**
When attempting to schedule a pending pod to existing capacity, host ports for all pods on that node are checked and influence scheduling decisions. When needing to make a new NodeClaim, there are no pods from which to get this information.

This change looks at daemon set pods that are compatible with the NodeClaimTemplate being used for the pending pods and then checks if required host ports will be available.

**How was this change tested?**
Unit test addition that shows pending pod does not schedule. Additionally, this log fires when run in my dev cluster:
>`
{"level":"ERROR","time":"2025-03-25T23:45:29.227Z","logger":"controller","caller":"provisioning/provisioner.go:357","message":"could not schedule pod","commit":"76aaae9-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0b9f3a42-15f2-4323-9e99-d01a32fd4e32","Pod":{"name":"nginx-deployment-5c4df47f4d-cfmmz","namespace":"default"},"error":"incompatible with nodepool \"arm-2cpu\", daemonset overhead={\"cpu\":\"250m\",\"memory\":\"200Mi\",\"pods\":\"6\"}, checking host port usage, IP=0.0.0.0 Port=8080 Proto=TCP conflicts with existing HostPort configuration IP=0.0.0.0 Port=8080 Proto=TCP"}
`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
