### PR TITLE
fix(BREAKING): update naming of karpenter_pods_drained_total

### DIFF
--- a/pkg/controllers/node/termination/terminator/metrics.go
+++ b/pkg/controllers/node/termination/terminator/metrics.go
@@ -47,7 +47,7 @@ var PodsDrainedTotal = opmetrics.NewPrometheusCounter(
 	prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
 		Subsystem: metrics.PodSubsystem,
-		Name:      "pods_drained_total",
+		Name:      "drained_total",
 		Help:      "The total number of pods drained during node termination by Karpenter, labeled by reason",
 	},
 	[]string{ReasonLabel},


### PR DESCRIPTION
Current config results in this `karpenter_pods_pods_drained_total`

<img width="416" height="241" alt="image" src="https://github.com/user-attachments/assets/eed6ed53-95a3-4b3c-98b2-0aa183891015" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
