### PR TITLE
feat: add `--log-encoding` command line flag

### DIFF
--- a/pkg/operator/logging/logging.go
+++ b/pkg/operator/logging/logging.go
@@ -46,6 +46,7 @@ func DefaultZapConfig(ctx context.Context, component string) zap.Config {
 		// Webhooks are deprecated, so support for changing their log level is also deprecated
 		logLevel = lo.Must(zap.ParseAtomicLevel(l))
 	}
+	logEncoding := lo.Ternary(options.FromContext(ctx).LogEncoding != "console", "json", "console")
 	return zap.Config{
 		Level:             logLevel,
 		Development:       false,
@@ -55,7 +56,7 @@ func DefaultZapConfig(ctx context.Context, component string) zap.Config {
 			Initial:    100,
 			Thereafter: 100,
 		},
-		Encoding: "json",
+		Encoding: logEncoding,
 		EncoderConfig: zapcore.EncoderConfig{
 			MessageKey:     "message",
 			LevelKey:       "level",

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -46,6 +46,7 @@ const (
 
 var (
 	validLogLevels          = []string{"", "debug", "info", "error"}
+	validLogEncodings       = []string{"json", "console"}
 	validPreferencePolicies = []PreferencePolicy{PreferencePolicyIgnore, PreferencePolicyRespect}
 
 	Injectables = []Injectable{&Options{}}
@@ -78,6 +79,7 @@ type Options struct {
 	MemoryLimit                      int64
 	CPURequests                      int64
 	LogLevel                         string
+	LogEncoding                      string
 	LogOutputPaths                   string
 	LogErrorOutputPaths              string
 	BatchMaxDuration                 time.Duration
@@ -121,6 +123,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.Int64Var(&o.MemoryLimit, "memory-limit", env.WithDefaultInt64("MEMORY_LIMIT", -1), "Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value.")
 	fs.Int64Var(&o.CPURequests, "cpu-requests", env.WithDefaultInt64("CPU_REQUESTS", 1000), "CPU requests in millicores on the container running the controller.")
 	fs.StringVar(&o.LogLevel, "log-level", env.WithDefaultString("LOG_LEVEL", "info"), "Log verbosity level. Can be one of 'debug', 'info', or 'error'")
+	fs.StringVar(&o.LogEncoding, "log-encoding", env.WithDefaultString("LOG_ENCODING", "json"), "Log encoding format. Can be one of 'json' or 'console'")
 	fs.StringVar(&o.LogOutputPaths, "log-output-paths", env.WithDefaultString("LOG_OUTPUT_PATHS", "stdout"), "Optional comma separated paths for directing log output")
 	fs.StringVar(&o.LogErrorOutputPaths, "log-error-output-paths", env.WithDefaultString("LOG_ERROR_OUTPUT_PATHS", "stderr"), "Optional comma separated paths for logging error output")
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
@@ -140,6 +143,9 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 	}
 	if !lo.Contains(validLogLevels, o.LogLevel) {
 		return fmt.Errorf("validating cli flags / env vars, invalid LOG_LEVEL %q", o.LogLevel)
+	}
+	if !lo.Contains(validLogEncodings, o.LogEncoding) {
+		return fmt.Errorf("validating cli flags / env vars, invalid LOG_ENCODING %q, should be 'json' or 'console'", o.LogEncoding)
 	}
 	if !lo.Contains(validPreferencePolicies, PreferencePolicy(o.preferencePolicyRaw)) {
 		return fmt.Errorf("validating cli flags / env vars, invalid PREFERENCE_POLICY %q", o.preferencePolicyRaw)

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Options", func() {
 		"LEADER_ELECTION_NAMESPACE",
 		"MEMORY_LIMIT",
 		"LOG_LEVEL",
+		"LOG_ENCODING",
 		"LOG_OUTPUT_PATHS",
 		"LOG_ERROR_OUTPUT_PATHS",
 		"BATCH_MAX_DURATION",
@@ -112,6 +113,7 @@ var _ = Describe("Options", func() {
 				LeaderElectionNamespace:          lo.ToPtr(""),
 				MemoryLimit:                      lo.ToPtr[int64](-1),
 				LogLevel:                         lo.ToPtr("info"),
+				LogEncoding:                      lo.ToPtr("json"),
 				LogOutputPaths:                   lo.ToPtr("stdout"),
 				LogErrorOutputPaths:              lo.ToPtr("stderr"),
 				BatchMaxDuration:                 lo.ToPtr(10 * time.Second),
@@ -146,6 +148,7 @@ var _ = Describe("Options", func() {
 				"--leader-election-namespace=karpenter",
 				"--memory-limit", "0",
 				"--log-level", "debug",
+				"--log-encoding", "console",
 				"--log-output-paths", "/etc/k8s/test",
 				"--log-error-output-paths", "/etc/k8s/testerror",
 				"--batch-max-duration", "5s",
@@ -168,6 +171,7 @@ var _ = Describe("Options", func() {
 				LeaderElectionNamespace:          lo.ToPtr("karpenter"),
 				MemoryLimit:                      lo.ToPtr[int64](0),
 				LogLevel:                         lo.ToPtr("debug"),
+				LogEncoding:                      lo.ToPtr("console"),
 				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
 				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
 				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
@@ -198,6 +202,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("LEADER_ELECTION_NAMESPACE", "karpenter")
 			os.Setenv("MEMORY_LIMIT", "0")
 			os.Setenv("LOG_LEVEL", "debug")
+			os.Setenv("LOG_ENCODING", "console")
 			os.Setenv("LOG_OUTPUT_PATHS", "/etc/k8s/test")
 			os.Setenv("LOG_ERROR_OUTPUT_PATHS", "/etc/k8s/testerror")
 			os.Setenv("BATCH_MAX_DURATION", "5s")
@@ -224,6 +229,7 @@ var _ = Describe("Options", func() {
 				LeaderElectionNamespace:          lo.ToPtr("karpenter"),
 				MemoryLimit:                      lo.ToPtr[int64](0),
 				LogLevel:                         lo.ToPtr("debug"),
+				LogEncoding:                      lo.ToPtr("console"),
 				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
 				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
 				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
@@ -282,6 +288,7 @@ var _ = Describe("Options", func() {
 				LeaderElectionNamespace:          lo.ToPtr(""),
 				MemoryLimit:                      lo.ToPtr[int64](0),
 				LogLevel:                         lo.ToPtr("debug"),
+				LogEncoding:                      lo.ToPtr("json"),
 				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
 				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
 				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
@@ -355,6 +362,21 @@ var _ = Describe("Options", func() {
 			err := opts.Parse(fs, "--log-level", "hello")
 			Expect(err).ToNot(BeNil())
 		})
+
+		DescribeTable(
+			"should parse valid log encoding successfully",
+			func(encoding string) {
+				err := opts.Parse(fs, "--log-encoding", encoding)
+				Expect(err).To(BeNil())
+			},
+			Entry("json", "json"),
+			Entry("console", "console"),
+		)
+		It("should error with an invalid log encoding", func() {
+			err := opts.Parse(fs, "--log-encoding", "hello")
+			Expect(err).ToNot(BeNil())
+		})
+
 		DescribeTable(
 			"should fallback to the default if a non-positive value is provided for CPU_REQUESTS",
 			func(value string) {
@@ -385,6 +407,7 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.DisableClusterStateObservability).To(Equal(optsB.DisableClusterStateObservability))
 	Expect(optsA.MemoryLimit).To(Equal(optsB.MemoryLimit))
 	Expect(optsA.LogLevel).To(Equal(optsB.LogLevel))
+	Expect(optsA.LogEncoding).To(Equal(optsB.LogEncoding))
 	Expect(optsA.LogOutputPaths).To(Equal(optsB.LogOutputPaths))
 	Expect(optsA.LogErrorOutputPaths).To(Equal(optsB.LogErrorOutputPaths))
 	Expect(optsA.BatchMaxDuration).To(Equal(optsB.BatchMaxDuration))

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -41,6 +41,7 @@ type OptionsFields struct {
 	MemoryLimit                      *int64
 	CPURequests                      *int64
 	LogLevel                         *string
+	LogEncoding                      *string
 	LogOutputPaths                   *string
 	LogErrorOutputPaths              *string
 	PreferencePolicy                 *options.PreferencePolicy
@@ -79,6 +80,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		MemoryLimit:                      lo.FromPtrOr(opts.MemoryLimit, -1),
 		CPURequests:                      lo.FromPtrOr(opts.CPURequests, 5000), // use 5 threads to enforce parallelism
 		LogLevel:                         lo.FromPtrOr(opts.LogLevel, ""),
+		LogEncoding:                      lo.FromPtrOr(opts.LogEncoding, "json"),
 		LogOutputPaths:                   lo.FromPtrOr(opts.LogOutputPaths, "stdout"),
 		LogErrorOutputPaths:              lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),
 		BatchMaxDuration:                 lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**
This patch introduces a new flag `--log-encoding`, that allows users to choose between `console` and `json` output formats. (default: `json`) By adding the `console` format, developers can now easily read and debug log messages directly without parsing the JSON structure.

**How was this change tested?**
Added a new test in `pkg/operator/options/suite_test.go`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.