### PR TITLE
chore: increase MaxInstanceTypes to give cloud-providers more control over instance type truncation

### DIFF
--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -1373,7 +1373,7 @@ var _ = Describe("Instance Type Selection", func() {
 			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts2))
 			// We have the required InstanceTypes that meet the minValues requirement.
 			cloudProvider.InstanceTypes = instanceTypes
-			// The truncation is changed from the default 100 to 1 for the ease of testing.
+			// The truncation is changed from the default to 1 for the ease of testing.
 			// This will truncate the 2 InstanceTypes to 1 resulting in breaking the minValue requirement and hence should fail the scheduling.
 			scheduling.MaxInstanceTypes = 1
 

--- a/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaimtemplate.go
@@ -37,7 +37,7 @@ var DefaultTerminationGracePeriod *metav1.Duration = nil
 
 // MaxInstanceTypes is a constant that restricts the number of instance types to be sent for launch. Note that this
 // is intentionally changed to var just to help in testing the code.
-var MaxInstanceTypes = 60
+var MaxInstanceTypes = 600
 
 // NodeClaimTemplate encapsulates the fields required to create a node and mirrors
 // the fields in NodePool. These structs are maintained separately in order
@@ -74,7 +74,7 @@ func NewNodeClaimTemplate(nodePool *v1.NodePool) *NodeClaimTemplate {
 }
 
 func (i *NodeClaimTemplate) ToNodeClaim() *v1.NodeClaim {
-	// Order the instance types by price and only take the first 100 of them to decrease the instance type size in the requirements
+	// Order the instance types by price and only take up to MaxInstanceTypes of them to decrease the instance type size in the requirements
 	instanceTypes := lo.Slice(i.InstanceTypeOptions.OrderByPrice(i.Requirements), 0, MaxInstanceTypes)
 	i.Requirements.Add(scheduling.NewRequirementWithFlexibility(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, i.Requirements.Get(corev1.LabelInstanceTypeStable).MinValues, lo.Map(instanceTypes, func(i *cloudprovider.InstanceType, _ int) string {
 		return i.Name


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change increases the instance types that are set in a NodeClaim from 60 to 600. The number 600 was chosen to be sufficiently high but still putting an upper-bound on the number of instance types set in the NodeClaim. 

This should not increase scheduling latency since truncation occurs after scheduling/bin-packing simulations. 

The AWS Cloud Provider is still truncating to 60 instance types, set [here](https://github.com/aws/karpenter-provider-aws/blob/main/pkg/providers/instance/instance.go#L62).

The Azure Cloud Provider sorts the NodeClaim's instance types and only passes 1 to the provisioning API [here](https://github.com/Azure/karpenter-provider-azure/blob/main/pkg/providers/instance/instance.go#L626).

**How was this change tested?**

Manual testing:
 1. Created a wide-open NodePool with AWS Cloud Provider 
 2. Created a small pod for Karpenter to provision a NodeClaim for
 3. Observed the NodeClaim contained 600 instance types
 4. Observed the CreateFleet request still contained 60 Instance Types from Cloud Provider truncation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
