### PR TITLE
chore: Remove mismatch with deps used for E2E tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -36,7 +36,6 @@ jobs:
     - name: install kwok and controller
       shell: bash
       run: |
-        make toolchain
         make install-kwok
         export KWOK_REPO=kind.local
         export KIND_CLUSTER_NAME=chart-testing


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Removed make toolchain and to relay on `install-deps` GH action: https://github.com/kubernetes-sigs/karpenter/actions/runs/14914182759/job/41895626909

**How was this change tested?**
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
