### PR TITLE
fix: Allow disabling syncing taints from nodeclaims to nodes (with node label)

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -51,6 +51,7 @@ const (
 	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"
 	NodeClaimTerminationTimestampAnnotationKey = apis.Group + "/nodeclaim-termination-timestamp"
+	NodeClaimSyncTaintsAnnotationKey           = apis.Group + "/nodeclaim-sync-taints"
 )
 
 // Karpenter specific finalizers

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -38,10 +38,11 @@ const (
 
 // Karpenter specific domains and labels
 const (
-	NodePoolLabelKey        = apis.Group + "/nodepool"
-	NodeInitializedLabelKey = apis.Group + "/initialized"
-	NodeRegisteredLabelKey  = apis.Group + "/registered"
-	CapacityTypeLabelKey    = apis.Group + "/capacity-type"
+	NodePoolLabelKey            = apis.Group + "/nodepool"
+	NodeInitializedLabelKey     = apis.Group + "/initialized"
+	NodeRegisteredLabelKey      = apis.Group + "/registered"
+	NodeDoNotSyncTaintsLabelKey = apis.Group + "/nodeclaim-do-not-sync-taints"
+	CapacityTypeLabelKey        = apis.Group + "/capacity-type"
 )
 
 // Karpenter specific annotations
@@ -51,7 +52,6 @@ const (
 	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"
 	NodeClaimTerminationTimestampAnnotationKey = apis.Group + "/nodeclaim-termination-timestamp"
-	NodeClaimSyncTaintsAnnotationKey           = apis.Group + "/nodeclaim-sync-taints"
 )
 
 // Karpenter specific finalizers

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -41,7 +41,7 @@ const (
 	NodePoolLabelKey            = apis.Group + "/nodepool"
 	NodeInitializedLabelKey     = apis.Group + "/initialized"
 	NodeRegisteredLabelKey      = apis.Group + "/registered"
-	NodeDoNotSyncTaintsLabelKey = apis.Group + "/nodeclaim-do-not-sync-taints"
+	NodeDoNotSyncTaintsLabelKey = apis.Group + "/do-not-sync-taints"
 	CapacityTypeLabelKey        = apis.Group + "/capacity-type"
 )
 

--- a/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
@@ -366,18 +366,6 @@ var _ = Describe("Initialization", func() {
 		Expect(ExpectStatusConditionExists(nodeClaim, v1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionTrue))
 	})
 	It("should not consider the Node to be initialized when all startupTaints aren't removed", func() {
-		startupTaints := []corev1.Taint{
-			{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		}
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -392,7 +380,18 @@ var _ = Describe("Initialization", func() {
 						corev1.ResourcePods:   resource.MustParse("5"),
 					},
 				},
-				StartupTaints: startupTaints,
+				StartupTaints: []corev1.Taint{
+					{
+						Key:    "custom-startup-taint",
+						Effect: corev1.TaintEffectNoSchedule,
+						Value:  "custom-startup-value",
+					},
+					{
+						Key:    "other-custom-startup-taint",
+						Effect: corev1.TaintEffectNoExecute,
+						Value:  "other-custom-startup-value",
+					},
+				},
 			},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
@@ -411,13 +410,13 @@ var _ = Describe("Initialization", func() {
 				corev1.ResourceMemory: resource.MustParse("80Mi"),
 				corev1.ResourcePods:   resource.MustParse("110"),
 			},
-			Taints: append(startupTaints, v1.UnregisteredNoExecuteTaint),
+			Taints: []corev1.Taint{v1.UnregisteredNoExecuteTaint},
 		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
 
-		// Startup taints should be the only taints remaining
+		// Should add the startup taints to the node
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 		Expect(node.Spec.Taints).To(ContainElements(
@@ -440,18 +439,6 @@ var _ = Describe("Initialization", func() {
 		Expect(ExpectStatusConditionExists(nodeClaim, v1.ConditionTypeInitialized).Status).To(Equal(metav1.ConditionUnknown))
 	})
 	It("should consider the Node to be initialized once the startupTaints are removed", func() {
-		startupTaints := []corev1.Taint{
-			{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		}
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -466,7 +453,18 @@ var _ = Describe("Initialization", func() {
 						corev1.ResourcePods:   resource.MustParse("5"),
 					},
 				},
-				StartupTaints: startupTaints,
+				StartupTaints: []corev1.Taint{
+					{
+						Key:    "custom-startup-taint",
+						Effect: corev1.TaintEffectNoSchedule,
+						Value:  "custom-startup-value",
+					},
+					{
+						Key:    "other-custom-startup-taint",
+						Effect: corev1.TaintEffectNoExecute,
+						Value:  "other-custom-startup-value",
+					},
+				},
 			},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
@@ -485,7 +483,7 @@ var _ = Describe("Initialization", func() {
 				corev1.ResourceMemory: resource.MustParse("80Mi"),
 				corev1.ResourcePods:   resource.MustParse("110"),
 			},
-			Taints: append(startupTaints, v1.UnregisteredNoExecuteTaint),
+			Taints: []corev1.Taint{v1.UnregisteredNoExecuteTaint},
 		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -19,6 +19,7 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -121,7 +121,6 @@ func (r *Registration) syncNode(ctx context.Context, nodeClaim *v1.NodeClaim, no
 	controllerutil.AddFinalizer(node, v1.TerminationFinalizer)
 
 	node = nodeclaimutils.UpdateNodeOwnerReferences(nodeClaim, node)
-	node.Labels = lo.Assign(node.Labels, nodeClaim.Labels)
 	node.Annotations = lo.Assign(node.Annotations, nodeClaim.Annotations)
 	// We do not sync the taints from the nodeclaim as we assume that the karpenter provider code
 	// is managing taints.

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -123,9 +123,8 @@ func (r *Registration) syncNode(ctx context.Context, nodeClaim *v1.NodeClaim, no
 	node = nodeclaimutils.UpdateNodeOwnerReferences(nodeClaim, node)
 	node.Labels = lo.Assign(node.Labels, nodeClaim.Labels)
 	node.Annotations = lo.Assign(node.Annotations, nodeClaim.Annotations)
-	// Sync all taints inside NodeClaim into the Node taints
-	node.Spec.Taints = scheduling.Taints(node.Spec.Taints).Merge(nodeClaim.Spec.Taints)
-	node.Spec.Taints = scheduling.Taints(node.Spec.Taints).Merge(nodeClaim.Spec.StartupTaints)
+	// We do not sync the taints from the nodeclaim as we assume that the karpenter provider code
+	// is managing taints.
 	// Remove karpenter.sh/unregistered taint
 	node.Spec.Taints = lo.Reject(node.Spec.Taints, func(t corev1.Taint, _ int) bool {
 		return t.MatchTaint(&v1.UnregisteredNoExecuteTaint)

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -123,7 +123,7 @@ func (r *Registration) syncNode(ctx context.Context, nodeClaim *v1.NodeClaim, no
 
 	// We do not sync the taints if the feature flag is enabled. We instead assume that the karpenter provider
 	// is managing taints. We still manage/remove the unregistered taint to signal the end of syncing.
-	if _, ok := node.Annotations[v1.NodeDoNotSyncTaintsLabelKey]; !ok {
+	if _, ok := node.Labels[v1.NodeDoNotSyncTaintsLabelKey]; !ok {
 		// Sync all taints inside NodeClaim into the Node taints
 		node.Spec.Taints = scheduling.Taints(node.Spec.Taints).Merge(nodeClaim.Spec.Taints)
 		node.Spec.Taints = scheduling.Taints(node.Spec.Taints).Merge(nodeClaim.Spec.StartupTaints)

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -121,7 +121,7 @@ func (r *Registration) syncNode(ctx context.Context, nodeClaim *v1.NodeClaim, no
 
 	node = nodeclaimutils.UpdateNodeOwnerReferences(nodeClaim, node)
 
-	// We do not sync the taints if the feature flag is enabled. We instead assume that the karpenter provider
+	// We do not sync the taints if this label is present. We instead assume that the karpenter provider
 	// is managing taints. We still manage/remove the unregistered taint to signal the end of syncing.
 	if _, ok := node.Labels[v1.NodeDoNotSyncTaintsLabelKey]; !ok {
 		// Sync all taints inside NodeClaim into the Node taints

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -123,7 +123,7 @@ func (r *Registration) syncNode(ctx context.Context, nodeClaim *v1.NodeClaim, no
 
 	// We do not sync the taints if this label is present. We instead assume that the karpenter provider
 	// is managing taints. We still manage/remove the unregistered taint to signal the end of syncing.
-	if _, ok := node.Labels[v1.NodeDoNotSyncTaintsLabelKey]; !ok {
+	if value, ok := node.Labels[v1.NodeDoNotSyncTaintsLabelKey]; !ok || value != "true" {
 		// Sync all taints inside NodeClaim into the Node taints
 		node.Spec.Taints = scheduling.Taints(node.Spec.Taints).Merge(nodeClaim.Spec.Taints)
 		node.Spec.Taints = scheduling.Taints(node.Spec.Taints).Merge(nodeClaim.Spec.StartupTaints)

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -477,7 +477,19 @@ var _ = Describe("Registration", func() {
 				Labels: map[string]string{v1.NodeDoNotSyncTaintsLabelKey: "do-not-sync"},
 			},
 			ProviderID: nodeClaim.Status.ProviderID,
-			Taints:     []corev1.Taint{v1.UnregisteredNoExecuteTaint},
+			Taints: []corev1.Taint{
+				v1.UnregisteredNoExecuteTaint,
+				{
+					Key:    "custom-startup-taint",
+					Effect: corev1.TaintEffectNoSchedule,
+					Value:  "custom-startup-value",
+				},
+				{
+					Key:    "other-custom-startup-taint",
+					Effect: corev1.TaintEffectNoExecute,
+					Value:  "other-custom-startup-value",
+				},
+			},
 		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -34,8 +34,35 @@ import (
 
 var _ = Describe("Registration", func() {
 	var nodePool *v1.NodePool
+	var taints []corev1.Taint
+	var startupTaints []corev1.Taint
 	BeforeEach(func() {
 		nodePool = test.NodePool()
+		taints = []corev1.Taint{
+			{
+				Key:    "custom-taint",
+				Effect: corev1.TaintEffectNoSchedule,
+				Value:  "custom-value",
+			},
+			{
+				Key:    "other-custom-taint",
+				Effect: corev1.TaintEffectNoExecute,
+				Value:  "other-custom-value",
+			},
+		}
+		startupTaints = []corev1.Taint{
+			{
+				Key:    "custom-startup-taint",
+				Effect: corev1.TaintEffectNoSchedule,
+				Value:  "custom-startup-value",
+			},
+			{
+				Key:    "other-custom-startup-taint",
+				Effect: corev1.TaintEffectNoExecute,
+				Value:  "other-custom-startup-value",
+			},
+		}
+
 	})
 	DescribeTable(
 		"Registration",
@@ -211,54 +238,19 @@ var _ = Describe("Registration", func() {
 					v1.NodePoolLabelKey: nodePool.Name,
 				},
 			},
-			Spec: v1.NodeClaimSpec{
-				Taints: []corev1.Taint{
-					{
-						Key:    "custom-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-value",
-					},
-					{
-						Key:    "other-custom-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-value",
-					},
-				},
-			},
+			Spec: v1.NodeClaimSpec{Taints: taints},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.Spec.Taints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-value",
-			},
-		))
+		Expect(nodeClaim.Spec.Taints).To(ContainElements(taints))
 
 		node := test.Node(test.NodeOptions{ProviderID: nodeClaim.Status.ProviderID, Taints: []corev1.Taint{v1.UnregisteredNoExecuteTaint}})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 
-		Expect(node.Spec.Taints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-value",
-			},
-		))
+		Expect(node.Spec.Taints).To(ContainElements(taints))
 	})
 	It("should not sync the taints to the Node when the Node comes online, with node label do not sync taints", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
@@ -267,36 +259,12 @@ var _ = Describe("Registration", func() {
 					v1.NodePoolLabelKey: nodePool.Name,
 				},
 			},
-			Spec: v1.NodeClaimSpec{
-				Taints: []corev1.Taint{
-					{
-						Key:    "custom-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-value",
-					},
-					{
-						Key:    "other-custom-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-value",
-					},
-				},
-			},
+			Spec: v1.NodeClaimSpec{Taints: taints},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.Spec.Taints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-value",
-			},
-		))
+		Expect(nodeClaim.Spec.Taints).To(ContainElements(taints))
 
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
@@ -309,7 +277,10 @@ var _ = Describe("Registration", func() {
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 
-		Expect(node.Spec.Taints).To(ContainElements())
+		Expect(node.Spec.Taints).To(HaveLen(1))
+		Expect(node.Spec.Taints).To(Not(ContainElements(taints)))
+		Expect(nodeClaim.Spec.Taints).To(ContainElements(taints))
+		Expect(node.Spec.Taints).To(ContainElements(corev1.Taint{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule}))
 	})
 	It("should not sync the startupTaints to the Node when the Node comes online, with node label do not sync taints", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
@@ -319,47 +290,14 @@ var _ = Describe("Registration", func() {
 				},
 			},
 			Spec: v1.NodeClaimSpec{
-				Taints: []corev1.Taint{
-					{
-						Key:    "custom-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-value",
-					},
-					{
-						Key:    "other-custom-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-value",
-					},
-				},
-				StartupTaints: []corev1.Taint{
-					{
-						Key:    "custom-startup-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-startup-value",
-					},
-					{
-						Key:    "other-custom-startup-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-startup-value",
-					},
-				},
+				Taints:        taints,
+				StartupTaints: startupTaints,
 			},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.Spec.StartupTaints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		))
+		Expect(nodeClaim.Spec.StartupTaints).To(ContainElements(startupTaints))
 
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
@@ -372,7 +310,10 @@ var _ = Describe("Registration", func() {
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 
-		Expect(node.Spec.Taints).To(ContainElements())
+		Expect(node.Spec.Taints).To(HaveLen(1))
+		Expect(node.Spec.Taints).To(Not(ContainElements(startupTaints)))
+		Expect(nodeClaim.Spec.StartupTaints).To(ContainElements(startupTaints))
+		Expect(node.Spec.Taints).To(ContainElements(corev1.Taint{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule}))
 	})
 	It("should sync the startupTaints to the Node when the Node comes online, if node label do not sync taints is not present", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
@@ -382,137 +323,45 @@ var _ = Describe("Registration", func() {
 				},
 			},
 			Spec: v1.NodeClaimSpec{
-				Taints: []corev1.Taint{
-					{
-						Key:    "custom-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-value",
-					},
-					{
-						Key:    "other-custom-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-value",
-					},
-				},
-				StartupTaints: []corev1.Taint{
-					{
-						Key:    "custom-startup-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-startup-value",
-					},
-					{
-						Key:    "other-custom-startup-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-startup-value",
-					},
-				},
+				Taints:        taints,
+				StartupTaints: startupTaints,
 			},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.Spec.StartupTaints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		))
+		Expect(nodeClaim.Spec.Taints).To(ContainElements(taints))
+		Expect(nodeClaim.Spec.StartupTaints).To(ContainElements(startupTaints))
 
 		node := test.Node(test.NodeOptions{ProviderID: nodeClaim.Status.ProviderID, Taints: []corev1.Taint{v1.UnregisteredNoExecuteTaint}})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 
-		Expect(node.Spec.Taints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-value",
-			},
-			corev1.Taint{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		))
+		Expect(node.Spec.Taints).To(ContainElements(startupTaints))
 	})
-	It("should not re-sync the startupTaints to the Node when the startupTaints are removed, with node label do not sync taints", func() {
+	It("should not re-sync the startupTaints to the Node when the startupTaints are removed", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1.NodePoolLabelKey: nodePool.Name,
 				},
 			},
-			Spec: v1.NodeClaimSpec{
-				StartupTaints: []corev1.Taint{
-					{
-						Key:    "custom-startup-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-startup-value",
-					},
-					{
-						Key:    "other-custom-startup-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-startup-value",
-					},
-				},
-			},
+			Spec: v1.NodeClaimSpec{StartupTaints: startupTaints},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 
 		node := test.Node(test.NodeOptions{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{v1.NodeDoNotSyncTaintsLabelKey: "do-not-sync"},
-			},
 			ProviderID: nodeClaim.Status.ProviderID,
-			Taints: []corev1.Taint{
-				v1.UnregisteredNoExecuteTaint,
-				{
-					Key:    "custom-startup-taint",
-					Effect: corev1.TaintEffectNoSchedule,
-					Value:  "custom-startup-value",
-				},
-				{
-					Key:    "other-custom-startup-taint",
-					Effect: corev1.TaintEffectNoExecute,
-					Value:  "other-custom-startup-value",
-				},
-			},
+			Taints:     append(startupTaints, v1.UnregisteredNoExecuteTaint),
 		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 
-		Expect(node.Spec.Taints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		))
+		Expect(node.Spec.Taints).To(ContainElements(startupTaints))
 		node.Spec.Taints = []corev1.Taint{}
 		ExpectApplied(ctx, env.Client, node)
 

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Registration", func() {
 			Expect(node.Annotations).To(HaveKeyWithValue(k, v))
 		}
 	})
-	It("should sync the taints to the Node when the Node comes online", func() {
+	It("should not sync the taints to the Node when the Node comes online", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -247,20 +247,9 @@ var _ = Describe("Registration", func() {
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 
-		Expect(node.Spec.Taints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-value",
-			},
-		))
+		Expect(node.Spec.Taints).To(ContainElements())
 	})
-	It("should sync the startupTaints to the Node when the Node comes online", func() {
+	It("should not sync the startupTaints to the Node when the Node comes online", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -315,78 +304,7 @@ var _ = Describe("Registration", func() {
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 
-		Expect(node.Spec.Taints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-value",
-			},
-			corev1.Taint{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		))
-	})
-	It("should not re-sync the startupTaints to the Node when the startupTaints are removed", func() {
-		nodeClaim := test.NodeClaim(v1.NodeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					v1.NodePoolLabelKey: nodePool.Name,
-				},
-			},
-			Spec: v1.NodeClaimSpec{
-				StartupTaints: []corev1.Taint{
-					{
-						Key:    "custom-startup-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-startup-value",
-					},
-					{
-						Key:    "other-custom-startup-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-startup-value",
-					},
-				},
-			},
-		})
-		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
-		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-
-		node := test.Node(test.NodeOptions{ProviderID: nodeClaim.Status.ProviderID, Taints: []corev1.Taint{v1.UnregisteredNoExecuteTaint}})
-		ExpectApplied(ctx, env.Client, node)
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
-		node = ExpectExists(ctx, env.Client, node)
-
-		Expect(node.Spec.Taints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		))
-		node.Spec.Taints = []corev1.Taint{}
-		ExpectApplied(ctx, env.Client, node)
-
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
-		node = ExpectExists(ctx, env.Client, node)
-		Expect(node.Spec.Taints).To(HaveLen(0))
+		Expect(node.Spec.Taints).To(ContainElements())
 	})
 	It("should add NodeRegistrationHealthy=true on the nodePool if registration succeeds and if it was previously false", func() {
 		nodeClaimOpts := []v1.NodeClaim{{

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Registration", func() {
 			Expect(node.Annotations).To(HaveKeyWithValue(k, v))
 		}
 	})
-	It("should not sync the taints to the Node when the Node comes online, without SyncNodeClaimTaints", func() {
+	It("should not sync the taints to the Node when the Node comes online, with node label do not sync taints", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -249,14 +249,11 @@ var _ = Describe("Registration", func() {
 
 		Expect(node.Spec.Taints).To(ContainElements())
 	})
-	It("should sync the taints to the Node when the Node comes online, with SyncNodeClaimTaints", func() {
+	It("should sync the taints to the Node when the Node comes online, if node label do not sync taints is missing", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1.NodePoolLabelKey: nodePool.Name,
-				},
-				Annotations: map[string]string{
-					v1.NodeClaimSyncTaintsAnnotationKey: "sync-taints",
 				},
 			},
 			Spec: v1.NodeClaimSpec{
@@ -308,7 +305,70 @@ var _ = Describe("Registration", func() {
 			},
 		))
 	})
-	It("should not sync the startupTaints to the Node when the Node comes online, without SyncNodeclaimTaints", func() {
+	It("should not sync the startupTaints to the Node when the Node comes online, with node label do not sync taints", func() {
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey: nodePool.Name,
+				},
+			},
+			Spec: v1.NodeClaimSpec{
+				Taints: []corev1.Taint{
+					{
+						Key:    "custom-taint",
+						Effect: corev1.TaintEffectNoSchedule,
+						Value:  "custom-value",
+					},
+					{
+						Key:    "other-custom-taint",
+						Effect: corev1.TaintEffectNoExecute,
+						Value:  "other-custom-value",
+					},
+				},
+				StartupTaints: []corev1.Taint{
+					{
+						Key:    "custom-startup-taint",
+						Effect: corev1.TaintEffectNoSchedule,
+						Value:  "custom-startup-value",
+					},
+					{
+						Key:    "other-custom-startup-taint",
+						Effect: corev1.TaintEffectNoExecute,
+						Value:  "other-custom-startup-value",
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(nodeClaim.Spec.StartupTaints).To(ContainElements(
+			corev1.Taint{
+				Key:    "custom-startup-taint",
+				Effect: corev1.TaintEffectNoSchedule,
+				Value:  "custom-startup-value",
+			},
+			corev1.Taint{
+				Key:    "other-custom-startup-taint",
+				Effect: corev1.TaintEffectNoExecute,
+				Value:  "other-custom-startup-value",
+			},
+		))
+
+		node := test.Node(test.NodeOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1.NodeDoNotSyncTaintsLabelKey: "do-not-sync"},
+			},
+			ProviderID: nodeClaim.Status.ProviderID,
+			Taints:     []corev1.Taint{v1.UnregisteredNoExecuteTaint},
+		})
+		ExpectApplied(ctx, env.Client, node)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		node = ExpectExists(ctx, env.Client, node)
+
+		Expect(node.Spec.Taints).To(ContainElements())
+	})
+	It("should sync the startupTaints to the Node when the Node comes online, if node label do not sync taints is missing", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -363,66 +423,6 @@ var _ = Describe("Registration", func() {
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
 
-		Expect(node.Spec.Taints).To(ContainElements())
-	})
-	It("should sync the startupTaints to the Node when the Node comes online, with SyncNodeclaimTaints", func() {
-		nodeClaim := test.NodeClaim(v1.NodeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					v1.NodePoolLabelKey: nodePool.Name,
-				},
-				Annotations: map[string]string{
-					v1.NodeClaimSyncTaintsAnnotationKey: "sync-taints",
-				},
-			},
-			Spec: v1.NodeClaimSpec{
-				Taints: []corev1.Taint{
-					{
-						Key:    "custom-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-value",
-					},
-					{
-						Key:    "other-custom-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-value",
-					},
-				},
-				StartupTaints: []corev1.Taint{
-					{
-						Key:    "custom-startup-taint",
-						Effect: corev1.TaintEffectNoSchedule,
-						Value:  "custom-startup-value",
-					},
-					{
-						Key:    "other-custom-startup-taint",
-						Effect: corev1.TaintEffectNoExecute,
-						Value:  "other-custom-startup-value",
-					},
-				},
-			},
-		})
-		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
-		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
-		Expect(nodeClaim.Spec.StartupTaints).To(ContainElements(
-			corev1.Taint{
-				Key:    "custom-startup-taint",
-				Effect: corev1.TaintEffectNoSchedule,
-				Value:  "custom-startup-value",
-			},
-			corev1.Taint{
-				Key:    "other-custom-startup-taint",
-				Effect: corev1.TaintEffectNoExecute,
-				Value:  "other-custom-startup-value",
-			},
-		))
-
-		node := test.Node(test.NodeOptions{ProviderID: nodeClaim.Status.ProviderID, Taints: []corev1.Taint{v1.UnregisteredNoExecuteTaint}})
-		ExpectApplied(ctx, env.Client, node)
-		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
-		node = ExpectExists(ctx, env.Client, node)
-
 		Expect(node.Spec.Taints).To(ContainElements(
 			corev1.Taint{
 				Key:    "custom-taint",
@@ -446,14 +446,11 @@ var _ = Describe("Registration", func() {
 			},
 		))
 	})
-	It("should not re-sync the startupTaints to the Node when the startupTaints are removed, with SyncNodeclaimOptions", func() {
+	It("should not re-sync the startupTaints to the Node when the startupTaints are removed, with node label do not sync taints", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1.NodePoolLabelKey: nodePool.Name,
-				},
-				Annotations: map[string]string{
-					v1.NodeClaimSyncTaintsAnnotationKey: "sync-taints",
 				},
 			},
 			Spec: v1.NodeClaimSpec{
@@ -475,7 +472,13 @@ var _ = Describe("Registration", func() {
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 
-		node := test.Node(test.NodeOptions{ProviderID: nodeClaim.Status.ProviderID, Taints: []corev1.Taint{v1.UnregisteredNoExecuteTaint}})
+		node := test.Node(test.NodeOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1.NodeDoNotSyncTaintsLabelKey: "do-not-sync"},
+			},
+			ProviderID: nodeClaim.Status.ProviderID,
+			Taints:     []corev1.Taint{v1.UnregisteredNoExecuteTaint},
+		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		node = ExpectExists(ctx, env.Client, node)
@@ -499,7 +502,7 @@ var _ = Describe("Registration", func() {
 		node = ExpectExists(ctx, env.Client, node)
 		Expect(node.Spec.Taints).To(HaveLen(0))
 	})
-	It("should add NodeRegistrationHealthy=true on the nodePool if registration succeeds and if it was previously false,", func() {
+	It("should add NodeRegistrationHealthy=true on the nodePool if registration succeeds and if it was previously false", func() {
 		nodeClaimOpts := []v1.NodeClaim{{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{


### PR DESCRIPTION
**Description**

This commit removes the code that syncs the taints from nodeclaims to nodes. This changes the behaviour of Karpenter as it is now expected that the providers will be responsible for setting taints on nodes. By giving up control of taints to the Karpenter provider, taints can be set via the kubelet `--register-with-taints` field. This ensures that taints exist as soon as the node starts. The Karpenter node registration taint is still managed/removed by Karpenter and labels and annotations will still be synchronized here.

This commit is required to work around daemonsets, such as the EBS and EFS drivers, that do not continuously reconcile. It is common practice for these daemonsets to tolerate all taints, and thus they will race with this section of code to remove the taint. If these daemonsets win then this code re-applies the taint that they removed. This leads to a node that will always be tainted.

Fixes: https://github.com/kubernetes-sigs/karpenter/issues/1772


**How was this change tested?**

I tested this in an EKS cluster with the karpenter aws provider.
I could prove the race condition by forcing it to occur with the following code.
```
func (r *Registration) syncNode(ctx context.Context, nodeClaim *v1.NodeClaim, node *corev1.Node) error {
+	time.Sleep(30 * time.Second)
```
I could prove the race condition was no longer triggered after this change by adding in the same sleep statement.

This change adds a behaviour-preserving feature flag for those that still want the buggy behaviour enabled. Otherwise it is the same change as https://github.com/kubernetes-sigs/karpenter/pull/2091


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.