### PR TITLE
test: Migrate the NodeClaim suite test from the AWS Karpenter Provider

### DIFF
--- a/designs/karpenter-integration-testing.md
+++ b/designs/karpenter-integration-testing.md
@@ -182,7 +182,6 @@ As part of the initial functional integration testing, the cloud-agnostic tests 
         * should create a NodeClaim propagating all NodeClaim spec details
         * should remove the cloudProvider NodeClaim when the cluster NodeClaim is deleted
         * should delete a NodeClaim from the node termination finalizer 
-        * should create a NodeClaim with custom labels passed through the userData
         * should delete a NodeClaim after the registration timeout when the node doesn’t register
         * should delete a NodeClaim if it references a NodeClass that doesn’t exist
         * should delete a NodeClaim if it references a NodeClass that isn’t Ready 

--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -19,6 +19,7 @@ package kwok
 import (
 	"context"
 	_ "embed"
+	stderrors "errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -77,6 +78,10 @@ func (c CloudProvider) Create(ctx context.Context, nodeClaim *v1.NodeClaim) (*v1
 			log.FromContext(ctx).Error(err, "failed creating node from nodeclaim")
 		}
 	}()
+	nodeClassReady := nodeClass.StatusConditions().Get(status.ConditionReady)
+	if nodeClassReady.IsFalse() {
+		return nil, cloudprovider.NewNodeClassNotReadyError(stderrors.New(nodeClassReady.Message))
+	}
 	// convert the node back into a node claim to get the chosen resolved requirement values.
 	return c.toNodeClaim(node)
 }

--- a/test/suites/integration/nodeclaim_test.go
+++ b/test/suites/integration/nodeclaim_test.go
@@ -1,0 +1,306 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/karpenter/pkg/utils/resources"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/awslabs/operatorpkg/object"
+	"github.com/awslabs/operatorpkg/status"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/test"
+)
+
+var _ = Describe("NodeClaim", func() {
+	Describe("StandaloneNodeClaim", func() {
+		var requirements []v1.NodeSelectorRequirementWithMinValues
+		BeforeEach(func() {
+			requirements = nodePool.Spec.Template.Spec.Requirements
+			if env.IsDefaultNodeClassKWOK() {
+				requirements = append(nodePool.Spec.Template.Spec.Requirements, v1.NodeSelectorRequirementWithMinValues{
+					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+						Key:      corev1.LabelInstanceTypeStable,
+						Operator: corev1.NodeSelectorOpIn,
+						Values: []string{
+							"c-16x-amd64-linux",
+							"c-16x-arm64-linux",
+						},
+					},
+				})
+			}
+		})
+		It("should create a standard NodeClaim", func() {
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+			env.ExpectCreated(nodeClass, nodeClaim)
+			node := env.EventuallyExpectInitializedNodeCount("==", 1)[0]
+			nodeClaim = env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
+			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeOnDemand))
+			env.EventuallyExpectNodeClaimsReady(nodeClaim)
+		})
+		It("should create a standard NodeClaim based on resource requests", func() {
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					Resources: v1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("3"),
+							corev1.ResourceMemory: resource.MustParse("64Gi"),
+						},
+					},
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+			env.ExpectCreated(nodeClass, nodeClaim)
+			node := env.EventuallyExpectInitializedNodeCount("==", 1)[0]
+			nodeClaim = env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
+			Expect(resources.Fits(nodeClaim.Spec.Resources.Requests, node.Status.Allocatable))
+			env.EventuallyExpectNodeClaimsReady(nodeClaim)
+		})
+		It("should create a NodeClaim propagating all the NodeClaim spec details", func() {
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"custom-annotation": "custom-value",
+					},
+					Labels: map[string]string{
+						"custom-label": "custom-value",
+					},
+				},
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					Taints: []corev1.Taint{
+						{
+							Key:    "custom-taint",
+							Effect: corev1.TaintEffectNoSchedule,
+							Value:  "custom-value",
+						},
+						{
+							Key:    "other-custom-taint",
+							Effect: corev1.TaintEffectNoExecute,
+							Value:  "other-custom-value",
+						},
+					},
+					Resources: v1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("3"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+					},
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+			env.ExpectCreated(nodeClass, nodeClaim)
+			node := env.EventuallyExpectInitializedNodeCount("==", 1)[0]
+			Expect(node.Annotations).To(HaveKeyWithValue("custom-annotation", "custom-value"))
+			Expect(node.Labels).To(HaveKeyWithValue("custom-label", "custom-value"))
+			Expect(node.Spec.Taints).To(ContainElements(
+				corev1.Taint{
+					Key:    "custom-taint",
+					Effect: corev1.TaintEffectNoSchedule,
+					Value:  "custom-value",
+				},
+				corev1.Taint{
+					Key:    "other-custom-taint",
+					Effect: corev1.TaintEffectNoExecute,
+					Value:  "other-custom-value",
+				},
+			))
+			Expect(node.OwnerReferences).To(ContainElement(
+				metav1.OwnerReference{
+					APIVersion:         object.GVK(nodeClaim).GroupVersion().String(),
+					Kind:               "NodeClaim",
+					Name:               nodeClaim.Name,
+					UID:                nodeClaim.UID,
+					BlockOwnerDeletion: lo.ToPtr(true),
+				},
+			))
+			env.EventuallyExpectCreatedNodeClaimCount("==", 1)
+			env.EventuallyExpectNodeClaimsReady(nodeClaim)
+		})
+		It("should remove the cloudProvider NodeClaim when the cluster NodeClaim is deleted", func() {
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+			env.ExpectCreated(nodeClass, nodeClaim)
+			node := env.EventuallyExpectInitializedNodeCount("==", 1)[0]
+			nodeClaim = env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
+
+			// Node is deleted and now should be not found
+			env.ExpectDeleted(nodeClaim)
+			env.EventuallyExpectNotFound(nodeClaim, node)
+		})
+		It("should delete a NodeClaim from the node termination finalizer", func() {
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+			env.ExpectCreated(nodeClass, nodeClaim)
+			node := env.EventuallyExpectInitializedNodeCount("==", 1)[0]
+			nodeClaim = env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
+
+			// Delete the node and expect both the node and nodeClaim to be gone as well as the instance to be shutting-down
+			env.ExpectDeleted(node)
+			env.EventuallyExpectNotFound(nodeClaim, node)
+		})
+		It("should delete a NodeClaim after the registration timeout when the node doesn't register", func() {
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+
+			env.ExpectCreated(nodeClass, nodeClaim)
+			nodeClaim = env.EventuallyExpectCreatedNodeClaimCount("==", 1)[0]
+			nodeClaim.Status = v1.NodeClaimStatus{
+				Conditions: []status.Condition{
+					{
+						Type:               v1.ConditionTypeLaunched,
+						Status:             metav1.ConditionStatus(corev1.ConditionTrue),
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               v1.ConditionTypeRegistered,
+						Status:             metav1.ConditionStatus(corev1.ConditionUnknown),
+						LastTransitionTime: metav1.Time{Time: metav1.Now().Add(-time.Minute * 14)},
+					},
+				},
+			}
+			env.ExpectStatusUpdated(nodeClaim)
+
+			// Expect that the nodeClaim eventually launches and has unknown Registration/Initialization
+			Eventually(func(g Gomega) {
+				temp := &v1.NodeClaim{}
+				g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeClaim), temp)).To(Succeed())
+				g.Expect(temp.StatusConditions().Get(v1.ConditionTypeRegistered).IsUnknown()).To(BeTrue())
+				g.Expect(temp.StatusConditions().Get(v1.ConditionTypeInitialized).IsUnknown()).To(BeTrue())
+			}).Should(Succeed())
+
+			// Expect that the nodeClaim is eventually de-provisioned due to the registration timeout
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeClaim), nodeClaim))).To(BeTrue())
+			}).WithTimeout(time.Minute * 3).Should(Succeed())
+		})
+		It("should delete a NodeClaim if it references a NodeClass that doesn't exist", func() {
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+			// Don't create the NodeClass and expect that the NodeClaim fails and gets deleted
+			env.ExpectCreated(nodeClaim)
+			env.EventuallyExpectNotFound(nodeClaim)
+		})
+		It("should delete a NodeClaim if it references a NodeClass that isn't Ready", func() {
+			env.ExpectCreated(nodeClass)
+			nodeClass = env.ExpectNodeClassCondition(env.DefaultNodeClass, []status.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "NotReady",
+					Message:            "NodeClass is not ready",
+				},
+			})
+			env.ExpectStatusUpdated(nodeClass)
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+			env.ExpectCreated(nodeClaim)
+			env.EventuallyExpectNotFound(nodeClaim)
+		})
+		It("should succeed to garbage collect an Instance that was launched by a NodeClaim but has no Instance mapping", func() {
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				Spec: v1.NodeClaimSpec{
+					Requirements: requirements,
+					NodeClassRef: &v1.NodeClassReference{
+						Group: object.GVK(nodeClass).Group,
+						Kind:  object.GVK(nodeClass).Kind,
+						Name:  nodeClass.GetName(),
+					},
+				},
+			})
+			env.ExpectCreated(nodeClass, nodeClaim)
+			env.EventuallyExpectNodeClaimsReady(nodeClaim)
+			nodeClaim = env.ExpectExists(nodeClaim).(*v1.NodeClaim)
+
+			By("Updated NodeClaim Status")
+			nodeClaim.Status.ProviderID = "test-provider-id"
+			env.ExpectStatusUpdated(nodeClaim)
+			env.EventuallyExpectNotFound(nodeClaim)
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
* High Level Description: Validate that action taken by the nodeclaim controllers. This validates standalone claims and the garbage collection mechanisms  
* Source: https://github.com/aws/karpenter-provider-aws/tree/main/test/suites/nodeclaim
* Test Cases: 
    * Standalone NodeClaim  
        * should create a standard NodeClaim based on resource requests
        * should create a NodeClaim propagating all NodeClaim spec details
        * should remove the cloudProvider NodeClaim when the cluster NodeClaim is deleted
        * should delete a NodeClaim from the node termination finalizer 
        * should delete a NodeClaim after the registration timeout when the node doesn’t register
        * should delete a NodeClaim if it references a NodeClass that doesn’t exist
        * should delete a NodeClaim if it references a NodeClass that isn’t Ready 
        * should succeed to garbage collect an Instance that was launched by a NodeClaim but has no cloudprovider mapping 


**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
