### PR TITLE
make sure nodeclaims hostname are also set

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -343,12 +343,8 @@ func (t *Topology) countDomains(ctx context.Context, tg *TopologyGroup) error {
 	// Note: long term we should handle this when constructing the domain groups, but that would require domain groups
 	// to handle affinity in addition to taints / tolerations.
 	for _, n := range t.stateNodes {
-		// ignore state nodes which are tracking in-flight NodeClaims
-		if n.Node == nil {
-			continue
-		}
 		// ignore the node if it doesn't match the topology group
-		if !tg.nodeFilter.Matches(n.Node.Spec.Taints, scheduling.NewLabelRequirements(n.Node.Labels)) {
+		if !tg.nodeFilter.Matches(n.Taints(), scheduling.NewLabelRequirements(n.Labels())) {
 			continue
 		}
 		domain, exists := n.Labels()[tg.Key]
@@ -360,7 +356,7 @@ func (t *Topology) countDomains(ctx context.Context, tg *TopologyGroup) error {
 			tg.emptyDomains.Insert(domain)
 		}
 	}
-
+	
 	// sort our pods by the node they are scheduled to
 	sort.Slice(pods, func(i, j int) bool {
 		return pods[i].Spec.NodeName < pods[j].Spec.NodeName


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2123  <!-- issue number -->

**Description**
While counting domains for topology group we ignored the existing nodeclaims that results in a huge amount of nodes being scaled up for a single pod

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
