### PR TITLE
fix: Correctly build nodepool mapping for complex clusters

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -250,26 +249,16 @@ func (r Results) ReservedOfferingErrors() map[*corev1.Pod]error {
 func (r Results) NodePoolToPodMapping() map[string][]*corev1.Pod {
 	result := make(map[string][]*corev1.Pod)
 
-	for k, v := range lo.SliceToMap(r.NewNodeClaims, func(n *NodeClaim) (string, []*corev1.Pod) {
-		return n.Labels[v1.NodePoolLabelKey], n.Pods
-	}) {
-		result[k] = v
+	for _, nc := range r.NewNodeClaims {
+		nodePoolName := nc.Labels[v1.NodePoolLabelKey]
+		result[nodePoolName] = append(result[nodePoolName], nc.Pods...)
 	}
 
-	for k, v := range lo.SliceToMap(lo.Filter(r.ExistingNodes, func(n *ExistingNode, _ int) bool {
-		// Filter out nodes that don't have the nodePool label
-		return n.Labels()[v1.NodePoolLabelKey] != ""
-	}), func(n *ExistingNode) (string, []*corev1.Pod) {
-		return n.Labels()[v1.NodePoolLabelKey], n.Pods
-	}) {
-		if existing, ok := result[k]; ok {
-			// If key exists, append the values
-			result[k] = append(slices.Clone(existing), v...)
-		} else {
-			// If key doesn't exist, add the new key-value pair
-			result[k] = v
-		}
+	for _, nc := range r.ExistingNodes {
+		nodePoolName := nc.Labels()[v1.NodePoolLabelKey]
+		result[nodePoolName] = append(result[nodePoolName], nc.Pods...)
 	}
+
 	return result
 }
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -413,7 +413,10 @@ func (c *Cluster) MarkPodSchedulingDecisions(ctx context.Context, podErrors map[
 	}
 	for nodePoolName, pods := range npPods {
 		nodePool := &v1.NodePool{}
-		err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool)
+		if nodePoolName != "" {
+			// Swallow errors if we can't get the nodepool
+			_ = c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool)
+		}
 		for _, p := range pods {
 			nn := client.ObjectKeyFromObject(p)
 			c.podsSchedulableTimes.LoadOrStore(nn, now)
@@ -425,16 +428,14 @@ func (c *Cluster) MarkPodSchedulingDecisions(ctx context.Context, podErrors map[
 					PodSchedulingDecisionSeconds.Observe(c.clock.Since(ackTime).Seconds(), nil)
 				}
 			}
-			if err == nil {
-				// If the pod is scheduled to a nodePool and if the nodePool has NodeRegistrationHealthy=true
-				// then mark the time when we thought it can schedule to now.
-				if nodePool.StatusConditions().IsTrue(v1.ConditionTypeNodeRegistrationHealthy) {
-					c.podHealthyNodePoolScheduledTime.LoadOrStore(nn, c.clock.Now())
-				} else {
-					// If the pod was scheduled to a healthy nodePool earlier but is now getting scheduled to an
-					// unhealthy one then we need to delete its entry from the map because it will not schedule successfully
-					c.podHealthyNodePoolScheduledTime.Delete(nn)
-				}
+			// If the pod is scheduled to a nodePool and if the nodePool has NodeRegistrationHealthy=true
+			// then mark the time when we thought it can schedule to now.
+			if nodePoolName != "" && nodePool.StatusConditions().IsTrue(v1.ConditionTypeNodeRegistrationHealthy) {
+				c.podHealthyNodePoolScheduledTime.LoadOrStore(nn, c.clock.Now())
+			} else {
+				// If the pod was scheduled to a healthy nodePool earlier but is now getting scheduled to an
+				// unhealthy one then we need to delete its entry from the map because it will not schedule successfully
+				c.podHealthyNodePoolScheduledTime.Delete(nn)
 			}
 		}
 	}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -123,6 +123,13 @@ func ExpectScheduled(ctx context.Context, c client.Client, pod *corev1.Pod) *cor
 	return ExpectNodeExists(ctx, c, p.Spec.NodeName)
 }
 
+func ExpectPodsScheduled(ctx context.Context, c client.Client, pods ...*corev1.Pod) {
+	GinkgoHelper()
+	for _, p := range pods {
+		ExpectScheduled(ctx, c, p)
+	}
+}
+
 func ExpectNotScheduled(ctx context.Context, c client.Client, pod *corev1.Pod) *corev1.Pod {
 	GinkgoHelper()
 	p := ExpectPodExists(ctx, c, pod.Name, pod.Namespace)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fixes some incorrect logic that doesn't map nodepools to pods correctly. Added unit test to verify the functionality.

**How was this change tested?**

Ran unit test against main:

```
Will run [1m1[0m of [1m99[0m specs

[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m

[38;5;243m------------------------------[0m

[38;5;9m• [FAILED] [4.859 seconds][0m

[0mProvisioning [38;5;9m[1m[It] Should provision nodes for multiple pods[0m

[38;5;243m/Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/suite_test.go:226[0m

  

[38;5;9m[FAILED] Metric karpenter_pods_scheduling_decision_duration_seconds should have the expected value

Expected

<uint64>: 5

to equal

<uint64>: 100[0m

[38;5;9mIn [1m[It][0m[38;5;9m at: [1m/Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/suite_test.go:235[0m [38;5;243m@ 05/28/25 16:59:48.769[0m
```

Then added my change and unit test succeeds

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
