### PR TITLE
feat: (BREAKING) addition of launch timeout for nodeclaim lifecycle

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -18,6 +18,7 @@ package lifecycle
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -39,10 +40,32 @@ type Liveness struct {
 	kubeClient client.Client
 }
 
-// registrationTTL is a heuristic time that we expect the node to register within
+// registrationTimeout is a heuristic time that we expect the node to register within
+// launchTimeout is a heuristic time that we expect to be able to launch within
 // If we don't see the node within this time, then we should delete the NodeClaim and try again
-const registrationTTL = time.Minute * 15
-const launchTTL = time.Minute * 5
+
+const (
+	registrationTimeout       = time.Minute * 15
+	registrationTimeoutReason = "registration_timeout"
+	launchTimeout             = time.Minute * 5
+	launchTimeoutReason       = "launch_timeout"
+)
+
+type NodeClaimTimeout struct {
+	duration time.Duration
+	reason   string
+}
+
+var (
+	RegistrationTimeout = NodeClaimTimeout{
+		duration: registrationTimeout,
+		reason:   registrationTimeoutReason,
+	}
+	LaunchTimeout = NodeClaimTimeout{
+		duration: launchTimeout,
+		reason:   launchTimeoutReason,
+	}
+)
 
 func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
 	registered := nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered)
@@ -53,18 +76,18 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 	if launched == nil {
 		return reconcile.Result{Requeue: true}, nil
 	}
-	if ttl := launchTTL - l.clock.Since(launched.LastTransitionTime.Time); ttl <= 0 {
-		if err := l.deleteNodeClaimForTTL(ctx, "launch_ttl", nodeClaim); err != nil {
+	if Timeout := launchTimeout - l.clock.Since(launched.LastTransitionTime.Time); Timeout <= 0 {
+		if err := l.deleteNodeClaimForTimeout(ctx, LaunchTimeout, nodeClaim); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 	if registered == nil {
 		return reconcile.Result{Requeue: true}, nil
 	}
-	// If the Registered statusCondition hasn't gone True during the TTL since we first updated it, we should terminate the NodeClaim
-	// NOTE: ttl has to be stored and checked in the same place since l.clock can advance after the check causing a race
-	if ttl := registrationTTL - l.clock.Since(registered.LastTransitionTime.Time); ttl > 0 {
-		return reconcile.Result{RequeueAfter: ttl}, nil
+	// If the Registered statusCondition hasn't gone True during the Timeout since we first updated it, we should terminate the NodeClaim
+	// NOTE: Timeout has to be stored and checked in the same place since l.clock can advance after the check causing a race
+	if timeout := registrationTimeout - l.clock.Since(registered.LastTransitionTime.Time); timeout > 0 {
+		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 	if err := l.updateNodePoolRegistrationHealth(ctx, nodeClaim); client.IgnoreNotFound(err) != nil {
 		if errors.IsConflict(err) {
@@ -73,7 +96,7 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 		return reconcile.Result{}, err
 	}
 	// Delete the NodeClaim if we believe the NodeClaim won't register since we haven't seen the node
-	if err := l.deleteNodeClaimForTTL(ctx, "liveness", nodeClaim); err != nil {
+	if err := l.deleteNodeClaimForTimeout(ctx, RegistrationTimeout, nodeClaim); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
@@ -90,7 +113,7 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 		}
 		if nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown() {
 			stored := nodePool.DeepCopy()
-			// If the nodeClaim failed to register during the TTL set NodeRegistrationHealthy status condition on
+			// If the nodeClaim failed to register during the Timeout set NodeRegistrationHealthy status condition on
 			// NodePool to False. If the launch failed get the launch failure reason and message from nodeClaim.
 			if launchCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched); launchCondition.IsTrue() {
 				nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "RegistrationFailed", "Failed to register node")
@@ -108,13 +131,13 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 	return nil
 }
 
-func (l *Liveness) deleteNodeClaimForTTL(ctx context.Context, reason string, nodeClaim *v1.NodeClaim) error {
+func (l *Liveness) deleteNodeClaimForTimeout(ctx context.Context, timeout NodeClaimTimeout, nodeClaim *v1.NodeClaim) error {
 	if err := l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	log.FromContext(ctx).V(1).WithValues("ttl", registrationTTL).Info("terminating due to registration ttl")
+	log.FromContext(ctx).V(1).WithValues("timeout", timeout.duration).Info(fmt.Sprintf("terminating due to %s timeout", timeout.reason))
 	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-		metrics.ReasonLabel:       reason,
+		metrics.ReasonLabel:       timeout.reason,
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
 	})

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -75,7 +75,10 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 	if launched == nil {
 		return reconcile.Result{Requeue: true}, nil
 	}
-	if timeUntilTimeout := launchTimeout - l.clock.Since(launched.LastTransitionTime.Time); timeUntilTimeout <= 0 {
+	if !launched.IsTrue() {
+		if timeUntilTimeout := launchTimeout - l.clock.Since(launched.LastTransitionTime.Time); timeUntilTimeout > 0 {
+			return reconcile.Result{RequeueAfter: timeUntilTimeout}, nil
+		}
 		if err := l.deleteNodeClaimForTimeout(ctx, LaunchTimeout, nodeClaim); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -91,7 +91,7 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 	if registered == nil {
 		return reconcile.Result{Requeue: true}, nil
 	}
-	// If the Registered statusCondition hasn't gone True during the Timeout since we first updated it, we should terminate the NodeClaim
+	// If the Registered statusCondition hasn't gone True during the timeout since we first updated it, we should terminate the NodeClaim
 	// NOTE: Timeout has to be stored and checked in the same place since l.clock can advance after the check causing a race
 	if timeUntilTimeout := registrationTimeout - l.clock.Since(registered.LastTransitionTime.Time); timeUntilTimeout > 0 {
 		return reconcile.Result{RequeueAfter: timeUntilTimeout}, nil
@@ -123,7 +123,7 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 		}
 		if nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown() {
 			stored := nodePool.DeepCopy()
-			// If the nodeClaim failed to register during the Timeout set NodeRegistrationHealthy status condition on
+			// If the nodeClaim failed to register during the timeout set NodeRegistrationHealthy status condition on
 			// NodePool to False. If the launch failed get the launch failure reason and message from nodeClaim.
 			if launchCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched); launchCondition.IsTrue() {
 				nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "RegistrationFailed", "Failed to register node")

--- a/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
@@ -23,6 +23,7 @@ import (
 
 	operatorpkg "github.com/awslabs/operatorpkg/test/expectations"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -184,7 +185,7 @@ var _ = Describe("Liveness", func() {
 		// expect that the nodeclaim was not deleted
 		ExpectExists(ctx, env.Client, nodeClaim)
 	})
-	It("should use the status condition transition times for timeouts, not the creation timestamp", func() {
+	It("should use the status condition transition time for launch timeout, not the creation timestamp", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -202,6 +203,7 @@ var _ = Describe("Liveness", func() {
 				},
 			},
 		})
+		// the result cannot be tested with launch because if the launch fails the error is returned instead of requeue after
 		cloudProvider.AllowedCreateCalls = 0 // Don't allow Create() calls to succeed
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
@@ -215,9 +217,49 @@ var _ = Describe("Liveness", func() {
 		}
 		nodeClaim.Status.Conditions = newConditions
 		ExpectApplied(ctx, env.Client, nodeClaim)
-		// advance the clock to show that the timeout is not based on creation timestamp
+		// advance the clock to show that the timeout is not based on creation timestamp when considering launch timeout
 		fakeClock.Step(12 * time.Minute)
 		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
+
+		// expect that the nodeclaim was not deleted after the timeout
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+
+	It("should use the status condition transition time for registration timeout, not the creation timestamp", func() {
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey: nodePool.Name,
+				},
+			},
+			Spec: v1.NodeClaimSpec{
+				Resources: v1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:      resource.MustParse("2"),
+						corev1.ResourceMemory:   resource.MustParse("50Mi"),
+						corev1.ResourcePods:     resource.MustParse("5"),
+						fake.ResourceGPUVendorA: resource.MustParse("1"),
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+
+		conditions := nodeClaim.Status.Conditions
+		newConditions := make([]status.Condition, len(conditions))
+		for i, condition := range conditions {
+			condition.LastTransitionTime = metav1.NewTime(fakeClock.Now().Add(10 * time.Minute))
+			newConditions[i] = condition
+		}
+		nodeClaim.Status.Conditions = newConditions
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		// advance the clock to show that the timeout is not based on creation timestamp when considering registration timeout
+		fakeClock.Step(16 * time.Minute)
+		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		Expect(result.RequeueAfter).To(Not(Equal(0 * time.Second)))
+		Expect(result.RequeueAfter > 0*time.Second && result.RequeueAfter < 15*time.Minute).To(BeTrue())
 
 		// expect that the nodeclaim was not deleted after the timeout
 		ExpectExists(ctx, env.Client, nodeClaim)

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -225,13 +225,6 @@ func ExpectObjectReconcileFailed[T client.Object](ctx context.Context, c client.
 	return err
 }
 
-func ExpectObjectReconciledWithError[T client.Object](ctx context.Context, c client.Client, reconciler reconcile.ObjectReconciler[T], object T) (reconcile.Result, error) {
-	GinkgoHelper()
-	result, err := reconcile.AsReconciler(c, reconciler).Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(object)})
-	Expect(err).To(HaveOccurred())
-	return result, err
-}
-
 // ExpectDeletionTimestampSetWithOffset ensures that the deletion timestamp is set on the objects by adding a finalizer
 // and then deleting the object immediately after. This holds the object until the finalizer is patched out in the DeferCleanup
 func ExpectDeletionTimestampSet(ctx context.Context, c client.Client, objects ...client.Object) {

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -225,6 +225,13 @@ func ExpectObjectReconcileFailed[T client.Object](ctx context.Context, c client.
 	return err
 }
 
+func ExpectObjectReconciledWithError[T client.Object](ctx context.Context, c client.Client, reconciler reconcile.ObjectReconciler[T], object T) (reconcile.Result, error) {
+	GinkgoHelper()
+	result, err := reconcile.AsReconciler(c, reconciler).Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(object)})
+	Expect(err).To(HaveOccurred())
+	return result, err
+}
+
 // ExpectDeletionTimestampSetWithOffset ensures that the deletion timestamp is set on the objects by adding a finalizer
 // and then deleting the object immediately after. This holds the object until the finalizer is patched out in the DeferCleanup
 func ExpectDeletionTimestampSet(ctx context.Context, c client.Client, objects ...client.Object) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
If Karpenter encounters issues launching instances then we should retry for a shorter amount of time than the full registration timeout. This unblocks provisioning decisions for pods that may be stuck waiting for compute that will not come up due to launch failures. This also allows Karpenter to make new decisions about what compute should be provisioned.

## BREAKING
This PR changes an alpha metric for nodeclaim disruptions. The metric reason `liveness` will change to `registration_timeout`.

**How was this change tested?**
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
