### PR TITLE
perf: Cache instance types for drift to avoid GetInstanceTypes() calls

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -18,7 +18,9 @@ package disruption
 
 import (
 	"context"
+	"time"
 
+	"github.com/patrickmn/go-cache"
 	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -61,7 +63,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider clou
 	return &Controller{
 		kubeClient:    kubeClient,
 		cloudProvider: cloudProvider,
-		drift:         &Drift{cloudProvider: cloudProvider},
+		drift:         &Drift{cloudProvider: cloudProvider, instanceTypeCache: cache.New(time.Minute*5, time.Second*30)},
 		consolidation: &Consolidation{kubeClient: kubeClient, clock: clk},
 	}
 }
@@ -129,4 +131,8 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 		b.Watches(nodeClass, nodeclaimutils.NodeClassEventHandler(c.kubeClient))
 	}
 	return b.Complete(reconcile.AsReconciler(m.GetClient(), c))
+}
+
+func (c *Controller) Reset() {
+	c.drift.instanceTypeCache.Flush()
 }

--- a/pkg/controllers/nodeclaim/disruption/suite_test.go
+++ b/pkg/controllers/nodeclaim/disruption/suite_test.go
@@ -102,6 +102,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
+	nodeClaimDisruptionController.Reset()
 	cp.Reset()
 	ExpectCleanedUp(ctx, env.Client)
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change caches instance type data in the drift controller to reduce the number of GetInstanceTypes() calls that are generated by the NodeClaim disruption controller

### Before Change

<img width="498" alt="Screenshot 2025-05-30 at 12 35 56 AM" src="https://github.com/user-attachments/assets/360e5df8-7635-4e54-99a9-e0d1bfff296a" />

### After Change

<img width="500" alt="Screenshot 2025-05-30 at 12 36 06 AM" src="https://github.com/user-attachments/assets/4263d8df-3625-463b-994c-663ce4fbfb77" />

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
