### PR TITLE
feat: add option to ignore pods on deleting nodes during scheduling decisions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,7 +26,7 @@ linters:
     - prealloc
 linters-settings:
   gocyclo:
-    min-complexity: 11
+    min-complexity: 12
   govet:
     enable-all: true
     disable:

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -91,7 +91,9 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	if err != nil {
 		return scheduling.Results{}, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
 	}
-	pods = append(pods, deletingNodePods...)
+	if !options.FromContext(ctx).IgnoreDeletingNodePods {
+		pods = append(pods, deletingNodePods...)
+	}
 
 	var opts []scheduling.Options
 	if options.FromContext(ctx).PreferencePolicy == options.PreferencePolicyIgnore {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -88,6 +88,7 @@ type Options struct {
 	MinValuesPolicy                  MinValuesPolicy
 	IgnoreDRARequests                bool // NOTE: This flag will be removed once formal DRA support is GA in Karpenter.
 	FeatureGates                     FeatureGates
+	IgnoreDeletingNodePods           bool
 }
 
 type FlagSet struct {
@@ -129,6 +130,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, and StaticCapacity.")
+	fs.BoolVarWithEnv(&o.IgnoreDeletingNodePods, "ignore-deleting-node-pods", "IGNORE_DELETING_NODE_PODS", false, "Ignore pods on deleting nodes when making scheduling decisions. This is useful when using an external eviction controller alongside Karpenter to avoid overprovisioning from pods that will be deleted anyway.")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2452

**Description**
When an external webhook or controller intercepts and delays the eviction of pods from nodes that Karpenter is preparing to delete (e.g., during consolidation), Karpenter may incorrectly provision additional capacity for these pods. This happens because Karpenter perceives the pods as still needing to be scheduled, even though a replacement pod may have already been provisioned elsewhere. This leads to a continuous cycle of provisioning and consolidation, as Karpenter repeatedly launches new nodes to accommodate the "ghost" pods on the deleting node.

This behavior is particularly problematic in scenarios where users are managing single-replica deployments and want to ensure a new pod is fully healthy before the old one is terminated, a common pattern that often involves a custom eviction webhook to delay the process, like the one discussed here https://github.com/kubernetes-sigs/karpenter/pull/2256#issuecomment-2938103811.

Ideally, users should have a configuration option to disable this behavior, preventing Karpenter from attempting to provision for pods that are in a "pending eviction" state due to external controllers.

**How was this change tested?**
Deployed to a testing cluster with and without the flag and confirmed the behaviour gets fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
