### PR TITLE
chore: Update the Node Repair Controller for requeue time 

### DIFF
--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -32,8 +32,10 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -68,7 +70,12 @@ func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudPr
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(m).
 		Named("node.health").
-		For(&corev1.Node{}, builder.WithPredicates(nodeutils.IsManagedPredicateFuncs(c.cloudProvider))).
+		For(&corev1.Node{}, builder.WithPredicates(nodeutils.IsManagedPredicateFuncs(c.cloudProvider), predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return !equality.Semantic.DeepEqual(e.ObjectOld.(*corev1.Node).Status.Conditions, e.ObjectNew.(*corev1.Node).Status.Conditions)
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool { return true },
+		})).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))
 }
 
@@ -104,7 +111,7 @@ func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcil
 			return reconcile.Result{}, client.IgnoreNotFound(err)
 		}
 		if !nodePoolHealthy {
-			return reconcile.Result{}, c.publishNodePoolHealthEvent(ctx, node, nodeClaim, nodePoolName)
+			return reconcile.Result{RequeueAfter: 5 * time.Minute}, c.publishNodePoolHealthEvent(ctx, node, nodeClaim, nodePoolName)
 		}
 	} else {
 		clusterHealthy, err := c.isClusterHealthy(ctx)
@@ -113,7 +120,7 @@ func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcil
 		}
 		if !clusterHealthy {
 			c.recorder.Publish(NodeRepairBlockedUnmanagedNodeClaim(node, nodeClaim, fmt.Sprintf("more then %s nodes are unhealthy in the cluster", allowedUnhealthyPercent.String()))...)
-			return reconcile.Result{}, nil
+			return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 		}
 	}
 	// For unhealthy past the tolerationDisruption window we can forcefully terminate the node

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -290,7 +290,7 @@ var _ = Describe("Node Health", func() {
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
 		})
-		It("should ignore unhealthy nodes if more then 20% of the nodes are unhealthy", func() {
+		It("should ignore unhealthy nodes if more then 20% of the nodes are unhealthy in a nodepool", func() {
 			ExpectApplied(ctx, env.Client, nodePool)
 			nodeClaims := []*v1.NodeClaim{}
 			nodes := []*corev1.Node{}
@@ -312,9 +312,42 @@ var _ = Describe("Node Health", func() {
 
 			fakeClock.Step(60 * time.Minute)
 
-			// Determine to delete unhealthy nodes
+			// Determine if we should delete unhealthy nodes
 			for i := range 4 {
-				ExpectObjectReconciled(ctx, env.Client, healthController, nodes[i])
+				result := ExpectObjectReconciled(ctx, env.Client, healthController, nodes[i])
+				if i < 3 {
+					Expect(result.RequeueAfter).To(BeNumerically("~", time.Minute*5, time.Second))
+				}
+				nodeClaim = ExpectExists(ctx, env.Client, nodeClaims[i])
+				Expect(nodeClaim.DeletionTimestamp).To(BeNil())
+			}
+		})
+		It("should ignore unhealthy nodes if more then 20% of the nodes are unhealthy in a cluster", func() {
+			ExpectApplied(ctx, env.Client, nodePool)
+			nodeClaims := []*v1.NodeClaim{}
+			nodes := []*corev1.Node{}
+			for i := range 10 {
+				nodeClaim, node = test.NodeClaimAndNode(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{v1.TerminationFinalizer}}})
+				if i < 3 {
+					node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+						Type:               "BadNode",
+						Status:             corev1.ConditionFalse,
+						LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+					})
+				}
+				nodeClaims = append(nodeClaims, nodeClaim)
+				nodes = append(nodes, node)
+				ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			}
+
+			fakeClock.Step(60 * time.Minute)
+
+			// Determine if we should delete unhealthy nodes
+			for i := range 4 {
+				result := ExpectObjectReconciled(ctx, env.Client, healthController, nodes[i])
+				if i < 3 {
+					Expect(result.RequeueAfter).To(BeNumerically("~", time.Minute*5, time.Second))
+				}
 				nodeClaim = ExpectExists(ctx, env.Client, nodeClaims[i])
 				Expect(nodeClaim.DeletionTimestamp).To(BeNil())
 			}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Implemented 5-minute requeue interval when >20% of node pools or clusters are unhealthy
- Added filtering to process node updates only when status conditions change
- Added unit tests to verify node disruption protection when cluster health is degraded (>20% unhealthy)

**How was this change tested?**
- Unit tests verify nodes are not disrupted when cluster health threshold is exceeded
- Validated requeue behavior with unhealthy node pools

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
