### PR TITLE
chore: Consider node.kubernetes.io/not-ready:NoExecute as ephemeral

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2051,7 +2051,7 @@ var _ = Context("Scheduling", func() {
 				// We try to provision a node for an initial unschedulable pod that will create nodeClaim and node bindings
 				ExpectApplied(ctx, kubeClient, nodePool)
 				initialPod := test.UnschedulablePod()
-				bindings := ExpectProvisionedFakeClient(ctx, kubeClient, cluster, cloudProvider, provisioner, initialPod)
+				bindings := ExpectProvisioned(ctx, kubeClient, cluster, cloudProvider, provisioner, initialPod)
 				// delete the pod so that the node is empty
 				ExpectDeleted(ctx, kubeClient, initialPod)
 				node1 := bindings.Get(initialPod).Node
@@ -2062,7 +2062,7 @@ var _ = Context("Scheduling", func() {
 				ExpectApplied(ctx, kubeClient, node1)
 				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node1))
 				secondPod := test.UnschedulablePod()
-				bindings = ExpectProvisionedFakeClient(ctx, kubeClient, cluster, cloudProvider, provisioner, secondPod)
+				bindings = ExpectProvisioned(ctx, kubeClient, cluster, cloudProvider, provisioner, secondPod)
 				Expect(bindings.Get(secondPod).Node.Name).To(BeEquivalentTo(node1.Name))
 				// delete the pod so that the node is empty
 				ExpectDeleted(ctx, kubeClient, secondPod)
@@ -2073,7 +2073,7 @@ var _ = Context("Scheduling", func() {
 				ExpectApplied(ctx, kubeClient, node1)
 				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node1))
 				thirdPod := test.UnschedulablePod()
-				bindings = ExpectProvisionedFakeClient(ctx, kubeClient, cluster, cloudProvider, provisioner, thirdPod)
+				bindings = ExpectProvisioned(ctx, kubeClient, cluster, cloudProvider, provisioner, thirdPod)
 				Expect(bindings.Get(thirdPod).Node.Name).ToNot(BeEquivalentTo(node1.Name))
 			})
 			It("should not assume pod will schedule to a tainted node", func() {

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -39,11 +39,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	"k8s.io/csi-translation-lib/plugins"
 	clock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -2037,31 +2039,42 @@ var _ = Context("Scheduling", func() {
 				Expect(node1.Name).To(Equal(node2.Name))
 			})
 			It("should assume pod will schedule to a node with ephemeral taint node.kubernetes.io/not-ready:NoExecute when the node is uninitialized", func() {
-				// We try to provision a node for an initial unschedulable pod that will create nodeClaim and node bindings.
-				// The node will not be initialized but the initial pod will still be schedulable against the node
-				// because the node has node.kubernetes.io/not-ready:NoSchedule taint which is ephemeral.
-				nodePool.Spec.Template.Spec.Taints = []corev1.Taint{{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute}}
-				ExpectApplied(ctx, env.Client, nodePool)
+				kubeClient := fakeClient.NewClientBuilder().WithScheme(scheme.Scheme).WithStatusSubresource(&v1.NodeClaim{}, &v1.NodePool{}).WithIndex(
+					&corev1.Pod{},
+					"spec.nodeName",
+					func(o client.Object) []string {
+						return []string{o.(*corev1.Pod).Spec.NodeName}
+					},
+				).Build()
+				provisioner := provisioning.NewProvisioner(kubeClient, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, fakeClock)
+				controller := informer.NewNodeController(kubeClient, cluster)
+				// We try to provision a node for an initial unschedulable pod that will create nodeClaim and node bindings
+				ExpectApplied(ctx, kubeClient, nodePool)
 				initialPod := test.UnschedulablePod()
-				bindings := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
-				ExpectScheduled(ctx, env.Client, initialPod)
-
+				bindings := ExpectProvisionedFakeClient(ctx, kubeClient, cluster, cloudProvider, provisioner, initialPod)
 				// delete the pod so that the node is empty
-				ExpectDeleted(ctx, env.Client, initialPod)
+				ExpectDeleted(ctx, kubeClient, initialPod)
 				node1 := bindings.Get(initialPod).Node
 				node1.Spec.Taints = []corev1.Taint{{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute}}
+
+				// We try to schedule another pod that does not have any toleration. This should schedule to the existing node because we
+				// consider node.kubernetes.io/not-ready:NoExecute as ephemeral during provisioning if node is not initialized.
+				ExpectApplied(ctx, kubeClient, node1)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node1))
+				secondPod := test.UnschedulablePod()
+				bindings = ExpectProvisionedFakeClient(ctx, kubeClient, cluster, cloudProvider, provisioner, secondPod)
+				Expect(bindings.Get(secondPod).Node.Name).To(BeEquivalentTo(node1.Name))
+				// delete the pod so that the node is empty
+				ExpectDeleted(ctx, kubeClient, secondPod)
+
+				// We try to schedule another pod that does not have any toleration. This should not schedule to the existing node because
+				// we do not consider node.kubernetes.io/not-ready:NoExecute as ephemeral during provisioning if node is initialized.
 				node1.Labels = lo.Assign(node1.Labels, map[string]string{v1.NodeInitializedLabelKey: "true"})
-
-				ExpectApplied(ctx, env.Client, node1)
-				ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
-
-				// We try to schedule another pod that only has one toleration. This should succeed because we consider node.kubernetes.io/not-ready:NoSchedule
-				// as ephemeral during provisioning as long as the node in uninitialized.
-				opts := test.PodOptions{Tolerations: []corev1.Toleration{{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule}}}
-				secondPod := test.UnschedulablePod(opts)
-				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, secondPod)
-				node2 := ExpectScheduled(ctx, env.Client, secondPod)
-				Expect(node1.Name).To(Equal(node2.Name))
+				ExpectApplied(ctx, kubeClient, node1)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node1))
+				thirdPod := test.UnschedulablePod()
+				bindings = ExpectProvisionedFakeClient(ctx, kubeClient, cluster, cloudProvider, provisioner, thirdPod)
+				Expect(bindings.Get(thirdPod).Node.Name).ToNot(BeEquivalentTo(node1.Name))
 			})
 			It("should not assume pod will schedule to a tainted node", func() {
 				opts := test.PodOptions{ResourceRequirements: corev1.ResourceRequirements{

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1805,6 +1805,7 @@ var _ = Describe("Taints", func() {
 		It("should not consider ephemeral taints on a managed node that isn't initialized", func() {
 			node.Spec.Taints = []corev1.Taint{
 				{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
+				{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute},
 				{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule},
 				{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: corev1.TaintEffectNoSchedule, Value: "true"},
 			}
@@ -1823,6 +1824,7 @@ var _ = Describe("Taints", func() {
 			node = ExpectExists(ctx, env.Client, node)
 			node.Spec.Taints = []corev1.Taint{
 				{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
+				{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute},
 				{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule},
 				{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: corev1.TaintEffectNoSchedule, Value: "true"},
 			}
@@ -1832,9 +1834,10 @@ var _ = Describe("Taints", func() {
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
 			stateNode := ExpectStateNodeExists(cluster, node)
-			Expect(stateNode.Taints()).To(HaveLen(3))
+			Expect(stateNode.Taints()).To(HaveLen(4))
 			Expect(stateNode.Taints()).To(ContainElements(
 				corev1.Taint{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
+				corev1.Taint{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute},
 				corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule},
 				corev1.Taint{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: corev1.TaintEffectNoSchedule, Value: "true"},
 			))
@@ -1883,6 +1886,7 @@ var _ = Describe("Taints", func() {
 		It("should consider ephemeral taints on an unmanaged node that isn't initialized", func() {
 			node.Spec.Taints = []corev1.Taint{
 				{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
+				{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute},
 				{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule},
 				{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: corev1.TaintEffectNoSchedule, Value: "true"},
 			}
@@ -1890,9 +1894,10 @@ var _ = Describe("Taints", func() {
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
 			stateNode := ExpectStateNodeExists(cluster, node)
-			Expect(stateNode.Taints()).To(HaveLen(3))
+			Expect(stateNode.Taints()).To(HaveLen(4))
 			Expect(stateNode.Taints()).To(ContainElements(
 				corev1.Taint{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
+				corev1.Taint{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute},
 				corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule},
 				corev1.Taint{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: corev1.TaintEffectNoSchedule, Value: "true"},
 			))
@@ -1904,6 +1909,7 @@ var _ = Describe("Taints", func() {
 			node = ExpectExists(ctx, env.Client, node)
 			node.Spec.Taints = []corev1.Taint{
 				{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
+				{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute},
 				{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule},
 				{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: corev1.TaintEffectNoSchedule, Value: "true"},
 			}
@@ -1912,9 +1918,10 @@ var _ = Describe("Taints", func() {
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
 			stateNode := ExpectStateNodeExists(cluster, node)
-			Expect(stateNode.Taints()).To(HaveLen(3))
+			Expect(stateNode.Taints()).To(HaveLen(4))
 			Expect(stateNode.Taints()).To(ContainElements(
 				corev1.Taint{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
+				corev1.Taint{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute},
 				corev1.Taint{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule},
 				corev1.Taint{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: corev1.TaintEffectNoSchedule, Value: "true"},
 			))

--- a/pkg/scheduling/taints.go
+++ b/pkg/scheduling/taints.go
@@ -35,6 +35,7 @@ import (
 // since we expect these taints to eventually be removed
 var KnownEphemeralTaints = []corev1.Taint{
 	{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
+	{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute},
 	{Key: corev1.TaintNodeUnreachable, Effect: corev1.TaintEffectNoSchedule},
 	{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: corev1.TaintEffectNoSchedule, Value: "true"},
 	v1.UnregisteredNoExecuteTaint,

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -287,6 +287,7 @@ func ExpectProvisioned(ctx context.Context, c client.Client, cluster *state.Clus
 	for pod, binding := range bindings {
 		// Only bind the pods that are passed through
 		if podKeys.Has(client.ObjectKeyFromObject(pod).String()) {
+			// We have to manually bind the pod to the node when using a fakeClient by setting the value for pod.Spec.NodeName
 			if strings.Contains(reflect.TypeOf(c).String(), "fake") {
 				pod.Spec.NodeName = binding.Node.Name
 				err := c.Update(ctx, pod)

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"reflect"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -286,25 +287,15 @@ func ExpectProvisioned(ctx context.Context, c client.Client, cluster *state.Clus
 	for pod, binding := range bindings {
 		// Only bind the pods that are passed through
 		if podKeys.Has(client.ObjectKeyFromObject(pod).String()) {
-			ExpectManualBinding(ctx, c, pod, binding.Node)
+			if strings.Contains(reflect.TypeOf(c).String(), "fake") {
+				pod.Spec.NodeName = binding.Node.Name
+				err := c.Update(ctx, pod)
+				Expect(err).ToNot(HaveOccurred())
+				ExpectExists(ctx, c, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: binding.Node.Name, Namespace: binding.Node.Namespace}})
+			} else {
+				ExpectManualBinding(ctx, c, pod, binding.Node)
+			}
 			Expect(cluster.UpdatePod(ctx, pod)).To(Succeed()) // track pod bindings
-		}
-	}
-	return bindings
-}
-
-func ExpectProvisionedFakeClient(ctx context.Context, c client.Client, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, pods ...*corev1.Pod) Bindings {
-	GinkgoHelper()
-	bindings := ExpectProvisionedNoBinding(ctx, c, cluster, cloudProvider, provisioner, pods...)
-	podKeys := sets.NewString(lo.Map(pods, func(p *corev1.Pod, _ int) string { return client.ObjectKeyFromObject(p).String() })...)
-	for pod, binding := range bindings {
-		// Only bind the pods that are passed through
-		if podKeys.Has(client.ObjectKeyFromObject(pod).String()) {
-			pod.Spec.NodeName = binding.Node.Name
-			err := c.Update(ctx, pod)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.UpdatePod(ctx, pod)).To(Succeed()) // track pod bindings
-			ExpectExists(ctx, c, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: binding.Node.Name, Namespace: binding.Node.Namespace}})
 		}
 	}
 	return bindings


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes issue in aws-provider - https://github.com/aws/karpenter-provider-aws/issues/8066

**Description**
When using Kyverno to apply tolerations to the pod, Karpenter was creating two nodeClaims because the node comes up with this taint that gets removed later - 
```
- key: "node.kubernetes.io/not-ready"
  operator: "Exists"
  effect: "NoExecute"
```
This PR will consider this taint as ephemeral if the node isn't initialized which will prevent karpenter from creating two nodeclaims for the same pod.

**How was this change tested?**
Added tests. Tested this on my dev cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
