### PR TITLE
fix: no longer allow the same hostname to take multiple capacity

### DIFF
--- a/pkg/controllers/provisioning/scheduling/reservationmanager.go
+++ b/pkg/controllers/provisioning/scheduling/reservationmanager.go
@@ -53,6 +53,7 @@ func NewReservationManager(instanceTypes map[string][]*cloudprovider.InstanceTyp
 	}
 }
 
+// Should always be idempotent
 func (rm *ReservationManager) CanReserve(hostname string, offering *cloudprovider.Offering) bool {
 	reservations, ok := rm.reservations[hostname]
 	if ok && reservations.Has(offering.ReservationID()) {
@@ -69,6 +70,7 @@ func (rm *ReservationManager) CanReserve(hostname string, offering *cloudprovide
 	return true
 }
 
+// Should always be idempotent
 func (rm *ReservationManager) Reserve(hostname string, offerings ...*cloudprovider.Offering) {
 	for _, of := range offerings {
 		reservations, ok := rm.reservations[hostname]
@@ -93,4 +95,16 @@ func (rm *ReservationManager) Release(hostname string, offerings ...*cloudprovid
 			rm.capacity[o.ReservationID()] += 1
 		}
 	}
+}
+
+func (rm *ReservationManager) HasReservation(hostname string, offering *cloudprovider.Offering) bool {
+	reservation, ok := rm.reservations[hostname]
+	if ok && reservation.Has(offering.ReservationID()) {
+		return true
+	}
+	return false
+}
+
+func (rm *ReservationManager) RemainingCapacity(offering *cloudprovider.Offering) int {
+	return rm.capacity[offering.ReservationID()]
 }

--- a/pkg/controllers/provisioning/scheduling/reservationmanager.go
+++ b/pkg/controllers/provisioning/scheduling/reservationmanager.go
@@ -71,11 +71,15 @@ func (rm *ReservationManager) CanReserve(hostname string, offering *cloudprovide
 
 func (rm *ReservationManager) Reserve(hostname string, offerings ...*cloudprovider.Offering) {
 	for _, of := range offerings {
+		reservations, ok := rm.reservations[hostname]
+		if ok && reservations.Has(of.ReservationID()) {
+			continue
+		}
 		rm.capacity[of.ReservationID()] -= 1
 		if rm.capacity[of.ReservationID()] < 0 {
 			panic(fmt.Sprintf("attempted to over-reserve an offering with reservation id %q", of.ReservationID()))
 		}
-		if _, ok := rm.reservations[hostname]; !ok {
+		if !ok {
 			rm.reservations[hostname] = sets.New[string]()
 		}
 		rm.reservations[hostname].Insert(of.ReservationID())

--- a/pkg/controllers/provisioning/scheduling/reservationmanager_test.go
+++ b/pkg/controllers/provisioning/scheduling/reservationmanager_test.go
@@ -1,0 +1,517 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
+	pscheduling "sigs.k8s.io/karpenter/pkg/scheduling"
+)
+
+var _ = Describe("ReservationManager", func() {
+	var rm *scheduling.ReservationManager
+	var offerings []cloudprovider.Offerings
+	var instanceTypes []*cloudprovider.InstanceType
+
+	BeforeEach(func() {
+		// Create hardcoded instance types with reserved offerings
+		instanceTypes = []*cloudprovider.InstanceType{
+			fake.NewInstanceType(fake.InstanceTypeOptions{
+				Name: "small-reserved",
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				},
+				Offerings: []*cloudprovider.Offering{
+					{
+						Available:           true,
+						ReservationCapacity: 3,
+						Requirements: pscheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
+							corev1.LabelTopologyZone:         "test-zone-1",
+							cloudprovider.ReservationIDLabel: "small-reserved",
+						}),
+					},
+				},
+			}),
+			fake.NewInstanceType(fake.InstanceTypeOptions{
+				Name: "medium-reserved",
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+					corev1.ResourcePods:   resource.MustParse("20"),
+				},
+				Offerings: []*cloudprovider.Offering{
+					{
+						Available:           true,
+						ReservationCapacity: 2,
+						Requirements: pscheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
+							corev1.LabelTopologyZone:         "test-zone-2",
+							cloudprovider.ReservationIDLabel: "medium-reserved",
+						}),
+					},
+				},
+			}),
+			fake.NewInstanceType(fake.InstanceTypeOptions{
+				Name: "large-reserved",
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+					corev1.ResourcePods:   resource.MustParse("40"),
+				},
+				Offerings: []*cloudprovider.Offering{
+					{
+						Available:           true,
+						ReservationCapacity: 1,
+						Requirements: pscheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
+							corev1.LabelTopologyZone:         "test-zone-3",
+							cloudprovider.ReservationIDLabel: "large-reserved",
+						}),
+					},
+				},
+			}),
+		}
+
+		// Extract offerings from instance types
+		offerings = nil // Reset offerings slice
+		for _, it := range instanceTypes {
+			offerings = append(offerings, it.Offerings)
+		}
+
+		rm = scheduling.NewReservationManager(map[string][]*cloudprovider.InstanceType{"": instanceTypes})
+	})
+
+	Describe("NewReservationManager", func() {
+		It("should handle empty instance types", func() {
+			emptyInstanceTypes := map[string][]*cloudprovider.InstanceType{}
+			emptyRM := scheduling.NewReservationManager(emptyInstanceTypes)
+			Expect(emptyRM).ToNot(BeNil())
+		})
+
+		It("should handle instance types without reserved offerings", func() {
+			nonReservedTypes := map[string][]*cloudprovider.InstanceType{
+				"nodepool-1": {
+					fake.NewInstanceType(fake.InstanceTypeOptions{
+						Name: "on-demand-only",
+						Offerings: []*cloudprovider.Offering{
+							{
+								Available: true,
+								Requirements: pscheduling.NewLabelRequirements(map[string]string{
+									v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand,
+								}),
+							},
+						},
+					}),
+				},
+			}
+			nonReservedRM := scheduling.NewReservationManager(nonReservedTypes)
+			Expect(nonReservedRM).ToNot(BeNil())
+		})
+
+		It("should track the minimum capacity when multiple offerings have the same reservation ID", func() {
+			duplicateReservationTypes := map[string][]*cloudprovider.InstanceType{
+				"nodepool-1": {
+					fake.NewInstanceType(fake.InstanceTypeOptions{
+						Name: "instance-1",
+						Offerings: []*cloudprovider.Offering{
+							{
+								Available:           true,
+								ReservationCapacity: 10,
+								Requirements: pscheduling.NewLabelRequirements(map[string]string{
+									v1.CapacityTypeLabelKey: v1.CapacityTypeReserved,
+								}),
+							},
+						},
+					}),
+					fake.NewInstanceType(fake.InstanceTypeOptions{
+						Name: "instance-2",
+						Offerings: []*cloudprovider.Offering{
+							{
+								Available:           true,
+								ReservationCapacity: 5, // Lower capacity should be tracked
+								Requirements: pscheduling.NewLabelRequirements(map[string]string{
+									v1.CapacityTypeLabelKey: v1.CapacityTypeReserved,
+								}),
+							},
+						},
+					}),
+				},
+			}
+			duplicateRM := scheduling.NewReservationManager(duplicateReservationTypes)
+			Expect(duplicateRM).ToNot(BeNil())
+		})
+	})
+
+	Describe("CanReserve", func() {
+		var testOffering *cloudprovider.Offering
+
+		BeforeEach(func() {
+			testOffering = offerings[0][0] // Use first offering from small-reserved (capacity 3)
+		})
+
+		Context("With Available Capacity", func() {
+			It("should return true when capacity is available", func() {
+				canReserve := rm.CanReserve("hostname-1", testOffering)
+				Expect(canReserve).To(BeTrue())
+			})
+
+			It("should return true when hostname already has the reservation", func() {
+				// First reserve
+				rm.Reserve("hostname-1", testOffering)
+				// Should still be able to "reserve" the same reservation for the same hostname
+				canReserve := rm.CanReserve("hostname-1", testOffering)
+				Expect(canReserve).To(BeTrue())
+			})
+		})
+
+		Context("With No Capacity", func() {
+			It("should return false when capacity is exhausted", func() {
+				// Exhaust all capacity
+				for i := 0; i < 3; i++ {
+					rm.Reserve(fmt.Sprintf("hostname-%d", i), testOffering)
+				}
+				// Should not be able to reserve more
+				canReserve := rm.CanReserve("hostname-new", testOffering)
+				Expect(canReserve).To(BeFalse())
+			})
+
+			It("should return true for existing hostname even when capacity is exhausted", func() {
+				// Reserve for hostname-1
+				rm.Reserve("hostname-1", testOffering)
+				// Exhaust remaining capacity with other hostnames
+				for i := 0; i < 2; i++ {
+					rm.Reserve(fmt.Sprintf("hostname-other-%d", i), testOffering)
+				}
+				// Should still return true for hostname-1
+				canReserve := rm.CanReserve("hostname-1", testOffering)
+				Expect(canReserve).To(BeTrue())
+			})
+		})
+
+		Context("Error Cases", func() {
+			It("should panic with non-existent reservation ID", func() {
+				nonExistentOffering := &cloudprovider.Offering{
+					Available:           true,
+					ReservationCapacity: 1,
+					Requirements: pscheduling.NewLabelRequirements(map[string]string{
+						v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
+						cloudprovider.ReservationIDLabel: "i-dont-exist",
+					}),
+				}
+				Expect(func() {
+					rm.CanReserve("hostname-1", nonExistentOffering)
+				}).To(Panic())
+			})
+		})
+	})
+
+	Describe("Reserve", func() {
+		var testOffering1, testOffering2 *cloudprovider.Offering
+
+		BeforeEach(func() {
+			testOffering1 = offerings[0][0] // Use first offering from small-reserved (capacity 3)
+			testOffering2 = offerings[1][0] // Use first offering from medium-reserved (capacity 2)
+		})
+
+		Context("Single Reservations", func() {
+			It("should successfully reserve capacity", func() {
+				rm.Reserve("hostname-1", testOffering1)
+				// Verify reservation was made by checking CanReserve behavior
+				canReserve := rm.CanReserve("hostname-1", testOffering1)
+				Expect(canReserve).To(BeTrue())
+			})
+
+			It("should not double-reserve for the same hostname and reservation", func() {
+				// Reserve twice for the same hostname and reservation
+				rm.Reserve("hostname-1", testOffering1)
+				rm.Reserve("hostname-1", testOffering1)
+
+				// Should still have capacity for other hostnames
+				canReserve := rm.CanReserve("hostname-2", testOffering1)
+				Expect(canReserve).To(BeTrue())
+			})
+
+			It("should decrement available capacity", func() {
+				// Reserve capacity and verify it's decremented
+				rm.Reserve("hostname-1", testOffering1)
+				rm.Reserve("hostname-2", testOffering1)
+				rm.Reserve("hostname-3", testOffering1)
+
+				// Should have no capacity left
+				canReserve := rm.CanReserve("hostname-4", testOffering1)
+				Expect(canReserve).To(BeFalse())
+			})
+		})
+
+		Context("Multiple Reservations", func() {
+			It("should handle multiple offerings in a single call", func() {
+				rm.Reserve("hostname-1", testOffering1, testOffering2)
+
+				// Verify both reservations were made
+				canReserve1 := rm.CanReserve("hostname-1", testOffering1)
+				canReserve2 := rm.CanReserve("hostname-1", testOffering2)
+				Expect(canReserve1).To(BeTrue())
+				Expect(canReserve2).To(BeTrue())
+			})
+
+			It("should handle mixed new and existing reservations", func() {
+				// First reserve one offering
+				rm.Reserve("hostname-1", testOffering1)
+
+				// Then reserve both (one existing, one new)
+				rm.Reserve("hostname-1", testOffering1, testOffering2)
+
+				// Verify both are reserved and capacity is correctly tracked
+				canReserve1 := rm.CanReserve("hostname-1", testOffering1)
+				canReserve2 := rm.CanReserve("hostname-1", testOffering2)
+				Expect(canReserve1).To(BeTrue())
+				Expect(canReserve2).To(BeTrue())
+
+				// Verify capacity was only decremented once for testOffering1
+				canReserveOther1 := rm.CanReserve("hostname-2", testOffering1)
+				Expect(canReserveOther1).To(BeTrue()) // Should still have capacity
+			})
+		})
+
+		Context("Error Cases", func() {
+			It("should panic when trying to over-reserve", func() {
+				// Exhaust capacity
+				for i := 0; i < 3; i++ {
+					rm.Reserve(fmt.Sprintf("hostname-%d", i), testOffering1)
+				}
+
+				// Attempting to reserve more should panic
+				Expect(func() {
+					rm.Reserve("hostname-new", testOffering1)
+				}).To(Panic())
+			})
+
+			It("should panic with non-existent reservation ID", func() {
+				nonExistentOffering := &cloudprovider.Offering{
+					Available:           true,
+					ReservationCapacity: 1,
+					Requirements: pscheduling.NewLabelRequirements(map[string]string{
+						v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
+						cloudprovider.ReservationIDLabel: "i-dont-exist",
+					}),
+				}
+				Expect(func() {
+					rm.Reserve("hostname-1", nonExistentOffering)
+				}).To(Panic())
+			})
+		})
+	})
+
+	Describe("Release", func() {
+		var testOffering1, testOffering2 *cloudprovider.Offering
+
+		BeforeEach(func() {
+			testOffering1 = offerings[0][0] // Use first offering from small-reserved (capacity 3)
+			testOffering2 = offerings[1][0] // Use first offering from medium-reserved (capacity 2)
+		})
+
+		Context("Valid Releases", func() {
+			It("should release a single reservation", func() {
+				// Reserve and then release
+				rm.Reserve("hostname-1", testOffering1)
+				rm.Release("hostname-1", testOffering1)
+
+				// Verify the reservation is no longer tracked for this hostname
+				// but capacity should be restored
+				canReserve := rm.CanReserve("hostname-2", testOffering1)
+				Expect(canReserve).To(BeTrue())
+			})
+
+			It("should handle releasing non-existent reservations gracefully", func() {
+				// Should not panic when releasing a reservation that doesn't exist
+				Expect(func() {
+					rm.Release("hostname-1", testOffering1)
+				}).ToNot(Panic())
+			})
+
+			It("should handle releasing from non-existent hostname gracefully", func() {
+				rm.Reserve("hostname-1", testOffering1)
+				// Should not panic when releasing from a different hostname
+				Expect(func() {
+					rm.Release("hostname-2", testOffering1)
+				}).ToNot(Panic())
+			})
+		})
+
+		Context("Multiple Releases", func() {
+			It("should handle multiple offerings in a single call", func() {
+				// Reserve both offerings
+				rm.Reserve("hostname-1", testOffering1, testOffering2)
+
+				// Release both
+				rm.Release("hostname-1", testOffering1, testOffering2)
+
+				// Verify capacity is restored for both
+				canReserve1 := rm.CanReserve("hostname-2", testOffering1)
+				canReserve2 := rm.CanReserve("hostname-2", testOffering2)
+				Expect(canReserve1).To(BeTrue())
+				Expect(canReserve2).To(BeTrue())
+			})
+
+			It("should handle partial releases", func() {
+				// Reserve both offerings
+				rm.Reserve("hostname-1", testOffering1, testOffering2)
+
+				// Release only one
+				rm.Release("hostname-1", testOffering1)
+
+				// Verify only the released one has restored capacity
+				canReserve1 := rm.CanReserve("hostname-1", testOffering1)
+				canReserve2 := rm.CanReserve("hostname-1", testOffering2)
+				Expect(canReserve1).To(BeTrue()) // Should still be reserved for hostname-1
+				Expect(canReserve2).To(BeTrue()) // Should still be reserved for hostname-1
+			})
+		})
+
+		Context("Capacity Restoration", func() {
+			It("should restore capacity when releasing reservations", func() {
+				// Exhaust capacity
+				rm.Reserve("hostname-1", testOffering1)
+				rm.Reserve("hostname-2", testOffering1)
+				rm.Reserve("hostname-3", testOffering1)
+
+				// Verify no capacity left
+				canReserve := rm.CanReserve("hostname-4", testOffering1)
+				Expect(canReserve).To(BeFalse())
+
+				// Release one reservation
+				rm.Release("hostname-1", testOffering1)
+
+				// Verify capacity is restored
+				canReserve = rm.CanReserve("hostname-4", testOffering1)
+				Expect(canReserve).To(BeTrue())
+			})
+
+			It("should correctly track capacity after multiple reserve/release cycles", func() {
+				// Reserve, release, reserve again
+				rm.Reserve("hostname-1", testOffering1)
+				rm.Release("hostname-1", testOffering1)
+				rm.Reserve("hostname-2", testOffering1)
+
+				// Should still have capacity available
+				canReserve := rm.CanReserve("hostname-3", testOffering1)
+				Expect(canReserve).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Integration Scenarios", func() {
+		var offering1, offering2, offering3 *cloudprovider.Offering
+
+		BeforeEach(func() {
+			offering1 = offerings[1][0] // Use medium-reserved offering (capacity 2)
+			offering2 = offerings[0][0] // Use small-reserved offering (capacity 3)
+			offering3 = offerings[2][0] // Use large-reserved offering (capacity 1)
+		})
+
+		It("should handle complex reservation patterns", func() {
+			// Multiple hostnames with multiple reservations
+			rm.Reserve("host-1", offering1, offering2)
+			rm.Reserve("host-2", offering1, offering3)
+			rm.Reserve("host-3", offering2)
+
+			// Verify all reservations are tracked
+			Expect(rm.CanReserve("host-1", offering1)).To(BeTrue())
+			Expect(rm.CanReserve("host-1", offering2)).To(BeTrue())
+			Expect(rm.CanReserve("host-2", offering1)).To(BeTrue())
+			Expect(rm.CanReserve("host-2", offering3)).To(BeTrue())
+			Expect(rm.CanReserve("host-3", offering2)).To(BeTrue())
+
+			// Verify capacity limits
+			Expect(rm.CanReserve("host-4", offering1)).To(BeFalse()) // Exhausted (2 capacity, 2 used)
+			Expect(rm.CanReserve("host-4", offering2)).To(BeTrue())  // Still available (3 capacity, 2 used)
+			Expect(rm.CanReserve("host-4", offering3)).To(BeFalse()) // Exhausted (1 capacity, 1 used)
+		})
+
+		It("should handle reservation conflicts correctly", func() {
+			// Reserve same offering for different hostnames
+			rm.Reserve("host-1", offering1)
+			rm.Reserve("host-2", offering1)
+
+			// Both should be able to "reserve" their existing reservations
+			Expect(rm.CanReserve("host-1", offering1)).To(BeTrue())
+			Expect(rm.CanReserve("host-2", offering1)).To(BeTrue())
+
+			// But no new reservations should be possible
+			Expect(rm.CanReserve("host-3", offering1)).To(BeFalse())
+		})
+
+		It("should maintain consistency during mixed operations", func() {
+			// Complex sequence of operations
+			rm.Reserve("host-1", offering1, offering2)
+			rm.Reserve("host-2", offering2, offering3)
+			rm.Release("host-1", offering1)
+			rm.Reserve("host-3", offering1)
+			rm.Release("host-2", offering3)
+
+			// Verify final state
+			Expect(rm.CanReserve("host-1", offering1)).To(BeTrue()) // Released, so not reserved for host-1
+			Expect(rm.CanReserve("host-1", offering2)).To(BeTrue()) // Still reserved for host-1
+			Expect(rm.CanReserve("host-2", offering2)).To(BeTrue()) // Still reserved for host-2
+			Expect(rm.CanReserve("host-2", offering3)).To(BeTrue()) // Released, so not reserved for host-2
+			Expect(rm.CanReserve("host-3", offering1)).To(BeTrue()) // Reserved for host-3
+
+			// Check capacity availability
+			Expect(rm.CanReserve("host-4", offering1)).To(BeTrue()) // Should have 1 available (2 total, 1 used by host-3)
+			Expect(rm.CanReserve("host-4", offering2)).To(BeTrue()) // Should have 1 available (3 total, 2 used)
+			Expect(rm.CanReserve("host-4", offering3)).To(BeTrue()) // Should have 1 available (1 total, 0 used after release)
+		})
+
+		It("should handle hostname cleanup correctly", func() {
+			// Reserve multiple offerings for a hostname
+			rm.Reserve("host-1", offering1, offering2, offering3)
+
+			// Release all offerings for the hostname
+			rm.Release("host-1", offering1, offering2, offering3)
+
+			// Verify capacity is fully restored
+			Expect(rm.CanReserve("host-2", offering1)).To(BeTrue())
+			Expect(rm.CanReserve("host-3", offering2)).To(BeTrue())
+			Expect(rm.CanReserve("host-4", offering3)).To(BeTrue())
+
+			// Verify we can use full capacity again
+			rm.Reserve("host-2", offering1)
+			rm.Reserve("host-3", offering1)
+			Expect(rm.CanReserve("host-4", offering1)).To(BeFalse()) // Should be exhausted again
+		})
+
+		It("should handle the same hostname reserving multiple times", func() {
+			rm.Reserve("host-1", offering1)
+			rm.Reserve("host-1", offering1)
+			rm.Reserve("host-1", offering1)
+			rm.Reserve("host-1", offering1)
+			rm.Reserve("host-1", offering1)
+		})
+	})
+})

--- a/pkg/controllers/provisioning/scheduling/reservationmanager_test.go
+++ b/pkg/controllers/provisioning/scheduling/reservationmanager_test.go
@@ -33,10 +33,40 @@ import (
 
 var _ = Describe("ReservationManager", func() {
 	var rm *scheduling.ReservationManager
-	var offerings []cloudprovider.Offerings
+	var offerings map[string]cloudprovider.Offerings
 	var instanceTypes []*cloudprovider.InstanceType
+	var threeCapacityOffering *cloudprovider.Offering
+	var twoCapacityOffering *cloudprovider.Offering
+	var oneCapacityOffering *cloudprovider.Offering
 
 	BeforeEach(func() {
+		threeCapacityOffering = &cloudprovider.Offering{
+			Available:           true,
+			ReservationCapacity: 3,
+			Requirements: pscheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
+				corev1.LabelTopologyZone:         "test-zone-1",
+				cloudprovider.ReservationIDLabel: "small-reserved",
+			}),
+		}
+		twoCapacityOffering = &cloudprovider.Offering{
+			Available:           true,
+			ReservationCapacity: 2,
+			Requirements: pscheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
+				corev1.LabelTopologyZone:         "test-zone-2",
+				cloudprovider.ReservationIDLabel: "medium-reserved",
+			}),
+		}
+		oneCapacityOffering = &cloudprovider.Offering{
+			Available:           true,
+			ReservationCapacity: 1,
+			Requirements: pscheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
+				corev1.LabelTopologyZone:         "test-zone-3",
+				cloudprovider.ReservationIDLabel: "large-reserved",
+			}),
+		}
 		// Create hardcoded instance types with reserved offerings
 		instanceTypes = []*cloudprovider.InstanceType{
 			fake.NewInstanceType(fake.InstanceTypeOptions{
@@ -46,17 +76,7 @@ var _ = Describe("ReservationManager", func() {
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 					corev1.ResourcePods:   resource.MustParse("10"),
 				},
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:           true,
-						ReservationCapacity: 3,
-						Requirements: pscheduling.NewLabelRequirements(map[string]string{
-							v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
-							corev1.LabelTopologyZone:         "test-zone-1",
-							cloudprovider.ReservationIDLabel: "small-reserved",
-						}),
-					},
-				},
+				Offerings: []*cloudprovider.Offering{threeCapacityOffering},
 			}),
 			fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name: "medium-reserved",
@@ -65,17 +85,7 @@ var _ = Describe("ReservationManager", func() {
 					corev1.ResourceMemory: resource.MustParse("8Gi"),
 					corev1.ResourcePods:   resource.MustParse("20"),
 				},
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:           true,
-						ReservationCapacity: 2,
-						Requirements: pscheduling.NewLabelRequirements(map[string]string{
-							v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
-							corev1.LabelTopologyZone:         "test-zone-2",
-							cloudprovider.ReservationIDLabel: "medium-reserved",
-						}),
-					},
-				},
+				Offerings: []*cloudprovider.Offering{twoCapacityOffering},
 			}),
 			fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name: "large-reserved",
@@ -84,108 +94,31 @@ var _ = Describe("ReservationManager", func() {
 					corev1.ResourceMemory: resource.MustParse("16Gi"),
 					corev1.ResourcePods:   resource.MustParse("40"),
 				},
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:           true,
-						ReservationCapacity: 1,
-						Requirements: pscheduling.NewLabelRequirements(map[string]string{
-							v1.CapacityTypeLabelKey:          v1.CapacityTypeReserved,
-							corev1.LabelTopologyZone:         "test-zone-3",
-							cloudprovider.ReservationIDLabel: "large-reserved",
-						}),
-					},
-				},
+				Offerings: []*cloudprovider.Offering{oneCapacityOffering},
 			}),
 		}
 
 		// Extract offerings from instance types
-		offerings = nil // Reset offerings slice
+		offerings = map[string]cloudprovider.Offerings{} // Reset offerings map
 		for _, it := range instanceTypes {
-			offerings = append(offerings, it.Offerings)
+			offerings[it.Name] = it.Offerings
 		}
 
 		rm = scheduling.NewReservationManager(map[string][]*cloudprovider.InstanceType{"": instanceTypes})
 	})
 
-	Describe("NewReservationManager", func() {
-		It("should handle empty instance types", func() {
-			emptyInstanceTypes := map[string][]*cloudprovider.InstanceType{}
-			emptyRM := scheduling.NewReservationManager(emptyInstanceTypes)
-			Expect(emptyRM).ToNot(BeNil())
-		})
-
-		It("should handle instance types without reserved offerings", func() {
-			nonReservedTypes := map[string][]*cloudprovider.InstanceType{
-				"nodepool-1": {
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name: "on-demand-only",
-						Offerings: []*cloudprovider.Offering{
-							{
-								Available: true,
-								Requirements: pscheduling.NewLabelRequirements(map[string]string{
-									v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand,
-								}),
-							},
-						},
-					}),
-				},
-			}
-			nonReservedRM := scheduling.NewReservationManager(nonReservedTypes)
-			Expect(nonReservedRM).ToNot(BeNil())
-		})
-
-		It("should track the minimum capacity when multiple offerings have the same reservation ID", func() {
-			duplicateReservationTypes := map[string][]*cloudprovider.InstanceType{
-				"nodepool-1": {
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name: "instance-1",
-						Offerings: []*cloudprovider.Offering{
-							{
-								Available:           true,
-								ReservationCapacity: 10,
-								Requirements: pscheduling.NewLabelRequirements(map[string]string{
-									v1.CapacityTypeLabelKey: v1.CapacityTypeReserved,
-								}),
-							},
-						},
-					}),
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name: "instance-2",
-						Offerings: []*cloudprovider.Offering{
-							{
-								Available:           true,
-								ReservationCapacity: 5, // Lower capacity should be tracked
-								Requirements: pscheduling.NewLabelRequirements(map[string]string{
-									v1.CapacityTypeLabelKey: v1.CapacityTypeReserved,
-								}),
-							},
-						},
-					}),
-				},
-			}
-			duplicateRM := scheduling.NewReservationManager(duplicateReservationTypes)
-			Expect(duplicateRM).ToNot(BeNil())
-		})
-	})
-
 	Describe("CanReserve", func() {
-		var testOffering *cloudprovider.Offering
-
-		BeforeEach(func() {
-			testOffering = offerings[0][0] // Use first offering from small-reserved (capacity 3)
-		})
-
 		Context("With Available Capacity", func() {
 			It("should return true when capacity is available", func() {
-				canReserve := rm.CanReserve("hostname-1", testOffering)
+				canReserve := rm.CanReserve("hostname-1", oneCapacityOffering)
 				Expect(canReserve).To(BeTrue())
 			})
 
 			It("should return true when hostname already has the reservation", func() {
 				// First reserve
-				rm.Reserve("hostname-1", testOffering)
+				rm.Reserve("hostname-1", oneCapacityOffering)
 				// Should still be able to "reserve" the same reservation for the same hostname
-				canReserve := rm.CanReserve("hostname-1", testOffering)
+				canReserve := rm.CanReserve("hostname-1", oneCapacityOffering)
 				Expect(canReserve).To(BeTrue())
 			})
 		})
@@ -193,23 +126,19 @@ var _ = Describe("ReservationManager", func() {
 		Context("With No Capacity", func() {
 			It("should return false when capacity is exhausted", func() {
 				// Exhaust all capacity
-				for i := 0; i < 3; i++ {
-					rm.Reserve(fmt.Sprintf("hostname-%d", i), testOffering)
+				for i := range oneCapacityOffering.ReservationCapacity {
+					rm.Reserve(fmt.Sprintf("hostname-%d", i), oneCapacityOffering)
 				}
 				// Should not be able to reserve more
-				canReserve := rm.CanReserve("hostname-new", testOffering)
+				canReserve := rm.CanReserve("hostname-new", oneCapacityOffering)
 				Expect(canReserve).To(BeFalse())
 			})
 
 			It("should return true for existing hostname even when capacity is exhausted", func() {
 				// Reserve for hostname-1
-				rm.Reserve("hostname-1", testOffering)
-				// Exhaust remaining capacity with other hostnames
-				for i := 0; i < 2; i++ {
-					rm.Reserve(fmt.Sprintf("hostname-other-%d", i), testOffering)
-				}
+				rm.Reserve("hostname-1", oneCapacityOffering)
 				// Should still return true for hostname-1
-				canReserve := rm.CanReserve("hostname-1", testOffering)
+				canReserve := rm.CanReserve("hostname-1", oneCapacityOffering)
 				Expect(canReserve).To(BeTrue())
 			})
 		})
@@ -232,83 +161,70 @@ var _ = Describe("ReservationManager", func() {
 	})
 
 	Describe("Reserve", func() {
-		var testOffering1, testOffering2 *cloudprovider.Offering
-
-		BeforeEach(func() {
-			testOffering1 = offerings[0][0] // Use first offering from small-reserved (capacity 3)
-			testOffering2 = offerings[1][0] // Use first offering from medium-reserved (capacity 2)
-		})
-
 		Context("Single Reservations", func() {
 			It("should successfully reserve capacity", func() {
-				rm.Reserve("hostname-1", testOffering1)
+				rm.Reserve("hostname-1", threeCapacityOffering)
 				// Verify reservation was made by checking CanReserve behavior
-				canReserve := rm.CanReserve("hostname-1", testOffering1)
-				Expect(canReserve).To(BeTrue())
+				Expect(rm.HasReservation("hostname-1", threeCapacityOffering)).To(BeTrue())
 			})
 
 			It("should not double-reserve for the same hostname and reservation", func() {
 				// Reserve twice for the same hostname and reservation
-				rm.Reserve("hostname-1", testOffering1)
-				rm.Reserve("hostname-1", testOffering1)
+				rm.Reserve("hostname-1", twoCapacityOffering)
+				rm.Reserve("hostname-1", twoCapacityOffering)
 
 				// Should still have capacity for other hostnames
-				canReserve := rm.CanReserve("hostname-2", testOffering1)
+				canReserve := rm.CanReserve("hostname-2", twoCapacityOffering)
 				Expect(canReserve).To(BeTrue())
 			})
 
 			It("should decrement available capacity", func() {
 				// Reserve capacity and verify it's decremented
-				rm.Reserve("hostname-1", testOffering1)
-				rm.Reserve("hostname-2", testOffering1)
-				rm.Reserve("hostname-3", testOffering1)
+				rm.Reserve("hostname-1", threeCapacityOffering)
+				rm.Reserve("hostname-2", threeCapacityOffering)
+				rm.Reserve("hostname-3", threeCapacityOffering)
 
 				// Should have no capacity left
-				canReserve := rm.CanReserve("hostname-4", testOffering1)
+				canReserve := rm.CanReserve("hostname-4", threeCapacityOffering)
 				Expect(canReserve).To(BeFalse())
 			})
 		})
 
 		Context("Multiple Reservations", func() {
 			It("should handle multiple offerings in a single call", func() {
-				rm.Reserve("hostname-1", testOffering1, testOffering2)
+				rm.Reserve("hostname-1", threeCapacityOffering, twoCapacityOffering)
 
 				// Verify both reservations were made
-				canReserve1 := rm.CanReserve("hostname-1", testOffering1)
-				canReserve2 := rm.CanReserve("hostname-1", testOffering2)
-				Expect(canReserve1).To(BeTrue())
-				Expect(canReserve2).To(BeTrue())
+				Expect(rm.HasReservation("hostname-1", threeCapacityOffering)).To(BeTrue())
+				Expect(rm.HasReservation("hostname-1", twoCapacityOffering)).To(BeTrue())
 			})
 
 			It("should handle mixed new and existing reservations", func() {
 				// First reserve one offering
-				rm.Reserve("hostname-1", testOffering1)
+				rm.Reserve("hostname-1", twoCapacityOffering)
 
 				// Then reserve both (one existing, one new)
-				rm.Reserve("hostname-1", testOffering1, testOffering2)
+				rm.Reserve("hostname-1", twoCapacityOffering, oneCapacityOffering)
 
 				// Verify both are reserved and capacity is correctly tracked
-				canReserve1 := rm.CanReserve("hostname-1", testOffering1)
-				canReserve2 := rm.CanReserve("hostname-1", testOffering2)
-				Expect(canReserve1).To(BeTrue())
-				Expect(canReserve2).To(BeTrue())
+				Expect(rm.HasReservation("hostname-1", twoCapacityOffering)).To(BeTrue())
+				Expect(rm.HasReservation("hostname-1", oneCapacityOffering)).To(BeTrue())
 
-				// Verify capacity was only decremented once for testOffering1
-				canReserveOther1 := rm.CanReserve("hostname-2", testOffering1)
-				Expect(canReserveOther1).To(BeTrue()) // Should still have capacity
+				// Verify capacity was only decremented once for twoCapacityOffering
+				Expect(rm.CanReserve("hostname-2", twoCapacityOffering)).To(BeTrue()) // Should still have capacity
 			})
 		})
 
 		Context("Error Cases", func() {
 			It("should panic when trying to over-reserve", func() {
 				// Exhaust capacity
-				for i := 0; i < 3; i++ {
-					rm.Reserve(fmt.Sprintf("hostname-%d", i), testOffering1)
+				for i := range threeCapacityOffering.ReservationCapacity {
+					rm.Reserve(fmt.Sprintf("hostname-%d", i), threeCapacityOffering)
 				}
 
 				// Attempting to reserve more should panic
 				Expect(func() {
-					rm.Reserve("hostname-new", testOffering1)
+					rm.Reserve("hostname-new", threeCapacityOffering)
 				}).To(Panic())
 			})
 
@@ -329,37 +245,29 @@ var _ = Describe("ReservationManager", func() {
 	})
 
 	Describe("Release", func() {
-		var testOffering1, testOffering2 *cloudprovider.Offering
-
-		BeforeEach(func() {
-			testOffering1 = offerings[0][0] // Use first offering from small-reserved (capacity 3)
-			testOffering2 = offerings[1][0] // Use first offering from medium-reserved (capacity 2)
-		})
-
 		Context("Valid Releases", func() {
 			It("should release a single reservation", func() {
 				// Reserve and then release
-				rm.Reserve("hostname-1", testOffering1)
-				rm.Release("hostname-1", testOffering1)
+				rm.Reserve("hostname-1", threeCapacityOffering)
+				rm.Release("hostname-1", threeCapacityOffering)
 
 				// Verify the reservation is no longer tracked for this hostname
 				// but capacity should be restored
-				canReserve := rm.CanReserve("hostname-2", testOffering1)
-				Expect(canReserve).To(BeTrue())
+				Expect(rm.HasReservation("hostname-1", threeCapacityOffering)).To(BeFalse())
 			})
 
 			It("should handle releasing non-existent reservations gracefully", func() {
 				// Should not panic when releasing a reservation that doesn't exist
 				Expect(func() {
-					rm.Release("hostname-1", testOffering1)
+					rm.Release("hostname-1", threeCapacityOffering)
 				}).ToNot(Panic())
 			})
 
 			It("should handle releasing from non-existent hostname gracefully", func() {
-				rm.Reserve("hostname-1", testOffering1)
+				rm.Reserve("hostname-1", threeCapacityOffering)
 				// Should not panic when releasing from a different hostname
 				Expect(func() {
-					rm.Release("hostname-2", testOffering1)
+					rm.Release("hostname-2", threeCapacityOffering)
 				}).ToNot(Panic())
 			})
 		})
@@ -367,151 +275,97 @@ var _ = Describe("ReservationManager", func() {
 		Context("Multiple Releases", func() {
 			It("should handle multiple offerings in a single call", func() {
 				// Reserve both offerings
-				rm.Reserve("hostname-1", testOffering1, testOffering2)
+				rm.Reserve("hostname-1", threeCapacityOffering, twoCapacityOffering)
 
 				// Release both
-				rm.Release("hostname-1", testOffering1, testOffering2)
+				rm.Release("hostname-1", threeCapacityOffering, twoCapacityOffering)
 
-				// Verify capacity is restored for both
-				canReserve1 := rm.CanReserve("hostname-2", testOffering1)
-				canReserve2 := rm.CanReserve("hostname-2", testOffering2)
-				Expect(canReserve1).To(BeTrue())
-				Expect(canReserve2).To(BeTrue())
+				// Verify capacity has been reserved for both
+				Expect(rm.HasReservation("hostname-1", threeCapacityOffering)).To(BeFalse())
+				Expect(rm.HasReservation("hostname-1", twoCapacityOffering)).To(BeFalse())
 			})
 
 			It("should handle partial releases", func() {
 				// Reserve both offerings
-				rm.Reserve("hostname-1", testOffering1, testOffering2)
+				rm.Reserve("hostname-1", threeCapacityOffering, twoCapacityOffering)
 
 				// Release only one
-				rm.Release("hostname-1", testOffering1)
+				rm.Release("hostname-1", threeCapacityOffering)
 
 				// Verify only the released one has restored capacity
-				canReserve1 := rm.CanReserve("hostname-1", testOffering1)
-				canReserve2 := rm.CanReserve("hostname-1", testOffering2)
-				Expect(canReserve1).To(BeTrue()) // Should still be reserved for hostname-1
-				Expect(canReserve2).To(BeTrue()) // Should still be reserved for hostname-1
+				Expect(rm.HasReservation("hostname-1", threeCapacityOffering)).To(BeFalse())
+				Expect(rm.HasReservation("hostname-1", twoCapacityOffering)).To(BeTrue())
 			})
 		})
 
 		Context("Capacity Restoration", func() {
 			It("should restore capacity when releasing reservations", func() {
 				// Exhaust capacity
-				rm.Reserve("hostname-1", testOffering1)
-				rm.Reserve("hostname-2", testOffering1)
-				rm.Reserve("hostname-3", testOffering1)
+				rm.Reserve("hostname-1", threeCapacityOffering)
+				rm.Reserve("hostname-2", threeCapacityOffering)
+				rm.Reserve("hostname-3", threeCapacityOffering)
 
 				// Verify no capacity left
-				canReserve := rm.CanReserve("hostname-4", testOffering1)
-				Expect(canReserve).To(BeFalse())
+				Expect(rm.RemainingCapacity(threeCapacityOffering)).To(Equal(0))
 
 				// Release one reservation
-				rm.Release("hostname-1", testOffering1)
+				rm.Release("hostname-1", threeCapacityOffering)
 
 				// Verify capacity is restored
-				canReserve = rm.CanReserve("hostname-4", testOffering1)
-				Expect(canReserve).To(BeTrue())
+				Expect(rm.RemainingCapacity(threeCapacityOffering)).To(Equal(1))
 			})
 
 			It("should correctly track capacity after multiple reserve/release cycles", func() {
 				// Reserve, release, reserve again
-				rm.Reserve("hostname-1", testOffering1)
-				rm.Release("hostname-1", testOffering1)
-				rm.Reserve("hostname-2", testOffering1)
+				rm.Reserve("hostname-1", threeCapacityOffering)
+				rm.Release("hostname-1", threeCapacityOffering)
+				rm.Reserve("hostname-2", threeCapacityOffering)
 
 				// Should still have capacity available
-				canReserve := rm.CanReserve("hostname-3", testOffering1)
-				Expect(canReserve).To(BeTrue())
+				Expect(rm.RemainingCapacity(threeCapacityOffering)).To(Equal(2))
 			})
 		})
 	})
 
 	Describe("Integration Scenarios", func() {
-		var offering1, offering2, offering3 *cloudprovider.Offering
-
-		BeforeEach(func() {
-			offering1 = offerings[1][0] // Use medium-reserved offering (capacity 2)
-			offering2 = offerings[0][0] // Use small-reserved offering (capacity 3)
-			offering3 = offerings[2][0] // Use large-reserved offering (capacity 1)
-		})
-
 		It("should handle complex reservation patterns", func() {
 			// Multiple hostnames with multiple reservations
-			rm.Reserve("host-1", offering1, offering2)
-			rm.Reserve("host-2", offering1, offering3)
-			rm.Reserve("host-3", offering2)
+			rm.Reserve("host-1", twoCapacityOffering, threeCapacityOffering)
+			rm.Reserve("host-2", twoCapacityOffering, oneCapacityOffering)
+			rm.Reserve("host-3", threeCapacityOffering)
 
 			// Verify all reservations are tracked
-			Expect(rm.CanReserve("host-1", offering1)).To(BeTrue())
-			Expect(rm.CanReserve("host-1", offering2)).To(BeTrue())
-			Expect(rm.CanReserve("host-2", offering1)).To(BeTrue())
-			Expect(rm.CanReserve("host-2", offering3)).To(BeTrue())
-			Expect(rm.CanReserve("host-3", offering2)).To(BeTrue())
+			Expect(rm.HasReservation("host-1", threeCapacityOffering)).To(BeTrue())
+			Expect(rm.HasReservation("host-1", twoCapacityOffering)).To(BeTrue())
+			Expect(rm.HasReservation("host-2", twoCapacityOffering)).To(BeTrue())
+			Expect(rm.HasReservation("host-2", oneCapacityOffering)).To(BeTrue())
+			Expect(rm.HasReservation("host-3", threeCapacityOffering)).To(BeTrue())
 
 			// Verify capacity limits
-			Expect(rm.CanReserve("host-4", offering1)).To(BeFalse()) // Exhausted (2 capacity, 2 used)
-			Expect(rm.CanReserve("host-4", offering2)).To(BeTrue())  // Still available (3 capacity, 2 used)
-			Expect(rm.CanReserve("host-4", offering3)).To(BeFalse()) // Exhausted (1 capacity, 1 used)
-		})
-
-		It("should handle reservation conflicts correctly", func() {
-			// Reserve same offering for different hostnames
-			rm.Reserve("host-1", offering1)
-			rm.Reserve("host-2", offering1)
-
-			// Both should be able to "reserve" their existing reservations
-			Expect(rm.CanReserve("host-1", offering1)).To(BeTrue())
-			Expect(rm.CanReserve("host-2", offering1)).To(BeTrue())
-
-			// But no new reservations should be possible
-			Expect(rm.CanReserve("host-3", offering1)).To(BeFalse())
+			Expect(rm.RemainingCapacity(twoCapacityOffering)).To(Equal(0))   // Exhausted (2 capacity, 2 used)
+			Expect(rm.RemainingCapacity(threeCapacityOffering)).To(Equal(1)) // Still available (3 capacity, 2 used)
+			Expect(rm.RemainingCapacity(oneCapacityOffering)).To(Equal(0))   // Exhausted (1 capacity, 1 used)
 		})
 
 		It("should maintain consistency during mixed operations", func() {
 			// Complex sequence of operations
-			rm.Reserve("host-1", offering1, offering2)
-			rm.Reserve("host-2", offering2, offering3)
-			rm.Release("host-1", offering1)
-			rm.Reserve("host-3", offering1)
-			rm.Release("host-2", offering3)
+			rm.Reserve("host-1", twoCapacityOffering, threeCapacityOffering)
+			rm.Reserve("host-2", threeCapacityOffering, oneCapacityOffering)
+			rm.Release("host-1", twoCapacityOffering)
+			rm.Reserve("host-3", twoCapacityOffering)
+			rm.Release("host-2", oneCapacityOffering)
 
 			// Verify final state
-			Expect(rm.CanReserve("host-1", offering1)).To(BeTrue()) // Released, so not reserved for host-1
-			Expect(rm.CanReserve("host-1", offering2)).To(BeTrue()) // Still reserved for host-1
-			Expect(rm.CanReserve("host-2", offering2)).To(BeTrue()) // Still reserved for host-2
-			Expect(rm.CanReserve("host-2", offering3)).To(BeTrue()) // Released, so not reserved for host-2
-			Expect(rm.CanReserve("host-3", offering1)).To(BeTrue()) // Reserved for host-3
+			Expect(rm.HasReservation("host-1", twoCapacityOffering)).To(BeFalse())  // Released, so not reserved for host-1
+			Expect(rm.HasReservation("host-1", threeCapacityOffering)).To(BeTrue()) // Still reserved for host-1
+			Expect(rm.HasReservation("host-2", threeCapacityOffering)).To(BeTrue()) // Still reserved for host-2
+			Expect(rm.HasReservation("host-2", oneCapacityOffering)).To(BeFalse())  // Released, so not reserved for host-2
+			Expect(rm.HasReservation("host-3", twoCapacityOffering)).To(BeTrue())   // Reserved for host-3
 
 			// Check capacity availability
-			Expect(rm.CanReserve("host-4", offering1)).To(BeTrue()) // Should have 1 available (2 total, 1 used by host-3)
-			Expect(rm.CanReserve("host-4", offering2)).To(BeTrue()) // Should have 1 available (3 total, 2 used)
-			Expect(rm.CanReserve("host-4", offering3)).To(BeTrue()) // Should have 1 available (1 total, 0 used after release)
-		})
-
-		It("should handle hostname cleanup correctly", func() {
-			// Reserve multiple offerings for a hostname
-			rm.Reserve("host-1", offering1, offering2, offering3)
-
-			// Release all offerings for the hostname
-			rm.Release("host-1", offering1, offering2, offering3)
-
-			// Verify capacity is fully restored
-			Expect(rm.CanReserve("host-2", offering1)).To(BeTrue())
-			Expect(rm.CanReserve("host-3", offering2)).To(BeTrue())
-			Expect(rm.CanReserve("host-4", offering3)).To(BeTrue())
-
-			// Verify we can use full capacity again
-			rm.Reserve("host-2", offering1)
-			rm.Reserve("host-3", offering1)
-			Expect(rm.CanReserve("host-4", offering1)).To(BeFalse()) // Should be exhausted again
-		})
-
-		It("should handle the same hostname reserving multiple times", func() {
-			rm.Reserve("host-1", offering1)
-			rm.Reserve("host-1", offering1)
-			rm.Reserve("host-1", offering1)
-			rm.Reserve("host-1", offering1)
-			rm.Reserve("host-1", offering1)
+			Expect(rm.RemainingCapacity(twoCapacityOffering)).To(Equal(1)) // Should have 1 available (2 total, 1 used by host-3)
+			Expect(rm.RemainingCapacity(twoCapacityOffering)).To(Equal(1)) // Should have 1 available (3 total, 2 used)
+			Expect(rm.RemainingCapacity(twoCapacityOffering)).To(Equal(1)) // Should have 1 available (1 total, 0 used after release)
 		})
 	})
 })

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -4298,6 +4298,59 @@ var _ = Context("Scheduling", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, targetInstanceTypeName))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.NodePoolLabelKey, nodePool.Name))
 		})
+		It("should handle multiple pods on reserved nodes", func() {
+			nodePool.Name = "np-1"
+			ExpectApplied(ctx, env.Client, nodePool)
+			affLabels := map[string]string{"app": "test"}
+
+			pods := lo.Times(2, func(i int) *corev1.Pod {
+				return test.UnschedulablePod(test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: affLabels,
+					},
+					NodeRequirements: []corev1.NodeSelectorRequirement{
+						{
+							Key:      corev1.LabelInstanceTypeStable,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"small-instance-type"},
+						},
+						{
+							Key:      v1.NodePoolLabelKey,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"np-1"},
+						},
+						{
+							Key:      v1.CapacityTypeLabelKey,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{v1.CapacityTypeReserved},
+						},
+						{
+							Key:      corev1.LabelTopologyZone,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"test-zone-1"},
+						},
+					},
+					PodRequirements: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: affLabels,
+							},
+							TopologyKey: corev1.LabelTopologyZone,
+						},
+					},
+				})
+			})
+
+			bindings := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+			Expect(len(bindings)).To(Equal(2))
+			node := lo.Values(bindings)[0].Node
+			for _, b := range lo.Values(bindings) {
+				Expect(b.Node.Name).To(Equal(node.Name))
+			}
+			Expect(node.Labels).To(HaveKeyWithValue(cloudprovider.ReservationIDLabel, "r-small-instance-type"))
+			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
+			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, "small-instance-type"))
+		})
 	})
 })
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2318

**Description**

Add a short circuit to the `Reserve` function that will prevent the same hostname from taking multiple capacity

**How was this change tested?**

Added a new test package for the reservation manager and a test specifically for the functionality.

## Prior to code change:

```
Running Suite: Scheduling - /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling
==============================================================================================================================
Random Seed: 1751928679

Will run 27 of 318 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••••••••••••••••••••••••••
------------------------------
• [PANICKED] [0.006 seconds]
ReservationManager Integration Scenarios [It] should handle the same hostname reserving multiple times
/Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/reservationmanager_test.go:509

  [PANICKED] Test Panicked
  In [It] at: /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/reservationmanager.go:80 @ 07/07/25 15:51:22.021

  attempted to over-reserve an offering with reservation id "medium-reserved"

  Full Stack Trace
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling.(*ReservationManager).Reserve(0x140007266f0, {0x1065512c5, 0x6}, {0x14000766f40, 0x1, 0x14000a48c40?})
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/reservationmanager.go:80 +0x23c
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling_test.init.func1.6.6()
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/reservationmanager_test.go:512 +0xbc
------------------------------

Summarizing 1 Failure:
  [PANICKED!] ReservationManager Integration Scenarios [It] should handle the same hostname reserving multiple times
  /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/reservationmanager.go:80

Ran 27 of 318 Specs in 3.830 seconds
FAIL! -- 26 Passed | 1 Failed | 0 Pending | 291 Skipped
--- FAIL: TestScheduling (3.83s)
FAIL
FAIL    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling   4.767s
```

```
/opt/homebrew/bin/go test -timeout 30s -run ^TestScheduling$ sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling
Running Suite: Scheduling - /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling
==============================================================================================================================
Random Seed: 1752093653

Will run 1 of 316 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
• [PANICKED] [2.148 seconds]
Scheduling Reserved Instance Types [It] should handle multiple pods on reserved nodes
/Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/suite_test.go:4301

  [PANICKED] Test Panicked
  In [It] at: /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/reservationmanager.go:82 @ 07/09/25 13:40:58.104

  attempted to over-reserve an offering with reservation id "r-small-instance-type"

  Full Stack Trace
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling.(*ReservationManager).Reserve(0x140000de970, {0x14000a0c660, 0x19}, {0x140001a2778, 0x1, 0x14000b08660?})
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/reservationmanager.go:82 +0x248
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling.(*NodeClaim).Add(0x1400031f8c8, 0x14000051b08, 0x14000694900?, 0x14000b08660, {0x140001a2760?, 0x1?, 0x1?}, {0x140001a2778, 0x1, 0x1})
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/nodeclaim.go:171 +0x288
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling.(*Scheduler).addToInflightNode(0x140006360e0, {0x104bedeb0, 0x14000320460}, 0x14000051b08)
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/scheduler.go:517 +0x1fc
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling.(*Scheduler).add(0x140006360e0, {0x104bedeb0, 0x14000320460}, 0x14000051b08)
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/scheduler.go:442 +0x80
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling.(*Scheduler).trySchedule(0x140006360e0, {0x104bedeb0, 0x14000320460}, 0x14000051b08)
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/scheduler.go:390 +0x64
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling.(*Scheduler).Solve(0x140006360e0, {0x104bedeb0, 0x14000320460}, {0x14000b12140, 0x14, 0x14})
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/scheduler.go:357 +0x75c
    sigs.k8s.io/karpenter/pkg/controllers/provisioning.(*Provisioner).Schedule(0x140006a5c80, {0x104bede08, 0x140008d7530})
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/provisioner.go:343 +0xa10
    sigs.k8s.io/karpenter/pkg/test/expectations.ExpectProvisionedNoBinding({0x104bede08, 0x140008d7530}, {0x104c00400, 0x1400014f320}, 0x140007b58c8, {0x104bfa7e0, 0x14000515c20}, 0x140006a5c80, {0x14000498000, 0x14, ...})
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/test/expectations/expectations.go:324 +0xc8
    sigs.k8s.io/karpenter/pkg/test/expectations.ExpectProvisioned({0x104bede08, 0x140008d7530}, {0x104c00400, 0x1400014f320}, 0x140007b58c8, {0x104bfa7e0, 0x14000515c20}, 0x140006a5c80, {0x14000498000, 0x14, ...})
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/test/expectations/expectations.go:304 +0x94
    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling_test.init.func7.12.8()
        /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/suite_test.go:4327 +0x3d8
------------------------------

Summarizing 1 Failure:
  [PANICKED!] Scheduling Reserved Instance Types [It] should handle multiple pods on reserved nodes
  /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling/reservationmanager.go:82

Ran 1 of 316 Specs in 5.495 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 315 Skipped
--- FAIL: TestScheduling (5.50s)
    logger.go:146: 2025-07-09T13:40:58.100-0700 DEBUG   provisioning/provisioner.go:316 computing scheduling decision for provisionable pod(s)  {"pending-pods": 20, "deleting-pods": 0}
FAIL
FAIL    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling   6.396s
FAIL
```

## After Code Change:

```
Running Suite: Scheduling - /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling
==============================================================================================================================
Random Seed: 1751928734

Will run 27 of 318 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••••••••••••••••••••••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 27 of 318 Specs in 4.515 seconds
SUCCESS! -- 27 Passed | 0 Failed | 0 Pending | 291 Skipped
PASS | FOCUSED
FAIL    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling   5.411s
FAIL
```

```
 /opt/homebrew/bin/go test -timeout 30s -run ^TestScheduling$ sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling
Running Suite: Scheduling - /Users/derekff/code/karpenter/forks/karpenter-testing-fork/pkg/controllers/provisioning/scheduling
==============================================================================================================================
Random Seed: 1752093967

Will run 1 of 316 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•

Ran 1 of 316 Specs in 6.470 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 315 Skipped
PASS | FOCUSED
FAIL    sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling   7.375s
FAIL
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
