### PR TITLE
chore: Fix getting current script directory in install-kwok.sh

### DIFF
--- a/hack/install-kwok.sh
+++ b/hack/install-kwok.sh
@@ -17,6 +17,7 @@ KWOK_REPO=kubernetes-sigs/kwok
 KWOK_RELEASE=v0.5.2
 # make a base directory for multi-base kustomization
 HOME_DIR=$(mktemp -d)
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 BASE=${HOME_DIR}/base
 mkdir ${BASE}
 
@@ -117,6 +118,6 @@ then
 else
   kubectl apply -f ${HOME_DIR}/kwok.yaml
   kubectl apply -f ${crdURL}
-  kubectl apply -f $(pwd)/hack/kwok/stages
+  kubectl apply -f ${SCRIPT_DIR}/kwok/stages
 fi
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This changes fixes getting the correct directory for the location of the script using a bash one-liner.

**How was this change tested?**

`UNINSTALL_KWOK=false ./github/karpenter/hack/install-kwok.sh`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
