### PR TITLE
perf: Add flag to disable costly metrics controllers

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -98,7 +98,7 @@ func NewControllers(
 		nodehydration.NewController(kubeClient, cloudProvider),
 	}
 
-	if !options.FromContext(ctx).SimplifiedMetrics {
+	if !options.FromContext(ctx).DisableClusterStateObservability {
 		controllers = append(controllers,
 			metricspod.NewController(kubeClient, cluster),
 			metricsnodepool.NewController(kubeClient, cloudProvider),

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -64,28 +64,28 @@ type FeatureGates struct {
 
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
 type Options struct {
-	ServiceName             string
-	MetricsPort             int
-	HealthProbePort         int
-	KubeClientQPS           int
-	KubeClientBurst         int
-	EnableProfiling         bool
-	DisableLeaderElection   bool
-	LeaderElectionName      string
-	LeaderElectionNamespace string
-	MemoryLimit             int64
-	CPURequests             int64
-	LogLevel                string
-	LogOutputPaths          string
-	LogErrorOutputPaths     string
-	BatchMaxDuration        time.Duration
-	BatchIdleDuration       time.Duration
-	preferencePolicyRaw     string
-	PreferencePolicy        PreferencePolicy
-	minValuesPolicyRaw      string
-	MinValuesPolicy         MinValuesPolicy
-	FeatureGates            FeatureGates
-	SimplifiedMetrics       bool
+	ServiceName                      string
+	MetricsPort                      int
+	HealthProbePort                  int
+	KubeClientQPS                    int
+	KubeClientBurst                  int
+	EnableProfiling                  bool
+	DisableLeaderElection            bool
+	DisableClusterStateObservability bool
+	LeaderElectionName               string
+	LeaderElectionNamespace          string
+	MemoryLimit                      int64
+	CPURequests                      int64
+	LogLevel                         string
+	LogOutputPaths                   string
+	LogErrorOutputPaths              string
+	BatchMaxDuration                 time.Duration
+	BatchIdleDuration                time.Duration
+	preferencePolicyRaw              string
+	PreferencePolicy                 PreferencePolicy
+	minValuesPolicyRaw               string
+	MinValuesPolicy                  MinValuesPolicy
+	FeatureGates                     FeatureGates
 }
 
 type FlagSet struct {
@@ -113,6 +113,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.IntVar(&o.KubeClientBurst, "kube-client-burst", env.WithDefaultInt("KUBE_CLIENT_BURST", 300), "The maximum allowed burst of queries to the kube-apiserver")
 	fs.BoolVarWithEnv(&o.EnableProfiling, "enable-profiling", "ENABLE_PROFILING", false, "Enable the profiling on the metric endpoint")
 	fs.BoolVarWithEnv(&o.DisableLeaderElection, "disable-leader-election", "DISABLE_LEADER_ELECTION", false, "Disable the leader election client before executing the main loop. Disable when running replicated components for high availability is not desired.")
+	fs.BoolVarWithEnv(&o.DisableClusterStateObservability, "disable-cluster-state-observability", "DISABLE_CLUSTER_STATE_OBSERVABILITY", false, "Disable cluster state metrics and events")
 	fs.StringVar(&o.LeaderElectionName, "leader-election-name", env.WithDefaultString("LEADER_ELECTION_NAME", "karpenter-leader-election"), "Leader election name to create and monitor the lease if running outside the cluster")
 	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", env.WithDefaultString("LEADER_ELECTION_NAMESPACE", ""), "Leader election namespace to create and monitor the lease if running outside the cluster")
 	fs.Int64Var(&o.MemoryLimit, "memory-limit", env.WithDefaultInt64("MEMORY_LIMIT", -1), "Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value.")
@@ -125,7 +126,6 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, and SpotToSpotConsolidation.")
-	fs.BoolVarWithEnv(&o.SimplifiedMetrics, "simplified-metrics", "SIMPLIFIED_METRICS", false, "Optionally disable generic cluster state metrics")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Options", func() {
 		"KUBE_CLIENT_BURST",
 		"ENABLE_PROFILING",
 		"DISABLE_LEADER_ELECTION",
+		"DISABLE_CLUSTER_STATE_OBSERVABILITY",
 		"LEADER_ELECTION_NAMESPACE",
 		"MEMORY_LIMIT",
 		"LOG_LEVEL",
@@ -99,23 +100,24 @@ var _ = Describe("Options", func() {
 			err := opts.Parse(fs)
 			Expect(err).To(BeNil())
 			expectOptionsMatch(opts, test.Options(test.OptionsFields{
-				ServiceName:             lo.ToPtr(""),
-				MetricsPort:             lo.ToPtr(8080),
-				HealthProbePort:         lo.ToPtr(8081),
-				KubeClientQPS:           lo.ToPtr(200),
-				KubeClientBurst:         lo.ToPtr(300),
-				EnableProfiling:         lo.ToPtr(false),
-				DisableLeaderElection:   lo.ToPtr(false),
-				LeaderElectionName:      lo.ToPtr("karpenter-leader-election"),
-				LeaderElectionNamespace: lo.ToPtr(""),
-				MemoryLimit:             lo.ToPtr[int64](-1),
-				LogLevel:                lo.ToPtr("info"),
-				LogOutputPaths:          lo.ToPtr("stdout"),
-				LogErrorOutputPaths:     lo.ToPtr("stderr"),
-				BatchMaxDuration:        lo.ToPtr(10 * time.Second),
-				BatchIdleDuration:       lo.ToPtr(time.Second),
-				PreferencePolicy:        lo.ToPtr(options.PreferencePolicyRespect),
-				MinValuesPolicy:         lo.ToPtr(options.MinValuesPolicyStrict),
+				ServiceName:                      lo.ToPtr(""),
+				MetricsPort:                      lo.ToPtr(8080),
+				HealthProbePort:                  lo.ToPtr(8081),
+				KubeClientQPS:                    lo.ToPtr(200),
+				KubeClientBurst:                  lo.ToPtr(300),
+				EnableProfiling:                  lo.ToPtr(false),
+				DisableLeaderElection:            lo.ToPtr(false),
+				DisableClusterStateObservability: lo.ToPtr(false),
+				LeaderElectionName:               lo.ToPtr("karpenter-leader-election"),
+				LeaderElectionNamespace:          lo.ToPtr(""),
+				MemoryLimit:                      lo.ToPtr[int64](-1),
+				LogLevel:                         lo.ToPtr("info"),
+				LogOutputPaths:                   lo.ToPtr("stdout"),
+				LogErrorOutputPaths:              lo.ToPtr("stderr"),
+				BatchMaxDuration:                 lo.ToPtr(10 * time.Second),
+				BatchIdleDuration:                lo.ToPtr(time.Second),
+				PreferencePolicy:                 lo.ToPtr(options.PreferencePolicyRespect),
+				MinValuesPolicy:                  lo.ToPtr(options.MinValuesPolicyStrict),
 				FeatureGates: test.FeatureGates{
 					ReservedCapacity:        lo.ToPtr(true),
 					NodeRepair:              lo.ToPtr(false),
@@ -137,6 +139,7 @@ var _ = Describe("Options", func() {
 				"--kube-client-burst", "0",
 				"--enable-profiling",
 				"--disable-leader-election=true",
+				"--disable-cluster-state-observability=true",
 				"--leader-election-name=karpenter-controller",
 				"--leader-election-namespace=karpenter",
 				"--memory-limit", "0",
@@ -151,23 +154,24 @@ var _ = Describe("Options", func() {
 			)
 			Expect(err).To(BeNil())
 			expectOptionsMatch(opts, test.Options(test.OptionsFields{
-				ServiceName:             lo.ToPtr("cli"),
-				MetricsPort:             lo.ToPtr(0),
-				HealthProbePort:         lo.ToPtr(0),
-				KubeClientQPS:           lo.ToPtr(0),
-				KubeClientBurst:         lo.ToPtr(0),
-				EnableProfiling:         lo.ToPtr(true),
-				DisableLeaderElection:   lo.ToPtr(true),
-				LeaderElectionName:      lo.ToPtr("karpenter-controller"),
-				LeaderElectionNamespace: lo.ToPtr("karpenter"),
-				MemoryLimit:             lo.ToPtr[int64](0),
-				LogLevel:                lo.ToPtr("debug"),
-				LogOutputPaths:          lo.ToPtr("/etc/k8s/test"),
-				LogErrorOutputPaths:     lo.ToPtr("/etc/k8s/testerror"),
-				BatchMaxDuration:        lo.ToPtr(5 * time.Second),
-				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
-				PreferencePolicy:        lo.ToPtr(options.PreferencePolicyIgnore),
-				MinValuesPolicy:         lo.ToPtr(options.MinValuesPolicyBestEffort),
+				ServiceName:                      lo.ToPtr("cli"),
+				MetricsPort:                      lo.ToPtr(0),
+				HealthProbePort:                  lo.ToPtr(0),
+				KubeClientQPS:                    lo.ToPtr(0),
+				KubeClientBurst:                  lo.ToPtr(0),
+				EnableProfiling:                  lo.ToPtr(true),
+				DisableLeaderElection:            lo.ToPtr(true),
+				DisableClusterStateObservability: lo.ToPtr(true),
+				LeaderElectionName:               lo.ToPtr("karpenter-controller"),
+				LeaderElectionNamespace:          lo.ToPtr("karpenter"),
+				MemoryLimit:                      lo.ToPtr[int64](0),
+				LogLevel:                         lo.ToPtr("debug"),
+				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
+				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
+				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
+				BatchIdleDuration:                lo.ToPtr(5 * time.Second),
+				PreferencePolicy:                 lo.ToPtr(options.PreferencePolicyIgnore),
+				MinValuesPolicy:                  lo.ToPtr(options.MinValuesPolicyBestEffort),
 				FeatureGates: test.FeatureGates{
 					ReservedCapacity:        lo.ToPtr(false),
 					NodeRepair:              lo.ToPtr(true),
@@ -185,6 +189,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("KUBE_CLIENT_BURST", "0")
 			os.Setenv("ENABLE_PROFILING", "true")
 			os.Setenv("DISABLE_LEADER_ELECTION", "true")
+			os.Setenv("DISABLE_CLUSTER_STATE_OBSERVABILITY", "true")
 			os.Setenv("LEADER_ELECTION_NAME", "karpenter-controller")
 			os.Setenv("LEADER_ELECTION_NAMESPACE", "karpenter")
 			os.Setenv("MEMORY_LIMIT", "0")
@@ -203,23 +208,24 @@ var _ = Describe("Options", func() {
 			err := opts.Parse(fs)
 			Expect(err).To(BeNil())
 			expectOptionsMatch(opts, test.Options(test.OptionsFields{
-				ServiceName:             lo.ToPtr("env"),
-				MetricsPort:             lo.ToPtr(0),
-				HealthProbePort:         lo.ToPtr(0),
-				KubeClientQPS:           lo.ToPtr(0),
-				KubeClientBurst:         lo.ToPtr(0),
-				EnableProfiling:         lo.ToPtr(true),
-				DisableLeaderElection:   lo.ToPtr(true),
-				LeaderElectionName:      lo.ToPtr("karpenter-controller"),
-				LeaderElectionNamespace: lo.ToPtr("karpenter"),
-				MemoryLimit:             lo.ToPtr[int64](0),
-				LogLevel:                lo.ToPtr("debug"),
-				LogOutputPaths:          lo.ToPtr("/etc/k8s/test"),
-				LogErrorOutputPaths:     lo.ToPtr("/etc/k8s/testerror"),
-				BatchMaxDuration:        lo.ToPtr(5 * time.Second),
-				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
-				PreferencePolicy:        lo.ToPtr(options.PreferencePolicyIgnore),
-				MinValuesPolicy:         lo.ToPtr(options.MinValuesPolicyBestEffort),
+				ServiceName:                      lo.ToPtr("env"),
+				MetricsPort:                      lo.ToPtr(0),
+				HealthProbePort:                  lo.ToPtr(0),
+				KubeClientQPS:                    lo.ToPtr(0),
+				KubeClientBurst:                  lo.ToPtr(0),
+				EnableProfiling:                  lo.ToPtr(true),
+				DisableLeaderElection:            lo.ToPtr(true),
+				DisableClusterStateObservability: lo.ToPtr(true),
+				LeaderElectionName:               lo.ToPtr("karpenter-controller"),
+				LeaderElectionNamespace:          lo.ToPtr("karpenter"),
+				MemoryLimit:                      lo.ToPtr[int64](0),
+				LogLevel:                         lo.ToPtr("debug"),
+				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
+				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
+				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
+				BatchIdleDuration:                lo.ToPtr(5 * time.Second),
+				PreferencePolicy:                 lo.ToPtr(options.PreferencePolicyIgnore),
+				MinValuesPolicy:                  lo.ToPtr(options.MinValuesPolicyBestEffort),
 				FeatureGates: test.FeatureGates{
 					ReservedCapacity:        lo.ToPtr(false),
 					NodeRepair:              lo.ToPtr(true),
@@ -236,6 +242,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("KUBE_CLIENT_BURST", "0")
 			os.Setenv("ENABLE_PROFILING", "true")
 			os.Setenv("DISABLE_LEADER_ELECTION", "true")
+			os.Setenv("DISABLE_CLUSTER_STATE_OBSERVABILITY", "true")
 			os.Setenv("MEMORY_LIMIT", "0")
 			os.Setenv("LOG_LEVEL", "debug")
 			os.Setenv("BATCH_MAX_DURATION", "5s")
@@ -257,23 +264,24 @@ var _ = Describe("Options", func() {
 			)
 			Expect(err).To(BeNil())
 			expectOptionsMatch(opts, test.Options(test.OptionsFields{
-				ServiceName:             lo.ToPtr("cli"),
-				MetricsPort:             lo.ToPtr(0),
-				HealthProbePort:         lo.ToPtr(0),
-				KubeClientQPS:           lo.ToPtr(0),
-				KubeClientBurst:         lo.ToPtr(0),
-				EnableProfiling:         lo.ToPtr(true),
-				DisableLeaderElection:   lo.ToPtr(true),
-				LeaderElectionName:      lo.ToPtr("karpenter-leader-election"),
-				LeaderElectionNamespace: lo.ToPtr(""),
-				MemoryLimit:             lo.ToPtr[int64](0),
-				LogLevel:                lo.ToPtr("debug"),
-				LogOutputPaths:          lo.ToPtr("/etc/k8s/test"),
-				LogErrorOutputPaths:     lo.ToPtr("/etc/k8s/testerror"),
-				BatchMaxDuration:        lo.ToPtr(5 * time.Second),
-				BatchIdleDuration:       lo.ToPtr(5 * time.Second),
-				PreferencePolicy:        lo.ToPtr(options.PreferencePolicyRespect),
-				MinValuesPolicy:         lo.ToPtr(options.MinValuesPolicyStrict),
+				ServiceName:                      lo.ToPtr("cli"),
+				MetricsPort:                      lo.ToPtr(0),
+				HealthProbePort:                  lo.ToPtr(0),
+				KubeClientQPS:                    lo.ToPtr(0),
+				KubeClientBurst:                  lo.ToPtr(0),
+				EnableProfiling:                  lo.ToPtr(true),
+				DisableLeaderElection:            lo.ToPtr(true),
+				DisableClusterStateObservability: lo.ToPtr(true),
+				LeaderElectionName:               lo.ToPtr("karpenter-leader-election"),
+				LeaderElectionNamespace:          lo.ToPtr(""),
+				MemoryLimit:                      lo.ToPtr[int64](0),
+				LogLevel:                         lo.ToPtr("debug"),
+				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
+				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
+				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
+				BatchIdleDuration:                lo.ToPtr(5 * time.Second),
+				PreferencePolicy:                 lo.ToPtr(options.PreferencePolicyRespect),
+				MinValuesPolicy:                  lo.ToPtr(options.MinValuesPolicyStrict),
 				FeatureGates: test.FeatureGates{
 					ReservedCapacity:        lo.ToPtr(false),
 					NodeRepair:              lo.ToPtr(true),
@@ -355,6 +363,7 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.KubeClientBurst).To(Equal(optsB.KubeClientBurst))
 	Expect(optsA.EnableProfiling).To(Equal(optsB.EnableProfiling))
 	Expect(optsA.DisableLeaderElection).To(Equal(optsB.DisableLeaderElection))
+	Expect(optsA.DisableClusterStateObservability).To(Equal(optsB.DisableClusterStateObservability))
 	Expect(optsA.MemoryLimit).To(Equal(optsB.MemoryLimit))
 	Expect(optsA.LogLevel).To(Equal(optsB.LogLevel))
 	Expect(optsA.LogOutputPaths).To(Equal(optsB.LogOutputPaths))

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -28,25 +28,26 @@ import (
 
 type OptionsFields struct {
 	// Vendor Neutral
-	ServiceName             *string
-	MetricsPort             *int
-	HealthProbePort         *int
-	KubeClientQPS           *int
-	KubeClientBurst         *int
-	EnableProfiling         *bool
-	DisableLeaderElection   *bool
-	LeaderElectionName      *string
-	LeaderElectionNamespace *string
-	MemoryLimit             *int64
-	CPURequests             *int64
-	LogLevel                *string
-	LogOutputPaths          *string
-	LogErrorOutputPaths     *string
-	PreferencePolicy        *options.PreferencePolicy
-	MinValuesPolicy         *options.MinValuesPolicy
-	BatchMaxDuration        *time.Duration
-	BatchIdleDuration       *time.Duration
-	FeatureGates            FeatureGates
+	ServiceName                      *string
+	MetricsPort                      *int
+	HealthProbePort                  *int
+	KubeClientQPS                    *int
+	KubeClientBurst                  *int
+	EnableProfiling                  *bool
+	DisableLeaderElection            *bool
+	DisableClusterStateObservability *bool
+	LeaderElectionName               *string
+	LeaderElectionNamespace          *string
+	MemoryLimit                      *int64
+	CPURequests                      *int64
+	LogLevel                         *string
+	LogOutputPaths                   *string
+	LogErrorOutputPaths              *string
+	PreferencePolicy                 *options.PreferencePolicy
+	MinValuesPolicy                  *options.MinValuesPolicy
+	BatchMaxDuration                 *time.Duration
+	BatchIdleDuration                *time.Duration
+	FeatureGates                     FeatureGates
 }
 
 type FeatureGates struct {
@@ -65,22 +66,23 @@ func Options(overrides ...OptionsFields) *options.Options {
 	}
 
 	return &options.Options{
-		ServiceName:           lo.FromPtrOr(opts.ServiceName, ""),
-		MetricsPort:           lo.FromPtrOr(opts.MetricsPort, 8080),
-		HealthProbePort:       lo.FromPtrOr(opts.HealthProbePort, 8081),
-		KubeClientQPS:         lo.FromPtrOr(opts.KubeClientQPS, 200),
-		KubeClientBurst:       lo.FromPtrOr(opts.KubeClientBurst, 300),
-		EnableProfiling:       lo.FromPtrOr(opts.EnableProfiling, false),
-		DisableLeaderElection: lo.FromPtrOr(opts.DisableLeaderElection, false),
-		MemoryLimit:           lo.FromPtrOr(opts.MemoryLimit, -1),
-		CPURequests:           lo.FromPtrOr(opts.CPURequests, 5000), // use 5 threads to enforce parallelism
-		LogLevel:              lo.FromPtrOr(opts.LogLevel, ""),
-		LogOutputPaths:        lo.FromPtrOr(opts.LogOutputPaths, "stdout"),
-		LogErrorOutputPaths:   lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),
-		BatchMaxDuration:      lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
-		BatchIdleDuration:     lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
-		PreferencePolicy:      lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
-		MinValuesPolicy:       lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
+		ServiceName:                      lo.FromPtrOr(opts.ServiceName, ""),
+		MetricsPort:                      lo.FromPtrOr(opts.MetricsPort, 8080),
+		HealthProbePort:                  lo.FromPtrOr(opts.HealthProbePort, 8081),
+		KubeClientQPS:                    lo.FromPtrOr(opts.KubeClientQPS, 200),
+		KubeClientBurst:                  lo.FromPtrOr(opts.KubeClientBurst, 300),
+		EnableProfiling:                  lo.FromPtrOr(opts.EnableProfiling, false),
+		DisableLeaderElection:            lo.FromPtrOr(opts.DisableLeaderElection, false),
+		DisableClusterStateObservability: lo.FromPtrOr(opts.DisableClusterStateObservability, false),
+		MemoryLimit:                      lo.FromPtrOr(opts.MemoryLimit, -1),
+		CPURequests:                      lo.FromPtrOr(opts.CPURequests, 5000), // use 5 threads to enforce parallelism
+		LogLevel:                         lo.FromPtrOr(opts.LogLevel, ""),
+		LogOutputPaths:                   lo.FromPtrOr(opts.LogOutputPaths, "stdout"),
+		LogErrorOutputPaths:              lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),
+		BatchMaxDuration:                 lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
+		BatchIdleDuration:                lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
+		PreferencePolicy:                 lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
+		MinValuesPolicy:                  lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
 		FeatureGates: options.FeatureGates{
 			NodeRepair:              lo.FromPtrOr(opts.FeatureGates.NodeRepair, false),
 			ReservedCapacity:        lo.FromPtrOr(opts.FeatureGates.ReservedCapacity, true),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Metrics controllers can cause metric scrape timeouts at scale, this adds an optional feature flag to disable them

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
