### PR TITLE
feat: consider pod disruptable with allow-disruption pod annotation (#2245)

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -48,6 +48,7 @@ const (
 
 // Karpenter specific annotations
 const (
+	AllowDisruptionAnnotationKey               = apis.Group + "/allow-disruption"
 	DoNotDisruptAnnotationKey                  = apis.Group + "/do-not-disrupt"
 	ProviderCompatibilityAnnotationKey         = apis.CompatibilityGroup + "/provider"
 	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"

--- a/pkg/utils/pdb/suite_test.go
+++ b/pkg/utils/pdb/suite_test.go
@@ -189,6 +189,26 @@ var _ = Describe("CanEvictPods", func() {
 			MaxUnavailable: lo.ToPtr(intstr.FromInt(0)),
 		})),
 	)
+	It("can evict pod with blocking PDB when disruptions are allowed for pod", func() {
+		podDisruptionBudget := test.PodDisruptionBudget(test.PDBOptions{
+			Labels:       podLabels,
+			MinAvailable: lo.ToPtr(intstr.FromString("100%")),
+		})
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{karpenterv1.AllowDisruptionAnnotationKey: "true"},
+				Labels:      podLabels,
+			},
+		})
+		ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		violatingPDB, canEvict := limits.CanEvictPods([]*v1.Pod{pod})
+		Expect(violatingPDB).To(Equal(client.ObjectKey{}))
+		Expect(canEvict).To(BeTrue())
+	})
 })
 
 var _ = Describe("IsCurrentlyReschedulable", func() {
@@ -285,5 +305,22 @@ var _ = Describe("IsCurrentlyReschedulable", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(limits.IsCurrentlyReschedulable(pod)).To(BeFalse())
+	})
+	It("considers pod as currently reschedulable with blocking PDB when disruptions are allowed for pod", func() {
+		podDisruptionBudget := test.PodDisruptionBudget(test.PDBOptions{
+			Labels:       podLabels,
+			MinAvailable: lo.ToPtr(intstr.FromString("100%")),
+		})
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{karpenterv1.AllowDisruptionAnnotationKey: "true"},
+				Labels:      podLabels,
+			}})
+		ExpectApplied(ctx, env.Client, podDisruptionBudget, pod)
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(limits.IsCurrentlyReschedulable(pod)).To(BeTrue())
 	})
 })

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -180,6 +180,13 @@ func HasDoNotDisrupt(pod *corev1.Pod) bool {
 	return pod.Annotations[v1.DoNotDisruptAnnotationKey] == "true"
 }
 
+func HasAllowDisruption(pod *corev1.Pod) bool {
+	if pod.Annotations == nil {
+		return false
+	}
+	return pod.Annotations[v1.AllowDisruptionAnnotationKey] == "true"
+}
+
 // ToleratesDisruptedNoScheduleTaint returns true if the pod tolerates karpenter.sh/disruption:NoSchedule taint
 func ToleratesDisruptedNoScheduleTaint(pod *corev1.Pod) bool {
 	return scheduling.Taints([]corev1.Taint{v1.DisruptedNoScheduleTaint}).ToleratesPod(pod) == nil


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Implements #2245 <!-- issue number -->

**Description**

For those who wish to have their pods from single-pod deployments gracefully terminated as part of rollout restarts of their deployments, rather than evicted, can utilize a custom or open source rollout node controller, and deploy blocking PDBs for such pods, and still have the benefits of Karpenter Consolidation, if this feature is implemented.

This Pull Request implements the necessary changes so that pods having blocking PDBs can indicate that they should be treated as pods without blocking PDBs with respect to Karpenter Consolidation.  Such pods would indicate this by being annotated with the annotation `karpenter.sh/allow-disruption` being set to a value of `"true"`.

**How was this change tested?**

- Unit tests were added to pkg/utils/pdb/suite_test.go and pass
- Built an aws karpenter provider image based on these changes and tested in an EKS 1.32 cluster where karpenter v1.4.0 was already installed and running.  The controller deployment was updated to use this built image which was pushed to AWS ECR for in-cluster testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
