### PR TITLE
fix: don't provision unnecessary capacity for pods which can't move to a new node (#2033)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.22.12
+go 1.24.2
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml
+++ b/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: kwoknodeclasses.karpenter.kwok.sh
 spec:
   group: karpenter.kwok.sh

--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -530,7 +530,7 @@ var _ = Describe("Drift", func() {
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
-		It("should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
+		It("should not create replacements for drifted nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
 			pod := test.Pod(test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -551,8 +551,7 @@ var _ = Describe("Drift", func() {
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
-		It("should drift nodes that have pods with the karpenter.sh/do-not-disrupt annotation when the NodePool's TerminationGracePeriod is not nil", func() {
-			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
+		It("should not create replacements for drifted nodes that have pods with the karpenter.sh/do-not-disrupt annotation when the NodePool's TerminationGracePeriod is not nil", func() {
 			pod := test.Pod(test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -568,12 +567,13 @@ var _ = Describe("Drift", func() {
 
 			ExpectSingletonReconciled(ctx, disruptionController)
 
-			// Expect to create a replacement but not delete the old nodeclaim
-			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2)) // new nodeclaim is created for drift
+			// Pods with `karpenter.sh/do-not-disrupt` can't be evicted and hence can't be rescheduled on a new node.
+			// Expect no new nodeclaims to be created.
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})
-		It("should drift nodes that have pods with the blocking PDBs when the NodePool's TerminationGracePeriod is not nil", func() {
+		It("should not create replacements for drifted nodes that have pods with the blocking PDBs when the NodePool's TerminationGracePeriod is not nil", func() {
 			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
 			podLabels := map[string]string{"test": "value"}
 			pod := test.Pod(test.PodOptions{
@@ -593,8 +593,9 @@ var _ = Describe("Drift", func() {
 
 			ExpectSingletonReconciled(ctx, disruptionController)
 
-			// Expect to create a replacement but not delete the old nodeclaim
-			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2)) // new nodeclaim is created for drift
+			// Pods with blocking PDBs can't be evicted and hence can't be rescheduled on a new node.
+			// Expect no new nodeclaims to be created.
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 			ExpectExists(ctx, env.Client, nodeClaim)
 		})

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -67,20 +67,33 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 		return pscheduling.Results{}, errCandidateDeleting
 	}
 
-	// We get the pods that are on nodes that are deleting
-	deletingNodePods, err := deletingNodes.ReschedulablePods(ctx, kubeClient)
-	if err != nil {
-		return pscheduling.Results{}, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
-	}
 	// start by getting all pending pods
 	pods, err := provisioner.GetPendingPods(ctx)
 	if err != nil {
 		return pscheduling.Results{}, fmt.Errorf("determining pending pods, %w", err)
 	}
+
+	// Don't provision capacity for pods which will not get evicted due to fully blocking PDBs.
+	// Since Karpenter doesn't know when these pods will be successfully evicted, spinning up capacity until
+	// these pods are evicted is wasteful.
+	pdbs, err := pdb.NewLimits(ctx, kubeClient)
+	if err != nil {
+		return pscheduling.Results{}, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
+	}
 	for _, n := range candidates {
-		pods = append(pods, n.reschedulablePods...)
+		currentlyReschedulablePods := lo.Filter(n.reschedulablePods, func(p *corev1.Pod, _ int) bool {
+			return pdbs.IsCurrentlyReschedulable(p)
+		})
+		pods = append(pods, currentlyReschedulablePods...)
+	}
+
+	// We get the pods that are on nodes that are deleting
+	deletingNodePods, err := deletingNodes.CurrentlyReschedulablePods(ctx, kubeClient)
+	if err != nil {
+		return pscheduling.Results{}, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
 	}
 	pods = append(pods, deletingNodePods...)
+
 	scheduler, err := provisioner.NewScheduler(log.IntoContext(ctx, operatorlogging.NopLogger), pods, stateNodes)
 	if err != nil {
 		return pscheduling.Results{}, fmt.Errorf("creating scheduler, %w", err)
@@ -150,7 +163,7 @@ func GetCandidates(ctx context.Context, cluster *state.Cluster, kubeClient clien
 	if err != nil {
 		return nil, err
 	}
-	pdbs, err := pdb.NewLimits(ctx, clk, kubeClient)
+	pdbs, err := pdb.NewLimits(ctx, kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
 	}

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Simulate Scheduling", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
 		}
 
-		pdbs, err := pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbs, err := pdb.NewLimits(ctx, env.Client)
 		Expect(err).To(Succeed())
 
 		// Generate a candidate
@@ -839,7 +839,7 @@ var _ = Describe("Candidate Filtering", func() {
 			}),
 		}
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 	})
 	It("should not consider candidates that have do-not-disrupt pods scheduled and no terminationGracePeriod", func() {
@@ -1064,7 +1064,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -1127,7 +1127,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -1254,7 +1254,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -1301,7 +1301,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -1347,7 +1347,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -1378,7 +1378,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -1412,7 +1412,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -1456,7 +1456,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))
@@ -1494,7 +1494,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		var err error
-		pdbLimits, err = pdb.NewLimits(ctx, fakeClock, env.Client)
+		pdbLimits, err = pdb.NewLimits(ctx, env.Client)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.Nodes()).To(HaveLen(1))

--- a/pkg/controllers/nodeclaim/consistency/termination.go
+++ b/pkg/controllers/nodeclaim/consistency/termination.go
@@ -31,13 +31,11 @@ import (
 
 // Termination detects nodes that are stuck terminating and reports why.
 type Termination struct {
-	clk        clock.Clock
 	kubeClient client.Client
 }
 
 func NewTermination(clk clock.Clock, kubeClient client.Client) Check {
 	return &Termination{
-		clk:        clk,
 		kubeClient: kubeClient,
 	}
 }
@@ -47,7 +45,7 @@ func (t *Termination) Check(ctx context.Context, node *corev1.Node, nodeClaim *v
 	if nodeClaim.DeletionTimestamp.IsZero() {
 		return nil, nil
 	}
-	pdbs, err := pdb.NewLimits(ctx, t.clk, t.kubeClient)
+	pdbs, err := pdb.NewLimits(ctx, t.kubeClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -335,10 +335,11 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	// We do this after getting the pending pods so that we undershoot if pods are
 	// actively migrating from a node that is being deleted
 	// NOTE: The assumption is that these nodes are cordoned and no additional pods will schedule to them
-	deletingNodePods, err := nodes.Deleting().ReschedulablePods(ctx, p.kubeClient)
+	deletingNodePods, err := nodes.Deleting().CurrentlyReschedulablePods(ctx, p.kubeClient)
 	if err != nil {
 		return scheduler.Results{}, err
 	}
+
 	pods := append(pendingPods, deletingNodePods...)
 	// nothing to schedule, so just return success
 	if len(pods) == 0 {

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -34,9 +34,11 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	cloudproviderapi "k8s.io/cloud-provider/api"
@@ -79,6 +81,8 @@ var podStateController *informer.PodController
 
 const csiProvider = "fake.csi.provider"
 const isDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+
+var podLabels = map[string]string{"pdb-test": "value"}
 
 func TestScheduling(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -3644,6 +3648,47 @@ var _ = Context("Scheduling", func() {
 				Expect(n.Labels[corev1.LabelInstanceTypeStable]).To(Equal("small-instance-type"))
 			}
 		})
+		DescribeTable("should not reschedule pods from a deleting node when pods are blocked due to fully blocking PDBs",
+			func(pdb *policyv1.PodDisruptionBudget) {
+				ExpectApplied(ctx, env.Client, nodePool)
+				pod := test.UnschedulablePod(
+					test.PodOptions{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: podLabels,
+						},
+						ResourceRequirements: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceMemory: resource.MustParse("100M"),
+							},
+						}})
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				ExpectApplied(ctx, env.Client, pdb)
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(node.Labels[corev1.LabelInstanceTypeStable]).To(Equal("small-instance-type"))
+
+				// Mark for deletion so that we consider all pods on this node for reschedulability
+				cluster.MarkForDeletion(node.Spec.ProviderID)
+
+				// Trigger a provisioning loop and expect that we don't create more nodes
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov)
+
+				// We shouldn't create an additional node here because this pod's eviction is blocked due to PDB
+				nodes := ExpectNodes(ctx, env.Client)
+				Expect(nodes).To(HaveLen(1))
+			},
+			Entry("0 max unavailable", test.PodDisruptionBudget(test.PDBOptions{
+				Labels:         podLabels,
+				MaxUnavailable: lo.ToPtr(intstr.FromInt(0)),
+			})),
+			Entry("0% max unavailable", test.PodDisruptionBudget(test.PDBOptions{
+				Labels:         podLabels,
+				MaxUnavailable: lo.ToPtr(intstr.FromString("0%")),
+			})),
+			Entry("100% min available", test.PodDisruptionBudget(test.PDBOptions{
+				Labels:       podLabels,
+				MinAvailable: lo.ToPtr(intstr.FromString("100%")),
+			})),
+		)
 	})
 
 	Describe("Metrics", func() {

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -91,7 +91,7 @@ func (n StateNodes) Pods(ctx context.Context, kubeClient client.Client) ([]*core
 
 // Disruptable filters StateNodes that are meet the IsDisruptable condition
 func (n StateNodes) Disruptable(ctx context.Context, clk clock.Clock, kubeClient client.Client) (StateNodes, error) {
-	pdbs, err := pdb.NewLimits(ctx, clk, kubeClient)
+	pdbs, err := pdb.NewLimits(ctx, kubeClient)
 	if err != nil {
 		return StateNodes{}, fmt.Errorf("constructing pdbs, %w", err)
 	}
@@ -103,10 +103,10 @@ func (n StateNodes) Disruptable(ctx context.Context, clk clock.Clock, kubeClient
 	return n, nil
 }
 
-func (n StateNodes) ReschedulablePods(ctx context.Context, kubeClient client.Client) ([]*corev1.Pod, error) {
+func (n StateNodes) CurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client) ([]*corev1.Pod, error) {
 	var pods []*corev1.Pod
 	for _, node := range n {
-		p, err := node.ReschedulablePods(ctx, kubeClient)
+		p, err := node.CurrentlyReschedulablePods(ctx, kubeClient)
 		if err != nil {
 			return nil, err
 		}
@@ -243,12 +243,12 @@ func (in *StateNode) ValidatePodsDisruptable(ctx context.Context, kubeClient cli
 	return pods, nil
 }
 
-// ReschedulablePods gets the pods assigned to the Node that are reschedulable based on the kubernetes api-server bindings
-func (in *StateNode) ReschedulablePods(ctx context.Context, kubeClient client.Client) ([]*corev1.Pod, error) {
+// CurrentlyReschedulablePods gets the pods assigned to the Node that are currently reschedulable based on the kubernetes api-server bindings
+func (in *StateNode) CurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client) ([]*corev1.Pod, error) {
 	if in.Node == nil {
 		return nil, nil
 	}
-	return nodeutils.GetReschedulablePods(ctx, kubeClient, in.Node)
+	return nodeutils.GetCurrentlyReschedulablePods(ctx, kubeClient, in.Node)
 }
 
 func (in *StateNode) HostName() string {

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -62,10 +62,11 @@ type PodOptions struct {
 
 type PDBOptions struct {
 	metav1.ObjectMeta
-	Labels         map[string]string
-	MinAvailable   *intstr.IntOrString
-	MaxUnavailable *intstr.IntOrString
-	Status         *policyv1.PodDisruptionBudgetStatus
+	Labels                     map[string]string
+	MinAvailable               *intstr.IntOrString
+	MaxUnavailable             *intstr.IntOrString
+	UnhealthyPodEvictionPolicy *policyv1.UnhealthyPodEvictionPolicyType
+	Status                     *policyv1.PodDisruptionBudgetStatus
 }
 
 type EphemeralVolumeTemplateOptions struct {
@@ -248,7 +249,8 @@ func PodDisruptionBudget(overrides ...PDBOptions) *policyv1.PodDisruptionBudget 
 			Selector: &metav1.LabelSelector{
 				MatchLabels: options.Labels,
 			},
-			MaxUnavailable: options.MaxUnavailable,
+			MaxUnavailable:             options.MaxUnavailable,
+			UnhealthyPodEvictionPolicy: options.UnhealthyPodEvictionPolicy,
 		},
 		Status: status,
 	}

--- a/pkg/test/v1alpha1/crds/karpenter.test.sh_testnodeclasses.yaml
+++ b/pkg/test/v1alpha1/crds/karpenter.test.sh_testnodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: testnodeclasses.karpenter.test.sh
 spec:
   group: karpenter.test.sh

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -29,6 +29,7 @@ import (
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"sigs.k8s.io/karpenter/pkg/utils/pdb"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
@@ -122,14 +123,20 @@ func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (
 	return nodes[0], nil
 }
 
-// GetReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
-func GetReschedulablePods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
+// GetCurrentlyReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
+func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
 	pods, err := GetPods(ctx, kubeClient, nodes...)
 	if err != nil {
 		return nil, fmt.Errorf("listing pods, %w", err)
 	}
+
+	pdbs, err := pdb.NewLimits(ctx, kubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
+	}
+
 	return lo.Filter(pods, func(p *corev1.Pod, _ int) bool {
-		return pod.IsReschedulable(p)
+		return pdbs.IsCurrentlyReschedulable(p)
 	}), nil
 }
 

--- a/pkg/utils/pdb/pdb.go
+++ b/pkg/utils/pdb/pdb.go
@@ -23,16 +23,23 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/clock"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	podutil "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
+type evictionBlocker int
+
+const (
+	zeroDisruptions evictionBlocker = iota
+	fullyBlockingPDBs
+)
+
 // Limits is used to evaluate if evicting a list of pods is possible.
 type Limits []*pdbItem
 
-func NewLimits(ctx context.Context, clk clock.Clock, kubeClient client.Client) (Limits, error) {
+func NewLimits(ctx context.Context, kubeClient client.Client) (Limits, error) {
 	pdbs := []*pdbItem{}
 
 	var pdbList policyv1.PodDisruptionBudgetList
@@ -55,28 +62,53 @@ func NewLimits(ctx context.Context, clk clock.Clock, kubeClient client.Client) (
 // nolint:gocyclo
 func (l Limits) CanEvictPods(pods []*v1.Pod) (client.ObjectKey, bool) {
 	for _, pod := range pods {
-		// If the pod isn't eligible for being evicted, then a fully blocking PDB doesn't matter
-		// This is due to the fact that we won't call the eviction API on these pods when we are disrupting the node
-		if !podutil.IsEvictable(pod) {
-			continue
-		}
-		for _, pdb := range l {
-			if pdb.key.Namespace == pod.ObjectMeta.Namespace {
-				if pdb.selector.Matches(labels.Set(pod.Labels)) {
+		pdb, evictable := l.isEvictable(pod, zeroDisruptions)
 
-					// if the PDB policy is set to allow evicting unhealthy pods, then it won't stop us from
-					// evicting unhealthy pods
-					ignorePod := false
-					if pdb.canAlwaysEvictUnhealthyPods {
-						for _, c := range pod.Status.Conditions {
-							if c.Type == v1.PodReady && c.Status == v1.ConditionFalse {
-								ignorePod = true
-								continue
-							}
+		if !evictable {
+			return pdb, false
+		}
+	}
+	return client.ObjectKey{}, true
+}
+
+// isFullyBlocked returns true if the given pod is fully blocked by a PDB.
+func (l Limits) isFullyBlocked(pod *v1.Pod) (client.ObjectKey, bool) {
+	pdb, evictable := l.isEvictable(pod, fullyBlockingPDBs)
+
+	if !evictable {
+		return pdb, true
+	}
+	return client.ObjectKey{}, false
+}
+
+// nolint:gocyclo
+func (l Limits) isEvictable(pod *v1.Pod, evictionBlocker evictionBlocker) (client.ObjectKey, bool) {
+	// If the pod isn't eligible for being evicted, then the predicate doesn't matter
+	// This is due to the fact that we won't call the eviction API on these pods when we are disrupting the node
+	if !podutil.IsEvictable(pod) {
+		return client.ObjectKey{}, true
+	}
+	for _, pdb := range l {
+		if pdb.key.Namespace == pod.ObjectMeta.Namespace {
+			if pdb.selector.Matches(labels.Set(pod.Labels)) {
+
+				// if the PDB policy is set to allow evicting unhealthy pods, then it won't stop us from
+				// evicting unhealthy pods
+				if pdb.canAlwaysEvictUnhealthyPods {
+					for _, c := range pod.Status.Conditions {
+						if c.Type == v1.PodReady && c.Status == v1.ConditionFalse {
+							return client.ObjectKey{}, true
 						}
 					}
+				}
 
-					if !ignorePod && pdb.disruptionsAllowed == 0 {
+				switch evictionBlocker {
+				case zeroDisruptions:
+					if pdb.disruptionsAllowed == 0 {
+						return pdb.key, false
+					}
+				case fullyBlockingPDBs:
+					if pdb.isFullyBlocking {
 						return pdb.key, false
 					}
 				}
@@ -86,13 +118,31 @@ func (l Limits) CanEvictPods(pods []*v1.Pod) (client.ObjectKey, bool) {
 	return client.ObjectKey{}, true
 }
 
+// IsCurrentlyReschedulable checks if a Karpenter should consider this pod when re-scheduling to new capacity by ensuring that the pod:
+// - Is reschedulable as per the checks in IsReschedulable(...)
+// - Does not have the "karpenter.sh/do-not-disrupt=true" annotation (https://karpenter.sh/docs/concepts/disruption/#pod-level-controls)
+// - Does not have fully blocking PDBs which would prevent the pod from being evicted
+// The way this is different from IsReschedulable is that this also considers non-permanent conditions which prevent a pod from being rescheduled
+// to a different node like the "do-not-disrupt" annotation or fully blocking PDBs.
+func (l Limits) IsCurrentlyReschedulable(pod *v1.Pod) bool {
+	// Don't provision capacity for pods which will not get evicted due to fully blocking PDBs.
+	// Since Karpenter doesn't know when these pods will be successfully evicted, spinning up capacity until these pods are evicted is wasteful.
+	_, isFullyBlocked := l.isFullyBlocked(pod)
+
+	return podutil.IsReschedulable(pod) &&
+		!podutil.HasDoNotDisrupt(pod) &&
+		!isFullyBlocked
+}
+
 type pdbItem struct {
 	key                         client.ObjectKey
 	selector                    labels.Selector
 	disruptionsAllowed          int32
+	isFullyBlocking             bool
 	canAlwaysEvictUnhealthyPods bool
 }
 
+// nolint:gocyclo
 func newPdb(pdb policyv1.PodDisruptionBudget) (*pdbItem, error) {
 	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
 	if err != nil {
@@ -103,10 +153,14 @@ func newPdb(pdb policyv1.PodDisruptionBudget) (*pdbItem, error) {
 	if pdb.Spec.UnhealthyPodEvictionPolicy != nil && *pdb.Spec.UnhealthyPodEvictionPolicy == policyv1.AlwaysAllow {
 		canAlwaysEvictUnhealthyPods = true
 	}
+
 	return &pdbItem{
-		key:                         client.ObjectKeyFromObject(&pdb),
-		selector:                    selector,
-		disruptionsAllowed:          pdb.Status.DisruptionsAllowed,
+		key:                client.ObjectKeyFromObject(&pdb),
+		selector:           selector,
+		disruptionsAllowed: pdb.Status.DisruptionsAllowed,
+		isFullyBlocking: (pdb.Spec.MaxUnavailable != nil && pdb.Spec.MaxUnavailable.Type == intstr.Int && pdb.Spec.MaxUnavailable.IntVal == 0) ||
+			(pdb.Spec.MaxUnavailable != nil && pdb.Spec.MaxUnavailable.Type == intstr.String && pdb.Spec.MaxUnavailable.StrVal == "0%") ||
+			(pdb.Spec.MinAvailable != nil && pdb.Spec.MinAvailable.Type == intstr.String && pdb.Spec.MinAvailable.StrVal == "100%"),
 		canAlwaysEvictUnhealthyPods: canAlwaysEvictUnhealthyPods,
 	}, nil
 }

--- a/pkg/utils/pdb/suite_test.go
+++ b/pkg/utils/pdb/suite_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pdb_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	"sigs.k8s.io/karpenter/pkg/utils/pdb"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+)
+
+var (
+	ctx       context.Context
+	env       *test.Environment
+	podLabels = map[string]string{"pdb-test": "value"}
+)
+
+func Test(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PDBUtils")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("CanEvictPods", func() {
+	It("can evict unhealthy pods when UnhealthyPodEvictionPolicy is set to always allow", func() {
+		if env.Version.Minor() < 27 {
+			Skip("PDB UnhealthyPodEvictionPolicy is only supported in 1.27+")
+		}
+		podDisruptionBudget := test.PodDisruptionBudget(test.PDBOptions{
+			Labels:                     podLabels,
+			MinAvailable:               lo.ToPtr(intstr.FromString("100%")),
+			UnhealthyPodEvictionPolicy: lo.ToPtr(policyv1.AlwaysAllow),
+		})
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: podLabels,
+			},
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}})
+		ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		violatingPDB, canEvict := limits.CanEvictPods([]*v1.Pod{pod})
+		Expect(violatingPDB).To(Equal(client.ObjectKey{}))
+		Expect(canEvict).To(BeTrue())
+	})
+	It("can't evict unhealthy pods when UnhealthyPodEvictionPolicy is not set", func() {
+		podDisruptionBudget := test.PodDisruptionBudget(test.PDBOptions{
+			Labels:       podLabels,
+			MinAvailable: lo.ToPtr(intstr.FromString("100%")),
+		})
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: podLabels,
+			},
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}})
+		ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		violatingPDB, canEvict := limits.CanEvictPods([]*v1.Pod{pod})
+		Expect(violatingPDB).To(Equal(client.ObjectKeyFromObject(podDisruptionBudget)))
+		Expect(canEvict).To(BeFalse())
+	})
+	It("can evict pods when no PDBs match", func() {
+		podDisruptionBudget := test.PodDisruptionBudget(test.PDBOptions{
+			Labels: map[string]string{"other": "value"},
+		})
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: podLabels,
+			}})
+		ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		violatingPDB, canEvict := limits.CanEvictPods([]*v1.Pod{pod})
+		Expect(violatingPDB).To(Equal(client.ObjectKey{}))
+		Expect(canEvict).To(BeTrue())
+	})
+	DescribeTable("can't evict pods when disruptions are not allowed for every pod in the list",
+		func(podDisruptionBudget *policyv1.PodDisruptionBudget) {
+			pod1 := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+			})
+			pod2 := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+			})
+			ExpectApplied(ctx, env.Client, podDisruptionBudget, pod1, pod2)
+
+			limits, err := pdb.NewLimits(ctx, env.Client)
+			Expect(err).NotTo(HaveOccurred())
+
+			violatingPDB, canEvict := limits.CanEvictPods([]*v1.Pod{pod1, pod2})
+			Expect(violatingPDB).To(Equal(client.ObjectKeyFromObject(podDisruptionBudget)))
+			Expect(canEvict).To(BeFalse())
+		},
+		Entry("100% min available", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:       podLabels,
+			MinAvailable: lo.ToPtr(intstr.FromString("100%")),
+		})),
+		Entry("0% max unavailable", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:         podLabels,
+			MaxUnavailable: lo.ToPtr(intstr.FromString("0%")),
+		})),
+		Entry("0 max unavailable", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:         podLabels,
+			MaxUnavailable: lo.ToPtr(intstr.FromInt(0)),
+		})),
+	)
+	DescribeTable("can't evict pods when disruptions are not allowed for one pod in the list",
+		func(podDisruptionBudget *policyv1.PodDisruptionBudget) {
+			pod1 := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+			})
+			pod2 := test.Pod(test.PodOptions{})
+			ExpectApplied(ctx, env.Client, podDisruptionBudget, pod1, pod2)
+
+			limits, err := pdb.NewLimits(ctx, env.Client)
+			Expect(err).NotTo(HaveOccurred())
+
+			violatingPDB, canEvict := limits.CanEvictPods([]*v1.Pod{pod1, pod2})
+			Expect(violatingPDB).To(Equal(client.ObjectKeyFromObject(podDisruptionBudget)))
+			Expect(canEvict).To(BeFalse())
+		},
+		Entry("100% min available", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:       podLabels,
+			MinAvailable: lo.ToPtr(intstr.FromString("100%")),
+		})),
+		Entry("0% max unavailable", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:         podLabels,
+			MaxUnavailable: lo.ToPtr(intstr.FromString("0%")),
+		})),
+		Entry("0 max unavailable", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:         podLabels,
+			MaxUnavailable: lo.ToPtr(intstr.FromInt(0)),
+		})),
+	)
+})
+
+var _ = Describe("IsCurrentlyReschedulable", func() {
+	It("considers unhealthy pod as currently reschedulable when UnhealthyPodEvictionPolicy is set to always allow", func() {
+		if env.Version.Minor() < 27 {
+			Skip("PDB UnhealthyPodEvictionPolicy is only supported in 1.27+")
+		}
+		podDisruptionBudget := test.PodDisruptionBudget(test.PDBOptions{
+			Labels:                     podLabels,
+			MinAvailable:               lo.ToPtr(intstr.FromString("100%")),
+			UnhealthyPodEvictionPolicy: lo.ToPtr(policyv1.AlwaysAllow),
+		})
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: podLabels,
+			},
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}})
+		ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(limits.IsCurrentlyReschedulable(pod)).To(BeTrue())
+	})
+	It("does not consider unhealthy pod as currently reschedulable when UnhealthyPodEvictionPolicy is not set", func() {
+		podDisruptionBudget := test.PodDisruptionBudget(test.PDBOptions{
+			Labels:       podLabels,
+			MinAvailable: lo.ToPtr(intstr.FromString("100%")),
+		})
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: podLabels,
+			},
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}})
+		ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(limits.IsCurrentlyReschedulable(pod)).To(BeFalse())
+	})
+	It("considers pod as currently reschedulable when no PDBs match", func() {
+		podDisruptionBudget := test.PodDisruptionBudget(test.PDBOptions{
+			Labels: map[string]string{"other": "value"},
+		})
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: podLabels,
+			}})
+		ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(limits.IsCurrentlyReschedulable(pod)).To(BeTrue())
+	})
+	DescribeTable("pods which are not currently reschedulable due to PDBs",
+		func(podDisruptionBudget *policyv1.PodDisruptionBudget) {
+			pod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+			})
+			ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+			limits, err := pdb.NewLimits(ctx, env.Client)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(limits.IsCurrentlyReschedulable(pod)).To(BeFalse())
+		},
+		Entry("100% min available", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:       podLabels,
+			MinAvailable: lo.ToPtr(intstr.FromString("100%")),
+		})),
+		Entry("0% max unavailable", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:         podLabels,
+			MaxUnavailable: lo.ToPtr(intstr.FromString("0%")),
+		})),
+		Entry("0 max unavailable", test.PodDisruptionBudget(test.PDBOptions{
+			Labels:         podLabels,
+			MaxUnavailable: lo.ToPtr(intstr.FromInt(0)),
+		})),
+	)
+	It("does not consider pod with do-not-disrupt annotation as currently reschedulable", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{karpenterv1.DoNotDisruptAnnotationKey: "true"},
+				Labels:      podLabels,
+			},
+		})
+		ExpectApplied(ctx, env.Client, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(limits.IsCurrentlyReschedulable(pod)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
fix: don't provision unnecessary capacity for pods which can't move to a new node (#2033)

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Backporting https://github.com/kubernetes-sigs/karpenter/pull/2033

**How was this change tested?**

Unit testing only for the backport.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
