### PR TITLE
chore: increase NodeClaim lifecycle liveness registration timeout

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -44,7 +44,7 @@ type Liveness struct {
 // If we don't see the node within this time, then we should delete the NodeClaim and try again
 
 const (
-	registrationTimeout       = time.Minute * 15
+	registrationTimeout       = time.Minute * 30
 	registrationTimeoutReason = "registration_timeout"
 	launchTimeout             = time.Minute * 5
 	launchTimeoutReason       = "launch_timeout"

--- a/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Liveness", func() {
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 
 			// If the node hasn't registered in the registration timeframe, then we deprovision the NodeClaim
-			fakeClock.Step(time.Minute * 20)
+			fakeClock.Step(time.Minute * 35)
 			ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 			ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
 			if isManagedNodeClaim {
@@ -122,7 +122,7 @@ var _ = Describe("Liveness", func() {
 		ExpectApplied(ctx, env.Client, node)
 
 		// Node and nodeClaim should still exist
-		fakeClock.Step(time.Minute * 20)
+		fakeClock.Step(time.Minute * 35)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		ExpectExists(ctx, env.Client, nodeClaim)
 		ExpectExists(ctx, env.Client, node)
@@ -256,7 +256,7 @@ var _ = Describe("Liveness", func() {
 		nodeClaim.Status.Conditions = newConditions
 		ExpectApplied(ctx, env.Client, nodeClaim)
 		// advance the clock to show that the timeout is not based on creation timestamp when considering registration timeout
-		fakeClock.Step(16 * time.Minute)
+		fakeClock.Step(31 * time.Minute)
 		result := ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		Expect(result.RequeueAfter).To(Not(Equal(0 * time.Second)))
 		Expect(result.RequeueAfter > 0*time.Second && result.RequeueAfter < 15*time.Minute).To(BeTrue())
@@ -290,7 +290,7 @@ var _ = Describe("Liveness", func() {
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 
 		// If the node hasn't registered in the registration timeframe, then we deprovision the nodeClaim
-		fakeClock.Step(time.Minute * 20)
+		fakeClock.Step(time.Minute * 35)
 		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
 
 		// NodeClaim registration failed, but we should not update the NodeRegistrationHealthy status condition if it is already True
@@ -306,7 +306,7 @@ var _ = Describe("Liveness", func() {
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 
 		// If the node hasn't registered in the registration timeframe, then we deprovision the nodeClaim
-		fakeClock.Step(time.Minute * 20)
+		fakeClock.Step(time.Minute * 35)
 		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
 		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
 		ExpectNotFound(ctx, env.Client, nodeClaim)


### PR DESCRIPTION
Fixes #N/A

**Description**
*  Increase NodeClaim lifecycle liveness `registrationTimeout` from 15 minutes to 30 minutes

**How was this change tested?**
* `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
