### PR TITLE
test: Add random name string for NodePool and NodeClass

### DIFF
--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -158,7 +158,7 @@ func NewClient(ctx context.Context, config *rest.Config) client.Client {
 	return c
 }
 
-func (env *Environment) DefaultNodePool(nodeClass client.Object) *v1.NodePool {
+func (env *Environment) DefaultNodePool(nodeClass *unstructured.Unstructured) *v1.NodePool {
 	nodePool := &v1.NodePool{}
 	if lo.FromPtr(nodePoolPath) == "" {
 		nodePool = object.Unmarshal[v1.NodePool](defaultNodePool)
@@ -169,12 +169,13 @@ func (env *Environment) DefaultNodePool(nodeClass client.Object) *v1.NodePool {
 
 	// Update to use the provided default nodeclass
 	nodePool.Spec.Template.Spec.NodeClassRef = &v1.NodeClassReference{
-		Kind:  env.DefaultNodeClass.GetObjectKind().GroupVersionKind().Kind,
-		Group: env.DefaultNodeClass.GetObjectKind().GroupVersionKind().Group,
-		Name:  env.DefaultNodeClass.GetName(),
+		Kind:  nodeClass.GetObjectKind().GroupVersionKind().Kind,
+		Group: nodeClass.GetObjectKind().GroupVersionKind().Group,
+		Name:  nodeClass.GetName(),
 	}
 	nodePool.ObjectMeta.Labels = lo.Assign(nodePool.ObjectMeta.Labels, map[string]string{test.DiscoveryLabel: "unspecified"})
 	nodePool.Spec.Template.ObjectMeta.Labels = lo.Assign(nodePool.Spec.Template.ObjectMeta.Labels, map[string]string{test.DiscoveryLabel: "unspecified"})
+	nodePool.ObjectMeta.Name = fmt.Sprintf("%s-%s", nodePool.GetName(), test.RandomName())
 	return nodePool
 }
 

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -115,7 +115,7 @@ func (env *Environment) ExpectStatusUpdated(objects ...client.Object) {
 	}
 }
 
-func (env *Environment) ExpectNodeClassCondition(nodeclass *unstructured.Unstructured, conditions []status.Condition) client.Object {
+func (env *Environment) ExpectNodeClassCondition(nodeclass *unstructured.Unstructured, conditions []status.Condition) *unstructured.Unstructured {
 	result := nodeclass.DeepCopy()
 
 	err := unstructured.SetNestedSlice(result.Object, lo.Map(conditions, func(condition status.Condition, _ int) interface{} {

--- a/test/suites/integration/nodeclaim_test.go
+++ b/test/suites/integration/nodeclaim_test.go
@@ -248,7 +248,7 @@ var _ = Describe("NodeClaim", func() {
 		})
 		It("should delete a NodeClaim if it references a NodeClass that isn't Ready", func() {
 			env.ExpectCreated(nodeClass)
-			nodeClass = env.ExpectNodeClassCondition(env.DefaultNodeClass, []status.Condition{
+			nodeClass = env.ExpectNodeClassCondition(nodeClass, []status.Condition{
 				{
 					Type:               "Ready",
 					Status:             metav1.ConditionFalse,

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/kwok/apis/v1alpha1"
@@ -35,7 +35,7 @@ import (
 )
 
 var nodePool *v1.NodePool
-var nodeClass client.Object
+var nodeClass *unstructured.Unstructured
 var env *common.Environment
 
 var testLabels = map[string]string{
@@ -61,6 +61,7 @@ func TestIntegration(t *testing.T) {
 var _ = BeforeEach(func() {
 	env.BeforeEach()
 	nodeClass = env.DefaultNodeClass.DeepCopy()
+	nodeClass.SetName(fmt.Sprintf("%s-%s", nodeClass.GetName(), test.RandomName()))
 	nodePool = env.DefaultNodePool(nodeClass)
 	if env.IsDefaultNodeClassKWOK() {
 		test.ReplaceRequirements(nodePool, v1.NodeSelectorRequirementWithMinValues{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Use a randomized name for NodePool and NodeClass objects

**How was this change tested?**
- `make e2etests`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
