### PR TITLE
perf: Don't deepcopy inside of watch handler functions

### DIFF
--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -87,7 +87,9 @@ func PodEventHandler(c client.Client, cloudProvider cloudprovider.CloudProvider)
 		if err := c.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
 			return nil
 		}
-		ncs, err := ListManaged(ctx, c, cloudProvider, ForProviderID(node.Spec.ProviderID))
+		// Because we get so many NodeClaims from this response, we are not DeepCopying the cached data here
+		// DO NOT MUTATE NodeClaims in this function as this will affect the underlying cached NodeClaim
+		ncs, err := ListManaged(ctx, c, cloudProvider, ForProviderID(node.Spec.ProviderID), client.UnsafeDisableDeepCopy)
 		if err != nil {
 			return nil
 		}
@@ -101,7 +103,9 @@ func PodEventHandler(c client.Client, cloudProvider cloudprovider.CloudProvider)
 // and enqueues reconcile.Requests for the NodeClaims
 func NodeEventHandler(c client.Client, cloudProvider cloudprovider.CloudProvider) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		ncs, err := ListManaged(ctx, c, cloudProvider, ForProviderID(o.(*corev1.Node).Spec.ProviderID))
+		// Because we get so many NodeClaims from this response, we are not DeepCopying the cached data here
+		// DO NOT MUTATE NodeClaims in this function as this will affect the underlying cached NodeClaim
+		ncs, err := ListManaged(ctx, c, cloudProvider, ForProviderID(o.(*corev1.Node).Spec.ProviderID), client.UnsafeDisableDeepCopy)
 		if err != nil {
 			return nil
 		}
@@ -115,7 +119,9 @@ func NodeEventHandler(c client.Client, cloudProvider cloudprovider.CloudProvider
 // on the v1.NodePoolLabelKey and enqueues reconcile.Requests for the NodeClaim
 func NodePoolEventHandler(c client.Client, cloudProvider cloudprovider.CloudProvider) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) (requests []reconcile.Request) {
-		ncs, err := ListManaged(ctx, c, cloudProvider, ForNodePool(o.GetName()))
+		// Because we get so many NodeClaims from this response, we are not DeepCopying the cached data here
+		// DO NOT MUTATE NodeClaims in this function as this will affect the underlying cached NodeClaim
+		ncs, err := ListManaged(ctx, c, cloudProvider, ForNodePool(o.GetName()), client.UnsafeDisableDeepCopy)
 		if err != nil {
 			return nil
 		}
@@ -134,7 +140,9 @@ func NodeClassEventHandler(c client.Client) handler.EventHandler {
 			"spec.nodeClassRef.group": object.GVK(o).Group,
 			"spec.nodeClassRef.kind":  object.GVK(o).Kind,
 			"spec.nodeClassRef.name":  o.GetName(),
-		}); err != nil {
+			// Because we get so many NodeClaims from this response, we are not DeepCopying the cached data here
+			// DO NOT MUTATE NodeClaims in this function as this will affect the underlying cached NodeClaim
+		}, client.UnsafeDisableDeepCopy); err != nil {
 			return requests
 		}
 		return lo.Map(nodeClaimList.Items, func(n v1.NodeClaim, _ int) reconcile.Request {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

These handler functions just read data and are extremely tightly scoped. Removing NodeClaim deep-copying from them to prevent a bunch of additional copying being done just for mapping

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
