### PR TITLE
fix: handle nil selector when hashing in topology

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topology_test.go
+++ b/pkg/controllers/provisioning/scheduling/topology_test.go
@@ -91,6 +91,21 @@ var _ = Describe("Topology", func() {
 		ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(2))
 	})
 
+	It("should not spread when a nil label selector is defined", func() {
+		topology := []corev1.TopologySpreadConstraint{{
+			TopologyKey:       corev1.LabelTopologyZone,
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			MaxSkew:           1,
+		}}
+		pods := test.UnschedulablePods(test.PodOptions{
+			ObjectMeta:                metav1.ObjectMeta{Labels: labels},
+			TopologySpreadConstraints: topology,
+		}, 2)
+		ExpectApplied(ctx, env.Client, nodePool)
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+		ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(2))
+	})
+
 	Context("Zonal", func() {
 		It("should balance pods across zones (match labels)", func() {
 			topology := []corev1.TopologySpreadConstraint{{

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -55,14 +55,17 @@ func (t TopologyType) String() string {
 // TopologyGroup is used to track pod counts that match a selector by the topology domain (e.g. SELECT COUNT(*) FROM pods GROUP BY(topology_ke
 type TopologyGroup struct {
 	// Hashed Fields
-	Key         string
-	Type        TopologyType
-	maxSkew     int32
-	minDomains  *int32
-	namespaces  sets.Set[string]
-	selector    labels.Selector
+	Key        string
+	Type       TopologyType
+	maxSkew    int32
+	minDomains *int32
+	namespaces sets.Set[string]
+	selector   labels.Selector
+
+	// NOTE: This is actually nillable since there's no API server validation to require it on affinity / TSC terms. A term without it is a no-op.
 	rawSelector *metav1.LabelSelector
 	nodeFilter  TopologyNodeFilter
+
 	// Index
 	owners       map[types.UID]struct{} // Pods that have this topology as a scheduling rule
 	domains      map[string]int32       // TODO(ellistarn) explore replacing with a minheap
@@ -206,13 +209,14 @@ func (t *TopologyGroup) Hash() uint64 {
 // and the API server inject an expression.
 func hashSelector(selector *metav1.LabelSelector) uint64 {
 	expressionHashes := sets.New[uint64]()
-	for i := range selector.MatchExpressions {
-		expressionHashes.Insert(lo.Must(hashstructure.Hash(selector.MatchExpressions[i], hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})))
+	var selectorHash uint64
+	if selector != nil {
+		for i := range selector.MatchExpressions {
+			expressionHashes.Insert(lo.Must(hashstructure.Hash(selector.MatchExpressions[i], hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})))
+		}
+		selectorHash = lo.Must(hashstructure.Hash(selector.MatchLabels, hashstructure.FormatV2, nil))
 	}
-	return lo.Must(hashstructure.Hash([]interface{}{
-		expressionHashes,
-		lo.Must(hashstructure.Hash(selector.MatchLabels, hashstructure.FormatV2, nil)),
-	}, hashstructure.FormatV2, nil))
+	return lo.Must(hashstructure.Hash([]interface{}{expressionHashes, selectorHash}, hashstructure.FormatV2, nil))
 }
 
 // nextDomainTopologySpread returns a scheduling.Requirement that includes a node domain that a pod should be scheduled to.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fixes an issue where a non-existent label selector on a pod affinity or TSC term causes a panic in topology. While this shouldn't happen in practice since a missing label selector makes the term a no-op, there isn't any validation on the API server to prevent it. 

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
