### PR TITLE
fix: flakiness in expiration tests

### DIFF
--- a/test/suites/regression/expiration_test.go
+++ b/test/suites/regression/expiration_test.go
@@ -24,14 +24,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	"sigs.k8s.io/karpenter/pkg/test"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Expiration", func() {
@@ -80,15 +78,6 @@ var _ = Describe("Expiration", func() {
 		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
 		env.EventuallyExpectHealthyPodCount(selector, numPods)
 		env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
-
-		// Eventually the node will be tainted, which means its actively being disrupted
-		Eventually(func(g Gomega) {
-			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).Should(Succeed())
-			_, ok := lo.Find(node.Spec.Taints, func(t corev1.Taint) bool {
-				return t.MatchTaint(&v1.DisruptedNoScheduleTaint)
-			})
-			g.Expect(ok).To(BeTrue())
-		}).Should(Succeed())
 
 		env.EventuallyExpectCreatedNodeCount("==", 1)
 		// Set the limit to 0 to make sure we don't continue to create nodeClaims.
@@ -145,15 +134,6 @@ var _ = Describe("Expiration", func() {
 		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
 		env.EventuallyExpectHealthyPodCount(selector, int(numPods))
 		env.Monitor.Reset() // Reset the monitor so that we can expect a single node to be spun up after expiration
-
-		// Eventually the node will be tainted, which means its actively being disrupted
-		Eventually(func(g Gomega) {
-			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).Should(Succeed())
-			_, ok := lo.Find(node.Spec.Taints, func(t corev1.Taint) bool {
-				return t.MatchTaint(&v1.DisruptedNoScheduleTaint)
-			})
-			g.Expect(ok).To(BeTrue())
-		}).Should(Succeed())
 
 		env.EventuallyExpectCreatedNodeCount("==", 1)
 		// Set the limit to 0 to make sure we don't continue to create nodeClaims.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

`should expire the node after the expiration is reached` has been failing fairly frequently after https://github.com/kubernetes-sigs/karpenter/pull/2324 since the node and nodeclaim objects are deleted so quickly that the current validation doesn't work. This commit removes that validation since the eventual check of the node and nodeclaim being deleted should be good enough. I looked around to see if we can use any event to validate the expiration more precisely but couldn't find anything else.

**How was this change tested?**

Ran the test and it succeeds locally now. It would fail before this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
