### PR TITLE
fix: default CPU_REQUESTS when non-positive value is provided

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -148,7 +148,7 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 		return fmt.Errorf("validating cli flags / env vars, invalid MIN_VALUES_POLICY %q", o.minValuesPolicyRaw)
 	}
 	if o.CPURequests <= 0 {
-		return fmt.Errorf("validating cli flags / env vars, invalid CPU_REQUESTS %d, must be positive", o.CPURequests)
+		o.CPURequests = 1000
 	}
 	gates, err := ParseFeatureGates(o.FeatureGates.inputStr)
 	if err != nil {

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -355,7 +355,17 @@ var _ = Describe("Options", func() {
 			err := opts.Parse(fs, "--log-level", "hello")
 			Expect(err).ToNot(BeNil())
 		})
+		DescribeTable(
+			"should fallback to the default if a non-positive value is provided for CPU_REQUESTS",
+			func(value string) {
+				Expect(opts.Parse(fs, "--cpu-requests", value)).To(Succeed())
+				Expect(opts.CPURequests).To(BeNumerically("==", 1000))
+			},
+			Entry("zero is provided", "0"),
+			Entry("negative value is provided", "-50"),
+		)
 	})
+
 })
 
 func expectOptionsMatch(optsA, optsB *options.Options) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter-provider-aws/issues/8495

**Description**

This change eases configuration by allowing helm charts to specify this env var as a function of the container's resource requests. When a container doesn't specify resource requests, or specifies a value of 0, we'll fall back to the default (1000).

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
