### PR TITLE
perf: Optimistically delete from the cache after launch

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -46,6 +46,10 @@ func (l *Launch) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconc
 	if cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched); !cond.IsUnknown() {
 		// Ensure that we always set the status condition to the latest generation
 		nodeClaim.StatusConditions().Set(*cond)
+		if cond.IsTrue() {
+			// Once the NodeClaim has successfully marked as launched, we no longer need to store it
+			l.cache.Delete(string(nodeClaim.UID))
+		}
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

#2307 bumped the cache expiration timeout for the lifecycle controller to one hour. This increases the number of NodeClaim pointers that we can store in this cache. To reduce the amount of time that we hold things in this cache, we can optimistically remove entries from this cache by deleting the entry when we know we have stored all of the data after we have marked the node as launched

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
