### PR TITLE
perf: Actively store NodePool resources in cluster state

### DIFF
--- a/pkg/controllers/nodepool/counter/controller.go
+++ b/pkg/controllers/nodepool/counter/controller.go
@@ -18,9 +18,9 @@ package counter
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -47,14 +47,12 @@ type Controller struct {
 	cluster       *state.Cluster
 }
 
-var ResourceNode = corev1.ResourceName("nodes")
-
 var BaseResources = corev1.ResourceList{
 	corev1.ResourceCPU:              resource.MustParse("0"),
 	corev1.ResourceMemory:           resource.MustParse("0"),
 	corev1.ResourcePods:             resource.MustParse("0"),
 	corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-	ResourceNode:                    resource.MustParse("0"),
+	resources.Node:                  resource.MustParse("0"),
 }
 
 // NewController is a constructor
@@ -81,48 +79,19 @@ func (c *Controller) Reconcile(ctx context.Context, nodePool *v1.NodePool) (reco
 	}
 	stored := nodePool.DeepCopy()
 	// Determine resource usage and update nodepool.status.resources
-	nodePool.Status.Resources = c.resourceCountsFor(v1.NodePoolLabelKey, nodePool.Name)
+	nodePool.Status.Resources = lo.Assign(BaseResources, c.cluster.NodePoolResourcesFor(nodePool.Name))
 	if !equality.Semantic.DeepEqual(stored, nodePool) {
 		if err := c.kubeClient.Status().Patch(ctx, nodePool, client.MergeFrom(stored)); err != nil {
 			return reconcile.Result{}, client.IgnoreNotFound(err)
 		}
 	}
-	return reconcile.Result{}, nil
-}
-
-func (c *Controller) resourceCountsFor(ownerLabel string, ownerName string) corev1.ResourceList {
-	res := BaseResources.DeepCopy()
-	nodeCount := 0
-	// Record all resources provisioned by the nodepools, we look at the cluster state nodes as their capacity
-	// is accurately reported even for nodes that haven't fully started yet. This allows us to update our nodepool
-	// status immediately upon node creation instead of waiting for the node to become ready.
-	c.cluster.ForEachNode(func(n *state.StateNode) bool {
-		// Don't count nodes that we are planning to delete. This is to ensure that we are consistent throughout
-		// our provisioning and deprovisioning loops
-		if n.MarkedForDeletion() {
-			return true
-		}
-		if n.Labels()[ownerLabel] == ownerName {
-			res = resources.MergeInto(res, n.Capacity())
-			nodeCount += 1
-		}
-		return true
-	})
-	res[ResourceNode] = resource.MustParse(fmt.Sprintf("%d", nodeCount))
-	return res
+	return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 }
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(m).
 		Named("nodepool.counter").
-		For(&v1.NodePool{}, builder.WithPredicates(nodepoolutils.IsManagedPredicateFuncs(c.cloudProvider))).
-		Watches(&v1.NodeClaim{}, nodepoolutils.NodeClaimEventHandler(), builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
-			// Add a predicate here to filter out NodeClaims triggering reconciliation if they haven't resolved their
-			// providerID (and therefore, their resources)
-			nc := o.(*v1.NodeClaim)
-			return nc.Status.ProviderID != ""
-		}))).
-		Watches(&corev1.Node{}, nodepoolutils.NodeEventHandler()).
+		For(&v1.NodePool{}, builder.WithPredicates(nodepoolutils.IsManagedPredicateFuncs(c.cloudProvider), predicate.GenerationChangedPredicate{})).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))
 

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -378,7 +378,7 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 	if err := p.kubeClient.Get(ctx, types.NamespacedName{Name: n.NodePoolName}, latest); err != nil {
 		return "", fmt.Errorf("getting current resource usage, %w", err)
 	}
-	if err := latest.Spec.Limits.ExceededBy(latest.Status.Resources); err != nil {
+	if err := latest.Spec.Limits.ExceededBy(p.cluster.NodePoolResourcesFor(n.NodePoolName)); err != nil {
 		return "", err
 	}
 	nodeClaim := n.ToNodeClaim()

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -663,12 +663,20 @@ var _ = Describe("Provisioning", func() {
 
 	Context("Resource Limits", func() {
 		It("should not schedule when limits are exceeded", func() {
-			ExpectApplied(ctx, env.Client, test.NodePool(v1.NodePool{
+			nodePool := test.NodePool(v1.NodePool{
 				Spec: v1.NodePoolSpec{
 					Limits: v1.Limits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}),
 				},
-				Status: v1.NodePoolStatus{
-					Resources: corev1.ResourceList{
+			})
+			ExpectApplied(ctx, env.Client, nodePool)
+			cluster.UpdateNodeClaim(test.NodeClaim(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey: nodePool.Name,
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					Capacity: corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("100"),
 					},
 				},

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,6 +43,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
+	"sigs.k8s.io/karpenter/pkg/utils/resources"
 )
 
 // Cluster maintains cluster state that is often needed but expensive to compute.
@@ -56,6 +58,7 @@ type Cluster struct {
 	bindings                  map[types.NamespacedName]string // pod namespaced named -> node name
 	nodeNameToProviderID      map[string]string               // node name -> provider id
 	nodeClaimNameToProviderID map[string]string               // node claim name -> provider id
+	nodePoolResources         map[string]corev1.ResourceList  // node pool name -> resource list
 	daemonSetPods             sync.Map                        // daemonSet -> existing pod
 
 	podAcks                         sync.Map // pod namespaced name -> time when Karpenter first saw the pod as pending
@@ -84,6 +87,7 @@ func NewCluster(clk clock.Clock, client client.Client, cloudProvider cloudprovid
 		daemonSetPods:             sync.Map{},
 		nodeNameToProviderID:      map[string]string{},
 		nodeClaimNameToProviderID: map[string]string{},
+		nodePoolResources:         map[string]corev1.ResourceList{},
 
 		podAcks:                         sync.Map{},
 		podsSchedulableTimes:            sync.Map{},
@@ -255,6 +259,7 @@ func (c *Cluster) UnmarkForDeletion(providerIDs ...string) {
 
 	for _, id := range providerIDs {
 		if n, ok := c.nodes[id]; ok {
+			c.updateNodePoolResources(nil, c.nodes[id])
 			n.markedForDeletion = false
 		}
 	}
@@ -269,6 +274,7 @@ func (c *Cluster) MarkForDeletion(providerIDs ...string) {
 
 	for _, id := range providerIDs {
 		if n, ok := c.nodes[id]; ok {
+			c.updateNodePoolResources(c.nodes[id], nil)
 			n.markedForDeletion = true
 		}
 	}
@@ -482,6 +488,13 @@ func (c *Cluster) ConsolidationState() time.Time {
 	return c.MarkUnconsolidated()
 }
 
+func (c *Cluster) NodePoolResourcesFor(nodePoolName string) corev1.ResourceList {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return lo.Assign(c.nodePoolResources[nodePoolName])
+}
+
 // Reset the cluster state for unit testing
 func (c *Cluster) Reset() {
 	c.mu.Lock()
@@ -492,6 +505,7 @@ func (c *Cluster) Reset() {
 	c.nodes = map[string]*StateNode{}
 	c.nodeNameToProviderID = map[string]string{}
 	c.nodeClaimNameToProviderID = map[string]string{}
+	c.nodePoolResources = map[string]corev1.ResourceList{}
 	c.bindings = map[types.NamespacedName]string{}
 	c.antiAffinityPods = sync.Map{}
 	c.daemonSetPods = sync.Map{}
@@ -562,6 +576,7 @@ func (c *Cluster) newStateFromNodeClaim(nodeClaim *v1.NodeClaim, oldNode *StateN
 	if id, ok := c.nodeClaimNameToProviderID[nodeClaim.Name]; ok && id != nodeClaim.Status.ProviderID {
 		c.cleanupNodeClaim(nodeClaim.Name)
 	}
+	c.updateNodePoolResources(oldNode, n)
 	c.triggerConsolidationOnChange(oldNode, n)
 	return n
 }
@@ -569,9 +584,12 @@ func (c *Cluster) newStateFromNodeClaim(nodeClaim *v1.NodeClaim, oldNode *StateN
 func (c *Cluster) cleanupNodeClaim(name string) {
 	if id := c.nodeClaimNameToProviderID[name]; id != "" {
 		if c.nodes[id].Node == nil {
+			c.updateNodePoolResources(c.nodes[id], nil)
 			delete(c.nodes, id)
 		} else {
+			oldNode := c.nodes[id].ShallowCopy()
 			c.nodes[id].NodeClaim = nil
+			c.updateNodePoolResources(oldNode, c.nodes[id])
 		}
 		c.MarkUnconsolidated()
 	}
@@ -609,6 +627,7 @@ func (c *Cluster) newStateFromNode(ctx context.Context, node *corev1.Node, oldNo
 	if id, ok := c.nodeNameToProviderID[node.Name]; ok && id != node.Spec.ProviderID {
 		c.cleanupNode(node.Name)
 	}
+	c.updateNodePoolResources(oldNode, n)
 	c.triggerConsolidationOnChange(oldNode, n)
 	return n, nil
 }
@@ -616,12 +635,64 @@ func (c *Cluster) newStateFromNode(ctx context.Context, node *corev1.Node, oldNo
 func (c *Cluster) cleanupNode(name string) {
 	if id := c.nodeNameToProviderID[name]; id != "" {
 		if c.nodes[id].NodeClaim == nil {
+			c.updateNodePoolResources(c.nodes[id], nil)
 			delete(c.nodes, id)
 		} else {
+			oldNode := c.nodes[id].ShallowCopy()
 			c.nodes[id].Node = nil
+			c.updateNodePoolResources(oldNode, c.nodes[id])
 		}
 		delete(c.nodeNameToProviderID, name)
 		c.MarkUnconsolidated()
+	}
+}
+
+// nolint:gocyclo
+func (c *Cluster) updateNodePoolResources(oldNode, newNode *StateNode) {
+	var oldNodePoolName, newNodePoolName string
+	var oldResources, newResources corev1.ResourceList
+	if oldNode != nil && (oldNode.Node != nil || oldNode.NodeClaim != nil) {
+		oldNodePoolName = oldNode.Labels()[v1.NodePoolLabelKey]
+		oldResources = lo.Ternary(oldNode.MarkedForDeletion(), corev1.ResourceList{}, oldNode.Capacity())
+	}
+	if newNode != nil && (newNode.Node != nil || newNode.NodeClaim != nil) {
+		newNodePoolName = newNode.Labels()[v1.NodePoolLabelKey]
+		newResources = lo.Ternary(newNode.MarkedForDeletion(), corev1.ResourceList{}, newNode.Capacity())
+	}
+	if len(oldResources) != 0 {
+		oldResources[resources.Node] = resource.MustParse("1")
+	}
+	if len(newResources) != 0 {
+		newResources[resources.Node] = resource.MustParse("1")
+	}
+	if _, ok := c.nodePoolResources[newNodePoolName]; !ok && newNodePoolName != "" {
+		c.nodePoolResources[newNodePoolName] = corev1.ResourceList{}
+	}
+	if oldNodePoolName != "" {
+		for resourceName, quantity := range oldResources {
+			current := c.nodePoolResources[oldNodePoolName][resourceName]
+			current.Sub(quantity)
+			c.nodePoolResources[oldNodePoolName][resourceName] = current
+		}
+	}
+	if newNodePoolName != "" {
+		for resourceName, quantity := range newResources {
+			current := c.nodePoolResources[newNodePoolName][resourceName]
+			current.Add(quantity)
+			c.nodePoolResources[newNodePoolName][resourceName] = current
+		}
+	}
+	for _, name := range []string{oldNodePoolName, newNodePoolName} {
+		allZero := true
+		for _, v := range c.nodePoolResources[name] {
+			if !v.IsZero() {
+				allZero = false
+				break
+			}
+		}
+		if allZero {
+			delete(c.nodePoolResources, name)
+		}
 	}
 }
 

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -144,6 +144,21 @@ func NewNode() *StateNode {
 	}
 }
 
+func (in *StateNode) ShallowCopy() *StateNode {
+	return &StateNode{
+		Node:              in.Node,
+		NodeClaim:         in.NodeClaim,
+		daemonSetRequests: in.daemonSetRequests,
+		daemonSetLimits:   in.daemonSetLimits,
+		podRequests:       in.podRequests,
+		podLimits:         in.podLimits,
+		hostPortUsage:     in.hostPortUsage,
+		volumeUsage:       in.volumeUsage,
+		markedForDeletion: in.markedForDeletion,
+		nominatedUntil:    in.nominatedUntil,
+	}
+}
+
 func (in *StateNode) Name() string {
 	if in.Node == nil {
 		return in.NodeClaim.Name

--- a/pkg/controllers/state/zz_generated.deepcopy.go
+++ b/pkg/controllers/state/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package state
 
 import (
 	"k8s.io/api/core/v1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	apisv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/scheduling"

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
 
+var Node = v1.ResourceName("nodes")
+
 // RequestsForPods returns the total resources of a variadic list of podspecs.
 func RequestsForPods(pods ...*v1.Pod) v1.ResourceList {
 	var resources []v1.ResourceList


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The counter controller is doing _a lot_ of repeated work by continually pulling nodes from cluster state to calculate the number of resources that a NodePool has deployed at any point in time. Rather than rebuilding the sum every time, we can use a diff-based approach where we just take the difference for resources as we make updates to the StateNodes. Likewise, when a StateNode is deleted, we just subtract the resources from the retained NodePool resources that is now stored in cluster state.

This makes our counter controller logic way more efficient and reduces CPU cycles that were given to it.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
