### PR TITLE
fix: add string replace to NodeClassLabelKey

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -169,5 +169,5 @@ func GetLabelDomain(key string) string {
 }
 
 func NodeClassLabelKey(gk schema.GroupKind) string {
-	return fmt.Sprintf("%s/%s", gk.Group, strings.ToLower(gk.Kind))
+	return fmt.Sprintf("%s/%s", strings.Replace(gk.Group, "-", "_", -1), strings.ToLower(gk.Kind))
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2268 

**Description**

This change adds a replacement for dashes (`-`) that appear in the API group for a cloud provider nodeclass. It is being added to prevent the use of disallowed characters in metric labels.

**How was this change tested?**

tested manually using the cluster-api provider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
