### PR TITLE
fix: merge limits into requests when constructing ds pods

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -54,6 +54,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/utils/daemonset"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodepoolutils "sigs.k8s.io/karpenter/pkg/utils/nodepool"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
@@ -471,7 +472,7 @@ func (p *Provisioner) getDaemonSetPods(ctx context.Context) ([]*corev1.Pod, erro
 	return lo.Map(daemonSetList.Items, func(d appsv1.DaemonSet, _ int) *corev1.Pod {
 		pod := p.cluster.GetDaemonSetPod(&d)
 		if pod == nil {
-			pod = &corev1.Pod{Spec: d.Spec.Template.Spec}
+			pod = daemonset.PodForDaemonSet(&d)
 		}
 		// Replacing retrieved pod affinity with daemonset pod template required node affinity since this is overridden
 		// by the daemonset controller during pod creation

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -1016,7 +1016,7 @@ var _ = Describe("Provisioning", func() {
 				test.DaemonSetOptions{PodOptions: test.PodOptions{
 					ResourceRequirements: corev1.ResourceRequirements{
 						Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10000"), corev1.ResourceMemory: resource.MustParse("10000Gi")},
-						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourceMemory: resource.MustParse("10000Gi")}, // simulate the API server’s defaulting from limits
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					},
 				}},
 			))
@@ -1063,7 +1063,7 @@ var _ = Describe("Provisioning", func() {
 						{
 							Resources: corev1.ResourceRequirements{
 								Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10000"), corev1.ResourceMemory: resource.MustParse("10000Gi")},
-								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourceMemory: resource.MustParse("10000Gi")}, // simulate the API server’s defaulting from limits
+								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 							},
 						},
 					},

--- a/pkg/utils/daemonset/daemonset.go
+++ b/pkg/utils/daemonset/daemonset.go
@@ -1,0 +1,53 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func PodForDaemonSet(daemonSet *appsv1.DaemonSet) *corev1.Pod {
+	if daemonSet == nil {
+		return nil
+	}
+	pod := &corev1.Pod{Spec: daemonSet.Spec.Template.Spec}
+	// The API server performs defaulting to merge limits into requests for pods. However, this is not performed for higher
+	// level objects (e.g. deployments, daemonsets, etc). We should perform this defaulting ourselves when we create a fake
+	// pod for a daemonset.
+	for i := range pod.Spec.Containers {
+		mergeResourceLimitsIntoRequests(&pod.Spec.Containers[i])
+	}
+	for i := range pod.Spec.InitContainers {
+		mergeResourceLimitsIntoRequests(&pod.Spec.InitContainers[i])
+	}
+	return pod
+}
+
+// mergeResourceLimitsIntoRequests merges resource limits into requests if no request exists for the given resource.
+// This is performed in place on the provided container.
+func mergeResourceLimitsIntoRequests(container *corev1.Container) {
+	if container.Resources.Requests == nil {
+		container.Resources.Requests = corev1.ResourceList{}
+	}
+	for resource, quantity := range container.Resources.Limits {
+		if _, ok := container.Resources.Requests[resource]; ok {
+			continue
+		}
+		container.Resources.Requests[resource] = quantity
+	}
+}

--- a/pkg/utils/daemonset/suite_test.go
+++ b/pkg/utils/daemonset/suite_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/karpenter/pkg/test"
+	"sigs.k8s.io/karpenter/pkg/utils/daemonset"
+)
+
+func TestReconciles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DaemonSetUtils")
+}
+
+var _ = Describe("DaemonSetUtils", func() {
+	It("should merge resource limits into requests if no requests exists for the given container", func() {
+		inputRequirements := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1000Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("750m"),
+			},
+		}
+		expectedRequirements := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1000Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("750m"),
+				corev1.ResourceMemory: resource.MustParse("1000Mi"),
+			},
+		}
+
+		daemonSet := test.DaemonSet(test.DaemonSetOptions{
+			PodOptions: test.PodOptions{
+				ResourceRequirements: inputRequirements,
+				InitContainers: []corev1.Container{{
+					Resources: inputRequirements,
+				}},
+			},
+		})
+		p := daemonset.PodForDaemonSet(daemonSet)
+		Expect(p.Spec.Containers).To(HaveLen(1))
+		Expect(p.Spec.Containers[0].Resources).To(Equal(expectedRequirements))
+		Expect(p.Spec.InitContainers).To(HaveLen(1))
+		Expect(p.Spec.InitContainers[0].Resources).To(Equal(expectedRequirements))
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Context can be found in this [comment](https://github.com/kubernetes-sigs/karpenter/pull/2383#issuecomment-3304327210).

> > Personally, I think Karpenter doesn't need to implement this logic explicitly, but WDYT?
> 
> So the issue is that the defaulting applies to the pods created for the daemonset, but not for the daemonset itself. Karpenter reads the daemonset spec to compute the "daemonset overhead" for a NodePool. We do this by creating fake daemonset pods based on the specs ([ref](https://github.com/kubernetes-sigs/karpenter/blob/6825a12e67c9c951a2b103120f164ce6c0f73281/pkg/controllers/provisioning/provisioner.go#L465-L490)) and then calling RequestsForPods against those pods ([ref](https://github.com/kubernetes-sigs/karpenter/blob/6825a12e67c9c951a2b103120f164ce6c0f73281/pkg/controllers/provisioning/scheduling/scheduler.go#L775-L781)).
> 
> That being said, I think it's reasonable for this interface to expect that the pods provided adhere to the API server's defaulting logic. It should be the responsibility of any component generating "fake" pods to ensure that they meet those requirements. In this case, we would want to update our getDaemonsetPods function to handle that defaulting.
> 
> Other than that, this PR looks good to me and I'm happy to take on this shared dependency and drop our custom logic. Apologies that it took a while to get review, our bandwidth right now is really limited and we're trying to get more folks promoted to reviewer / approver. We are actually in a bit of a hurry to get this in for 1.34 - I was about to get a PR up but saw yours - so since the rest of the PR looks good I'm going to go ahead and approve then follow up with the change to getDaemonsetPods.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
