### PR TITLE
ci: Enable Kind Cluster Testing on PR Merge

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,5 +1,7 @@
 name: kind-e2e
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 jobs:
   kind-e2e:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Enable integration test to run on Kind clusters on PR merges

**How was this change tested?**
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
