### PR TITLE
feat: Add `PreferencePolicy` as an environment variable option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ apply: verify build ## Deploy the kwok controller from the current state of your
 		--set controller.image.repository=$(IMG_REPOSITORY) \
 		--set controller.image.tag=$(IMG_TAG) \
 		--set controller.image.digest=$(IMG_DIGEST) \
+		--set settings.preferencePolicy=Ignore \
 		--set-string controller.env[0].name=ENABLE_PROFILING \
 		--set-string controller.env[0].value=true
 

--- a/kwok/charts/README.md
+++ b/kwok/charts/README.md
@@ -51,11 +51,12 @@ For full Karpenter documentation please checkout [https://karpenter.sh](https://
 | serviceMonitor.additionalLabels | object | `{}` | Additional labels for the ServiceMonitor. |
 | serviceMonitor.enabled | bool | `false` | Specifies whether a ServiceMonitor should be created. |
 | serviceMonitor.endpointConfig | object | `{}` | Endpoint configuration for the ServiceMonitor. |
-| settings | object | `{"batchIdleDuration":"1s","batchMaxDuration":"10s","featureGates":{"spotToSpotConsolidation":false}}` | Global Settings to configure Karpenter |
-| settings.batchIdleDuration | string | `"1s"` | The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately. |
+| settings | object | `{"batchIdleDuration":"1s","batchMaxDuration":"10s","featureGates":{"spotToSpotConsolidation":false},"preferencePolicy":"Respect"}` | Global Settings to configure Karpenter |
+| settings.batchIdleDuration | string | `"1s"` | The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately. |
 | settings.batchMaxDuration | string | `"10s"` | The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes. |
 | settings.featureGates | object | `{"spotToSpotConsolidation":false}` | Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features |
 | settings.featureGates.spotToSpotConsolidation | bool | `false` | spotToSpotConsolidation is ALPHA and is disabled by default. Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation. |
+| settings.preferencePolicy | string | `"Respect"` | How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect' |
 | strategy | object | `{"rollingUpdate":{"maxUnavailable":1}}` | Strategy for updating the pod. |
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period for the pod. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Tolerations to allow the pod to be scheduled to nodes with taints. |

--- a/kwok/charts/templates/deployment.yaml
+++ b/kwok/charts/templates/deployment.yaml
@@ -104,6 +104,10 @@ spec:
             - name: BATCH_IDLE_DURATION
               value: "{{ . }}"
           {{- end }}
+          {{- with .Values.settings.preferencePolicy }}
+            - name: PREFERENCE_POLICY
+              value: "{{ . }}"
+          {{- end }}
           {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/kwok/charts/values.yaml
+++ b/kwok/charts/values.yaml
@@ -129,10 +129,13 @@ settings:
   # -- The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one
   # time which usually results in fewer but larger nodes.
   batchMaxDuration: 10s
-  # -- The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive
+  # -- The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive
   # faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods
   # will be batched separately.
   batchIdleDuration: 1s
+  # -- How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution
+  # node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'
+  preferencePolicy: Respect
   # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
   # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
   featureGates:

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -40,6 +40,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	scheduler "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
@@ -178,12 +180,13 @@ func (p *Provisioner) GetPendingPods(ctx context.Context) ([]*corev1.Pod, error)
 
 // consolidationWarnings potentially writes logs warning about possible unexpected interactions
 // between scheduling constraints and consolidation
+// nolint:gocyclo
 func (p *Provisioner) consolidationWarnings(ctx context.Context, pods []*corev1.Pod) {
 	// We have pending pods that have preferred anti-affinity or topology spread constraints.  These can interact
 	// unexpectedly with consolidation, so we warn once per hour when we see these pods.
 	antiAffinityPods := lo.FilterMap(pods, func(po *corev1.Pod, _ int) (client.ObjectKey, bool) {
 		if po.Spec.Affinity != nil && po.Spec.Affinity.PodAntiAffinity != nil {
-			if len(po.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0 {
+			if len(po.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0 && options.FromContext(ctx).PreferencePolicy != options.PreferencePolicyIgnore {
 				if p.cm.HasChanged(string(po.UID), "pod-antiaffinity") {
 					return client.ObjectKeyFromObject(po), true
 				}
@@ -193,7 +196,7 @@ func (p *Provisioner) consolidationWarnings(ctx context.Context, pods []*corev1.
 	})
 	topologySpreadPods := lo.FilterMap(pods, func(po *corev1.Pod, _ int) (client.ObjectKey, bool) {
 		for _, tsc := range po.Spec.TopologySpreadConstraints {
-			if tsc.WhenUnsatisfiable == corev1.ScheduleAnyway {
+			if tsc.WhenUnsatisfiable == corev1.ScheduleAnyway && options.FromContext(ctx).PreferencePolicy != options.PreferencePolicyIgnore {
 				if p.cm.HasChanged(string(po.UID), "pod-topology-spread") {
 					return client.ObjectKeyFromObject(po), true
 				}
@@ -263,7 +266,7 @@ func (p *Provisioner) NewScheduler(
 	}
 
 	// Calculate cluster topology, if a context error occurs, it is wrapped and returned
-	topology, err := scheduler.NewTopology(ctx, p.kubeClient, p.cluster, stateNodes, nodePools, instanceTypes, pods)
+	topology, err := scheduler.NewTopology(ctx, p.kubeClient, p.cluster, stateNodes, nodePools, instanceTypes, pods, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("tracking topology counts, %w", err)
 	}
@@ -310,7 +313,17 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 		return scheduler.Results{}, nil
 	}
 	log.FromContext(ctx).V(1).WithValues("pending-pods", len(pendingPods), "deleting-pods", len(deletingNodePods)).Info("computing scheduling decision for provisionable pod(s)")
-	s, err := p.NewScheduler(ctx, pods, nodes.Active(), scheduler.DisableReservedCapacityFallback)
+
+	opts := []scheduler.Options{scheduler.DisableReservedCapacityFallback}
+	if options.FromContext(ctx).PreferencePolicy == options.PreferencePolicyIgnore {
+		opts = append(opts, scheduler.IgnorePreferences)
+	}
+	s, err := p.NewScheduler(
+		ctx,
+		pods,
+		nodes.Active(),
+		opts...,
+	)
 	if err != nil {
 		if errors.Is(err, ErrNodePoolsNotFound) {
 			log.FromContext(ctx).Info("no nodepools found")

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
 	fakecr "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -44,9 +45,15 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/logging"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/test"
 )
+
+func init() {
+	log.SetLogger(logging.NopLogger)
+}
 
 const MinPodsPerSec = 100.0
 const PrintStats = false
@@ -68,31 +75,37 @@ var r = rand.New(rand.NewSource(42))
 //
 // ```
 func BenchmarkScheduling1(b *testing.B) {
-	benchmarkScheduler(b, 400, 1)
+	benchmarkScheduler(b, makeDiversePods(1))
 }
 func BenchmarkScheduling50(b *testing.B) {
-	benchmarkScheduler(b, 400, 50)
+	benchmarkScheduler(b, makeDiversePods(50))
 }
 func BenchmarkScheduling100(b *testing.B) {
-	benchmarkScheduler(b, 400, 100)
+	benchmarkScheduler(b, makeDiversePods(100))
 }
 func BenchmarkScheduling500(b *testing.B) {
-	benchmarkScheduler(b, 400, 500)
+	benchmarkScheduler(b, makeDiversePods(500))
 }
 func BenchmarkScheduling1000(b *testing.B) {
-	benchmarkScheduler(b, 400, 1000)
+	benchmarkScheduler(b, makeDiversePods(1000))
 }
 func BenchmarkScheduling2000(b *testing.B) {
-	benchmarkScheduler(b, 400, 2000)
+	benchmarkScheduler(b, makeDiversePods(2000))
 }
 func BenchmarkScheduling5000(b *testing.B) {
-	benchmarkScheduler(b, 400, 5000)
+	benchmarkScheduler(b, makeDiversePods(5000))
 }
 func BenchmarkScheduling10000(b *testing.B) {
-	benchmarkScheduler(b, 400, 10000)
+	benchmarkScheduler(b, makeDiversePods(10000))
 }
 func BenchmarkScheduling20000(b *testing.B) {
-	benchmarkScheduler(b, 400, 20000)
+	benchmarkScheduler(b, makeDiversePods(20000))
+}
+func BenchmarkRespectPreferences(b *testing.B) {
+	benchmarkScheduler(b, makePreferencePods(4000))
+}
+func BenchmarkIgnorePreferences(b *testing.B) {
+	benchmarkScheduler(b, makePreferencePods(4000), scheduling.IgnorePreferences)
 }
 
 // TestSchedulingProfile is used to gather profiling metrics, benchmarking is primarily done with standard
@@ -117,64 +130,41 @@ func TestSchedulingProfile(t *testing.T) {
 	totalPods := 0
 	totalNodes := 0
 	var totalTime time.Duration
-	for _, instanceCount := range []int{400} {
-		for _, podCount := range []int{1, 50, 100, 500, 1000, 1500, 2000, 5000, 10000, 20000} {
-			start := time.Now()
-			res := testing.Benchmark(func(b *testing.B) { benchmarkScheduler(b, instanceCount, podCount) })
-			totalTime += time.Since(start) / time.Duration(res.N)
-			nodeCount := res.Extra["nodes"]
-			fmt.Fprintf(tw, "%d instances %d pods\t%d nodes\t%s per scheduling\t%s per pod\n", instanceCount, podCount, int(nodeCount), time.Duration(res.NsPerOp()), time.Duration(res.NsPerOp()/int64(podCount)))
-			totalPods += podCount
-			totalNodes += int(nodeCount)
-		}
+	fmt.Fprintf(tw, "============== Generic Pods ==============\n")
+	for _, podCount := range []int{1, 50, 100, 500, 1000, 1500, 2000, 5000, 10000, 20000} {
+		start := time.Now()
+		res := testing.Benchmark(func(b *testing.B) {
+			benchmarkScheduler(b, makeDiversePods(podCount))
+		})
+		totalTime += time.Since(start) / time.Duration(res.N)
+		nodeCount := res.Extra["nodes"]
+		fmt.Fprintf(tw, "%s\t%d pods\t%d nodes\t%s per scheduling\t%s per pod\n", fmt.Sprintf("%d Pods", podCount), podCount, int(nodeCount), time.Duration(res.NsPerOp()), time.Duration(res.NsPerOp()/int64(podCount)))
+		totalPods += podCount
+		totalNodes += int(nodeCount)
 	}
-	fmt.Println("scheduled", totalPods, "against", totalNodes, "nodes in total in", totalTime, float64(totalPods)/totalTime.Seconds(), "pods/sec")
+	fmt.Fprintf(tw, "============== Preference Pods ==============\n")
+	for _, opt := range []scheduling.Options{nil, scheduling.IgnorePreferences} {
+		start := time.Now()
+		podCount := 4000
+		res := testing.Benchmark(func(b *testing.B) {
+			benchmarkScheduler(b, makePreferencePods(podCount), opt)
+		})
+		totalTime += time.Since(start) / time.Duration(res.N)
+		nodeCount := res.Extra["nodes"]
+		fmt.Fprintf(tw, "%s\t%d pods\t%d nodes\t%s per scheduling\t%s per pod\n", lo.Ternary(opt == nil, "PreferencePolicy=Respect", "PreferencePolicy=Ignore"), podCount, int(nodeCount), time.Duration(res.NsPerOp()), time.Duration(res.NsPerOp()/int64(podCount)))
+		totalPods += podCount
+		totalNodes += int(nodeCount)
+	}
+	fmt.Fprintf(tw, "\nscheduled %d against %d nodes in total in %s %f pods/sec\n", totalPods, totalNodes, totalTime, float64(totalPods)/totalTime.Seconds())
 	tw.Flush()
 }
 
-// nolint:gocyclo
-func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
-	// create context from background with test options
-	// test options disable logging by default
-	ctx = options.ToContext(context.Background(), test.Options())
-	nodePool := test.NodePool(v1.NodePool{
-		Spec: v1.NodePoolSpec{
-			Limits: v1.Limits{
-				corev1.ResourceCPU:    resource.MustParse("10000000"),
-				corev1.ResourceMemory: resource.MustParse("10000000Gi"),
-			},
-		},
-	})
-
-	// Apply limits to both of the NodePools
-	instanceTypes := fake.InstanceTypes(instanceCount)
-	cloudProvider = fake.NewCloudProvider()
-	cloudProvider.InstanceTypes = instanceTypes
-
-	client := fakecr.NewFakeClient()
-	pods := makeDiversePods(podCount)
-	clock := &clock.RealClock{}
-	cluster = state.NewCluster(clock, client, cloudProvider)
-	topology, err := scheduling.NewTopology(ctx, client, cluster, nil, []*v1.NodePool{nodePool}, map[string][]*cloudprovider.InstanceType{
-		nodePool.Name: instanceTypes,
-	}, pods)
+func benchmarkScheduler(b *testing.B, pods []*corev1.Pod, opts ...scheduling.Options) {
+	ctx = options.ToContext(injection.WithControllerName(context.Background(), "provisioner"), test.Options())
+	scheduler, err := setupScheduler(ctx, pods, opts...)
 	if err != nil {
-		b.Fatalf("creating topology, %s", err)
+		b.Fatalf("creating scheduler, %s", err)
 	}
-
-	scheduler := scheduling.NewScheduler(
-		ctx,
-		client,
-		[]*v1.NodePool{nodePool},
-		cluster,
-		nil,
-		topology,
-		map[string][]*cloudprovider.InstanceType{nodePool.Name: instanceTypes},
-		nil,
-		events.NewRecorder(&record.FakeRecorder{}),
-		clock,
-		scheduling.DisableReservedCapacityFallback,
-	)
 
 	b.ResetTimer()
 	// Pack benchmark
@@ -212,8 +202,8 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 				}
 				variance /= float64(nodesInRound1)
 				stddev := math.Sqrt(variance)
-				fmt.Printf("%d instance types %d pods resulted in %d nodes with pods per node min=%d max=%d mean=%f stddev=%f\n",
-					instanceCount, podCount, nodesInRound1, minPods, maxPods, meanPodsPerNode, stddev)
+				fmt.Printf("400 instance types %d pods resulted in %d nodes with pods per node min=%d max=%d mean=%f stddev=%f\n",
+					len(pods), nodesInRound1, minPods, maxPods, meanPodsPerNode, stddev)
 			}
 		}
 	}
@@ -222,15 +212,46 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 	b.ReportMetric(podsPerSec, "pods/sec")
 	b.ReportMetric(float64(podsScheduledInRound1), "pods")
 	b.ReportMetric(float64(nodesInRound1), "nodes")
+}
 
-	// we don't care if it takes a bit of time to schedule a few pods as there is some setup time required for sorting
-	// instance types, computing topologies, etc.  We want to ensure that the larger batches of pods don't become too
-	// slow.
-	if len(pods) > 100 {
-		if podsPerSec < MinPodsPerSec {
-			b.Fatalf("scheduled %f pods/sec, expected at least %f", podsPerSec, MinPodsPerSec)
-		}
+func setupScheduler(ctx context.Context, pods []*corev1.Pod, opts ...scheduling.Options) (*scheduling.Scheduler, error) {
+	nodePool := test.NodePool(v1.NodePool{
+		Spec: v1.NodePoolSpec{
+			Limits: v1.Limits{
+				corev1.ResourceCPU:    resource.MustParse("10000000"),
+				corev1.ResourceMemory: resource.MustParse("10000000Gi"),
+			},
+		},
+	})
+
+	// Apply limits to both of the NodePools
+	cloudProvider = fake.NewCloudProvider()
+	instanceTypes := fake.InstanceTypes(400)
+	cloudProvider.InstanceTypes = instanceTypes
+
+	client := fakecr.NewFakeClient()
+	clock := &clock.RealClock{}
+	cluster = state.NewCluster(clock, client, cloudProvider)
+	topology, err := scheduling.NewTopology(ctx, client, cluster, nil, []*v1.NodePool{nodePool}, map[string][]*cloudprovider.InstanceType{
+		nodePool.Name: instanceTypes,
+	}, pods, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating topology, %w", err)
 	}
+
+	return scheduling.NewScheduler(
+		ctx,
+		client,
+		[]*v1.NodePool{nodePool},
+		cluster,
+		nil,
+		topology,
+		map[string][]*cloudprovider.InstanceType{nodePool.Name: instanceTypes},
+		nil,
+		events.NewRecorder(&record.FakeRecorder{}),
+		clock,
+		opts...,
+	), nil
 }
 
 func makeDiversePods(count int) []*corev1.Pod {
@@ -259,7 +280,7 @@ func makePodAntiAffinityPods(count int, key string) []*corev1.Pod {
 			test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
-					UID:    uuid.NewUUID(),
+					UID:    uuid.NewUUID(), // set the UUID so the cached data is properly stored in the scheduler
 				},
 				PodAntiRequirements: []corev1.PodAffinityTerm{
 					{
@@ -288,7 +309,7 @@ func makePodAffinityPods(count int, key string) []*corev1.Pod {
 			test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
-					UID:    uuid.NewUUID(),
+					UID:    uuid.NewUUID(), // set the UUID so the cached data is properly stored in the scheduler
 				},
 				PodRequirements: []corev1.PodAffinityTerm{
 					{
@@ -313,7 +334,7 @@ func makeTopologySpreadPods(count int, key string) []*corev1.Pod {
 			test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: randomLabels(),
-					UID:    uuid.NewUUID(),
+					UID:    uuid.NewUUID(), // set the UUID so the cached data is properly stored in the scheduler
 				},
 				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 					{
@@ -342,7 +363,7 @@ func makeGenericPods(count int) []*corev1.Pod {
 			test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: randomLabels(),
-					UID:    uuid.NewUUID(),
+					UID:    uuid.NewUUID(), // set the UUID so the cached data is properly stored in the scheduler
 				},
 				ResourceRequirements: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -350,6 +371,56 @@ func makeGenericPods(count int) []*corev1.Pod {
 						corev1.ResourceMemory: randomMemory(),
 					},
 				}}))
+	}
+	return pods
+}
+
+func makePreferencePods(count int) []*corev1.Pod {
+	pods := test.Pods(count, test.PodOptions{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app": "nginx",
+			},
+		},
+		NodePreferences: []corev1.NodeSelectorRequirement{
+			// This is a preference that can be satisfied
+			{
+				Key:      corev1.LabelTopologyZone,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"test-zone-1"},
+			},
+		},
+		PodAntiPreferences: []corev1.WeightedPodAffinityTerm{
+			// This is a preference that can't be satisfied
+			{
+				Weight: 10,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"app": "nginx",
+					}},
+					TopologyKey: corev1.LabelTopologyZone,
+				},
+			},
+			// This is a preference that can be satisfied
+			{
+				Weight: 1,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"app": "nginx",
+					}},
+					TopologyKey: corev1.LabelHostname,
+				},
+			},
+		},
+		ResourceRequirements: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    randomCPU(),
+				corev1.ResourceMemory: randomMemory(),
+			},
+		},
+	})
+	for _, p := range pods {
+		p.UID = uuid.NewUUID() // set the UUID so the cached data is properly stored in the scheduler
 	}
 	return pods
 }

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -30,8 +30,16 @@ import (
 	"sigs.k8s.io/karpenter/pkg/utils/env"
 )
 
+type PreferencePolicy string
+
+const (
+	PreferencePolicyIgnore  PreferencePolicy = "Ignore"
+	PreferencePolicyRespect PreferencePolicy = "Respect"
+)
+
 var (
-	validLogLevels = []string{"", "debug", "info", "error"}
+	validLogLevels          = []string{"", "debug", "info", "error"}
+	validPreferencePolicies = []PreferencePolicy{PreferencePolicyIgnore, PreferencePolicyRespect}
 
 	Injectables = []Injectable{&Options{}}
 )
@@ -63,6 +71,8 @@ type Options struct {
 	LogErrorOutputPaths     string
 	BatchMaxDuration        time.Duration
 	BatchIdleDuration       time.Duration
+	preferencePolicyRaw     string
+	PreferencePolicy        PreferencePolicy
 	FeatureGates            FeatureGates
 }
 
@@ -99,6 +109,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.LogErrorOutputPaths, "log-error-output-paths", env.WithDefaultString("LOG_ERROR_OUTPUT_PATHS", "stderr"), "Optional comma separated paths for logging error output")
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
+	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=false,SpotToSpotConsolidation=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, and SpotToSpotConsolidation")
 }
 
@@ -109,15 +120,18 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 		}
 		return fmt.Errorf("parsing flags, %w", err)
 	}
-
 	if !lo.Contains(validLogLevels, o.LogLevel) {
 		return fmt.Errorf("validating cli flags / env vars, invalid LOG_LEVEL %q", o.LogLevel)
+	}
+	if !lo.Contains(validPreferencePolicies, PreferencePolicy(o.preferencePolicyRaw)) {
+		return fmt.Errorf("validating cli flags / env vars, invalid PREFERENCE_POLICY %q", o.preferencePolicyRaw)
 	}
 	gates, err := ParseFeatureGates(o.FeatureGates.inputStr)
 	if err != nil {
 		return fmt.Errorf("parsing feature gates, %w", err)
 	}
 	o.FeatureGates = gates
+	o.PreferencePolicy = PreferencePolicy(o.preferencePolicyRaw)
 	return nil
 }
 

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -41,6 +41,7 @@ type OptionsFields struct {
 	LogLevel                *string
 	LogOutputPaths          *string
 	LogErrorOutputPaths     *string
+	PreferencePolicy        *options.PreferencePolicy
 	BatchMaxDuration        *time.Duration
 	BatchIdleDuration       *time.Duration
 	FeatureGates            FeatureGates
@@ -74,6 +75,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		LogErrorOutputPaths:   lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),
 		BatchMaxDuration:      lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
 		BatchIdleDuration:     lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
+		PreferencePolicy:      lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
 		FeatureGates: options.FeatureGates{
 			NodeRepair:              lo.FromPtrOr(opts.FeatureGates.NodeRepair, false),
 			ReservedCapacity:        lo.FromPtrOr(opts.FeatureGates.ReservedCapacity, false),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds an environment variable option called `PreferencePolicy` with the following definitions:

- `Respect`: Karpenter will attempt to respect all preferences as requirements. If Karpenter cannot simulate pods against the node given these requirements, it will begin removing preferences from the pod until it is able to schedule the pod. `Respect` can also block consolidation more frequently due to the way that the preference relaxation ordering is orchestrated.
- `Ignore`: Karpenter will ignore all preferences when it performs its scheduling simulations. In general, this is a more efficient way to run Karpenter because Karpenter will have to give less effort to satisfying all of the preferences on the application pods. In addition, it's currently not guaranteed that even if Karpenter does respect all of the preferences, then they will still be respected by the kube-scheduler. In particular, when considering things like `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity preferences and `ScheduleAnyways` topologySpreadConstraints, it's very timing-dependent and non-deterministic on whether or not the kube-scheduler will see the pods in time to respect the preferences.

### CI Benchmark Testing Results

```
============== Generic Pods ==============
1 pods      1 nodes     162.759µs per scheduling      162.759µs per pod
50 pods     10 nodes    38.027579ms per scheduling    760.551µs per pod
100 pods    20 nodes    87.226431ms per scheduling    872.264µs per pod
500 pods    100 nodes   406.788638ms per scheduling   813.577µs per pod
1000 pods   200 nodes   589.950666ms per scheduling   589.95µs per pod
1500 pods   300 nodes   1.902119667s per scheduling   1.268079ms per pod
2000 pods   400 nodes   2.537366s per scheduling      1.268683ms per pod
5000 pods   1000 nodes  5.126445375s per scheduling   1.025289ms per pod
10000 pods  2000 nodes  20.038828125s per scheduling  2.003882ms per pod
20000 pods  4000 nodes  50.439955s per scheduling     2.521997ms per pod
============== Preference Pods ==============
4000 pods  4000 nodes  51.578981334s per scheduling  12.894745ms per pod
4000 pods  6 nodes     711.665062ms per scheduling   177.916µs per pod
scheduled 48151 against 12037 nodes in total in 2m15.715480943s 354.793717 pods/sec
```

### Scale Testing

I validated this change by creating a testing workload that had a preference that was unsatisfiable and therefore would have to be relaxed with `PreferencePolicy=Respect`. By setting `PreferencePolicy=Ignore`, we wouldn't capture these preferences in our cluster topology or consider it when adding pods to nodes.

#### Test Workload

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: inflate
  namespace: default
spec:
  replicas: 10000
  selector:
    matchLabels:
      app: inflate
  template:
    metadata:
      labels:
        app: inflate
    spec:
      affinity: 
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                - test-zone-a
                - test-zone-b
                - test-zone-c
                - test-zone-d
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            - topologyKey: kubernetes.io/hostname
              labelSelector:
                matchLabels:
                  app: inflate
          # Can't satisfy this term
          preferredDuringSchedulingIgnoredDuringExecution:
            - weight: 100
              podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app: inflate
                topologyKey: topology.kubernetes.io/zone
      topologySpreadConstraints:
      - maxSkew: 1
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: DoNotSchedule
        labelSelector:
          matchLabels:
            app: inflate
      containers:
        - name: inflate
          image: public.ecr.aws/ubuntu/ubuntu:22.04_stable
          command: ["/bin/sh", "-ec", "while :; do echo '.'; sleep 5 ; done"]
          resources:
            requests:
              memory: 100Mi
              cpu: 1
      terminationGracePeriodSeconds: 0
```

#### `PreferencePolicy=Respect` (19m)

<img width="1443" alt="Screenshot 2025-03-25 at 12 00 12 AM" src="https://github.com/user-attachments/assets/1950b0bf-8766-4baf-a15d-ce961d1255c5" />

#### `PreferencePolicy=Ignore` (7m)

<img width="1443" alt="Screenshot 2025-03-26 at 12 25 06 AM" src="https://github.com/user-attachments/assets/d8f1f430-d8dd-477b-9298-48e94a98bc3d" />

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
