### PR TITLE
perf: Only call .Available() once which prevents duplicate allocs

### DIFF
--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -50,12 +50,13 @@ func NewExistingNode(n *state.StateNode, topology *Topology, taints []v1.Taint, 
 			daemonResources[k] = v
 		}
 	}
+	available := n.Available()
 	node := &ExistingNode{
 		StateNode:          n,
-		cachedAvailable:    n.Available(),
+		cachedAvailable:    available,
 		cachedTaints:       taints,
 		topology:           topology,
-		remainingResources: resources.Subtract(n.Available(), daemonResources),
+		remainingResources: resources.Subtract(available, daemonResources),
 		requirements:       scheduling.NewLabelRequirements(n.Labels()),
 	}
 	node.requirements.Add(scheduling.NewRequirement(v1.LabelHostname, v1.NodeSelectorOpIn, n.HostName()))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

.Available allocates a whole new list into which to do the subtraction. Only calling it once saves on performance

**How was this change tested?**

`make presubmit`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
