### PR TITLE
fix: Don't schedule a pod with DRA requirements

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -86,6 +86,7 @@ type Options struct {
 	PreferencePolicy                 PreferencePolicy
 	minValuesPolicyRaw               string
 	MinValuesPolicy                  MinValuesPolicy
+	IgnoreDRARequests                bool // NOTE: This flag will be removed once formal DRA support is GA in Karpenter.
 	FeatureGates                     FeatureGates
 }
 
@@ -126,7 +127,8 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
 	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
-	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay and StaticCapacity.")
+	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")
+	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, and StaticCapacity.")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {
@@ -167,6 +169,8 @@ func DefaultFeatureGates() FeatureGates {
 		NodeRepair:              false,
 		ReservedCapacity:        true,
 		SpotToSpotConsolidation: false,
+		NodeOverlay:             false,
+		StaticCapacity:          false,
 	}
 }
 

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -125,6 +125,7 @@ var _ = Describe("Options", func() {
 					NodeOverlay:             lo.ToPtr(false),
 					StaticCapacity:          lo.ToPtr(false),
 				},
+				IgnoreDRARequests: lo.ToPtr(true),
 			}))
 		})
 
@@ -180,6 +181,7 @@ var _ = Describe("Options", func() {
 					NodeOverlay:             lo.ToPtr(true),
 					StaticCapacity:          lo.ToPtr(true),
 				},
+				IgnoreDRARequests: lo.ToPtr(true),
 			}))
 		})
 
@@ -235,6 +237,7 @@ var _ = Describe("Options", func() {
 					NodeOverlay:             lo.ToPtr(true),
 					StaticCapacity:          lo.ToPtr(true),
 				},
+				IgnoreDRARequests: lo.ToPtr(true),
 			}))
 		})
 
@@ -292,6 +295,7 @@ var _ = Describe("Options", func() {
 					NodeOverlay:             lo.ToPtr(true),
 					StaticCapacity:          lo.ToPtr(true),
 				},
+				IgnoreDRARequests: lo.ToPtr(true),
 			}))
 		})
 
@@ -382,4 +386,5 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.FeatureGates.NodeOverlay).To(Equal(optsB.FeatureGates.NodeOverlay))
 	Expect(optsA.FeatureGates.StaticCapacity).To(Equal(optsB.FeatureGates.StaticCapacity))
 	Expect(optsA.FeatureGates.SpotToSpotConsolidation).To(Equal(optsB.FeatureGates.SpotToSpotConsolidation))
+	Expect(optsA.IgnoreDRARequests).To(Equal(optsB.IgnoreDRARequests))
 }

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -47,6 +47,7 @@ type OptionsFields struct {
 	MinValuesPolicy                  *options.MinValuesPolicy
 	BatchMaxDuration                 *time.Duration
 	BatchIdleDuration                *time.Duration
+	IgnoreDRARequests                *bool
 	FeatureGates                     FeatureGates
 }
 
@@ -84,6 +85,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		BatchIdleDuration:                lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
 		PreferencePolicy:                 lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
 		MinValuesPolicy:                  lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
+		IgnoreDRARequests:                lo.FromPtrOr(opts.IgnoreDRARequests, true),
 		FeatureGates: options.FeatureGates{
 			NodeRepair:              lo.FromPtrOr(opts.FeatureGates.NodeRepair, false),
 			ReservedCapacity:        lo.FromPtrOr(opts.FeatureGates.ReservedCapacity, true),

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -207,3 +207,18 @@ func HasPodAntiAffinity(pod *corev1.Pod) bool {
 		(len(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 ||
 			len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0)
 }
+
+// HasDRARequirements returns true if any pod containers consume ResourceClaims
+func HasDRARequirements(pod *corev1.Pod) bool {
+	for _, container := range pod.Spec.InitContainers {
+		if len(container.Resources.Claims) > 0 {
+			return true
+		}
+	}
+	for _, container := range pod.Spec.Containers {
+		if len(container.Resources.Claims) > 0 {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

**Description**
Currently Karpenter creates nodes that can't satisfy DRA requirements and keep trying to schedule pod to the node.
Karpenter should recognize that pods are DRA enabled and not try to create nodes to fulfill them.

**How was this change tested?**
Unit tests and manually tested pod with resourceClaims in spec and scheduler correctly logs skipping message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
