### PR TITLE
fix: update provider ID to ensure that Cloud Provider tests pass

### DIFF
--- a/test/suites/regression/nodeclaim_test.go
+++ b/test/suites/regression/nodeclaim_test.go
@@ -300,7 +300,7 @@ var _ = Describe("NodeClaim", func() {
 			nodeClaim = env.ExpectExists(nodeClaim).(*v1.NodeClaim)
 
 			By("Updated NodeClaim Status")
-			nodeClaim.Status.ProviderID = "test-provider-id"
+			nodeClaim.Status.ProviderID = "Provider:///AZ/i-01234567890123456"
 			nodeClaim.Status.NodeName = "test-node-name"
 			nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeLaunched)
 			nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeRegistered)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number --> Fixes error encountered in https://github.com/aws/karpenter-provider-aws/pull/8250/#issuecomment-3059863501.

**Description** `kubernetes-sigs/karpenter` tests running in `aws/karpenter-provider-aws` fail due to `{"level":"ERROR","time":"2025-07-11T00:38:25.533Z","logger":"controller","caller":"controller/controller.go:353","message":"Reconciler error","commit":"5bf129e-dirty","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"swisherdestiny-3-y3pfejlvlb"},"namespace":"","name":"swisherdestiny-3-y3pfejlvlb","reconcileID":"67645973-bcb1-443b-8de8-ead0fdffb70c","provider-id":"test-provider-id","error":"getting instance ID, provider id does not match known format (provider-id=test-provider-id)"}`. This change fixes that error.

**How was this change tested?** Ran the test locally and it passed after this fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
