### PR TITLE
fix: avoid hash collisions with duplicate match expressions

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -182,20 +182,37 @@ func (t *TopologyGroup) IsOwnedBy(key types.UID) bool {
 // with self anti-affinity, we track that as a single topology with 100 owners instead of 100x topologies.
 func (t *TopologyGroup) Hash() uint64 {
 	return lo.Must(hashstructure.Hash(struct {
-		TopologyKey string
-		Type        TopologyType
-		Namespaces  sets.Set[string]
-		RawSelector *metav1.LabelSelector
-		MaxSkew     int32
-		NodeFilter  TopologyNodeFilter
+		TopologyKey  string
+		Type         TopologyType
+		Namespaces   sets.Set[string]
+		MaxSkew      int32
+		NodeFilter   TopologyNodeFilter
+		SelectorHash uint64
 	}{
-		TopologyKey: t.Key,
-		Type:        t.Type,
-		Namespaces:  t.namespaces,
-		RawSelector: t.rawSelector,
-		MaxSkew:     t.maxSkew,
-		NodeFilter:  t.nodeFilter,
+		TopologyKey:  t.Key,
+		Type:         t.Type,
+		Namespaces:   t.namespaces,
+		MaxSkew:      t.maxSkew,
+		NodeFilter:   t.nodeFilter,
+		SelectorHash: hashSelector(t.rawSelector),
 	}, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true}))
+}
+
+// hashSelector is a specialized hash function for a metav1.LabelSelector. Due to https://github.com/mitchellh/hashstructure/issues/36
+// repeated requirements inside a label selector can result in hash collisions when using SlicesAsSets. This function provides the same
+// behavior while avoiding that bug by storing the individual expression hashes in a set, ensuring there aren't repeated elements.
+//
+// NOTE: Although repeated elements typically won't occur, they can occur on k8s 1.34+ when using matchLabelKeys since both Karpenter
+// and the API server inject an expression.
+func hashSelector(selector *metav1.LabelSelector) uint64 {
+	expressionHashes := sets.New[uint64]()
+	for i := range selector.MatchExpressions {
+		expressionHashes.Insert(lo.Must(hashstructure.Hash(selector.MatchExpressions[i], hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})))
+	}
+	return lo.Must(hashstructure.Hash([]interface{}{
+		expressionHashes,
+		lo.Must(hashstructure.Hash(selector.MatchLabels, hashstructure.FormatV2, nil)),
+	}, hashstructure.FormatV2, nil))
 }
 
 // nextDomainTopologySpread returns a scheduling.Requirement that includes a node domain that a pod should be scheduled to.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

When a topology spread constraint defines duplicate expressions in it's label selector, it can result in a hash collision with other `TopologyGroups` even if they have a different expression. This is a manifestation of https://github.com/mitchellh/hashstructure/issues/36. 

This issue surfaced itself when we enabled k8s 1.34 testing. This is due to https://github.com/kubernetes/kubernetes/pull/129874, which changed the behavior of `matchLabelKeys` for TSC to match that of pod affinity. As a result, both Karpenter and the API server are injecting expressions for `MatchLabelKeys`. Consider the following example from our tests:

```yaml
kind: Pod
apiVersion: v1
metadata:
  labels:
    test-label: "value-a"
spec:
  topologySpreadConstraints:
  - topologyKey: "kubernetes.io/hostname"
    whenUnsatisfiable: "DoNotSchedule"
    matchLabelKeys:
    - "test-label"
    maxSkew: 1
```

In memory, this results in the following label selector:
```yaml
labelSelector:
  matchExpressions:
  - key: "test-label"
    operator: "In"
    values:
    - "value-a"
  - key: "test-label"
    operator: "In"
    values:
    - "value-a"
```

Now if we have a second set of pods, where `test-label` is `value-b`, we would expect the same label selector except that instead of `value-a` it would be `value-b` in `values`. We would also expect to construct a separate topology group for pods with each of those label selectors. However, because of the aforementioned bug the two selectors have a hash collision and we use the same topology group for both.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
