### PR TITLE
fix: remove unsupported capacity_type label from karpenter_nodeclaims…

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -413,7 +413,6 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 		metrics.NodeClaimsCreatedTotal.Inc(map[string]string{
 			metrics.ReasonLabel:           options.Reason,
 			metrics.NodePoolLabel:         nodeClaim.Labels[v1.NodePoolLabelKey],
-			metrics.CapacityTypeLabel:     nodeClaim.Labels[v1.CapacityTypeLabelKey],
 			metrics.MinValuesRelaxedLabel: val,
 		})
 	} else {
@@ -421,7 +420,6 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 		metrics.NodeClaimsCreatedTotal.Inc(map[string]string{
 			metrics.ReasonLabel:           options.Reason,
 			metrics.NodePoolLabel:         nodeClaim.Labels[v1.NodePoolLabelKey],
-			metrics.CapacityTypeLabel:     nodeClaim.Labels[v1.CapacityTypeLabelKey],
 			metrics.MinValuesRelaxedLabel: "false",
 		})
 	}

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -2736,7 +2736,6 @@ var _ = Describe("Provisioning", func() {
 					ExpectMetricCounterValue(metrics.NodeClaimsCreatedTotal, 1, map[string]string{
 						metrics.ReasonLabel:           metrics.ProvisionedReason,
 						metrics.NodePoolLabel:         nodeClaim.Labels[v1.NodePoolLabelKey],
-						metrics.CapacityTypeLabel:     "",
 						metrics.MinValuesRelaxedLabel: "true",
 					})
 					Expect(nodeClaim.Spec.Requirements).To(ContainElements(
@@ -2917,7 +2916,6 @@ var _ = Describe("Provisioning", func() {
 					ExpectMetricCounterValue(metrics.NodeClaimsCreatedTotal, 1, map[string]string{
 						metrics.ReasonLabel:           metrics.ProvisionedReason,
 						metrics.NodePoolLabel:         nodeClaim.Labels[v1.NodePoolLabelKey],
-						metrics.CapacityTypeLabel:     "",
 						metrics.MinValuesRelaxedLabel: "true",
 					})
 					Expect(nodeClaim.Spec.Requirements).To(ContainElements(
@@ -3053,7 +3051,6 @@ var _ = Describe("Provisioning", func() {
 					ExpectMetricCounterValue(metrics.NodeClaimsCreatedTotal, 1, map[string]string{
 						metrics.ReasonLabel:           metrics.ProvisionedReason,
 						metrics.NodePoolLabel:         nodeClaim.Labels[v1.NodePoolLabelKey],
-						metrics.CapacityTypeLabel:     "",
 						metrics.MinValuesRelaxedLabel: "true",
 					})
 					Expect(nodeClaim.Spec.Requirements).To(ContainElements(
@@ -3170,7 +3167,6 @@ var _ = Describe("Provisioning", func() {
 					ExpectMetricCounterValue(metrics.NodeClaimsCreatedTotal, 1, map[string]string{
 						metrics.ReasonLabel:           metrics.ProvisionedReason,
 						metrics.NodePoolLabel:         nodeClaim.Labels[v1.NodePoolLabelKey],
-						metrics.CapacityTypeLabel:     "",
 						metrics.MinValuesRelaxedLabel: "true",
 					})
 				})

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -36,12 +36,11 @@ var (
 			Namespace: Namespace,
 			Subsystem: NodeClaimSubsystem,
 			Name:      "created_total",
-			Help:      "Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created, the owning nodepool, the capacity type and if min values was relaxed for this nodeclaim.",
+			Help:      "Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created, the owning nodepool, and if min values was relaxed for this nodeclaim.",
 		},
 		[]string{
 			ReasonLabel,
 			NodePoolLabel,
-			CapacityTypeLabel,
 			MinValuesRelaxedLabel,
 		},
 	)


### PR DESCRIPTION
…_created_total metric

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2362 <!-- issue number -->

**Description**

Remove stale label for metric, this is populated by cloud providers so the metric label is always empty since the nodeclaim doesn't have the capacity type label set when this metric is published.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
