### PR TITLE
perf: Parallelize node filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ deflake: ## Run randomized, racing tests until the test fails to catch flakes
 		--randomize-all \
 		--until-it-fails \
 		-v \
-		./pkg/controllers/disruption
+		./pkg/...
 
 vulncheck: ## Verify code vulnerabilities
 	@govulncheck ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ deflake: ## Run randomized, racing tests until the test fails to catch flakes
 		--randomize-all \
 		--until-it-fails \
 		-v \
-		./pkg/...
+		./pkg/controllers/disruption
 
 vulncheck: ## Verify code vulnerabilities
 	@govulncheck ./pkg/...

--- a/kwok/charts/templates/deployment.yaml
+++ b/kwok/charts/templates/deployment.yaml
@@ -94,6 +94,12 @@ spec:
                   containerName: controller
                   divisor: "0"
                   resource: limits.memory
+            - name: CPU_REQUESTS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: controller
+                  divisor: 1m
+                  resource: requests.cpu
             - name: FEATURE_GATES
               value: "SpotToSpotConsolidation={{ .Values.settings.featureGates.spotToSpotConsolidation }}"
           {{- with .Values.settings.batchMaxDuration }}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -315,7 +316,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	}
 	log.FromContext(ctx).V(1).WithValues("pending-pods", len(pendingPods), "deleting-pods", len(deletingNodePods)).Info("computing scheduling decision for provisionable pod(s)")
 
-	opts := []scheduler.Options{scheduler.DisableReservedCapacityFallback}
+	opts := []scheduler.Options{scheduler.DisableReservedCapacityFallback, scheduler.NumConcurrentReconciles(int(math.Ceil(float64(options.FromContext(ctx).CPURequests) / 1000.0)))}
 	if options.FromContext(ctx).PreferencePolicy == options.PreferencePolicyIgnore {
 		opts = append(opts, scheduler.IgnorePreferences)
 	}

--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -65,23 +65,26 @@ func NewExistingNode(n *state.StateNode, topology *Topology, taints []v1.Taint, 
 	return node
 }
 
-func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v1.Pod, podData *PodData) error {
+// CanAdd returns whether the pod can be added to the ExistingNode
+// based on the taints/tolerations, volume requirements, host port compatibility,
+// requirements, resources, and topology requirements
+func (n *ExistingNode) CanAdd(ctx context.Context, kubeClient client.Client, pod *v1.Pod, podData *PodData) (updatedRequirements scheduling.Requirements, updatedVolumes scheduling.Volumes, err error) {
 	// Check Taints
 	if err := scheduling.Taints(n.cachedTaints).ToleratesPod(pod); err != nil {
-		return err
+		return nil, nil, err
 	}
 	// determine the volumes that will be mounted if the pod schedules
 	volumes, err := scheduling.GetVolumes(ctx, kubeClient, pod)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	// determine the host ports that will be used if the pod schedules
 	hostPorts := scheduling.GetHostPorts(pod)
 	if err = n.VolumeUsage().ExceedsLimits(volumes); err != nil {
-		return fmt.Errorf("checking volume usage, %w", err)
+		return nil, nil, fmt.Errorf("checking volume usage, %w", err)
 	}
 	if err = n.HostPortUsage().Conflicts(pod, hostPorts); err != nil {
-		return fmt.Errorf("checking host port usage, %w", err)
+		return nil, nil, fmt.Errorf("checking host port usage, %w", err)
 	}
 
 	// check resource requests first since that's a pretty likely reason the pod won't schedule on an in-flight
@@ -89,12 +92,12 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 	requests := resources.Merge(n.requests, podData.Requests)
 
 	if !resources.Fits(requests, n.cachedAvailable) {
-		return fmt.Errorf("exceeds node resources")
+		return nil, nil, fmt.Errorf("exceeds node resources")
 	}
 
 	// Check NodeClaim Affinity Requirements
 	if err = n.requirements.Compatible(podData.Requirements); err != nil {
-		return err
+		return nil, nil, err
 	}
 	// avoid creating our temp set of requirements until after we've ensured that at least
 	// the pod is compatible
@@ -104,19 +107,23 @@ func (n *ExistingNode) Add(ctx context.Context, kubeClient client.Client, pod *v
 	// Check Topology Requirements
 	topologyRequirements, err := n.topology.AddRequirements(pod, n.cachedTaints, podData.StrictRequirements, nodeRequirements)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	if err = nodeRequirements.Compatible(topologyRequirements); err != nil {
-		return err
+		return nil, nil, err
 	}
 	nodeRequirements.Add(topologyRequirements.Values()...)
+	return nodeRequirements, volumes, nil
+}
 
+// Add updates the ExistingNode to schedule the pod to this ExistingNode, updating
+// the ExistingNode with new requirements and volumes based on the pod scheduling
+func (n *ExistingNode) Add(pod *v1.Pod, podData *PodData, nodeRequirements scheduling.Requirements, volumes scheduling.Volumes) {
 	// Update node
 	n.Pods = append(n.Pods, pod)
-	n.requests = requests
+	n.requests = resources.Merge(n.requests, podData.Requests)
 	n.requirements = nodeRequirements
 	n.topology.Record(pod, n.cachedTaints, nodeRequirements)
-	n.HostPortUsage().Add(pod, hostPorts)
+	n.HostPortUsage().Add(pod, scheduling.GetHostPorts(pod))
 	n.VolumeUsage().Add(pod, volumes)
-	return nil
 }

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -109,32 +109,35 @@ func NewNodeClaim(
 	}
 }
 
-func (n *NodeClaim) Add(ctx context.Context, pod *corev1.Pod, podData *PodData) error {
+// CanAdd returns whether the pod can be added to the NodeClaim
+// based on the taints/tolerations, host port compatibility,
+// requirements, resources, reserved capacity reservations, and topology requirements
+func (n *NodeClaim) CanAdd(ctx context.Context, pod *corev1.Pod, podData *PodData) (updateRequirements scheduling.Requirements, updatedInstanceTypes []*cloudprovider.InstanceType, offeringsToReserve []*cloudprovider.Offering, err error) {
 	// Check Taints
 	if err := scheduling.Taints(n.Spec.Taints).ToleratesPod(pod); err != nil {
-		return err
+		return nil, nil, nil, err
 	}
 
 	// exposed host ports on the node
 	hostPorts := scheduling.GetHostPorts(pod)
 	if err := n.hostPortUsage.Conflicts(pod, hostPorts); err != nil {
-		return fmt.Errorf("checking host port usage, %w", err)
+		return nil, nil, nil, fmt.Errorf("checking host port usage, %w", err)
 	}
 	nodeClaimRequirements := scheduling.NewRequirements(n.Requirements.Values()...)
 
 	// Check NodeClaim Affinity Requirements
 	if err := nodeClaimRequirements.Compatible(podData.Requirements, scheduling.AllowUndefinedWellKnownLabels); err != nil {
-		return fmt.Errorf("incompatible requirements, %w", err)
+		return nil, nil, nil, fmt.Errorf("incompatible requirements, %w", err)
 	}
 	nodeClaimRequirements.Add(podData.Requirements.Values()...)
 
 	// Check Topology Requirements
 	topologyRequirements, err := n.topology.AddRequirements(pod, n.NodeClaimTemplate.Spec.Taints, podData.StrictRequirements, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
 	if err != nil {
-		return err
+		return nil, nil, nil, err
 	}
 	if err = nodeClaimRequirements.Compatible(topologyRequirements, scheduling.AllowUndefinedWellKnownLabels); err != nil {
-		return err
+		return nil, nil, nil, err
 	}
 	nodeClaimRequirements.Add(topologyRequirements.Values()...)
 
@@ -145,28 +148,33 @@ func (n *NodeClaim) Add(ctx context.Context, pod *corev1.Pod, podData *PodData) 
 	if err != nil {
 		// We avoid wrapping this err because calling String() on InstanceTypeFilterError is an expensive operation
 		// due to calls to resources.Merge and stringifying the nodeClaimRequirements
-		return err
+		return nil, nil, nil, err
 	}
-
-	reservedOfferings, err := n.reserveOfferings(ctx, remaining, nodeClaimRequirements)
+	ofs, err := n.offeringsToReserve(ctx, remaining, nodeClaimRequirements)
 	if err != nil {
-		return err
+		return nil, nil, nil, err
 	}
+	return nodeClaimRequirements, remaining, ofs, nil
+}
 
+// Add updates the NodeClaim to schedule the pod to this NodeClaim, updating
+// the NodeClaim with new requirements, instance types, and offerings to reserve
+// based on the pod scheduling
+func (n *NodeClaim) Add(pod *corev1.Pod, podData *PodData, nodeClaimRequirements scheduling.Requirements, instanceTypes []*cloudprovider.InstanceType, offeringsToReserve []*cloudprovider.Offering) {
 	// Update node
 	n.Pods = append(n.Pods, pod)
-	n.InstanceTypeOptions = remaining
-	n.Spec.Resources.Requests = requests
+	n.InstanceTypeOptions = instanceTypes
+	n.Spec.Resources.Requests = resources.Merge(n.Spec.Resources.Requests, podData.Requests)
 	n.Requirements = nodeClaimRequirements
 	n.topology.Record(pod, n.NodeClaim.Spec.Taints, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
-	n.hostPortUsage.Add(pod, hostPorts)
-	n.releaseReservedOfferings(n.reservedOfferings, reservedOfferings)
-	n.reservedOfferings = reservedOfferings
-	return nil
+	n.hostPortUsage.Add(pod, scheduling.GetHostPorts(pod))
+	n.reservationManager.Reserve(n.hostname, offeringsToReserve...)
+	n.releaseReservedOfferings(n.reservedOfferings, offeringsToReserve)
+	n.reservedOfferings = offeringsToReserve
 }
 
 // releaseReservedOfferings releases all offerings which are present in the current reserved offerings, but are not
-// present in the updated reserved offerings.
+// present in the updated reserved offerings
 func (n *NodeClaim) releaseReservedOfferings(current, updated cloudprovider.Offerings) {
 	updatedIDs := sets.New[string]()
 	for _, o := range updated {
@@ -184,7 +192,7 @@ func (n *NodeClaim) releaseReservedOfferings(current, updated cloudprovider.Offe
 // to reserve compatible offerings when some were available.
 //
 //nolint:gocyclo
-func (n *NodeClaim) reserveOfferings(
+func (n *NodeClaim) offeringsToReserve(
 	ctx context.Context,
 	instanceTypes []*cloudprovider.InstanceType,
 	nodeClaimRequirements scheduling.Requirements,
@@ -209,7 +217,7 @@ func (n *NodeClaim) reserveOfferings(
 			// Note that reservation is an idempotent operation - if we have previously successfully reserved an offering for
 			// this host, this operation is guaranteed to succeed. We may also succeed to make reservations for offerings which
 			// failed in previous iterations if other NodeClaims have released them since the last attempt.
-			if n.reservationManager.Reserve(n.hostname, o) {
+			if n.reservationManager.CanReserve(n.hostname, o) {
 				reservedOfferings = append(reservedOfferings, o)
 			}
 		}

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -111,7 +111,7 @@ func NewNodeClaim(
 // CanAdd returns whether the pod can be added to the NodeClaim
 // based on the taints/tolerations, host port compatibility,
 // requirements, resources, reserved capacity reservations, and topology requirements
-func (n *NodeClaim) CanAdd(ctx context.Context, pod *corev1.Pod, podData *PodData) (updateRequirements scheduling.Requirements, updatedInstanceTypes []*cloudprovider.InstanceType, offeringsToReserve []*cloudprovider.Offering, err error) {
+func (n *NodeClaim) CanAdd(ctx context.Context, pod *corev1.Pod, podData *PodData) (updatedRequirements scheduling.Requirements, updatedInstanceTypes []*cloudprovider.InstanceType, offeringsToReserve []*cloudprovider.Offering, err error) {
 	// Check Taints
 	if err := scheduling.Taints(n.Spec.Taints).ToleratesPod(pod); err != nil {
 		return nil, nil, nil, err

--- a/pkg/controllers/provisioning/scheduling/reservationmanager.go
+++ b/pkg/controllers/provisioning/scheduling/reservationmanager.go
@@ -72,6 +72,9 @@ func (rm *ReservationManager) CanReserve(hostname string, offering *cloudprovide
 func (rm *ReservationManager) Reserve(hostname string, offerings ...*cloudprovider.Offering) {
 	for _, of := range offerings {
 		rm.capacity[of.ReservationID()] -= 1
+		if rm.capacity[of.ReservationID()] < 0 {
+			panic(fmt.Sprintf("attempted to over-reserve an offering with reservation id %q", of.ReservationID()))
+		}
 		if _, ok := rm.reservations[hostname]; !ok {
 			rm.reservations[hostname] = sets.New[string]()
 		}

--- a/pkg/controllers/provisioning/scheduling/reservationmanager.go
+++ b/pkg/controllers/provisioning/scheduling/reservationmanager.go
@@ -53,14 +53,10 @@ func NewReservationManager(instanceTypes map[string][]*cloudprovider.InstanceTyp
 	}
 }
 
-func (rm *ReservationManager) Reserve(hostname string, offering *cloudprovider.Offering) bool {
+func (rm *ReservationManager) CanReserve(hostname string, offering *cloudprovider.Offering) bool {
 	reservations, ok := rm.reservations[hostname]
 	if ok && reservations.Has(offering.ReservationID()) {
 		return true
-	}
-	if !ok {
-		reservations = sets.New[string]()
-		rm.reservations[hostname] = reservations
 	}
 	capacity, ok := rm.capacity[offering.ReservationID()]
 	if !ok {
@@ -70,9 +66,17 @@ func (rm *ReservationManager) Reserve(hostname string, offering *cloudprovider.O
 	if capacity == 0 {
 		return false
 	}
-	rm.capacity[offering.ReservationID()] -= 1
-	reservations.Insert(offering.ReservationID())
 	return true
+}
+
+func (rm *ReservationManager) Reserve(hostname string, offerings ...*cloudprovider.Offering) {
+	for _, of := range offerings {
+		rm.capacity[of.ReservationID()] -= 1
+		if _, ok := rm.reservations[hostname]; !ok {
+			rm.reservations[hostname] = sets.New[string]()
+		}
+		rm.reservations[hostname].Insert(of.ReservationID())
+	}
 }
 
 func (rm *ReservationManager) Release(hostname string, offerings ...*cloudprovider.Offering) {

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -161,6 +161,7 @@ func TestSchedulingProfile(t *testing.T) {
 
 func benchmarkScheduler(b *testing.B, pods []*corev1.Pod, opts ...scheduling.Options) {
 	ctx = options.ToContext(injection.WithControllerName(context.Background(), "provisioner"), test.Options())
+	opts = append(opts, scheduling.NumConcurrentReconciles(5))
 	scheduler, err := setupScheduler(ctx, pods, opts...)
 	if err != nil {
 		b.Fatalf("creating scheduler, %s", err)

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -161,8 +161,7 @@ func TestSchedulingProfile(t *testing.T) {
 
 func benchmarkScheduler(b *testing.B, pods []*corev1.Pod, opts ...scheduling.Options) {
 	ctx = options.ToContext(injection.WithControllerName(context.Background(), "provisioner"), test.Options())
-	opts = append(opts, scheduling.NumConcurrentReconciles(5))
-	scheduler, err := setupScheduler(ctx, pods, opts...)
+	scheduler, err := setupScheduler(ctx, pods, append(opts, scheduling.NumConcurrentReconciles(5))...)
 	if err != nil {
 		b.Fatalf("creating scheduler, %s", err)
 	}

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -217,6 +217,8 @@ func (t *TopologyGroup) nextDomainTopologySpread(pod *corev1.Pod, podDomains, no
 		if selfSelecting {
 			count++
 		}
+		// Because Karpenter can always create a new domain for hostname, we assume the global miniumum is always zero
+		// This means we can just check whether our current count is less than or equal to the skew to check if the domain is valid
 		if count <= t.maxSkew {
 			return scheduling.NewRequirement(t.Key, corev1.NodeSelectorOpIn, hostName)
 		}

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1201,6 +1201,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 1000 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				node := test.Node(test.NodeOptions{
 					ProviderID: test.RandomProviderID(),
@@ -1242,6 +1243,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 1000 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				node := test.Node()
 				ExpectApplied(ctx, env.Client, node)
@@ -1261,6 +1263,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for i := range 1000 {
 			wg.Add(1)
 			go func(index int) {
+				defer GinkgoRecover()
 				defer wg.Done()
 				node := test.Node()
 				ExpectApplied(ctx, env.Client, node)
@@ -1274,6 +1277,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for i := range 1000 {
 			wg.Add(1)
 			go func(index int) {
+				defer GinkgoRecover()
 				defer wg.Done()
 				nodes[index].Spec.ProviderID = test.RandomProviderID()
 				ExpectApplied(ctx, env.Client, nodes[index])
@@ -1291,6 +1295,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 1000 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				nodeClaim := test.NodeClaim(v1.NodeClaim{
 					Status: v1.NodeClaimStatus{
@@ -1310,6 +1315,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 250 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				node := test.Node(test.NodeOptions{
 					ProviderID: test.RandomProviderID(),
@@ -1329,6 +1335,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 250 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				node := test.Node(test.NodeOptions{
 					ProviderID: test.RandomProviderID(),
@@ -1342,6 +1349,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 500 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				nodeClaim := test.NodeClaim(v1.NodeClaim{
 					Status: v1.NodeClaimStatus{
@@ -1361,6 +1369,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 500 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				nodeClaim := test.NodeClaim(v1.NodeClaim{
 					Status: v1.NodeClaimStatus{
@@ -1384,6 +1393,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for i := range 1000 {
 			wg.Add(1)
 			go func(index int) {
+				defer GinkgoRecover()
 				defer wg.Done()
 				nodeClaim := test.NodeClaim(v1.NodeClaim{
 					Status: v1.NodeClaimStatus{
@@ -1407,6 +1417,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for i := range 1000 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				nodeClaim := test.NodeClaim(v1.NodeClaim{
 					Status: v1.NodeClaimStatus{
@@ -1430,6 +1441,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for i := range 1000 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				node := test.Node(test.NodeOptions{
 					ProviderID: test.RandomProviderID(),
@@ -1478,6 +1490,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 250 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				node := test.Node(test.NodeOptions{
 					ProviderID: test.RandomProviderID(),
@@ -1497,6 +1510,7 @@ var _ = Describe("Cluster State Sync", func() {
 		for range 250 {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 				node := test.Node(test.NodeOptions{
 					ProviderID: test.RandomProviderID(),
@@ -1707,6 +1721,7 @@ var _ = Describe("Data Races", func() {
 		// Keep calling Synced for the entirety of this test
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
 			for {
 				_ = cluster.Synced(ctx)
@@ -1729,6 +1744,7 @@ var _ = Describe("Data Races", func() {
 		// Keep calling Synced for the entirety of this test
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
 			for {
 				_ = cluster.Synced(ctx)

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -66,6 +66,7 @@ type Options struct {
 	LeaderElectionName      string
 	LeaderElectionNamespace string
 	MemoryLimit             int64
+	CPURequests             int64
 	LogLevel                string
 	LogOutputPaths          string
 	LogErrorOutputPaths     string
@@ -104,6 +105,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.LeaderElectionName, "leader-election-name", env.WithDefaultString("LEADER_ELECTION_NAME", "karpenter-leader-election"), "Leader election name to create and monitor the lease if running outside the cluster")
 	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", env.WithDefaultString("LEADER_ELECTION_NAMESPACE", ""), "Leader election namespace to create and monitor the lease if running outside the cluster")
 	fs.Int64Var(&o.MemoryLimit, "memory-limit", env.WithDefaultInt64("MEMORY_LIMIT", -1), "Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value.")
+	fs.Int64Var(&o.CPURequests, "cpu-requests", env.WithDefaultInt64("CPU_REQUESTS", 1000), "CPU requests in millicores on the container running the controller.")
 	fs.StringVar(&o.LogLevel, "log-level", env.WithDefaultString("LOG_LEVEL", "info"), "Log verbosity level. Can be one of 'debug', 'info', or 'error'")
 	fs.StringVar(&o.LogOutputPaths, "log-output-paths", env.WithDefaultString("LOG_OUTPUT_PATHS", "stdout"), "Optional comma separated paths for directing log output")
 	fs.StringVar(&o.LogErrorOutputPaths, "log-error-output-paths", env.WithDefaultString("LOG_ERROR_OUTPUT_PATHS", "stderr"), "Optional comma separated paths for logging error output")
@@ -125,6 +127,9 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 	}
 	if !lo.Contains(validPreferencePolicies, PreferencePolicy(o.preferencePolicyRaw)) {
 		return fmt.Errorf("validating cli flags / env vars, invalid PREFERENCE_POLICY %q", o.preferencePolicyRaw)
+	}
+	if o.CPURequests <= 0 {
+		return fmt.Errorf("validating cli flags / env vars, invalid CPU_REQUESTS %d, must be positive", o.CPURequests)
 	}
 	gates, err := ParseFeatureGates(o.FeatureGates.inputStr)
 	if err != nil {

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -38,6 +38,7 @@ type OptionsFields struct {
 	LeaderElectionName      *string
 	LeaderElectionNamespace *string
 	MemoryLimit             *int64
+	CPURequests             *int64
 	LogLevel                *string
 	LogOutputPaths          *string
 	LogErrorOutputPaths     *string
@@ -70,6 +71,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		EnableProfiling:       lo.FromPtrOr(opts.EnableProfiling, false),
 		DisableLeaderElection: lo.FromPtrOr(opts.DisableLeaderElection, false),
 		MemoryLimit:           lo.FromPtrOr(opts.MemoryLimit, -1),
+		CPURequests:           lo.FromPtrOr(opts.CPURequests, 5000), // use 5 threads to enforce parallelism
 		LogLevel:              lo.FromPtrOr(opts.LogLevel, ""),
 		LogOutputPaths:        lo.FromPtrOr(opts.LogOutputPaths, "stdout"),
 		LogErrorOutputPaths:   lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds parallelism to the node filtering logic in the scheduler. It adds the `NumConcurrentReconciles` option to the scheduler to increase the number of worker threads that can do node filtering at any given point in time. This transforms the code to first validate whether the pod is eligible to schedule to the node with the `CanAdd` call and then, once it finds a successful decision, it bails out of the filtering code and calls `Add` for the decision that it found.

Since there are multiple threads that are running at a given point in time, it's possible that an element that is further down in the array may succeed before something that is earlier in the array -- to keep the same ordering, I add a check that validates that if something succeeds and there is already a NodeClaim that has been assigned as something that has succeeded, that if the index of the current NodeClaim is lower than the NodeClaim that is stored, we replace it.

### CI Benchmark Testing Results

#### Before PR

```
=== RUN   TestSchedulingProfile
============== Generic Pods ==============
1 Pods      1 pods      1 nodes     108.284µs per scheduling      108.284µs per pod
50 Pods     50 pods     10 nodes    25.736993ms per scheduling    514.739µs per pod
100 Pods    100 pods    20 nodes    57.129186ms per scheduling    571.291µs per pod
500 Pods    500 pods    100 nodes   264.545427ms per scheduling   529.09µs per pod
1000 Pods   1000 pods   200 nodes   545.493791ms per scheduling   545.493µs per pod
1500 Pods   1500 pods   300 nodes   869.215333ms per scheduling   579.476µs per pod
2000 Pods   2000 pods   400 nodes   1.034069542s per scheduling   517.034µs per pod
5000 Pods   5000 pods   1000 nodes  3.207326958s per scheduling   641.465µs per pod
10000 Pods  10000 pods  2000 nodes  8.9329105s per scheduling     893.291µs per pod
20000 Pods  20000 pods  4000 nodes  25.585288208s per scheduling  1.279264ms per pod
============== Preference Pods ==============
PreferencePolicy=Respect  4000 pods  4000 nodes  35.857739167s per scheduling  8.964434ms per pod
PreferencePolicy=Ignore   4000 pods  3 nodes     418.773611ms per scheduling   104.693µs per pod

scheduled 48151 against 12034 nodes in total in 1m19.161600282s 608.262085 pods/sec
--- PASS: TestSchedulingProfile (90.31s)
```

#### After PR

```
=== RUN   TestSchedulingProfile
============== Generic Pods ==============
1 Pods      1 pods      1 nodes     121.96µs per scheduling       121.96µs per pod
50 Pods     50 pods     10 nodes    38.251325ms per scheduling    765.026µs per pod
100 Pods    100 pods    20 nodes    72.285394ms per scheduling    722.853µs per pod
500 Pods    500 pods    100 nodes   391.950055ms per scheduling   783.9µs per pod
1000 Pods   1000 pods   200 nodes   759.167396ms per scheduling   759.167µs per pod
1500 Pods   1500 pods   300 nodes   1.136690292s per scheduling   757.793µs per pod
2000 Pods   2000 pods   400 nodes   1.545552875s per scheduling   772.776µs per pod
5000 Pods   5000 pods   1000 nodes  3.823707166s per scheduling   764.741µs per pod
10000 Pods  10000 pods  2000 nodes  9.200160792s per scheduling   920.016µs per pod
20000 Pods  20000 pods  4000 nodes  20.614699417s per scheduling  1.030734ms per pod
============== Preference Pods ==============
PreferencePolicy=Respect  4000 pods  4000 nodes  17.314432333s per scheduling  4.328608ms per pod
PreferencePolicy=Ignore   4000 pods  11 nodes    480.080625ms per scheduling   120.02µs per pod

scheduled 48151 against 12042 nodes in total in 57.386706003s 839.061925 pods/sec
--- PASS: TestSchedulingProfile (66.11s)
```

### Scale Testing

#### Before PR

<img width="1441" alt="Screenshot 2025-03-11 at 1 07 59 AM (1)" src="https://github.com/user-attachments/assets/fbff252e-9f88-4100-8b27-3537f33b445c" />

#### After PR (8m)

<img width="1445" alt="Screenshot 2025-04-01 at 2 53 07 PM" src="https://github.com/user-attachments/assets/2ea22980-3588-4a10-a03b-54960a45c305" />

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
