### PR TITLE
chore: Avoid validating admission policy for clusters older then 1.30

### DIFF
--- a/.github/actions/install-prometheus/values.yaml
+++ b/.github/actions/install-prometheus/values.yaml
@@ -41,6 +41,7 @@ kubelet:
       scrape: enabled
 prometheus:
   prometheusSpec:
+    maximumStartupDurationSeconds: 60
     tolerations:
       - key: CriticalAddonsOnly
         operator: Exists


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Add maximumStartupDurationSeconds to fix the following error:
```
Error: 1 error occurred:
	* Prometheus.monitoring.coreos.com "prometheus-kube-prometheus-prometheus" is invalid: spec.maximumStartupDurationSeconds: Invalid value: 0: spec.maximumStartupDurationSeconds in body should be greater than or equal to 60
``` 
- Avoid cleaning up `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` as the v1 API is not present for clusters older 1.30 

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
