### PR TITLE
perf: Be more resilient to deletion failures in disruption controller

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -128,6 +129,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	outdatedNodes := lo.Filter(c.cluster.Nodes(), func(s *state.StateNode, _ int) bool {
 		return !c.queue.HasAny(s.ProviderID()) && !s.Deleted()
 	})
+	c.cluster.UnmarkForDeletion(lo.Map(outdatedNodes, func(s *state.StateNode, _ int) string { return s.ProviderID() })...)
 	if err := state.RequireNoScheduleTaint(ctx, c.kubeClient, false, outdatedNodes...); err != nil {
 		if errors.IsConflict(err) {
 			return reconcile.Result{Requeue: true}, nil
@@ -205,19 +207,21 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command, 
 	commandID := uuid.NewUUID()
 	log.FromContext(ctx).WithValues(append([]any{"command-id", string(commandID), "reason", strings.ToLower(string(m.Reason()))}, cmd.LogValues()...)...).Info("disrupting node(s)")
 
+	c.cluster.MarkForDeletion(lo.Map(cmd.candidates, func(c *Candidate, _ int) string { return c.ProviderID() })...)
+
 	// Cordon the old nodes before we launch the replacements to prevent new pods from scheduling to the old nodes
-	if err := c.MarkDisrupted(ctx, m, cmd.candidates...); err != nil {
-		return serrors.Wrap(fmt.Errorf("marking disrupted, %w", err), "command-id", commandID)
+	markedCandidates, markDisruptedErr := c.MarkDisrupted(ctx, m, cmd.candidates...)
+	// If we get a failure marking some nodes as disrupted, if we are launching replacements, we shouldn't continue
+	// with disrupting the candidates. If it's just a delete operation, we can proceed
+	if markDisruptedErr != nil && len(cmd.replacements) > 0 {
+		return serrors.Wrap(fmt.Errorf("marking disrupted, %w", markDisruptedErr), "command-id", commandID)
 	}
 
-	var nodeClaimNames []string
-	var err error
-	if len(cmd.replacements) > 0 {
-		if nodeClaimNames, err = c.createReplacementNodeClaims(ctx, m, cmd); err != nil {
-			// If we failed to launch the replacement, don't disrupt.  If this is some permanent failure,
-			// we don't want to disrupt workloads with no way to provision new nodes for them.
-			return serrors.Wrap(fmt.Errorf("launching replacement nodeclaim, %w", err), "command-id", commandID)
-		}
+	nodeClaimNames, err := c.createReplacementNodeClaims(ctx, m, cmd)
+	if err != nil {
+		// If we failed to launch the replacement, don't disrupt.  If this is some permanent failure,
+		// we don't want to disrupt workloads with no way to provision new nodes for them.
+		return serrors.Wrap(fmt.Errorf("launching replacement nodeclaim, %w", err), "command-id", commandID)
 	}
 
 	// Nominate each node for scheduling and emit pod nomination events
@@ -231,20 +235,17 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command, 
 	// the node is cleaned up.
 	schedulingResults.Record(log.IntoContext(ctx, operatorlogging.NopLogger), c.recorder, c.cluster)
 
-	stateNodes := lo.Map(cmd.candidates, func(c *Candidate, _ int) *state.StateNode { return c.StateNode })
+	stateNodes := lo.Map(markedCandidates, func(c *Candidate, _ int) *state.StateNode { return c.StateNode })
 	if err = c.queue.Add(orchestration.NewCommand(nodeClaimNames, stateNodes, commandID, m.Reason(), m.ConsolidationType())); err != nil {
-		providerIDs := lo.Map(cmd.candidates, func(c *Candidate, _ int) string { return c.ProviderID() })
-		c.cluster.UnmarkForDeletion(providerIDs...)
-		return serrors.Wrap(fmt.Errorf("adding command to queue, %w", err), "command-id", commandID)
+		return multierr.Append(markDisruptedErr, serrors.Wrap(fmt.Errorf("adding command to queue, %w", err), "command-id", commandID))
 	}
-
 	// An action is only performed and pods/nodes are only disrupted after a successful add to the queue
 	DecisionsPerformedTotal.Inc(map[string]string{
 		decisionLabel:          string(cmd.Decision()),
 		metrics.ReasonLabel:    strings.ToLower(string(m.Reason())),
 		ConsolidationTypeLabel: m.ConsolidationType(),
 	})
-	return nil
+	return markDisruptedErr
 }
 
 // createReplacementNodeClaims creates replacement NodeClaims
@@ -260,31 +261,36 @@ func (c *Controller) createReplacementNodeClaims(ctx context.Context, m Method, 
 	return nodeClaimNames, nil
 }
 
-func (c *Controller) MarkDisrupted(ctx context.Context, m Method, candidates ...*Candidate) error {
-	stateNodes := lo.Map(candidates, func(c *Candidate, _ int) *state.StateNode {
-		return c.StateNode
-	})
-	if err := state.RequireNoScheduleTaint(ctx, c.kubeClient, true, stateNodes...); err != nil {
-		return serrors.Wrap(fmt.Errorf("tainting nodes, %w", err), "taint", pretty.Taint(v1.DisruptedNoScheduleTaint))
-	}
-
-	providerIDs := lo.Map(candidates, func(c *Candidate, _ int) string { return c.ProviderID() })
-	c.cluster.MarkForDeletion(providerIDs...)
-
+func (c *Controller) MarkDisrupted(ctx context.Context, m Method, candidates ...*Candidate) ([]*Candidate, error) {
 	errs := make([]error, len(candidates))
 	workqueue.ParallelizeUntil(ctx, len(candidates), len(candidates), func(i int) {
+		if err := state.RequireNoScheduleTaint(ctx, c.kubeClient, true, candidates[i].StateNode); err != nil {
+			errs[i] = serrors.Wrap(fmt.Errorf("tainting nodes, %w", err), "taint", pretty.Taint(v1.DisruptedNoScheduleTaint))
+			return
+		}
 		// refresh nodeclaim before updating status
 		nodeClaim := &v1.NodeClaim{}
-
-		if err := c.kubeClient.Get(ctx, client.ObjectKeyFromObject(candidates[i].NodeClaim), nodeClaim); err != nil {
+		if err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return client.IgnoreNotFound(err) != nil }, func() error {
+			return c.kubeClient.Get(ctx, client.ObjectKeyFromObject(candidates[i].NodeClaim), nodeClaim)
+		}); err != nil {
 			errs[i] = client.IgnoreNotFound(err)
 			return
 		}
 		stored := nodeClaim.DeepCopy()
 		nodeClaim.StatusConditions().SetTrueWithReason(v1.ConditionTypeDisruptionReason, string(m.Reason()), string(m.Reason()))
-		errs[i] = client.IgnoreNotFound(c.kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFrom(stored)))
+		if err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return client.IgnoreNotFound(err) != nil }, func() error { return c.kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFrom(stored)) }); err != nil {
+			errs[i] = client.IgnoreNotFound(err)
+			return
+		}
 	})
-	return multierr.Combine(errs...)
+	var markedCandidates []*Candidate
+	for i := range errs {
+		if errs[i] != nil {
+			continue
+		}
+		markedCandidates = append(markedCandidates, candidates[i])
+	}
+	return markedCandidates, multierr.Combine(errs...)
 }
 
 func (c *Controller) recordRun(s string) {

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/multierr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -283,26 +284,24 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) error {
 	// All replacements have been provisioned.
 	// All we need to do now is get a successful delete call for each node claim,
 	// then the termination controller will handle the eventual deletion of the nodes.
-	var multiErr error
-	for i := range cmd.candidates {
-		candidate := cmd.candidates[i]
-		q.recorder.Publish(disruptionevents.Terminating(candidate.Node, candidate.NodeClaim, cmd.Reason())...)
-		if err := q.kubeClient.Delete(ctx, candidate.NodeClaim); err != nil {
-			multiErr = multierr.Append(multiErr, client.IgnoreNotFound(err))
-		} else {
-			metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-				metrics.ReasonLabel:       pretty.ToSnakeCase(string(cmd.reason)),
-				metrics.NodePoolLabel:     cmd.candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
-				metrics.CapacityTypeLabel: cmd.candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
-			})
+	errs := make([]error, len(cmd.candidates))
+	workqueue.ParallelizeUntil(ctx, len(cmd.candidates), len(cmd.candidates), func(i int) {
+		if err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return client.IgnoreNotFound(err) != nil }, func() error {
+			return q.kubeClient.Delete(ctx, cmd.candidates[i].NodeClaim)
+		}); err != nil {
+			errs[i] = client.IgnoreNotFound(err)
+			return
 		}
-	}
+		q.recorder.Publish(disruptionevents.Terminating(cmd.candidates[i].Node, cmd.candidates[i].NodeClaim, cmd.Reason())...)
+		metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+			metrics.ReasonLabel:       pretty.ToSnakeCase(string(cmd.reason)),
+			metrics.NodePoolLabel:     cmd.candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
+			metrics.CapacityTypeLabel: cmd.candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
+		})
+	})
 	// If there were any deletion failures, we should requeue.
 	// In the case where we requeue, but the timeout for the command is reached, we'll mark this as a failure.
-	if multiErr != nil {
-		return fmt.Errorf("terminating nodeclaims, %w", multiErr)
-	}
-	return nil
+	return multierr.Combine(errs...)
 }
 
 // Add adds commands to the Queue


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Be more resilient to single node failures during disruption deletion operations. Currently, if we have a single node failure while we are moving through `executeCommand`, it will stop the _whole_ command from executing. This is particularly problematic when you have a large emptiness command that you aren't able to make any progress on. This changes the code so that we can continue to make progress on deletion commands even if all of the nodes don't succeed.

It also adds retries for the apiserver actions to attempt to be more resilient to transient failures.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
