### PR TITLE
perf: Don't deep-copy nodes and nodeclaims in our synced check

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -156,13 +156,17 @@ func (c *Cluster) Synced(ctx context.Context) (synced bool) {
 
 	// If we haven't synced before, then we need to make sure that our internal cache is fully hydrated
 	// before we start doing operations against the state
-	nodeClaims, err := nodeclaimutils.ListManaged(ctx, c.kubeClient, c.cloudProvider)
+	// Because we get so many NodeClaims from this response, we are not DeepCopying the cached data here
+	// DO NOT MUTATE NodeClaims in this function as this will affect the underlying cached NodeClaim
+	nodeClaims, err := nodeclaimutils.ListManaged(ctx, c.kubeClient, c.cloudProvider, client.UnsafeDisableDeepCopy)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed checking cluster state sync")
 		return false
 	}
 	nodeList := &corev1.NodeList{}
-	if err := c.kubeClient.List(ctx, nodeList); err != nil {
+	// Because we get so many Nodes from this response, we are not DeepCopying the cached data here
+	// DO NOT MUTATE Nodes in this function as this will affect the underlying cached Node
+	if err := c.kubeClient.List(ctx, nodeList, client.UnsafeDisableDeepCopy); err != nil {
 		log.FromContext(ctx).Error(err, "failed checking cluster state sync")
 		return false
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Avoid continually deep-copying Nodes and NodeClaims during `Synced` checks

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
