### PR TITLE
perf: add method for DeepCopyNodesWithReject

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -31,7 +31,6 @@ import (
 	"github.com/awslabs/operatorpkg/singleton"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -136,7 +135,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 	// Karpenter taints nodes with a karpenter.sh/disruption taint as part of the disruption process while it progresses in memory.
 	// If Karpenter restarts or fails with an error during a disruption action, some nodes can be left tainted.
 	// Idempotently remove this taint from candidates that are not in the orchestration queue before continuing.
-	outdatedNodes := lo.Reject(c.cluster.DeepCopyNodes(), func(s *state.StateNode, _ int) bool {
+	outdatedNodes := c.cluster.DeepCopyNodesWithReject(func(s *state.StateNode) bool {
 		return c.queue.HasAny(s.ProviderID()) || s.MarkedForDeletion()
 	})
 	if err := state.RequireNoScheduleTaint(ctx, c.kubeClient, false, outdatedNodes...); err != nil {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -232,25 +232,22 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 	disruptionBudgetMapping := map[string]int{}
 	numNodes := map[string]int{}   // map[nodepool] -> node count in nodepool
 	disrupting := map[string]int{} // map[nodepool] -> nodes undergoing disruption
-	for _, node := range cluster.DeepCopyNodes() {
-		// We only consider nodes that we own and are initialized towards the total.
-		// If a node is launched/registered, but not initialized, pods aren't scheduled
-		// to the node, and these are treated as unhealthy until they're cleaned up.
-		// This prevents odd roundup cases with percentages where replacement nodes that
-		// aren't initialized could be counted towards the total, resulting in more disruptions
-		// to active nodes than desired, where Karpenter should wait for these nodes to be
-		// healthy before continuing.
-		if !node.Managed() || !node.Initialized() {
-			continue
-		}
 
-		// Additionally, don't consider nodeclaims that have the terminating condition. A nodeclaim should have
-		// the Terminating condition only when the node is drained and cloudprovider.Delete() was successful
-		// on the underlying cloud provider machine.
-		if node.NodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue() {
-			continue
-		}
+	// We only consider nodes that we own and are initialized towards the total.
+	// If a node is launched/registered, but not initialized, pods aren't scheduled
+	// to the node, and these are treated as unhealthy until they're cleaned up.
+	// This prevents odd roundup cases with percentages where replacement nodes that
+	// aren't initialized could be counted towards the total, resulting in more disruptions
+	// to active nodes than desired, where Karpenter should wait for these nodes to be
+	// healthy before continuing.
+	// Additionally, don't consider nodeclaims that have the terminating condition. A nodeclaim should have
+	// the Terminating condition only when the node is drained and cloudprovider.Delete() was successful
+	// on the underlying cloud provider machine.
+	filteredNodes := cluster.DeepCopyNodesWithReject(func(node *state.StateNode) bool {
+		return !node.Managed() || !node.Initialized() || node.NodeClaim.StatusConditions().Get(v1.ConditionTypeInstanceTerminating).IsTrue()
+	})
 
+	for _, node := range filteredNodes {
 		nodePool := node.Labels()[v1.NodePoolLabelKey]
 		numNodes[nodePool]++
 

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -176,7 +176,7 @@ func NewController(cluster *state.Cluster) *Controller {
 func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 	ctx = injection.WithControllerName(ctx, "metrics.node") //nolint:ineffassign,staticcheck
 
-	nodes := lo.Reject(c.cluster.DeepCopyNodes(), func(n *state.StateNode, _ int) bool {
+	nodes := c.cluster.DeepCopyNodesWithReject(func(n *state.StateNode) bool {
 		return n.Node == nil
 	})
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -255,6 +255,21 @@ func (c *Cluster) DeepCopyNodes() StateNodes {
 	})
 }
 
+// DeepCopyNodesWithReject create a DeepCopy of all state nodes in which the reject function returns false (i.e. we don't reject the node).
+// NOTE: This is very inefficient so this should only be used when DeepCopying is absolutely necessary
+func (c *Cluster) DeepCopyNodesWithReject(reject func(*StateNode) bool) StateNodes {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var result StateNodes
+	for _, node := range c.nodes {
+		if !reject(node) {
+			result = append(result, node.DeepCopy())
+		}
+	}
+	return result
+}
+
 // IsNodeNominated returns true if the given node was expected to have a pod bound to it during a recent scheduling
 // batch
 func (c *Cluster) IsNodeNominated(providerID string) bool {


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**
* add method for cluster state to deep copy nodes with a rejection filter
   * decreases number of expensive DeepCopy operations

**How was this change tested?**
* `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
