### PR TITLE
perf: Speed-up resource checking for existing nodes

### DIFF
--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -95,6 +95,19 @@ func Subtract(lhs, rhs v1.ResourceList) v1.ResourceList {
 	return result
 }
 
+// SubtractFrom subtracts the src v1.ResourceList from the dest v1.ResourceList in-place
+func SubtractFrom(dest v1.ResourceList, src v1.ResourceList) {
+	if dest == nil {
+		sz := len(src)
+		dest = make(v1.ResourceList, sz)
+	}
+	for resourceName, quantity := range src {
+		current := dest[resourceName]
+		current.Sub(quantity)
+		dest[resourceName] = current
+	}
+}
+
 // podRequests calculates the max between the sum of container resources and max of initContainers along with sidecar feature consideration
 // inspired from https://github.com/kubernetes/kubernetes/blob/e2afa175e4077d767745246662170acd86affeaf/pkg/api/v1/resource/helpers.go#L96
 // https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change speeds-up our existing node check by doing a quick check on whether some set of resources fits rather than re-creating a new resource set every time

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
