### PR TITLE
fix: Ensure DaemonSets with '/initialized' and '/registered' are considered during nodeclaim calculations

### DIFF
--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -135,13 +135,10 @@ func (i *NodeClaimTemplate) ToNodeClaim() *v1.NodeClaim {
 	// Karpenter can't reason about which label domains would belong to each instance type.
 	i.Labels = lo.Assign(i.Labels, i.resolveCustomLabelsFromRequirements())
 
-	// Filter out DaemonSet scheduling-only requirements for the actual NodeClaim
-	requirements := scheduling.NewRequirements()
-	for key, req := range i.Requirements {
-		if key != v1.NodeRegisteredLabelKey && key != v1.NodeInitializedLabelKey {
-			requirements.Add(req)
-		}
-	}
+	// Exclude node lifecycle requirements used only for scheduling simulation.
+	requirements := scheduling.NewRequirements(lo.Filter(i.Requirements.Values(), func(req *scheduling.Requirement, _ int) bool {
+		return req.Key != v1.NodeRegisteredLabelKey && req.Key != v1.NodeInitializedLabelKey
+	})...)
 
 	nc := &v1.NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -73,6 +73,12 @@ func NewNodeClaimTemplate(nodePool *v1.NodePool) *NodeClaimTemplate {
 	})
 	nct.Requirements.Add(scheduling.NewNodeSelectorRequirementsWithMinValues(nct.Spec.Requirements...).Values()...)
 	nct.Requirements.Add(scheduling.NewLabelRequirements(nct.Labels).Values()...)
+
+	// Add requirements for DaemonSet scheduling calculations
+	// These ensure DaemonSets with nodeAffinity for these labels are considered
+	nct.Requirements.Add(scheduling.NewRequirement(v1.NodeRegisteredLabelKey, corev1.NodeSelectorOpIn, "true"))
+	nct.Requirements.Add(scheduling.NewRequirement(v1.NodeInitializedLabelKey, corev1.NodeSelectorOpIn, "true"))
+
 	return nct
 }
 
@@ -129,6 +135,14 @@ func (i *NodeClaimTemplate) ToNodeClaim() *v1.NodeClaim {
 	// Karpenter can't reason about which label domains would belong to each instance type.
 	i.Labels = lo.Assign(i.Labels, i.resolveCustomLabelsFromRequirements())
 
+	// Filter out DaemonSet scheduling-only requirements for the actual NodeClaim
+	requirements := scheduling.NewRequirements()
+	for key, req := range i.Requirements {
+		if key != v1.NodeRegisteredLabelKey && key != v1.NodeInitializedLabelKey {
+			requirements.Add(req)
+		}
+	}
+
 	nc := &v1.NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", i.NodePoolName),
@@ -146,7 +160,7 @@ func (i *NodeClaimTemplate) ToNodeClaim() *v1.NodeClaim {
 		},
 		Spec: i.Spec,
 	}
-	nc.Spec.Requirements = i.Requirements.NodeSelectorRequirements()
+	nc.Spec.Requirements = requirements.NodeSelectorRequirements()
 	if nc.Spec.TerminationGracePeriod == nil {
 		nc.Spec.TerminationGracePeriod = DefaultTerminationGracePeriod
 	}

--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/apis/v1alpha1"
@@ -35,6 +36,14 @@ import (
 // This would be a mechanism to allow cloud providers to enforce a TerminationGracePeriod on all node
 // provisioned by Karpenter
 var DefaultTerminationGracePeriod *metav1.Duration = nil
+
+// schedulingSimulationKeys are requirement keys added to NodeClaimTemplate solely for
+// DaemonSet scheduling simulation. They must be excluded from NodeClaim labels and
+// spec.requirements to avoid affecting node lifecycle state (e.g. Initialized/Registered).
+var schedulingSimulationKeys = sets.New(
+	v1.NodeRegisteredLabelKey,
+	v1.NodeInitializedLabelKey,
+)
 
 // MaxInstanceTypes is a constant that restricts the number of instance types to be sent for launch. Note that this
 // is intentionally changed to var just to help in testing the code.
@@ -87,7 +96,7 @@ func NewNodeClaimTemplate(nodePool *v1.NodePool) *NodeClaimTemplate {
 func (i *NodeClaimTemplate) resolveCustomLabelsFromRequirements() map[string]string {
 	labels := map[string]string{}
 	for key, requirement := range i.Requirements {
-		if v1.WellKnownLabels.Has(key) || v1.RestrictedLabels.Has(key) {
+		if v1.WellKnownLabels.Has(key) || v1.RestrictedLabels.Has(key) || schedulingSimulationKeys.Has(key) {
 			continue
 		}
 		if value := requirement.Any(); value != "" {
@@ -135,9 +144,9 @@ func (i *NodeClaimTemplate) ToNodeClaim() *v1.NodeClaim {
 	// Karpenter can't reason about which label domains would belong to each instance type.
 	i.Labels = lo.Assign(i.Labels, i.resolveCustomLabelsFromRequirements())
 
-	// Exclude node lifecycle requirements used only for scheduling simulation.
+	// Exclude scheduling-simulation-only requirements from the actual NodeClaim.
 	requirements := scheduling.NewRequirements(lo.Filter(i.Requirements.Values(), func(req *scheduling.Requirement, _ int) bool {
-		return req.Key != v1.NodeRegisteredLabelKey && req.Key != v1.NodeInitializedLabelKey
+		return !schedulingSimulationKeys.Has(req.Key)
 	})...)
 
 	nc := &v1.NodeClaim{

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2425,6 +2425,15 @@ var _ = Context("Scheduling", func() {
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
 				node1 := ExpectScheduled(ctx, env.Client, initialPod)
 
+				// Verify simulation-only requirements don't leak into the created NodeClaim
+				Expect(cloudProvider.CreateCalls).To(HaveLen(1))
+				createdNodeClaim := cloudProvider.CreateCalls[0]
+				reqs := pscheduling.NewNodeSelectorRequirementsWithMinValues(createdNodeClaim.Spec.Requirements...)
+				Expect(reqs).ToNot(HaveKey(v1.NodeRegisteredLabelKey))
+				Expect(reqs).ToNot(HaveKey(v1.NodeInitializedLabelKey))
+				Expect(createdNodeClaim.Labels).ToNot(HaveKey(v1.NodeRegisteredLabelKey))
+				Expect(createdNodeClaim.Labels).ToNot(HaveKey(v1.NodeInitializedLabelKey))
+
 				// create our daemonset pod and manually bind it to the node
 				ds1Pod := test.UnschedulablePod(test.PodOptions{
 					ResourceRequirements: corev1.ResourceRequirements{

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2462,16 +2462,15 @@ var _ = Context("Scheduling", func() {
 				ExpectDeleted(ctx, env.Client, initialPod)
 				ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
-				cluster.ForEachNode(func(f *state.StateNode) bool {
-					dsRequests := f.DaemonSetRequests()
-					available := f.Available()
+				for n := range cluster.Nodes() {
+					dsRequests := n.DaemonSetRequests()
+					available := n.Available()
 					Expect(dsRequests.Cpu().AsApproximateFloat64()).To(BeNumerically("~", 0))
 					// When daemonOverhead is considered for both ds1 and ds2, a 16 CPU Node is launched,
 					// whereas when only one or neither is considered, only a 4 CPU Node is launched.
 					// no pods so we have the full (16 cpu - 100m overhead)
 					Expect(available.Cpu().AsApproximateFloat64()).To(BeNumerically("~", 15.9))
-					return true
-				})
+				}
 
 				// manually bind the daemonset pods to the node
 				ExpectManualBinding(ctx, env.Client, ds1Pod, node1)
@@ -2480,16 +2479,14 @@ var _ = Context("Scheduling", func() {
 				ExpectManualBinding(ctx, env.Client, ds2Pod, node1)
 				ExpectReconcileSucceeded(ctx, podStateController, client.ObjectKeyFromObject(ds2Pod))
 
-				cluster.ForEachNode(func(f *state.StateNode) bool {
-					dsRequests := f.DaemonSetRequests()
-					available := f.Available()
+				for n := range cluster.Nodes() {
+					dsRequests := n.DaemonSetRequests()
+					available := n.Available()
 					Expect(dsRequests.Cpu().AsApproximateFloat64()).To(BeNumerically("~", 2))
 					// only the DS pods are bound, so available is reduced by two and the DS requested is incremented by two
 					Expect(available.Cpu().AsApproximateFloat64()).To(BeNumerically("~", 13.9))
-					return true
-				})
+				}
 			})
-
 		})
 		// nolint:gosec
 		It("should pack in-flight nodes before launching new nodes", func() {

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2370,6 +2370,125 @@ var _ = Context("Scheduling", func() {
 				// must create a new node
 				Expect(node1.Name).ToNot(Equal(node2.Name))
 			})
+			It("Should properly handle DaemonSet resources with Node Affinity for `karpenter.sh/initialized` and `karpenter.sh/registered`", func() {
+
+				// This test verifies that when DaemonSets are configured with node affinity for the "karpenter.sh/initialized"
+				// and "karpenter.sh/registered" labels, nodes are launched with properly calculated
+				// daemonOverhead. (Issue #2116)
+
+				// Daemonset with node affinity for `karpenter.sh/initialized`
+				ds1 := test.DaemonSet(
+					test.DaemonSetOptions{
+						PodOptions: test.PodOptions{
+							NodeRequirements: []corev1.NodeSelectorRequirement{
+								{
+									Key:      v1.NodeInitializedLabelKey,
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"true"},
+								},
+							},
+							ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							}},
+						},
+					},
+				)
+				ExpectApplied(ctx, env.Client, nodePool, ds1)
+				Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(ds1), ds1)).To(Succeed())
+
+				// Daemonset with node affinity for `karpenter.sh/registered`
+				ds2 := test.DaemonSet(
+					test.DaemonSetOptions{
+						PodOptions: test.PodOptions{
+							NodeRequirements: []corev1.NodeSelectorRequirement{
+								{
+									Key:      v1.NodeRegisteredLabelKey,
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"true"},
+								},
+							},
+							ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							}},
+						},
+					},
+				)
+				ExpectApplied(ctx, env.Client, nodePool, ds2)
+				Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(ds2), ds2)).To(Succeed())
+
+				opts := test.PodOptions{ResourceRequirements: corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU: resource.MustParse("2"),
+					},
+				}}
+				initialPod := test.UnschedulablePod(opts)
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
+				node1 := ExpectScheduled(ctx, env.Client, initialPod)
+
+				// create our daemonset pod and manually bind it to the node
+				ds1Pod := test.UnschedulablePod(test.PodOptions{
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						}},
+				})
+				ds1Pod.OwnerReferences = append(ds1Pod.OwnerReferences, metav1.OwnerReference{
+					APIVersion:         "apps/v1",
+					Kind:               "DaemonSet",
+					Name:               ds1.Name,
+					UID:                ds1.UID,
+					Controller:         lo.ToPtr(true),
+					BlockOwnerDeletion: lo.ToPtr(true),
+				})
+				ExpectApplied(ctx, env.Client, nodePool, ds1Pod)
+
+				ds2Pod := test.UnschedulablePod(test.PodOptions{
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						}},
+				})
+				ds2Pod.OwnerReferences = append(ds2Pod.OwnerReferences, metav1.OwnerReference{
+					APIVersion:         "apps/v1",
+					Kind:               "DaemonSet",
+					Name:               ds2.Name,
+					UID:                ds2.UID,
+					Controller:         lo.ToPtr(true),
+					BlockOwnerDeletion: lo.ToPtr(true),
+				})
+				ExpectApplied(ctx, env.Client, nodePool, ds2Pod)
+
+				// delete the pod so that the node is empty
+				ExpectDeleted(ctx, env.Client, initialPod)
+				ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
+
+				cluster.ForEachNode(func(f *state.StateNode) bool {
+					dsRequests := f.DaemonSetRequests()
+					available := f.Available()
+					Expect(dsRequests.Cpu().AsApproximateFloat64()).To(BeNumerically("~", 0))
+					// When daemonOverhead is considered for both ds1 and ds2, a 16 CPU Node is launched,
+					// whereas when only one or neither is considered, only a 4 CPU Node is launched.
+					// no pods so we have the full (16 cpu - 100m overhead)
+					Expect(available.Cpu().AsApproximateFloat64()).To(BeNumerically("~", 15.9))
+					return true
+				})
+
+				// manually bind the daemonset pods to the node
+				ExpectManualBinding(ctx, env.Client, ds1Pod, node1)
+				ExpectReconcileSucceeded(ctx, podStateController, client.ObjectKeyFromObject(ds1Pod))
+
+				ExpectManualBinding(ctx, env.Client, ds2Pod, node1)
+				ExpectReconcileSucceeded(ctx, podStateController, client.ObjectKeyFromObject(ds2Pod))
+
+				cluster.ForEachNode(func(f *state.StateNode) bool {
+					dsRequests := f.DaemonSetRequests()
+					available := f.Available()
+					Expect(dsRequests.Cpu().AsApproximateFloat64()).To(BeNumerically("~", 2))
+					// only the DS pods are bound, so available is reduced by two and the DS requested is incremented by two
+					Expect(available.Cpu().AsApproximateFloat64()).To(BeNumerically("~", 13.9))
+					return true
+				})
+			})
 
 		})
 		// nolint:gosec


### PR DESCRIPTION
Fixes #2116 

**Description**

- When Daemonsets has nodeAffinity or nodeSelector related to `karpenter.sh/registered` and `karpenter.sh/initialized` labels, these are not considered during NodeClaim calculations, resulting in nodes being launched with smaller sizes than expected.
  - This leads to unexpected behaviors such as resource shortages on nodes, preventing Daemonset Pods running, or Deployment Pods remaining in Pending state causing new NodeClaims to be created.

- Modified the code to consider `karpenter.sh/registered` and `karpenter.sh/initialized` labels during Daemonset overhead calculations.

**How was this change tested?**

- Prerequisites
  - Prepared the following Daemonset and Deployment
    - Daemonset
      - Pod Identity
        - No setting
      - VPC CNI (aws-node)
        - Cpu request: 25m
      - Kube Proxy
        - Cpu request: 100m
      - My Daemonset (with required nodeAffinity that specifies nodeSelectorTerms with matchExpressions for the `karpenter.sh/registered` label)
        - Cpu request: 2 (2000m)
    - Deployment
      - My Deployment
        - Cpu request: 1 (1000m)

- Before the change
  - Confirmed from Karpenter logs that My Daemonset was not considered in the request value (`"cpu":"1150m"`)
   
    ```
    {"level":"INFO","time":"2025-04-23T13:11:26.806Z","logger":"controller","caller":"provisioning/provisioner.go:413","message":"created nodeclaim","commit":"3f9eb00-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"e786ef2c-95ea-4607-b317-d684dd519b89","NodePool":{"name":"my-nodepool"},"NodeClaim":{"name":"my-nodepool-jtzvc"},"requests":{"cpu":"1150m","pods":"4"},"instance-types":"c5.large, c5.xlarge, c5a.large, c5a.xlarge, c5d.large and 55 other(s)"}
    ```

  - As a result, an EC2 instance of type c5d.large (allocatable cpu: 1930m) was launched, but the Daemonset remained in Pending state

- After the change
  - Confirmed from Karpenter logs that My Daemonset was now considered in the request value (`"cpu":"3150m"`)

    ```
    {"level":"INFO","time":"2025-04-23T13:45:02.609Z","logger":"controller","caller":"provisioning/provisioner.go:413","message":"created nodeclaim","commit":"3f9eb00-dirty","controller":"provisioner","namespace":"","name":"","reconcileID":"061608ab-f9ad-41fa-ade5-fd19a2ccec58","NodePool":{"name":"my-nodepool"},"NodeClaim":{"name":"my-nodepool-wbh4m"},"requests":{"cpu":"3150m","pods":"5"},"instance-types":"c5.2xlarge, c5.xlarge, c5a.2xlarge, c5a.xlarge, c5d.xlarge and 55 other(s)"}
    ```

  - The Daemonset started successfully without issues
 
**Manifests used for verification**

- NodePool
  
  <details><summary>nodepool.yaml</summary>
  <p>

    ```yaml
    apiVersion: karpenter.sh/v1
    kind: NodePool
    metadata:
    name: my-nodepool
    spec:
    template:
        metadata:
        labels:
            cluster-name: cluster-31-3923-alb
        spec:
        nodeClassRef:
            group: karpenter.k8s.aws
            kind: EC2NodeClass
            name: default
        requirements:
        - key: karpenter.k8s.aws/instance-category
            operator: In
            values:
            - m
            - c
            - r
        - key: karpenter.k8s.aws/instance-generation
            operator: Gt
            values:
            - "4"
        - key: kubernetes.io/arch
            operator: In
            values:
            - amd64
        - key: kubernetes.io/os
            operator: In
            values:
            - linux
    ```

  </p>
  </details> 

- Deployment and Deamonset

  </p>
  </details> 
  <details><summary>dep_deamon.yaml</summary>

    ```yaml
    apiVersion: apps/v1
    kind: Deployment
    metadata:
    name: my-deploy
    spec:
    replicas: 1
    selector:
        matchLabels:
        jeremy: my-deploy
    template:
        metadata:
        labels:
            jeremy: my-deploy
        spec:
        nodeSelector:
            karpenter.sh/nodepool: my-nodepool
        containers:
        - name: my-dep-container
            image: nginx:latest
            ports:
            - containerPort: 80
            resources:
            requests:
                cpu: "1"

    ---

    apiVersion: apps/v1
    kind: DaemonSet
    metadata:
    name: my-daemonset
    spec:
    selector:
        matchLabels:
        app.kubernetes.io/name: my-daemonset-app
    template:
        metadata:
        labels:
            app.kubernetes.io/name: my-daemonset-app
        spec:
        affinity:
            nodeAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
                nodeSelectorTerms:
                - matchExpressions:
                - key: karpenter.sh/registered
                    operator: In
                    values:
                    - "true"
                - key: karpenter.sh/nodepool
                    operator: In
                    values:
                    - my-nodepool
        containers:
        - image: nginx:latest
            imagePullPolicy: IfNotPresent
            name: my-ds-container
            resources:
            requests:
                cpu: "2"
        tolerations:
        - operator: Exists
    ```

  <p>



 