### PR TITLE
ci: Temporarily Disable Karpenter KPI Analysis Package

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -49,12 +49,17 @@ jobs:
         kubectl get nodepools
         kubectl get pods -A
         kubectl describe nodes
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      with:
-        repository: nathangeology/karpenter_evaluate
-        path: ./karpenter_eval/ # Installs to a folder in the Karpenter repo for the test
-        ref: "1130af927302e6913a4947952112f793eeafc564"
-        fetch-depth: 0
+    # TEMPORARILY DISABLED: Karpenter KPI Analysis Package
+    # This package analyzes key performance indicators (KPIs) for integration tests.
+    # Currently non-functional due to changes in core Karpenter metrics.
+    # Disabled due to test flakiness until underlying metric changes are addressed.
+    # Reference: https://github.com/nathangeology/karpenter_evaluate/blob/main/main.py
+    # - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    #   with:
+    #     repository: nathangeology/karpenter_evaluate
+    #     path: ./karpenter_eval/ # Installs to a folder in the Karpenter repo for the test
+    #     ref: "1130af927302e6913a4947952112f793eeafc564"
+    #     fetch-depth: 0
     - name: install KPI report dependencies
       shell: bash
       run: |


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Temporarily disabling the Karpenter KPI analysis package due to test flakiness and incompatibility with recent metric changes. The package is designed to analyze key performance indicators during integration tests but requires updates to align with current Karpenter metric structures.
- Example: https://github.com/kubernetes-sigs/karpenter/actions/runs/14866169301/job/41743367742

**How was this change tested?**
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
