### PR TITLE
test: allow e2e tests to output junit report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,14 @@ apply-with-kind: verify build-with-kind ## Deploy the kwok controller from the c
 		--set-string controller.env[0].name=ENABLE_PROFILING \
 		--set-string controller.env[0].value=true
 
+JUNIT_REPORT := $(if $(ARTIFACT_DIR), --ginkgo.junit-report="$(ARTIFACT_DIR)/junit_report.xml")
 e2etests: ## Run the e2e suite against your local cluster
 	cd test && go test \
 		-count 1 \
 		-timeout 2h \
 		-v \
 		./suites/$(shell echo $(TEST_SUITE) | tr A-Z a-z)/... \
+		$(JUNIT_REPORT) \
 		--ginkgo.focus="${FOCUS}" \
 		--ginkgo.skip="${SKIP}" \
 		--ginkgo.timeout=2h \


### PR DESCRIPTION
Fixes #N/A 

**Description**
Adds the ability to specify `ARTIFACT_DIR` in the `Makefile` which allows e2e tests to output a `junit_report.xml` file to it, if `ARTIFACT_DIR` is specified.

**How was this change tested?**
Running
```bash
ARTIFACT_DIR=some_dir make e2etests
```
on a kind cluster with all prerequisite steps (`make install-kwok`, `make apply-with-kind`, etc.).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
