### PR TITLE
feat: prioritize emptiness over other consolidation methods

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -83,10 +83,10 @@ func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provi
 		cloudProvider: cp,
 		lastRun:       map[string]time.Time{},
 		methods: []Method{
-			// Terminate any NodeClaims that have drifted from provisioning specifications, allowing the pods to reschedule.
-			NewDrift(kubeClient, cluster, provisioner, recorder),
 			// Delete any empty NodeClaims as there is zero cost in terms of disruption.
 			NewEmptiness(c),
+			// Terminate any NodeClaims that have drifted from provisioning specifications, allowing the pods to reschedule.
+			NewDrift(kubeClient, cluster, provisioner, recorder),
 			// Attempt to identify multiple NodeClaims that we can consolidate simultaneously to reduce pod churn
 			NewMultiNodeConsolidation(c),
 			// And finally fall back our single NodeClaim consolidation to further reduce cluster cost.


### PR DESCRIPTION
# Prioritizing Emptiness - Reordering Graceful Consolidation copy

## Background:

Karpenter performs dataplane right-sizing for Kubernetes clusters. When performing consolidation, Karpenter considers if a node should be deleted, replaced, or if it isn't a candidate for disruption at all. There are multiple criteria used when determining a node's disrupt-ability and this PR proposes a re-ordering of them. Disruption via Expiration, Interruption, and Node Auto Repair are forceful consolidation methods, and are out of scope for this change.

## Goal:

Unblock emptiness consolidation as it is fast to validate and special in that it is the only graceful consolidation that results in only a deletion operation.

## Graceful Consolidation:

Karpenter evaluates four methods of graceful disruption.

The four methods happen sequentially and are:

* Drift
* Emptiness
* Multi-node consolidation
* Single-node consoldiation

If a valid disruption is found for any of these methods then it is sent to the termination orchestrator, exits the loop, and begins evaluating drift again.

## Consolidation Controls:

Disruption can be controlled by a Node Disruption Budget. These budgets are part of the NodePool spec and enables users to determine how many nodes should be disrupted for a given reason and during what time. For example, a user may want to block all consolidation except for an overnight maintenance window for 2 hours.

When multiple budgets are present on a NodePool, the most restrictive budget applies.

```
spec:
  disruption:
    budgets:
    - nodes: 50%
      reasons:
      - Drifted
      - Underutilized
    - nodes: 100%
      reasons:
      - Empty
```

While the semantic around the application of these budgets is not wrong - this PR argues that it’s unexpected that emptiness would be blocked by other disruption methods and that it instead should be the first graceful disruption performed.

## Problem:

Today, when Karpenter runs Drift, it first checks for any nodes that are both empty and drifted. 
These nodes are then sent to the termination orchestrator and Karpenter exits, and returns to the top of the graceful consolidation loop and starts evaluating Drift again. As a result, nodes that are `Drifted && Empty` are taking priority over `Drifted` nodes, being counted against the Drift node disruption budget, and are sending fewer than expected nodes to be terminated. 

Even more confusing for users, when Karpenter logs these disruptions, the disruption reason is Drifted as evidenced by this log line:

```
"controller":"disruption.queue","namespace":"","name":"","reason":"Drifted","decision":"delete","disrupted-node-count":1,"replacement-node-count":0,"disrupted-nodes":[{"Node":{"name":"ip-node"},"NodeClaim":{"name":"nodeclaim"}}],"replacement-nodes":[]}
```

While this isn’t strictly wrong, it’s perhaps unexpected.

To repro this, a sleep was added (otherwise the 1 node disruption budget causes Karpenter to skip over Drift entirely) before evaluating consolidation methods for the following cluster:

```
1. 1000 nodes one pod per node
2. Block all disruption
3. Drift NodePool
4. Scale down deployment by half
5. Set Drift Budget to: 1 Nodes and Empty Budget to: 500 nodes
6. Observe 1 Node terminated by Drift down to 500 nodes
```

## Proposals:

### 1. Update Drift's Handling of Empty Nodes

Specifically handle Empty nodes within Drift as being Empty, applying relevant Node Disruption Budgets for Emptiness as well as correctly logging the disruption reason as Empty. Alternatively, empty nodes can be skipped over when evaluating Drift and then handled by the Emptiness consolidation method.

Pros:
* Keeps Drift the first considered graceful disruption, prioritizing patching and getting requirements in line over everything else

Cons:
* The issue covered in this PR still exists
* Complicates how we reason about disruption methods

### 2. Reorder Graceful Consolidation and Skip Emptiness in Other Methods (this PR)

Update Drift such that if it detects empty nodes, those nodes are skipped over like we do in other disruption methods. Then, these nodes are picked up in Emptiness and are deleted when evaluating Empty nodes. Additionally, Emptiness should be evaluated before Drift is evaluated so that zero-simulation consolidation options are performed first. In the above repro, 500 nodes would be consolidated before evaluating drift for the remaining nodes.

Pros:
* Higher priority for deleting empty nodes
* Requirements changing doesn't mean anything for a node destined for deletion
* Fully separates out Emptiness as its own method and budget

Cons:
* Drift not being performed first could introduce some unexpected behavior where a user is relying on patching due to AMI or requirements drift before any other changes are made to their dataplane.
