### PR TITLE
feat: add nodeclaim disruption status for forceful disruptions

### DIFF
--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -33,6 +33,12 @@ const (
 	ConditionTypeDisruptionReason     = "DisruptionReason"
 )
 
+const (
+	DisruptionReasonExpired          = "Expired"
+	DisruptionReasonUnhealthy        = "Unhealthy"
+	DisruptionReasonGarbageCollected = "GarbageCollected"
+)
+
 // NodeClaimStatus defines the observed state of NodeClaim
 type NodeClaimStatus struct {
 	// NodeName is the name of the corresponding node object

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -112,6 +112,10 @@ var _ = Describe("Node Health", func() {
 
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
+			condition := nodeClaim.StatusConditions().Get(v1.ConditionTypeDisruptionReason)
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(condition.Reason).To(Equal(v1.DisruptionReasonUnhealthy))
 		})
 		It("should not delete node when unhealthy type does not match cloud provider passed in value", func() {
 			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2023  <!-- issue number -->

**Description**
Add disruption status to forceful disruptions so that we can improve tracking of things like [how many pods disrupted for a reason ](https://github.com/kubernetes-sigs/karpenter/issues/2020)

**How was this change tested?**
Unit test & local kwok provider

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
