### PR TITLE
test: Use Pod Metadata field for test objects

### DIFF
--- a/pkg/test/daemonsets.go
+++ b/pkg/test/daemonsets.go
@@ -53,7 +53,7 @@ func DaemonSet(overrides ...DaemonSetOptions) *appsv1.DaemonSet {
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: options.PodOptions.Labels},
 			Template: v1.PodTemplateSpec{
-				ObjectMeta: ObjectMeta(options.PodOptions.ObjectMeta),
+				ObjectMeta: pod.ObjectMeta,
 				Spec:       pod.Spec,
 			},
 		},

--- a/pkg/test/deployment.go
+++ b/pkg/test/deployment.go
@@ -58,7 +58,7 @@ func Deployment(overrides ...DeploymentOptions) *appsv1.Deployment {
 			Replicas: lo.ToPtr(options.Replicas),
 			Selector: &metav1.LabelSelector{MatchLabels: options.PodOptions.Labels},
 			Template: v1.PodTemplateSpec{
-				ObjectMeta: ObjectMeta(options.PodOptions.ObjectMeta),
+				ObjectMeta: pod.ObjectMeta,
 				Spec:       pod.Spec,
 			},
 		},

--- a/pkg/test/statefulsets.go
+++ b/pkg/test/statefulsets.go
@@ -58,7 +58,7 @@ func StatefulSet(overrides ...StatefulSetOptions) *appsv1.StatefulSet {
 			Replicas: lo.ToPtr(options.Replicas),
 			Selector: &metav1.LabelSelector{MatchLabels: options.PodOptions.Labels},
 			Template: v1.PodTemplateSpec{
-				ObjectMeta: ObjectMeta(options.PodOptions.ObjectMeta),
+				ObjectMeta: pod.ObjectMeta,
 				Spec:       pod.Spec,
 			},
 		},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Use the objectMeta value provided from the generated pod object. It's possible to pass have conditional pod annotation, so opt for generated  pod objects 

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
