### PR TITLE
fix: rate limit eviction when PDBs are blocking

### DIFF
--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -53,9 +53,8 @@ import (
 )
 
 const (
-	evictionQueueBaseDelay                 = 100 * time.Millisecond
-	evictionQueueUserMisconfigurationDelay = 1 * time.Second
-	evictionQueueMaxDelay                  = 10 * time.Second
+	evictionQueueBaseDelay = 100 * time.Millisecond
+	evictionQueueMaxDelay  = 10 * time.Second
 
 	multiplePodDisruptionBudgetsError = "This pod has more than one PodDisruptionBudget, which the eviction subresource does not support."
 )
@@ -198,9 +197,8 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 				return reconcile.Result{}, err2
 			}
 			errorMessage := lo.Ternary(message == multiplePodDisruptionBudgetsError, "eviction does not support multiple PDBs", "evicting pod violates a PDB")
-			requeueDuration := lo.Ternary(message == multiplePodDisruptionBudgetsError, evictionQueueUserMisconfigurationDelay, evictionQueueBaseDelay)
 			q.recorder.Publish(terminatorevents.NodeFailedToDrain(node, serrors.Wrap(errors.New(errorMessage), "Pod", klog.KRef(pod.Namespace, pod.Name))))
-			return reconcile.Result{RequeueAfter: requeueDuration}, nil
+			return reconcile.Result{Requeue: true}, nil
 		}
 		// Its not a PDB, we should requeue
 		return reconcile.Result{}, err

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -138,7 +138,8 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectManualBinding(ctx, env.Client, pod, node)
 			queue.Add(pod)
 			result := ExpectObjectReconciled(ctx, env.Client, queue, pod)
-			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+			//nolint:staticcheck
+			Expect(result.Requeue).To(BeTrue())
 			ExpectMetricCounterValue(terminator.NodesEvictionRequestsTotal, 1, map[string]string{terminator.CodeLabel: "429"})
 			e := recorder.Events()
 			Expect(e).To(HaveLen(1))
@@ -154,7 +155,8 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectManualBinding(ctx, env.Client, pod, node)
 			queue.Add(pod)
 			result := ExpectObjectReconciled(ctx, env.Client, queue, pod)
-			Expect(result.RequeueAfter).To(BeNumerically("==", time.Second))
+			//nolint:staticcheck
+			Expect(result.Requeue).To(BeTrue())
 			ExpectMetricCounterValue(terminator.NodesEvictionRequestsTotal, 1, map[string]string{terminator.CodeLabel: "500"})
 			e := recorder.Events()
 			Expect(e).To(HaveLen(1))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Updates the requeue behavior in the eviction controller to use `Requeue: true` rather than `RequeueAfter` when there are blocking PDBs. Previously, this resulted in us requeuing once every 100ms per pod bypassing any rate limiting on the work queue. With this change, we will enter exponential backoff (max of 10s) and still respect the overall controller rate limit.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
