### PR TITLE
test: deflake NodeClaim and presubmit tests

### DIFF
--- a/test/suites/regression/nodeclaim_test.go
+++ b/test/suites/regression/nodeclaim_test.go
@@ -229,7 +229,7 @@ var _ = Describe("NodeClaim", func() {
 			// Expect that the nodeClaim is eventually de-provisioned due to the registration timeout
 			Eventually(func(g Gomega) {
 				g.Expect(errors.IsNotFound(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeClaim), nodeClaim))).To(BeTrue())
-			}).WithTimeout(time.Minute * 16).Should(Succeed())
+			}).WithTimeout(time.Minute * 17).Should(Succeed())
 		})
 		It("should delete a NodeClaim if it references a NodeClass that doesn't exist", func() {
 			nodeClaim := test.NodeClaim(v1.NodeClaim{
@@ -291,8 +291,8 @@ var _ = Describe("NodeClaim", func() {
 			nodeClaim = env.ExpectExists(nodeClaim).(*v1.NodeClaim)
 
 			By("Updated NodeClaim Status")
-			nodeClaim.Status.ProviderID = "test-provider-id"
-			nodeClaim.Status.NodeName = "test-node-name"
+			nodeClaim.Status.ProviderID = ""
+			nodeClaim.Status.NodeName = ""
 			nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeLaunched)
 			nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeRegistered)
 			nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeInitialized)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
The presubmit test was calling `cluster.Nodes()` which returns nodes based on a map. This adds a sort so the nodes are deterministically selected for churn.

Deflakes registration by adding time since it can take longer than 1 minute to move from TTL to deletion completing:

>          {"level":"DEBUG","time":"2025-05-21T19:04:08.017Z","logger":"controller","caller":"lifecycle/liveness.go:69","message":"terminating due to registration ttl","commit":"91d8ecc","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"fighterribbon-23-rfpvpgytno"},"namespace":"","name":"fighterribbon-23-rfpvpgytno","reconcileID":"ea4d5c90-7f46-4f6b-80d6-3e3d38602624","provider-id":"aws:///us-east-2b/i-0349b1aa449d49a2d","ttl":"15m0s"}
>         {"level":"INFO","time":"2025-05-21T19:05:25.282Z","logger":"controller","caller":"lifecycle/controller.go:242","message":"deleted nodeclaim","commit":"91d8ecc","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"fighterribbon-23-rfpvpgytno"},"namespace":"","name":"fighterribbon-23-rfpvpgytno","reconcileID":"9be9e594-65de-45de-a195-10b54561cf8b","provider-id":"aws:///us-east-2b/i-0349b1aa449d49a2d"}

Also fixes a case where the old test providerID failed the regex. Having no providerID accomplishes the desired garbage collection behavior.

**How was this change tested?**
make upstream-e2etests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
