### PR TITLE
ci: revert k8s 1.34 addition

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8sVersion: ["1.28.x", "1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x"]
+        k8sVersion: ["1.28.x", "1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x"]
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Set up Python 3.10
@@ -29,9 +29,9 @@ jobs:
         kubectl config current-context
         kubectl get nodes
         kubectl taint nodes chart-testing-control-plane CriticalAddonsOnly:NoSchedule
-    - name: install prometheus 
+    - name: install prometheus
       uses: ./.github/actions/install-prometheus
-    - name: install pyroscope 
+    - name: install pyroscope
       uses: ./.github/actions/install-pyroscope
     - name: install kwok and controller
       shell: bash
@@ -42,9 +42,9 @@ jobs:
         make apply-with-kind
     - name: ping cluster
       shell: bash
-      run: | 
+      run: |
         sleep 15
-        kubectl get pods -n kube-system | grep karpenter 
+        kubectl get pods -n kube-system | grep karpenter
         kubectl get nodepools
         kubectl get pods -A
         kubectl describe nodes
@@ -63,7 +63,7 @@ jobs:
     #   shell: bash
     #   run: |
     #     pip install pandas==2.2.2
-    #     pip install pyarrow==16.1.0 
+    #     pip install pyarrow==16.1.0
     #     pip install tabulate==0.9.0
     #     pip install prometheus-api-client==0.5.5
     #     pip install ./karpenter_eval/
@@ -78,10 +78,10 @@ jobs:
     #   shell: bash
     #   run: |
     #     OUTPUT_DIR=${{ env.OUTPUT_DIR }} python ./karpenter_eval/main.py
-    - name: cleanup 
+    - name: cleanup
       shell: bash
-      run: | 
-        kubectl delete nodepools --all 
+      run: |
+        kubectl delete nodepools --all
         make delete
         make uninstall-kwok
-        
+

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8sVersion: ["1.28.x", "1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x"]
+        k8sVersion: ["1.28.x", "1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x"]
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - uses: ./.github/actions/install-deps
@@ -25,7 +25,7 @@ jobs:
     - run: K8S_VERSION=${{ matrix.k8sVersion }} make presubmit
     - name: Send coverage
       # should only send converage once https://docs.coveralls.io/parallel-builds
-      if: matrix.k8sVersion == '1.34.x'
+      if: matrix.k8sVersion == '1.33.x'
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: goveralls -coverprofile=coverage.out -service=github

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-K8S_VERSION="${K8S_VERSION:="1.34.x"}"
+K8S_VERSION="${K8S_VERSION:="1.33.x"}"
 KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:=/usr/local/kubebuilder/bin}"
 
 main() {

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -139,7 +139,7 @@ func NewEnvironment(options ...option.Function[EnvironmentOptions]) *Environment
 	opts := option.Resolve(options...)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	version := version.MustParseSemantic(strings.Replace(env.WithDefaultString("K8S_VERSION", "1.34.x"), ".x", ".0", -1))
+	version := version.MustParseSemantic(strings.Replace(env.WithDefaultString("K8S_VERSION", "1.33.x"), ".x", ".0", -1))
 	environment := envtest.Environment{Scheme: scheme.Scheme, CRDs: opts.crds}
 	if version.Minor() >= 21 && version.Minor() < 32 {
 		// PodAffinityNamespaceSelector is used for label selectors in pod affinities.  If the feature-gate is turned off,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Reverts the addition of the k8s 1.34 tests. A change was made to how `matchLabelKeys` for TSC is injected by the API server which causes this test suite to fail. A fix for the issue can be tracked in https://github.com/kubernetes-sigs/karpenter/pull/2471.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
