### PR TITLE
fix: Fix re-retrieving object on retry

### DIFF
--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -486,44 +486,44 @@ func RequireNoScheduleTaint(ctx context.Context, kubeClient client.Client, addTa
 			return
 		}
 		node := &corev1.Node{}
-		if err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return client.IgnoreNotFound(err) != nil }, func() error { return kubeClient.Get(ctx, client.ObjectKey{Name: nodes[i].Node.Name}, node) }); err != nil {
+		if err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return client.IgnoreNotFound(err) != nil }, func() error {
+			if e := kubeClient.Get(ctx, client.ObjectKey{Name: nodes[i].Node.Name}, node); e != nil {
+				return e
+			}
+			// If the node already has the taint, continue to the next
+			_, hasTaint := lo.Find(node.Spec.Taints, func(taint corev1.Taint) bool {
+				return taint.MatchTaint(&v1.DisruptedNoScheduleTaint)
+			})
+			// Node is being deleted, so no need to remove taint as the node will be gone soon.
+			// This ensures that the disruption controller doesn't modify taints that the Termination
+			// controller is also modifying
+			if hasTaint && !node.DeletionTimestamp.IsZero() {
+				return nil
+			}
+			stored := node.DeepCopy()
+			// If the taint is present and we want to remove the taint, remove it.
+			if !addTaint {
+				node.Spec.Taints = lo.Reject(node.Spec.Taints, func(taint corev1.Taint, _ int) bool {
+					return taint.MatchTaint(&v1.DisruptedNoScheduleTaint)
+				})
+				// otherwise, add it.
+			} else if addTaint && !hasTaint {
+				// If the taint key is present (but with a different value or effect), remove it.
+				node.Spec.Taints = lo.Reject(node.Spec.Taints, func(taint corev1.Taint, _ int) bool {
+					return taint.MatchTaint(&v1.DisruptedNoScheduleTaint)
+				})
+				node.Spec.Taints = append(node.Spec.Taints, v1.DisruptedNoScheduleTaint)
+			}
+			if !equality.Semantic.DeepEqual(stored, node) {
+				// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
+				// can cause races due to the fact that it fully replaces the list on a change
+				// Here, we are updating the taint list
+				return kubeClient.Patch(ctx, node, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{}))
+			}
+			return nil
+		}); err != nil {
 			errs[i] = client.IgnoreNotFound(fmt.Errorf("getting node, %w", err))
 			return
-		}
-		// If the node already has the taint, continue to the next
-		_, hasTaint := lo.Find(node.Spec.Taints, func(taint corev1.Taint) bool {
-			return taint.MatchTaint(&v1.DisruptedNoScheduleTaint)
-		})
-		// Node is being deleted, so no need to remove taint as the node will be gone soon.
-		// This ensures that the disruption controller doesn't modify taints that the Termination
-		// controller is also modifying
-		if hasTaint && !node.DeletionTimestamp.IsZero() {
-			return
-		}
-		stored := node.DeepCopy()
-		// If the taint is present and we want to remove the taint, remove it.
-		if !addTaint {
-			node.Spec.Taints = lo.Reject(node.Spec.Taints, func(taint corev1.Taint, _ int) bool {
-				return taint.MatchTaint(&v1.DisruptedNoScheduleTaint)
-			})
-			// otherwise, add it.
-		} else if addTaint && !hasTaint {
-			// If the taint key is present (but with a different value or effect), remove it.
-			node.Spec.Taints = lo.Reject(node.Spec.Taints, func(taint corev1.Taint, _ int) bool {
-				return taint.MatchTaint(&v1.DisruptedNoScheduleTaint)
-			})
-			node.Spec.Taints = append(node.Spec.Taints, v1.DisruptedNoScheduleTaint)
-		}
-		if !equality.Semantic.DeepEqual(stored, node) {
-			// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
-			// can cause races due to the fact that it fully replaces the list on a change
-			// Here, we are updating the taint list
-			if err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return client.IgnoreNotFound(err) != nil }, func() error {
-				return kubeClient.Patch(ctx, node, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{}))
-			}); err != nil {
-				errs[i] = client.IgnoreNotFound(serrors.Wrap(fmt.Errorf("patching node, %w", err), "Node", klog.KObj(node)))
-				return
-			}
 		}
 	})
 	return multierr.Combine(errs...)
@@ -538,22 +538,20 @@ func ClearNodeClaimsCondition(ctx context.Context, kubeClient client.Client, con
 		}
 		nodeClaim := &v1.NodeClaim{}
 		if err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return client.IgnoreNotFound(err) != nil }, func() error {
-			return kubeClient.Get(ctx, client.ObjectKeyFromObject(nodes[i].NodeClaim), nodeClaim)
+			if e := kubeClient.Get(ctx, client.ObjectKeyFromObject(nodes[i].NodeClaim), nodeClaim); e != nil {
+				return e
+			}
+			stored := nodeClaim.DeepCopy()
+			_ = nodeClaim.StatusConditions().Clear(conditionType)
+			if !equality.Semantic.DeepEqual(stored, nodeClaim) {
+				return kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{}))
+			}
+			return nil
 		}); err != nil {
 			errs[i] = client.IgnoreNotFound(err)
 			return
 		}
-		stored := nodeClaim.DeepCopy()
-		_ = nodeClaim.StatusConditions().Clear(conditionType)
 
-		if !equality.Semantic.DeepEqual(stored, nodeClaim) {
-			if err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return client.IgnoreNotFound(err) != nil }, func() error {
-				return kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{}))
-			}); err != nil {
-				errs[i] = client.IgnoreNotFound(err)
-				return
-			}
-		}
 	})
 	return multierr.Combine(errs...)
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change ensures that we re-grab the object when doing retries in-code rather than continually trying to patch with an old version of the object

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
