### PR TITLE
fix: pod metrics when pod is terminal

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -319,9 +319,11 @@ func (c *Controller) recordPodStartupMetric(pod *corev1.Pod, schedulableTime tim
 				podName:      pod.Name,
 				podNamespace: pod.Namespace,
 			})
-			PodStartupDurationSeconds.Observe(cond.LastTransitionTime.Sub(pod.CreationTimestamp.Time).Seconds(), nil)
-			if !schedulableTime.IsZero() {
-				PodProvisioningStartupDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), nil)
+			if ready {
+				PodStartupDurationSeconds.Observe(cond.LastTransitionTime.Sub(pod.CreationTimestamp.Time).Seconds(), nil)
+				if !schedulableTime.IsZero() {
+					PodProvisioningStartupDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), nil)
+				}
 			}
 			c.pendingPods.Delete(key)
 			// Clear cluster state's representation of these pods as we don't need to keep track of them anymore

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -250,7 +250,7 @@ var _ = Describe("Pod Metrics", func() {
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_startup_duration_seconds", nil)
 		Expect(found).To(BeTrue())
 	})
-	It("should update the pod startup and unstarted time metrics when the pod has succeeded", func() {
+	It("should update the pod unstarted time metrics when the pod has succeeded", func() {
 		p := test.Pod()
 		p.Status.Phase = corev1.PodPending
 
@@ -293,7 +293,7 @@ var _ = Describe("Pod Metrics", func() {
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_startup_duration_seconds", nil)
 		Expect(found).To(BeFalse())
 	})
-	It("should update the pod startup and unstarted time metrics when the pod has failed", func() {
+	It("should update the pod unstarted time metrics when the pod has failed", func() {
 		p := test.Pod()
 		p.Status.Phase = corev1.PodPending
 

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -61,6 +61,8 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterEach(func() {
 	cluster.Reset()
+	pod.PodStartupDurationSeconds.Reset()
+	pod.PodProvisioningStartupDurationSeconds.Reset()
 })
 
 var _ = AfterSuite(func() {
@@ -287,9 +289,9 @@ var _ = Describe("Pod Metrics", func() {
 		Expect(found).To(BeFalse())
 
 		_, found = FindMetricWithLabelValues("karpenter_pods_startup_duration_seconds", nil)
-		Expect(found).To(BeTrue())
+		Expect(found).To(BeFalse())
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_startup_duration_seconds", nil)
-		Expect(found).To(BeTrue())
+		Expect(found).To(BeFalse())
 	})
 	It("should update the pod startup and unstarted time metrics when the pod has failed", func() {
 		p := test.Pod()
@@ -330,9 +332,9 @@ var _ = Describe("Pod Metrics", func() {
 		Expect(found).To(BeFalse())
 
 		_, found = FindMetricWithLabelValues("karpenter_pods_startup_duration_seconds", nil)
-		Expect(found).To(BeTrue())
+		Expect(found).To(BeFalse())
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_startup_duration_seconds", nil)
-		Expect(found).To(BeTrue())
+		Expect(found).To(BeFalse())
 	})
 	It("should create and delete provisioning undecided metrics based on scheduling simulatinos", func() {
 		p := test.Pod()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2403 

**Description**
`karpenter_pods_startup_duration_seconds` is taking negative values for terminal pods because pod status condition Ready is set to False for terminal pods. 

**How was this change tested?**
Added unit tests. Deployed to my dev cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
