### PR TITLE
perf: Ensure cluster topology building completes before giving up RLock

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -183,10 +183,11 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 // currently bound to a node. The pod returned may not be up-to-date with respect to status, however since the
 // anti-affinity terms can't be modified, they will be correct.
 func (c *Cluster) ForPodsWithAntiAffinity(fn func(p *corev1.Pod, n *corev1.Node) bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	c.antiAffinityPods.Range(func(key, value interface{}) bool {
 		pod := value.(*corev1.Pod)
-		c.mu.RLock()
-		defer c.mu.RUnlock()
 		nodeName, ok := c.bindings[client.ObjectKeyFromObject(pod)]
 		if !ok {
 			return true


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

### After Change

```
{"level":"DEBUG","time":"2025-04-02T18:33:07.120Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"d79b55e2-288e-40e1-9b8f-f79d9c57b76d","duration":"7.648607ms"}
{"level":"DEBUG","time":"2025-04-02T18:34:19.615Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"649d9666-418f-413a-a873-dea0c02beb3e","duration":"6.81428ms"}
{"level":"DEBUG","time":"2025-04-02T18:35:06.555Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"aab48aec-d504-4e77-8dfc-1549e9dc8641","duration":"5.759655ms"}
{"level":"DEBUG","time":"2025-04-02T18:35:27.740Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"f054c421-10df-4007-aadb-f372ab925cd4","duration":"394.981901ms"}
{"level":"DEBUG","time":"2025-04-02T18:35:46.187Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"ccc6eacf-943d-46ca-bfdc-895bb05d6b26","duration":"5.549665ms"}
{"level":"DEBUG","time":"2025-04-02T18:35:53.626Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"076c372e-0d6e-4a4c-925b-c9de7d1c6418","duration":"5.516298ms"}
{"level":"DEBUG","time":"2025-04-02T18:36:03.794Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"e548ae35-9400-4a71-b6bb-d2ec285b1b57","duration":"5.164914ms"}
{"level":"DEBUG","time":"2025-04-02T18:36:14.278Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"caa7e709-313f-424d-bb72-c2e73462d6c8","duration":"5.273962ms"}
{"level":"DEBUG","time":"2025-04-02T18:36:23.968Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"1a0050f9-232e-4ba3-9198-b4f3263e3676","duration":"5.931285ms"}
{"level":"DEBUG","time":"2025-04-02T18:36:33.766Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"40cb358e-f17b-4519-8835-136ecaa40ee7","duration":"5.562903ms"}
{"level":"DEBUG","time":"2025-04-02T18:36:44.113Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"720f0d61-cc6d-471d-bd6e-23476c0f78f3","duration":"5.159168ms"}
{"level":"DEBUG","time":"2025-04-02T18:36:54.135Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"f198f488-a829-4603-b0da-59f9e12aecc9","duration":"6.892891ms"}
{"level":"DEBUG","time":"2025-04-02T18:37:04.057Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"f1eb73f8-7dc2-444b-95db-e7002ded38ff","duration":"5.680824ms"}
{"level":"DEBUG","time":"2025-04-02T18:37:14.466Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"0c905a1b-43c0-4126-b028-dcff5673cd6d","duration":"430.347689ms"}
{"level":"DEBUG","time":"2025-04-02T18:37:22.896Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"8654cf10-4da9-4124-a281-7afe586b836e","duration":"5.455662ms"}
{"level":"DEBUG","time":"2025-04-02T18:37:33.362Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"e7b9378c-a565-4a43-a268-26fcb507f1ef","duration":"5.362169ms"}
{"level":"DEBUG","time":"2025-04-02T18:37:42.906Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"7056796c-3a30-456f-9e3c-b22c87351c14","duration":"5.591167ms"}
{"level":"DEBUG","time":"2025-04-02T18:37:52.966Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"e2b4c350-1050-480e-8a8e-791f4c5871c9","duration":"5.486635ms"}
{"level":"DEBUG","time":"2025-04-02T18:38:03.782Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"ecf0e617-1d07-44e3-a798-6c36a4af660c","duration":"5.441455ms"}
{"level":"DEBUG","time":"2025-04-02T18:38:13.687Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"dd7cdc88-8924-4b6c-b171-fece81e37d10","duration":"6.277614ms"}
{"level":"DEBUG","time":"2025-04-02T18:38:23.008Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"272bc2d2-4e85-4f18-a042-e17668c10401","duration":"5.162743ms"}
{"level":"DEBUG","time":"2025-04-02T18:38:33.192Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"ca264a2b-8e8e-48c8-a7ed-8f965f3f03c3","duration":"5.187936ms"}
{"level":"DEBUG","time":"2025-04-02T18:39:03.683Z","logger":"controller","caller":"provisioning/provisioner.go:321","message":"constructed cluster topology","commit":"2f5fa36-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"9e1e6160-38a8-4904-b738-137d5efba20b","duration":"5.607207ms"}
```

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
