### PR TITLE
fix: add missing rlock to disruption queue

### DIFF
--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -125,7 +125,9 @@ func (q *Queue) Register(_ context.Context, m manager.Manager) error {
 
 func (q *Queue) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
 	ctx = injection.WithControllerName(ctx, "disruption.queue")
+	q.RLock()
 	cmd, exists := q.providerIDToCommand[nodeClaim.Status.ProviderID]
+	q.RUnlock()
 	if !exists {
 		log.FromContext(ctx).Error(fmt.Errorf("no command found"), "")
 		return reconcile.Result{}, nil


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Without this RLock on the map, there is a chance for a concurrent read\write


**How was this change tested?**

`make presubmit`, and deployed to a test cluster and drifted successfully

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
