### PR TITLE
fix: show the cron parse error to users to allow them to debug

### DIFF
--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -359,7 +359,7 @@ func (in *Budget) IsActive(c clock.Clock) (bool, error) {
 	if err != nil {
 		// Should only occur if there's a discrepancy
 		// with the validation regex and the cron package.
-		return false, serrors.Wrap(fmt.Errorf("invariant violated, invalid cron"), "cron", schedule)
+		return false, serrors.Wrap(fmt.Errorf("invariant violated, invalid cron, %w", err), "cron", schedule)
 	}
 	// Walk back in time for the duration associated with the schedule
 	checkPoint := c.Now().UTC().Add(-lo.FromPtr(in.Duration).Duration)

--- a/pkg/apis/v1/nodepool_budgets_test.go
+++ b/pkg/apis/v1/nodepool_budgets_test.go
@@ -264,5 +264,13 @@ var _ = Describe("Budgets", func() {
 			Expect(err).To(Succeed())
 			Expect(active).ToNot(BeTrue())
 		})
+		It("should return an error indicating why the cron fails to parse", func() {
+			// Set the date to the first monday in 2024, the best year ever
+			fakeClock = clock.NewFakeClock(time.Date(2024, time.January, 7, 0, 0, 0, 0, time.UTC))
+			budgets[0].Schedule = lo.ToPtr("0 0 * * tue-mon")
+			budgets[0].Duration = lo.ToPtr(metav1.Duration{Duration: lo.Must(time.ParseDuration("6h"))})
+			_, err := budgets[0].IsActive(fakeClock)
+			Expect(err).To(MatchError(ContainSubstring("beginning of range (2) beyond end of range (1)")))
+		})
 	})
 })


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**

Before this change, users got an indicating that the cron failed to parse but no indication as to why.

**How was this change tested?**

Unit testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
