### PR TITLE
fix: nodeAffinity ignore restricted label

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -539,7 +539,11 @@ func validateAffinity(ctx context.Context, p *corev1.Pod) (errs error) {
 	if p.Spec.Affinity.NodeAffinity != nil {
 		if p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 			for _, term := range p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
-				errs = multierr.Append(errs, validateNodeSelectorTerm(ctx, term))
+				err := validateNodeSelectorTerm(ctx, term)
+				if err == nil {
+					return nil
+				}
+				errs = multierr.Append(errs, err)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #2230

**Description**
- Affinity validation passes if at least one of nodeSelectorTerm passes

**How was this change tested?**
Unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
