### PR TITLE
fix: do not block drifted nodes from being terminated if consolidation is disabled

### DIFF
--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -19,8 +19,10 @@ package disruption
 import (
 	"context"
 	"errors"
+	"slices"
 	"sort"
 
+	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
@@ -61,14 +63,15 @@ func (d *Drift) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[
 			candidates[j].NodeClaim.StatusConditions().Get(string(d.Reason())).LastTransitionTime.Time)
 	})
 
-	for _, candidate := range candidates {
-		// Filter out empty candidates. If there was an empty node that wasn't consolidated before this, we should
-		// assume that it was due to budgets. If we don't filter out budgets, users who set a budget for `empty`
-		// can find their nodes disrupted here, which while that in itself isn't an issue for empty nodes, it could
-		// constrain the `drift` budget.
-		if len(candidate.reschedulablePods) == 0 {
-			continue
-		}
+	emptyCandidates := lo.Filter(candidates, func(c *Candidate, _ int) bool {
+		return len(c.reschedulablePods) == 0
+	})
+	nonEmptyCandidates := lo.Filter(candidates, func(c *Candidate, _ int) bool {
+		return len(c.reschedulablePods) > 0
+	})
+
+	// Prioritize non-empty candidates since we want them to get priority over empty candidates if the budget is constrained.
+	for _, candidate := range slices.Concat(nonEmptyCandidates, emptyCandidates) {
 		// If the disruption budget doesn't allow this candidate to be disrupted,
 		// continue to the next candidate. We don't need to decrement any budget
 		// counter since drift commands can only have one candidate.


### PR DESCRIPTION


<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

There was a regression introduced in https://github.com/kubernetes-sigs/karpenter/pull/2180:

```
        // Filter out empty candidates. If there was an empty node that wasn't consolidated before this, we should
        // assume that it was due to budgets. If we don't filter out budgets, users who set a budget for `empty`
        // can find their nodes disrupted here, which while that in itself isn't an issue for empty nodes, it could
        // constrain the `drift` budget.
        if len(candidate.reschedulablePods) == 0 {
            continue
        }
```

This doesn't account for cases where consolidation is disabled (or for that matter has a really long consolidation period). Drift shouldn't be blocked on consolidation since they are independent disruption methods.

So, what happens is that emptiness doesn't disrupt the node since consolidation is disabled. But drift also doesn't terminate the node since the node is empty and it incorrectly assumes that emptiness would always disrupt it.

The original intent makes sense though which is why I am also making a change to prioritize non-empty nodes over empty nodes for drift.

With this change, it is totally possible that nodes which aren't eligible to be consolidated at a moment in time get disrupted due to drift and consume a disruption budget but I think it is more important to still allow drift to happen so that we don't have stale nodes (either with outdated AMI or otherwise) even if they are empty because those empty nodes can still get pods scheduled on them which means that the user runs a risk of having their applications run on outdated AMIs.

This is also why I somehow feel that the original priority order of drift being the first disruption method makes sense since it should be more important for customers to be running a more up-to-date node than being more efficient with their workloads but as the original PR mentions, there are rough edges to that approach especially when customers drift nodes for non-critical reasons.

All of this could've been prevented in the first place if we actually had separate buckets for each disruption reason. Something that https://github.com/kubernetes-sigs/karpenter/issues/2387 intends to solve.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
