### PR TITLE
perf: Timeout scheduling simulation after 1m to schedule pods/nodes

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -322,7 +322,11 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 		return scheduler.Results{}, fmt.Errorf("creating scheduler, %w", err)
 	}
 
-	results, err := s.Solve(ctx, pods)
+	// Timeout the Solve() method after 1m to ensure that we move faster through provisioning
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	results, err := s.Solve(timeoutCtx, pods)
 	// context errors are ignored because we want to finish provisioning for what has already been scheduled
 	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		return scheduler.Results{}, err


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Timeout the scheduling simulation after 1m during provisioning to ensure we make faster progress when scheduling pods/nodes. 

To validate this change, I ran simulations of large scale-ups with and without the timeout. I found that, when running the provisioning loops with the timeouts, we were significantly faster (2x) compared to running without it.

### Before PR (32m)

<img width="1441" alt="Screenshot 2025-03-11 at 1 07 59 AM" src="https://github.com/user-attachments/assets/52c0734a-1cce-4fbf-a009-e84e5a5fddf0" />

### After PR (16m)

<img width="1442" alt="Screenshot 2025-03-23 at 9 50 39 PM" src="https://github.com/user-attachments/assets/e0b79cdc-2040-4ad2-bd84-dc996e43c3f3" />

**How was this change tested?**

`make presubmit`
- Running scale testing with the Kwok cloudprovider

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
