### PR TITLE
ci: Removing github comment to unblock CI

### DIFF
--- a/.github/workflows/run-bench-test.yaml
+++ b/.github/workflows/run-bench-test.yaml
@@ -39,15 +39,3 @@ jobs:
         with:
           name: ${{ inputs.runName }}
           path: ${{ inputs.path }}/output
-      - uses: actions/github-script@v7
-        env:
-          RESULTS: ${{ steps.test-run.outputs.OUTPUT }}
-          UPLOAD: ${{ steps.artifact-upload.outputs.artifact-url }}
-        with:
-          script: |
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `# :mag: ${{ inputs.runName }} :mag:\nResults of benchmarking testing in \`${{ inputs.path }}\`: \n\`\`\`${process.env.RESULTS}\n\`\`\`\n${process.env.UPLOAD}`
-              })

--- a/.github/workflows/scheduling-benchmarking.yaml
+++ b/.github/workflows/scheduling-benchmarking.yaml
@@ -10,8 +10,6 @@ on:
 jobs:
   before:
     name: Before PR
-    permissions:
-        pull-requests: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The current CI is breaking with a 403: https://github.com/kubernetes-sigs/karpenter/actions/runs/13710441815

This change removes the github comment on the PR to unblock the CI while a solution can be worked on

**How was this change tested?**

https://github.com/DerekFrank/karpenter-testing-fork/actions/runs/14250780735

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
