### PR TITLE
fix: don't need to deepcopy nodeclaim when lastPodEvent has not been set before the timeout

### DIFF
--- a/pkg/controllers/nodeclaim/podevents/controller.go
+++ b/pkg/controllers/nodeclaim/podevents/controller.go
@@ -81,12 +81,13 @@ func (c *Controller) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.
 		return reconcile.Result{}, nil
 	}
 
-	stored := nc.DeepCopy()
 	// If we've set the lastPodEvent before and it hasn't been before the timeout, don't do anything
 	if !nc.Status.LastPodEventTime.Time.IsZero() && c.clock.Since(nc.Status.LastPodEventTime.Time) < dedupeTimeout {
 		return reconcile.Result{}, nil
 	}
+
 	// otherwise, set the pod event time to now
+	stored := nc.DeepCopy()
 	nc.Status.LastPodEventTime.Time = c.clock.Now()
 	if !equality.Semantic.DeepEqual(stored, nc) {
 		if err = c.kubeClient.Status().Patch(ctx, nc, client.MergeFrom(stored)); err != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

we can deep copy nodeclaim when we need to change it. because deepcopy will not be executed if lastPodEvent has not been set before the timeout.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
