### PR TITLE
fix: panic in cluster.updateNodePoolResources

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -669,6 +669,9 @@ func (c *Cluster) updateNodePoolResources(oldNode, newNode *StateNode) {
 	if _, ok := c.nodePoolResources[newNodePoolName]; !ok && newNodePoolName != "" {
 		c.nodePoolResources[newNodePoolName] = corev1.ResourceList{}
 	}
+	if _, ok := c.nodePoolResources[oldNodePoolName]; !ok && oldNodePoolName != "" {
+		c.nodePoolResources[oldNodePoolName] = corev1.ResourceList{}
+	}
 	if oldNodePoolName != "" {
 		for resourceName, quantity := range oldResources {
 			current := c.nodePoolResources[oldNodePoolName][resourceName]


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Panic observed running the main branch of Karpenter:
```
{"level":"ERROR","time":"2025-04-15T21:16:54.603Z","logger":"controller","caller":"state/cluster.go:278","message":"Observed a panic","commit":"1d3a2f8-dirty","controller":"disruption","namespace":"","name":"","reconcileID":"8efb3fae-f662-4aeb-96d6-bf1ff8ce3c10","panic":"assignment to entry in nil map","panicGoValue":"\"assignment to entry in nil map\"","stacktrace":"goroutine 400 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x472b750, 0xc01012c0f0}, {0x3c24020, 0x61abd20})  
k8s.io/apimachinery@v0.32.3/pkg/util/runtime/runtime.go:107 +0xbc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()  
sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:108 +0x112
panic({0x3c24020?, 0x61abd20?})  
runtime/panic.go:792 +0x132
sigs.k8s.io/karpenter/pkg/controllers/state.(*Cluster).updateNodePoolResources(0xc000ebc960, 0xc0108f6180?, 0x0)  
sigs.k8s.io/karpenter@v1.3.2-0.20250410233846-2e769bdaa9f8/pkg/controllers/state/cluster.go:676 +0xb65
sigs.k8s.io/karpenter/pkg/controllers/state.(*Cluster).MarkForDeletion(0xc000ebc960, {0xc01cfa92d0, 0x1, 0xc0007c2870?})  
sigs.k8s.io/karpenter@v1.3.2-0.20250410233846-2e769bdaa9f8/pkg/controllers/state/cluster.go:278 +0x10d
sigs.k8s.io/karpenter/pkg/controllers/disruption.(*Controller).MarkDisrupted(0xc00064ea80, {0x472b750, 0xc01012c120}, {0x472e840, 0xc00028b800}, {0xc00cb71758, 0x1, 0x0?})  
sigs.k8s.io/karpenter@v1.3.2-0.20250410233846-2e769bdaa9f8/pkg/controllers/disruption/controller.go:280 +0x26f
sigs.k8s.io/karpenter/pkg/controllers/disruption.(*Controller).executeCommand(0xc00064ea80, {0x472b750, 0xc01012c120}, {0x472e840, 0xc00028b800}, {{0xc00cb71758, 0x1, 0x1}, {0xc0123718d8, 0x1, ...}}, ...)  
sigs.k8s.io/karpenter@v1.3.2-0.20250410233846-2e769bdaa9f8/pkg/controllers/disruption/controller.go:217 +0x33b
sigs.k8s.io/karpenter/pkg/controllers/disruption.(*Controller).disrupt(0xc00064ea80, {0x472b750, 0xc01012c120}, {0x472e840, 0xc00028b800})  
sigs.k8s.io/karpenter@v1.3.2-0.20250410233846-2e769bdaa9f8/pkg/controllers/disruption/controller.go:202 +0x914
sigs.k8s.io/karpenter/pkg/controllers/disruption.(*Controller).Reconcile(0xc00064ea80, {0x472b750, 0xc01012c0f0})  
sigs.k8s.io/karpenter@v1.3.2-0.20250410233846-2e769bdaa9f8/pkg/controllers/disruption/controller.go:155 +0x7cf
sigs.k8s.io/karpenter/pkg/controllers/disruption.(*Controller).Register.AsReconciler.func1({0x472b750?, 0xc01012c0f0?}, {{{0xc01e756180?, 0x0?}, {0x0?, 0x412eaec?}}})  
github.com/awslabs/operatorpkg@v0.0.0-20250325071853-9b4e36db18ce/singleton/controller.go:26 +0x2f
sigs.k8s.io/controller-runtime/pkg/reconcile.TypedFunc[...].Reconcile(...)  
sigs.k8s.io/controller-runtime@v0.20.4/pkg/reconcile/reconcile.go:124
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc01012c060?, {0x472b750?, 0xc01012c0f0?}, {{{0x0?, 0x0?}, {0x0?, 0x0?}}})  
sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119 +0xbf
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x4757060, {0x472b788, 0xc000444f00}, {{{0x0, 0x0}, {0x0, 0x0}}}, 0x0)  
sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334 +0x3ad
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x4757060, {0x472b788, 0xc000444f00})  
sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294 +0x21b
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()  
sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 332sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:251 +0x6b5
"}
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
