### PR TITLE
chore: Fix event log line for a pointer

### DIFF
--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -41,7 +42,7 @@ func DisruptPodDelete(pod *corev1.Pod, gracePeriodSeconds *int64, nodeGracePerio
 		InvolvedObject: pod,
 		Type:           corev1.EventTypeNormal,
 		Reason:         events.Disrupted,
-		Message:        fmt.Sprintf("Deleting the pod to accommodate the terminationTime %v of the node. The pod was granted %v seconds of grace-period of its %v terminationGracePeriodSeconds. This bypasses the PDB of the pod and the do-not-disrupt annotation.", *nodeGracePeriodTerminationTime, *gracePeriodSeconds, pod.Spec.TerminationGracePeriodSeconds),
+		Message:        fmt.Sprintf("Deleting the pod to accommodate the terminationTime %v of the node. The pod was granted %v seconds of grace-period of its %v terminationGracePeriodSeconds. This bypasses the PDB of the pod and the do-not-disrupt annotation.", lo.FromPtr(nodeGracePeriodTerminationTime), lo.FromPtr(gracePeriodSeconds), lo.FromPtr(pod.Spec.TerminationGracePeriodSeconds)),
 		DedupeValues:   []string{pod.Name},
 	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Fix event log line pointer deference 

### Before 
```
Normal    Disrupted                        pod/venomcyber-1-zsoyy2brdu                         Deleting the pod to accommodate the terminationTime 2025-05-05 15:00:39 +0000 UTC of the node. The pod was granted 29 seconds of grace-period of its 0xc00172cce8 terminationGracePeriodSeconds. This bypasses the PDB of the pod and the do-not-disrupt annotation.
```

### After 
```
Normal    Disrupted                        pod/eaterleaf-1-y93sz5tngb                          Deleting the pod to accommodate the terminationTime 2025-05-05 15:08:56 +0000 UTC of the node. The pod was granted 29 seconds of grace-period of its 30 terminationGracePeriodSeconds. This bypasses the PDB of the pod and the do-not-disrupt annotation.
```

**How was this change tested?**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
