### PR TITLE
perf: Remove deep equals in favor of checking if the status has been updated

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/consolidation.go
+++ b/pkg/controllers/nodeclaim/disruption/consolidation.go
@@ -34,6 +34,8 @@ type Consolidation struct {
 	clock      clock.Clock
 }
 
+// This function should only modify the nodeclaim's Status section
+//
 //nolint:gocyclo
 func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
 	hasConsolidatableCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeConsolidatable) != nil

--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 		errs = multierr.Append(errs, err)
 		results = append(results, res)
 	}
-	if !equality.Semantic.DeepEqual(stored, nodeClaim) {
+	if !equality.Semantic.DeepEqual(stored.Status, nodeClaim.Status) {
 		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 		// can cause races due to the fact that it fully replaces the list on a change
 		// Here, we are updating the status condition list

--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -47,6 +47,7 @@ type Drift struct {
 	instanceTypeNotFoundCheckCache *cache.Cache
 }
 
+// This function should only modify the nodeclaim's Status section
 func (d *Drift) Reconcile(ctx context.Context, nodePool *v1.NodePool, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
 	hasDriftedCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted) != nil
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change optimizes the disruption controller's memory footprint by only comparing the the status conditions to verify if a nodeclaim has been drifted

**How was this change tested?**


`make presubmit`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
