### PR TITLE
chore: Delete podSchedulableTime and associated metric if pod can't be scheduled

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -294,6 +294,12 @@ func (c *Controller) recordPodStartupMetric(pod *corev1.Pod, schedulableTime tim
 				podName:      pod.Name,
 				podNamespace: pod.Namespace,
 			})
+		} else {
+			// Idempotently delete the unstarted_time_seconds metric if the schedulable time is zero
+			PodProvisioningUnstartedTimeSeconds.Delete(map[string]string{
+				podName:      pod.Name,
+				podNamespace: pod.Namespace,
+			})
 		}
 		c.pendingPods.Insert(key)
 		return
@@ -309,6 +315,12 @@ func (c *Controller) recordPodStartupMetric(pod *corev1.Pod, schedulableTime tim
 			})
 			if !schedulableTime.IsZero() {
 				PodProvisioningUnstartedTimeSeconds.Set(time.Since(schedulableTime).Seconds(), map[string]string{
+					podName:      pod.Name,
+					podNamespace: pod.Namespace,
+				})
+			} else {
+				// Idempotently delete the unstarted_time_seconds metric if the schedulable time is zero
+				PodProvisioningUnstartedTimeSeconds.Delete(map[string]string{
 					podName:      pod.Name,
 					podNamespace: pod.Namespace,
 				})
@@ -347,6 +359,12 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 			})
 			if !schedulableTime.IsZero() {
 				PodProvisioningUnboundTimeSeconds.Set(time.Since(schedulableTime).Seconds(), map[string]string{
+					podName:      pod.Name,
+					podNamespace: pod.Namespace,
+				})
+			} else {
+				// Idempotently delete the unbound_time_seconds metric if the schedulable time is zero
+				PodProvisioningUnboundTimeSeconds.Delete(map[string]string{
 					podName:      pod.Name,
 					podNamespace: pod.Namespace,
 				})

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Pod Metrics", func() {
 		p.Status.Phase = corev1.PodPending
 
 		fakeClock.Step(1 * time.Hour)
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, p)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {p}})
 
 		// PodScheduled condition does not exist, emit pods_unbound_time_seconds metric
 		ExpectApplied(ctx, env.Client, p)
@@ -183,7 +183,7 @@ var _ = Describe("Pod Metrics", func() {
 		p.Status.Phase = corev1.PodPending
 
 		fakeClock.Step(1 * time.Hour)
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, p)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {p}})
 		ExpectApplied(ctx, env.Client, p)
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p)) //This will add pod to pending pods and unscheduled pods set
 		_, found := FindMetricWithLabelValues("karpenter_pods_unstarted_time_seconds", map[string]string{
@@ -272,7 +272,7 @@ var _ = Describe("Pod Metrics", func() {
 		})
 		Expect(found).To(BeTrue())
 
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, p)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {p}})
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_scheduling_undecided_time_seconds", map[string]string{
@@ -344,7 +344,7 @@ var _ = Describe("Pod Metrics", func() {
 		p.Status.Phase = corev1.PodPending
 		ExpectApplied(ctx, env.Client, p)
 
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, p)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {p}})
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 
 		_, found := FindMetricWithLabelValues("karpenter_pods_unbound_time_seconds", map[string]string{
@@ -396,7 +396,7 @@ var _ = Describe("Pod Metrics", func() {
 		p.Status.Phase = corev1.PodPending
 		ExpectApplied(ctx, env.Client, p)
 
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, p)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {p}})
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		_, found := FindMetricWithLabelValues("karpenter_pods_provisioning_unbound_time_seconds", map[string]string{
 			"name":      p.GetName(),
@@ -408,8 +408,7 @@ var _ = Describe("Pod Metrics", func() {
 			"namespace": p.GetNamespace(),
 		})
 		Expect(found).To(BeTrue())
-
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{p: fmt.Errorf("ignoring pod")}, p)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{p: fmt.Errorf("ignoring pod")}, map[string][]*corev1.Pod{})
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_unbound_time_seconds", map[string]string{
 			"name":      p.GetName(),

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -169,6 +169,7 @@ func (p *Provisioner) GetPendingPods(ctx context.Context) ([]*corev1.Pod, error)
 		if err := p.Validate(ctx, po); err != nil {
 			// Mark in memory that this pod is unschedulable
 			p.cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{po: fmt.Errorf("ignoring pod, %w", err)}, po)
+			p.cluster.DeletePodHealthyNodePoolScheduledTime(map[*corev1.Pod]error{po: fmt.Errorf("ignoring pod, %w", err)}, po)
 			log.FromContext(ctx).WithValues("Pod", klog.KObj(po)).V(1).Info(fmt.Sprintf("ignoring pod, %s", err))
 			return true
 		}
@@ -330,6 +331,9 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 			log.FromContext(ctx).Info("no nodepools found")
 			// Mark in memory that these pods are unschedulable
 			p.cluster.MarkPodSchedulingDecisions(lo.SliceToMap(pods, func(p *corev1.Pod) (*corev1.Pod, error) {
+				return p, fmt.Errorf("no nodepools found")
+			}), pods...)
+			p.cluster.DeletePodHealthyNodePoolScheduledTime(lo.SliceToMap(pods, func(p *corev1.Pod) (*corev1.Pod, error) {
 				return p, fmt.Errorf("no nodepools found")
 			}), pods...)
 			return scheduler.Results{}, nil

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -106,8 +106,7 @@ var _ = Describe("Pod Healthy NodePool", func() {
 	It("should not store pod schedulable time if the nodePool that pod is scheduled to does not have NodeRegistrationHealthy=true", func() {
 		pod := test.Pod()
 		ExpectApplied(ctx, env.Client, pod, nodePool)
-
-		cluster.UpdatePodHealthyNodePoolScheduledTime(ctx, nodePool.Name, []*corev1.Pod{pod}...)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		setTime := cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))
 		Expect(setTime.IsZero()).To(BeTrue())
 	})
@@ -116,7 +115,7 @@ var _ = Describe("Pod Healthy NodePool", func() {
 		nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy)
 		ExpectApplied(ctx, env.Client, pod, nodePool)
 
-		cluster.UpdatePodHealthyNodePoolScheduledTime(ctx, nodePool.Name, []*corev1.Pod{pod}...)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		setTime := cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))
 		Expect(setTime.IsZero()).To(BeFalse())
 	})
@@ -126,13 +125,13 @@ var _ = Describe("Pod Healthy NodePool", func() {
 		ExpectApplied(ctx, env.Client, pod, nodePool)
 
 		// This will store the pod schedulable time
-		cluster.UpdatePodHealthyNodePoolScheduledTime(ctx, nodePool.Name, []*corev1.Pod{pod}...)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		setTime := cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))
 		Expect(setTime.IsZero()).To(BeFalse())
 
 		fakeClock.Step(time.Minute)
 		// We try to update pod schedulable time, but it should not change as we have already stored it
-		cluster.UpdatePodHealthyNodePoolScheduledTime(ctx, nodePool.Name, []*corev1.Pod{pod}...)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		Expect(cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))).To(Equal(setTime))
 	})
 	It("should delete the pod schedulable time if the pod is deleted", func() {
@@ -141,7 +140,7 @@ var _ = Describe("Pod Healthy NodePool", func() {
 		ExpectApplied(ctx, env.Client, pod, nodePool)
 
 		// This will store the pod schedulable time
-		cluster.UpdatePodHealthyNodePoolScheduledTime(ctx, nodePool.Name, []*corev1.Pod{pod}...)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		setTime := cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))
 		Expect(setTime.IsZero()).To(BeFalse())
 
@@ -160,7 +159,7 @@ var _ = Describe("Pod Ack", func() {
 		setTime := cluster.PodSchedulingSuccessTime(nn)
 		Expect(setTime.IsZero()).To(BeTrue())
 
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, pod)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {pod}})
 		setTime = cluster.PodSchedulingSuccessTime(nn)
 		Expect(setTime.IsZero()).To(BeFalse())
 
@@ -174,14 +173,13 @@ var _ = Describe("Pod Ack", func() {
 
 		setTime := cluster.PodSchedulingSuccessTime(nn)
 		Expect(setTime.IsZero()).To(BeTrue())
-
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{}, pod)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {pod}})
 		setTime = cluster.PodSchedulingSuccessTime(nn)
 		Expect(setTime.IsZero()).To(BeFalse())
 
-		cluster.MarkPodSchedulingDecisions(map[*corev1.Pod]error{
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{
 			pod: fmt.Errorf("ignoring pod"),
-		}, pod)
+		}, map[string][]*corev1.Pod{})
 		Expect(cluster.PodSchedulingSuccessTime(nn).IsZero()).To(BeTrue())
 	})
 })

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Pod Healthy NodePool", func() {
 	It("should not store pod schedulable time if the nodePool that pod is scheduled to does not have NodeRegistrationHealthy=true", func() {
 		pod := test.Pod()
 		ExpectApplied(ctx, env.Client, pod, nodePool)
-		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
+		cluster.MarkPodSchedulingDecisions(ctx, nil, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		setTime := cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))
 		Expect(setTime.IsZero()).To(BeTrue())
 	})
@@ -115,7 +115,7 @@ var _ = Describe("Pod Healthy NodePool", func() {
 		nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy)
 		ExpectApplied(ctx, env.Client, pod, nodePool)
 
-		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
+		cluster.MarkPodSchedulingDecisions(ctx, nil, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		setTime := cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))
 		Expect(setTime.IsZero()).To(BeFalse())
 	})
@@ -125,13 +125,13 @@ var _ = Describe("Pod Healthy NodePool", func() {
 		ExpectApplied(ctx, env.Client, pod, nodePool)
 
 		// This will store the pod schedulable time
-		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
+		cluster.MarkPodSchedulingDecisions(ctx, nil, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		setTime := cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))
 		Expect(setTime.IsZero()).To(BeFalse())
 
 		fakeClock.Step(time.Minute)
 		// We try to update pod schedulable time, but it should not change as we have already stored it
-		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
+		cluster.MarkPodSchedulingDecisions(ctx, nil, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		Expect(cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))).To(Equal(setTime))
 	})
 	It("should delete the pod schedulable time if the pod is deleted", func() {
@@ -140,7 +140,7 @@ var _ = Describe("Pod Healthy NodePool", func() {
 		ExpectApplied(ctx, env.Client, pod, nodePool)
 
 		// This will store the pod schedulable time
-		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{nodePool.Name: {pod}})
+		cluster.MarkPodSchedulingDecisions(ctx, nil, map[string][]*corev1.Pod{nodePool.Name: {pod}})
 		setTime := cluster.PodSchedulingSuccessTimeRegistrationHealthyCheck(client.ObjectKeyFromObject(pod))
 		Expect(setTime.IsZero()).To(BeFalse())
 
@@ -159,7 +159,7 @@ var _ = Describe("Pod Ack", func() {
 		setTime := cluster.PodSchedulingSuccessTime(nn)
 		Expect(setTime.IsZero()).To(BeTrue())
 
-		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {pod}})
+		cluster.MarkPodSchedulingDecisions(ctx, nil, map[string][]*corev1.Pod{"n1": {pod}})
 		setTime = cluster.PodSchedulingSuccessTime(nn)
 		Expect(setTime.IsZero()).To(BeFalse())
 
@@ -173,13 +173,13 @@ var _ = Describe("Pod Ack", func() {
 
 		setTime := cluster.PodSchedulingSuccessTime(nn)
 		Expect(setTime.IsZero()).To(BeTrue())
-		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {pod}})
+		cluster.MarkPodSchedulingDecisions(ctx, nil, map[string][]*corev1.Pod{"n1": {pod}})
 		setTime = cluster.PodSchedulingSuccessTime(nn)
 		Expect(setTime.IsZero()).To(BeFalse())
 
 		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{
 			pod: fmt.Errorf("ignoring pod"),
-		}, map[string][]*corev1.Pod{})
+		}, nil)
 		Expect(cluster.PodSchedulingSuccessTime(nn).IsZero()).To(BeTrue())
 	})
 })

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -238,14 +238,3 @@ func String(list v1.ResourceList) string {
 	}
 	return pretty.Concise(list)
 }
-
-// MergePodsMaps helps to merge maps of type map[string][]*v1.Pod
-func MergePodsMaps(maps ...map[string][]*v1.Pod) map[string][]*v1.Pod {
-	result := make(map[string][]*v1.Pod)
-	for _, m := range maps {
-		for k, v := range m {
-			result[k] = append(result[k], v...)
-		}
-	}
-	return result
-}

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -238,3 +238,14 @@ func String(list v1.ResourceList) string {
 	}
 	return pretty.Concise(list)
 }
+
+// MergePodsMaps helps to merge maps of type map[string][]*v1.Pod
+func MergePodsMaps(maps ...map[string][]*v1.Pod) map[string][]*v1.Pod {
+	result := make(map[string][]*v1.Pod)
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = append(result[k], v...)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Is we successfully schedule a pod during a scheduling simulation but it doesn't get scheduled and after simulating again it is unschedulable, we should delete it's entry from `podsSchedulableTimes` map. We should also delete the gauge metrics emitted around this - 
1. provisioning_unstarted_time_seconds
2. provisioning_unbound_time_seconds

**How was this change tested?**
Added unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
