### PR TITLE
docs: Add Oracle Cloud Infrastructure (OCI) provider 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Karpenter is a multi-cloud project with implementations by the following cloud p
 - [Cluster API](https://github.com/kubernetes-sigs/karpenter-provider-cluster-api)
 - [GCP](https://github.com/cloudpilot-ai/karpenter-provider-gcp)
 - [Proxmox](https://github.com/sergelogvinov/karpenter-provider-proxmox)
+- [Oracle Cloud Infrastructure (OCI)](https://github.com/zoom/karpenter-oci)
 
 ## Community, discussion, contribution, and support
 

--- a/designs/capacity-reservations.md
+++ b/designs/capacity-reservations.md
@@ -10,6 +10,7 @@ Cloud providers including GCP, Azure, and AWS allow you to pre-reserve VM (or ba
 > 1. GCP: Reservations - https://cloud.google.com/compute/docs/instances/reservations-overview
 > 2. Azure: Capacity Reservations - https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview
 > 3. AWS: Capacity Reservations - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html
+> 4. Oracle Cloud Infrastructure (OCI): Capacity Reservations - https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/reserve-capacity.htm
 
 Karpenter doesn't currently support reasoning about this capacity type. Karpenter may need to be aware about this as a separate capacity type from on-demand for a few reasons:
 1. Reservations are pre-paid -- meaning that if a user opts-in to Karpenter using that instance type, it's always preferable to use the reservation before launching capacity outside the reservation

--- a/designs/kwok-provider.md
+++ b/designs/kwok-provider.md
@@ -43,6 +43,7 @@ The pricing for each of the instance types will be a function of the size and ca
 AWS: Discount is [< 90%](https://aws.amazon.com/ec2/spot/pricing/#:~:text=Spot%20Instances%20are%20available%20at%20a%20discount%20of%20up%20to%2090%25%20off%20compared%20to%20On%2DDemand%20pricing.)
 AKS: Discount is [48-90%](https://azure.microsoft.com/en-us/pricing/details/virtual-machine-scale-sets/linux/)
 GCE: Discount is [60-91%](https://cloud.google.com/compute/docs/instances/create-use-spot#:~:text=Spot%20VMs%20are%20available%20at%20a%2060%2D91%25%20discount%20compared%20to%20the%20price%20of%20standard%20VMs.)
+OCI: Discount is [50%](https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/preemptible.htm)
 
 We'll define the pricing functions:
 


### PR DESCRIPTION
**Description**
Add Oracle Cloud Infrastructure (OCI) provider on docs

**How was this change tested?**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
