### PR TITLE
chore: Pin GH action SHAs for run-bench-test

### DIFF
--- a/.github/workflows/run-bench-test.yaml
+++ b/.github/workflows/run-bench-test.yaml
@@ -19,7 +19,7 @@ jobs:
   run-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ inputs.githubSha }}
       - name: Run Test
@@ -34,7 +34,7 @@ jobs:
             cat output/results.txt
             echo EOF
           } >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         id: artifact-upload
         with:
           name: ${{ inputs.runName }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR pins all of our third-party actions to a full-length SHA to ensure they are not vulnerable to a supply-chain attack. This is the best practice for third-party GHA as described here: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

This work was originally done in other actions in #801 and is being added here for the new run-bench-test workflow

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
