### PR TITLE
feat: Add `SimplifiedMetrics` as an environment variable

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -85,9 +85,6 @@ func NewControllers(
 		informer.NewNodePoolController(kubeClient, cloudProvider, cluster),
 		informer.NewNodeClaimController(kubeClient, cloudProvider, cluster),
 		termination.NewController(clock, kubeClient, cloudProvider, terminator.NewTerminator(clock, kubeClient, evictionQueue, recorder), recorder),
-		metricspod.NewController(kubeClient, cluster),
-		metricsnodepool.NewController(kubeClient, cloudProvider),
-		metricsnode.NewController(cluster),
 		nodepoolreadiness.NewController(kubeClient, cloudProvider),
 		nodepoolregistrationhealth.NewController(kubeClient, cloudProvider),
 		nodepoolcounter.NewController(kubeClient, cloudProvider, cluster),
@@ -99,25 +96,32 @@ func NewControllers(
 		nodeclaimdisruption.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimhydration.NewController(kubeClient, cloudProvider),
 		nodehydration.NewController(kubeClient, cloudProvider),
-		status.NewController[*v1.NodeClaim](
-			kubeClient,
-			mgr.GetEventRecorderFor("karpenter"),
-			status.EmitDeprecatedMetrics,
-			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
-			status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey)...),
-		),
-		status.NewController[*v1.NodePool](
-			kubeClient,
-			mgr.GetEventRecorderFor("karpenter"),
-			status.EmitDeprecatedMetrics,
-			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
-		),
-		status.NewGenericObjectController[*corev1.Node](
-			kubeClient,
-			mgr.GetEventRecorderFor("karpenter"),
-			status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
-			status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey, v1.NodeInitializedLabelKey)...),
-		),
+	}
+	if !options.FromContext(ctx).SimplifiedMetrics {
+		controllers = append(controllers,
+			metricspod.NewController(kubeClient, cluster),
+			metricsnodepool.NewController(kubeClient, cloudProvider),
+			metricsnode.NewController(cluster),
+			status.NewController[*v1.NodeClaim](
+				kubeClient,
+				mgr.GetEventRecorderFor("karpenter"),
+				status.EmitDeprecatedMetrics,
+				status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+				status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey)...),
+			),
+			status.NewController[*v1.NodePool](
+				kubeClient,
+				mgr.GetEventRecorderFor("karpenter"),
+				status.EmitDeprecatedMetrics,
+				status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+			),
+			status.NewGenericObjectController[*corev1.Node](
+				kubeClient,
+				mgr.GetEventRecorderFor("karpenter"),
+				status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
+				status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey, v1.NodeInitializedLabelKey)...),
+			),
+		)
 	}
 
 	// The cloud provider must define status conditions for the node repair controller to use to detect unhealthy nodes

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -70,6 +70,7 @@ type Options struct {
 	KubeClientQPS           int
 	KubeClientBurst         int
 	EnableProfiling         bool
+	SimplifiedMetrics       bool
 	DisableLeaderElection   bool
 	LeaderElectionName      string
 	LeaderElectionNamespace string
@@ -111,6 +112,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.IntVar(&o.KubeClientQPS, "kube-client-qps", env.WithDefaultInt("KUBE_CLIENT_QPS", 200), "The smoothed rate of qps to kube-apiserver")
 	fs.IntVar(&o.KubeClientBurst, "kube-client-burst", env.WithDefaultInt("KUBE_CLIENT_BURST", 300), "The maximum allowed burst of queries to the kube-apiserver")
 	fs.BoolVarWithEnv(&o.EnableProfiling, "enable-profiling", "ENABLE_PROFILING", false, "Enable the profiling on the metric endpoint")
+	fs.BoolVarWithEnv(&o.SimplifiedMetrics, "simplified-metrics", "SIMPLIFIED_METRICS", false, "Enable simplified metrics for the controllers")
 	fs.BoolVarWithEnv(&o.DisableLeaderElection, "disable-leader-election", "DISABLE_LEADER_ELECTION", false, "Disable the leader election client before executing the main loop. Disable when running replicated components for high availability is not desired.")
 	fs.StringVar(&o.LeaderElectionName, "leader-election-name", env.WithDefaultString("LEADER_ELECTION_NAME", "karpenter-leader-election"), "Leader election name to create and monitor the lease if running outside the cluster")
 	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", env.WithDefaultString("LEADER_ELECTION_NAMESPACE", ""), "Leader election namespace to create and monitor the lease if running outside the cluster")

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -52,6 +52,7 @@ var _ = Describe("Options", func() {
 		"KUBE_CLIENT_QPS",
 		"KUBE_CLIENT_BURST",
 		"ENABLE_PROFILING",
+		"SIMPLIFIED_METRICS",
 		"DISABLE_LEADER_ELECTION",
 		"LEADER_ELECTION_NAMESPACE",
 		"MEMORY_LIMIT",
@@ -105,6 +106,7 @@ var _ = Describe("Options", func() {
 				KubeClientQPS:           lo.ToPtr(200),
 				KubeClientBurst:         lo.ToPtr(300),
 				EnableProfiling:         lo.ToPtr(false),
+				SimplifiedMetrics:       lo.ToPtr(false),
 				DisableLeaderElection:   lo.ToPtr(false),
 				LeaderElectionName:      lo.ToPtr("karpenter-leader-election"),
 				LeaderElectionNamespace: lo.ToPtr(""),
@@ -136,6 +138,7 @@ var _ = Describe("Options", func() {
 				"--kube-client-qps", "0",
 				"--kube-client-burst", "0",
 				"--enable-profiling",
+				"--simplified-metrics",
 				"--disable-leader-election=true",
 				"--leader-election-name=karpenter-controller",
 				"--leader-election-namespace=karpenter",
@@ -157,6 +160,7 @@ var _ = Describe("Options", func() {
 				KubeClientQPS:           lo.ToPtr(0),
 				KubeClientBurst:         lo.ToPtr(0),
 				EnableProfiling:         lo.ToPtr(true),
+				SimplifiedMetrics:       lo.ToPtr(true),
 				DisableLeaderElection:   lo.ToPtr(true),
 				LeaderElectionName:      lo.ToPtr("karpenter-controller"),
 				LeaderElectionNamespace: lo.ToPtr("karpenter"),
@@ -184,6 +188,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("KUBE_CLIENT_QPS", "0")
 			os.Setenv("KUBE_CLIENT_BURST", "0")
 			os.Setenv("ENABLE_PROFILING", "true")
+			os.Setenv("SIMPLIFIED_METRICS", "true")
 			os.Setenv("DISABLE_LEADER_ELECTION", "true")
 			os.Setenv("LEADER_ELECTION_NAME", "karpenter-controller")
 			os.Setenv("LEADER_ELECTION_NAMESPACE", "karpenter")
@@ -209,6 +214,7 @@ var _ = Describe("Options", func() {
 				KubeClientQPS:           lo.ToPtr(0),
 				KubeClientBurst:         lo.ToPtr(0),
 				EnableProfiling:         lo.ToPtr(true),
+				SimplifiedMetrics:       lo.ToPtr(true),
 				DisableLeaderElection:   lo.ToPtr(true),
 				LeaderElectionName:      lo.ToPtr("karpenter-controller"),
 				LeaderElectionNamespace: lo.ToPtr("karpenter"),
@@ -235,6 +241,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("KUBE_CLIENT_QPS", "0")
 			os.Setenv("KUBE_CLIENT_BURST", "0")
 			os.Setenv("ENABLE_PROFILING", "true")
+			os.Setenv("SIMPLIFIED_METRICS", "true")
 			os.Setenv("DISABLE_LEADER_ELECTION", "true")
 			os.Setenv("MEMORY_LIMIT", "0")
 			os.Setenv("LOG_LEVEL", "debug")
@@ -263,6 +270,7 @@ var _ = Describe("Options", func() {
 				KubeClientQPS:           lo.ToPtr(0),
 				KubeClientBurst:         lo.ToPtr(0),
 				EnableProfiling:         lo.ToPtr(true),
+				SimplifiedMetrics:       lo.ToPtr(true),
 				DisableLeaderElection:   lo.ToPtr(true),
 				LeaderElectionName:      lo.ToPtr("karpenter-leader-election"),
 				LeaderElectionNamespace: lo.ToPtr(""),
@@ -354,6 +362,7 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.KubeClientQPS).To(Equal(optsB.KubeClientQPS))
 	Expect(optsA.KubeClientBurst).To(Equal(optsB.KubeClientBurst))
 	Expect(optsA.EnableProfiling).To(Equal(optsB.EnableProfiling))
+	Expect(optsA.SimplifiedMetrics).To(Equal(optsB.SimplifiedMetrics))
 	Expect(optsA.DisableLeaderElection).To(Equal(optsB.DisableLeaderElection))
 	Expect(optsA.MemoryLimit).To(Equal(optsB.MemoryLimit))
 	Expect(optsA.LogLevel).To(Equal(optsB.LogLevel))

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -34,6 +34,7 @@ type OptionsFields struct {
 	KubeClientQPS           *int
 	KubeClientBurst         *int
 	EnableProfiling         *bool
+	SimplifiedMetrics       *bool
 	DisableLeaderElection   *bool
 	LeaderElectionName      *string
 	LeaderElectionNamespace *string
@@ -71,6 +72,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		KubeClientQPS:         lo.FromPtrOr(opts.KubeClientQPS, 200),
 		KubeClientBurst:       lo.FromPtrOr(opts.KubeClientBurst, 300),
 		EnableProfiling:       lo.FromPtrOr(opts.EnableProfiling, false),
+		SimplifiedMetrics:     lo.FromPtrOr(opts.SimplifiedMetrics, false),
 		DisableLeaderElection: lo.FromPtrOr(opts.DisableLeaderElection, false),
 		MemoryLimit:           lo.FromPtrOr(opts.MemoryLimit, -1),
 		CPURequests:           lo.FromPtrOr(opts.CPURequests, 5000), // use 5 threads to enforce parallelism


### PR DESCRIPTION
Fixes #N/A

**Description**
* Add `SimplifiedMetrics` as an environment variable option
   * When true, excludes observability metrics for Pods, NodePools, and Nodes and status transition metrics for NodeClaims, NodePools, and Nodes.

**How was this change tested?**
* `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
