### PR TITLE
fix: add helm rbac for kwok-provider to update finalizers

### DIFF
--- a/kwok/charts/templates/clusterrole.yaml
+++ b/kwok/charts/templates/clusterrole.yaml
@@ -49,10 +49,10 @@ rules:
     verbs: ["get", "list", "watch"]
   # Write
   - apiGroups: ["karpenter.sh"]
-    resources: ["nodeclaims", "nodeclaims/status"]
+    resources: ["nodeclaims", "nodeclaims/status", "nodeclaims/finalizers"]
     verbs: ["create", "delete", "update", "patch"]
   - apiGroups: ["karpenter.sh"]
-    resources: ["nodepools", "nodepools/status"]
+    resources: ["nodepools", "nodepools/status", "nodepools/finalizers"]
     verbs: ["update", "patch"]
   - apiGroups: [""]
     resources: ["events"]


### PR DESCRIPTION
This commit adds additional rbac rules to allow the kwok-provider when deployed with Helm to patch `nodeclaims` and `nodepools` finalizers. This is needed for kwok-provider to work on clusters that have the `OwnerReferencesPermissionEnforcement` admission webhook enabled (e.g., OpenShift).

Fixes #2323

**Description**

**How was this change tested?**
Installed a kind cluster with this config:
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  kubeadmConfigPatches:
  - |
    kind: ClusterConfiguration
    apiServer:
        extraArgs:
          enable-admission-plugins: OwnerReferencesPermissionEnforcement,CertificateApproval,CertificateSigning,CertificateSubjectRestriction,DefaultIngressClass,DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,PersistentVolumeClaimResize,PodSecurity,Priority,ResourceQuota,RuntimeClass,ServiceAccount,StorageObjectInUseProtection,TaintNodesByCondition,ValidatingAdmissionPolicy,ValidatingAdmissionWebhook
```
then did
```bash
make toolchain
make install-kwok
make apply-with-kind
kubectl taint nodes --all CriticalAddonsOnly:NoSchedule --overwrite
make e2etests
```
which failed because of the permissions errors.

Running the above steps with this fix, gets rid of the errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
