### PR TITLE
feat: configure CRD status operator with larger histogram buckets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/awslabs/operatorpkg v0.0.0-20250616190804-f562c7d91bac
+	github.com/awslabs/operatorpkg v0.0.0-20250624064700-e9977193119b
 	github.com/docker/docker v28.2.2+incompatible
 	github.com/go-logr/logr v1.4.3
 	github.com/imdario/mergo v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/awslabs/operatorpkg v0.0.0-20250616190804-f562c7d91bac h1:mcvpCNR2Uz2C7104zp0m1sAkvwOYacGeNQyjevWOxLs=
-github.com/awslabs/operatorpkg v0.0.0-20250616190804-f562c7d91bac/go.mod h1:/zZATJDHdXVLFH8EIm292zuAyISzmC8enkO5nZ8F26o=
+github.com/awslabs/operatorpkg v0.0.0-20250624064700-e9977193119b h1:0yddGrvwF5JFzgIbiGw+oBVWftYp2VjvrPcj7jP9uXo=
+github.com/awslabs/operatorpkg v0.0.0-20250624064700-e9977193119b/go.mod h1:xBfJQWoAadppFHU2BBNkLAz/0BbCMrUC6jiDt2N7+bc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/awslabs/operatorpkg/controller"
 	"github.com/awslabs/operatorpkg/object"
 	"github.com/awslabs/operatorpkg/status"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -98,9 +99,25 @@ func NewControllers(
 		nodeclaimdisruption.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimhydration.NewController(kubeClient, cloudProvider),
 		nodehydration.NewController(kubeClient, cloudProvider),
-		status.NewController[*v1.NodeClaim](kubeClient, mgr.GetEventRecorderFor("karpenter"), status.EmitDeprecatedMetrics, status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey)...)),
-		status.NewController[*v1.NodePool](kubeClient, mgr.GetEventRecorderFor("karpenter"), status.EmitDeprecatedMetrics),
-		status.NewGenericObjectController[*corev1.Node](kubeClient, mgr.GetEventRecorderFor("karpenter"), status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey, v1.NodeInitializedLabelKey)...)),
+		status.NewController[*v1.NodeClaim](
+			kubeClient,
+			mgr.GetEventRecorderFor("karpenter"),
+			status.EmitDeprecatedMetrics,
+			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+			status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey)...),
+		),
+		status.NewController[*v1.NodePool](
+			kubeClient,
+			mgr.GetEventRecorderFor("karpenter"),
+			status.EmitDeprecatedMetrics,
+			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+		),
+		status.NewGenericObjectController[*corev1.Node](
+			kubeClient,
+			mgr.GetEventRecorderFor("karpenter"),
+			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+			status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey, v1.NodeInitializedLabelKey)...),
+		),
 	}
 
 	// The cloud provider must define status conditions for the node repair controller to use to detect unhealthy nodes


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**
The `operator_nodeclaim_status_condition_transition_seconds_bucket` and `operator_nodeclaim_termination_duration_seconds_bucket ` metrics emitted by Karpenter can be used to time the life-cycling of NodeClaim's and identifying potential bottlenecks.  Unfortunately they are configured with a default set of buckets that cap out at 5seconds.  This largely makes the metrics unusable.

https://github.com/awslabs/operatorpkg/pull/164 adds the ability to configure these buckets.  

This PR uses that configuration with 15 buckets increasing exponentially from 0.5 to 8192 (0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192).  Open to suggestions on a more suitable spread.

**How was this change tested?**
`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
