### PR TITLE
chore: ignore pods that use unsupported provisioner in the storageClass

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -3242,7 +3242,7 @@ var _ = Context("Scheduling", func() {
 			Expect(node.Name).ToNot(Equal(node2.Name))
 		})
 		It("should not launch nodes for pod with storageClass that uses an unsupported provisioner", func() {
-			scheduling.UnsupportedProvisioners = lo.Assign(scheduling.UnsupportedProvisioners, map[string]struct{}{"other-provider": {}})
+			scheduling.UnsupportedProvisioners = lo.Assign(scheduling.UnsupportedProvisioners, sets.New("other-provider"))
 			// Launch an initial pod onto a node and register the CSI Node with a volume count limit of 1
 			sc := test.StorageClass(test.StorageClassOptions{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -3241,6 +3241,58 @@ var _ = Context("Scheduling", func() {
 			node2 := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Name).ToNot(Equal(node2.Name))
 		})
+		It("should not launch nodes for pod with storageClass that uses an unsupported provisioner", func() {
+			scheduling.DeniedStorageClassProvisioners = lo.Assign(scheduling.DeniedStorageClassProvisioners, map[string]struct{}{"other-provider": {}})
+			// Launch an initial pod onto a node and register the CSI Node with a volume count limit of 1
+			sc := test.StorageClass(test.StorageClassOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default-storage-class",
+					Annotations: map[string]string{
+						isDefaultStorageClassAnnotation: "true",
+					},
+				},
+				Provisioner: lo.ToPtr("other-provider"),
+				Zones:       []string{"test-zone-1"}})
+
+			ExpectApplied(ctx, env.Client, sc)
+			volumeName := "tmp-ephemeral"
+			pod := test.UnschedulablePod(test.PodOptions{})
+			// Pod has an ephemeral volume claim that has NO storage class, so it should use the default one
+			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					Ephemeral: &corev1.EphemeralVolumeSource{
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+								Resources: corev1.VolumeResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+			pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: pod.Namespace,
+					Name:      fmt.Sprintf("%s-%s", pod.Name, volumeName),
+				},
+				StorageClassName: lo.ToPtr(sc.Name),
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool, pvc, pod)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+
+			var nodeList corev1.NodeList
+			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
+			// no nodes should be created as the storage class is using an unsupported provisioner
+			Expect(nodeList.Items).To(HaveLen(0))
+		})
 		DescribeTable(
 			"should launch nodes for pods with ephemeral volume without a storage class when the PVC is bound",
 			func(storageClassName string) {

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -3242,7 +3242,7 @@ var _ = Context("Scheduling", func() {
 			Expect(node.Name).ToNot(Equal(node2.Name))
 		})
 		It("should not launch nodes for pod with storageClass that uses an unsupported provisioner", func() {
-			scheduling.DeniedStorageClassProvisioners = lo.Assign(scheduling.DeniedStorageClassProvisioners, map[string]struct{}{"other-provider": {}})
+			scheduling.UnsupportedProvisioners = lo.Assign(scheduling.UnsupportedProvisioners, map[string]struct{}{"other-provider": {}})
 			// Launch an initial pod onto a node and register the CSI Node with a volume count limit of 1
 			sc := test.StorageClass(test.StorageClassOptions{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This change allows Karpenter to ignore pods that use unsupported provisioner within their storageClass. Cloudproviders can use this to ignore pods with certain provisioners.

**How was this change tested?**
Tested on my dev cluster with aws-provider by tweaking it to ignore a fakeProvisioner and ensuring that we don't create a node for it. Also added unit test for it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
