### PR TITLE
chore: Update NodeRegistrationHealthy SC to use a buffer mechanism

### DIFF
--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -38,18 +38,21 @@ import (
 	nodeclaimlifcycle "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 )
 
-var ctx context.Context
-var nodeClaimController *nodeclaimlifcycle.Controller
-var garbageCollectionController *nodeclaimgarbagecollection.Controller
-var env *test.Environment
-var fakeClock *clock.FakeClock
-var cloudProvider *fake.CloudProvider
+var (
+	ctx                         context.Context
+	nodeClaimController         *nodeclaimlifcycle.Controller
+	garbageCollectionController *nodeclaimgarbagecollection.Controller
+	env                         *test.Environment
+	fakeClock                   *clock.FakeClock
+	cloudProvider               *fake.CloudProvider
+)
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -63,7 +66,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	garbageCollectionController = nodeclaimgarbagecollection.NewController(fakeClock, env.Client, cloudProvider)
-	nodeClaimController = nodeclaimlifcycle.NewController(fakeClock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}))
+	nodeClaimController = nodeclaimlifcycle.NewController(fakeClock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.State{})
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -65,6 +66,7 @@ type Controller struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
 	recorder      events.Recorder
+	nodePoolState nodepoolhealth.State
 
 	launch         *Launch
 	registration   *Registration
@@ -72,16 +74,17 @@ type Controller struct {
 	liveness       *Liveness
 }
 
-func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, recorder events.Recorder) *Controller {
+func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, nodePoolState nodepoolhealth.State) *Controller {
 	return &Controller{
 		kubeClient:    kubeClient,
 		cloudProvider: cloudProvider,
 		recorder:      recorder,
+		nodePoolState: nodePoolState,
 
 		launch:         &Launch{kubeClient: kubeClient, cloudProvider: cloudProvider, cache: cache.New(time.Hour, time.Minute), recorder: recorder},
-		registration:   &Registration{kubeClient: kubeClient, recorder: recorder},
+		registration:   &Registration{kubeClient: kubeClient, recorder: recorder, npState: nodePoolState},
 		initialization: &Initialization{kubeClient: kubeClient},
-		liveness:       &Liveness{clock: clk, kubeClient: kubeClient},
+		liveness:       &Liveness{clock: clk, kubeClient: kubeClient, npState: nodePoolState},
 	}
 }
 

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -129,9 +129,9 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 		if err := l.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
 			return err
 		}
-		l.npState.Update(string(nodePool.UID), false)
+		l.npState.Update(nodePool.UID, false)
 		stored := nodePool.DeepCopy()
-		if l.npState.Status(string(nodePool.UID)) == nodepoolhealth.StatusUnhealthy && !nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsFalse() {
+		if l.npState.Status(nodePool.UID) == nodepoolhealth.StatusUnhealthy && !nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsFalse() {
 			// If the nodeClaim failed to register during the timeout set NodeRegistrationHealthy status condition on
 			// NodePool to False. If the launch failed get the launch failure reason and message from nodeClaim.
 			if launchCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched); launchCondition.IsTrue() {

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/awslabs/operatorpkg/object"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -132,7 +133,7 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 			return err
 		}
 		if _, found := lo.Find(nodeClaim.GetOwnerReferences(), func(o metav1.OwnerReference) bool {
-			return o.UID == nodePool.UID
+			return o.Kind == object.GVK(nodePool).Kind && o.UID == nodePool.UID
 		}); !found {
 			return nil
 		}

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/types"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"k8s.io/utils/clock"
@@ -129,22 +131,27 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 		if err := l.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
 			return err
 		}
-		l.npState.Update(nodePool.UID, false)
-		stored := nodePool.DeepCopy()
-		if l.npState.Status(nodePool.UID) == nodepoolhealth.StatusUnhealthy && !nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsFalse() {
-			// If the nodeClaim failed to register during the timeout set NodeRegistrationHealthy status condition on
-			// NodePool to False. If the launch failed get the launch failure reason and message from nodeClaim.
-			if launchCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched); launchCondition.IsTrue() {
-				nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "RegistrationFailed", "Failed to register node")
-			} else {
-				nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, launchCondition.Reason, launchCondition.Message)
+		_, found := lo.Find(nodeClaim.GetOwnerReferences(), func(o metav1.OwnerReference) bool {
+			return o.UID == nodePool.UID
+		})
+		if found {
+			stored := nodePool.DeepCopy()
+			if l.npState.DryRun(nodePool.UID, false).Status() == nodepoolhealth.StatusUnhealthy && !nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsFalse() {
+				// If the nodeClaim failed to register during the timeout set NodeRegistrationHealthy status condition on
+				// NodePool to False. If the launch failed get the launch failure reason and message from nodeClaim.
+				if launchCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched); launchCondition.IsTrue() {
+					nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "RegistrationFailed", "Failed to register node")
+				} else {
+					nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, launchCondition.Reason, launchCondition.Message)
+				}
+				// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
+				// can cause races due to the fact that it fully replaces the list on a change
+				// Here, we are updating the status condition list
+				if err := l.kubeClient.Status().Patch(ctx, nodePool, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
+					return err
+				}
 			}
-			// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
-			// can cause races due to the fact that it fully replaces the list on a change
-			// Here, we are updating the status condition list
-			if err := l.kubeClient.Status().Patch(ctx, nodePool, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
-				return err
-			}
+			l.npState.Update(nodePool.UID, false)
 		}
 	}
 	return nil

--- a/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
@@ -85,10 +85,8 @@ var _ = Describe("Liveness", func() {
 			if isManagedNodeClaim {
 				ExpectNotFound(ctx, env.Client, nodeClaim)
 				operatorpkg.ExpectStatusConditions(ctx, env.Client, 1*time.Minute, nodePool, status.Condition{
-					Type:    v1.ConditionTypeNodeRegistrationHealthy,
-					Status:  metav1.ConditionFalse,
-					Reason:  "RegistrationFailed",
-					Message: "Failed to register node",
+					Type:   v1.ConditionTypeNodeRegistrationHealthy,
+					Status: metav1.ConditionUnknown,
 				})
 			} else {
 				ExpectExists(ctx, env.Client, nodeClaim)
@@ -265,38 +263,66 @@ var _ = Describe("Liveness", func() {
 		ExpectExists(ctx, env.Client, nodeClaim)
 	})
 
-	It("should not update NodeRegistrationHealthy status condition if it is already set to True", func() {
+	It("should update NodeRegistrationHealthy status condition to False if it was previously set to True and there are >=2 registration failures", func() {
 		nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy)
-		nodeClaim := test.NodeClaim(v1.NodeClaim{
+		nodeClaim1 := test.NodeClaim(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1.NodePoolLabelKey: nodePool.Name,
 				},
 			},
-			Spec: v1.NodeClaimSpec{
-				Resources: v1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:      resource.MustParse("2"),
-						corev1.ResourceMemory:   resource.MustParse("50Mi"),
-						corev1.ResourcePods:     resource.MustParse("5"),
-						fake.ResourceGPUVendorA: resource.MustParse("1"),
-					},
+		})
+		nodeClaim2 := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey: nodePool.Name,
 				},
 			},
 		})
 		cloudProvider.AllowedCreateCalls = 0 // Don't allow Create() calls to succeed
-		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
-		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
-		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim1, nodeClaim2)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim1)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim2)
 
 		// If the node hasn't registered in the registration timeframe, then we deprovision the nodeClaim
-		fakeClock.Step(time.Minute * 20)
-		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
+		fakeClock.Step(time.Minute * 6)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim1)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim2)
 
-		// NodeClaim registration failed, but we should not update the NodeRegistrationHealthy status condition if it is already True
-		operatorpkg.ExpectStatusConditions(ctx, env.Client, 1*time.Minute, nodePool, status.Condition{Type: v1.ConditionTypeNodeRegistrationHealthy, Status: metav1.ConditionTrue})
-		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
-		ExpectNotFound(ctx, env.Client, nodeClaim)
+		// NodeClaim registration failed twice which is greater than our threshold so update the NodeRegistrationHealthy status condition
+		operatorpkg.ExpectStatusConditions(ctx, env.Client, 1*time.Minute, nodePool, status.Condition{Type: v1.ConditionTypeNodeRegistrationHealthy, Status: metav1.ConditionFalse})
+		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim1, nodeClaim2)
+		ExpectNotFound(ctx, env.Client, nodeClaim1, nodeClaim2)
+	})
+	It("should update NodeRegistrationHealthy status condition to False if it was previously set to Unknown and there are >=2 registration failures", func() {
+		nodeClaim1 := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey: nodePool.Name,
+				},
+			},
+		})
+		nodeClaim2 := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey: nodePool.Name,
+				},
+			},
+		})
+		cloudProvider.AllowedCreateCalls = 0 // Don't allow Create() calls to succeed
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim1, nodeClaim2)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim1)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim2)
+
+		// If the node hasn't registered in the registration timeframe, then we deprovision the nodeClaim
+		fakeClock.Step(time.Minute * 6)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim1)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim2)
+
+		// NodeClaim registration failed twice which is greater than our threshold so update the NodeRegistrationHealthy status condition
+		operatorpkg.ExpectStatusConditions(ctx, env.Client, 1*time.Minute, nodePool, status.Condition{Type: v1.ConditionTypeNodeRegistrationHealthy, Status: metav1.ConditionFalse})
+		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim1, nodeClaim2)
+		ExpectNotFound(ctx, env.Client, nodeClaim1, nodeClaim2)
 	})
 	It("should not block on updating NodeRegistrationHealthy status condition if nodeClaim is not owned by a nodePool", func() {
 		nodeClaim := test.NodeClaim()

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -104,9 +104,9 @@ func (r *Registration) updateNodePoolRegistrationHealth(ctx context.Context, nod
 		if err := r.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
 			return err
 		}
-		r.npState.Update(string(nodePool.UID), true)
+		r.npState.Update(nodePool.UID, true)
 		stored := nodePool.DeepCopy()
-		if r.npState.Status(string(nodePool.UID)) == nodepoolhealth.StatusHealthy && nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy) {
+		if r.npState.Status(nodePool.UID) == nodepoolhealth.StatusHealthy && nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy) {
 			// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 			// can cause races due to the fact that it fully replaces the list on a change
 			// Here, we are updating the status condition list

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/awslabs/operatorpkg/object"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -106,7 +107,7 @@ func (r *Registration) updateNodePoolRegistrationHealth(ctx context.Context, nod
 			return err
 		}
 		if _, found := lo.Find(nodeClaim.GetOwnerReferences(), func(o metav1.OwnerReference) bool {
-			return o.UID == nodePool.UID
+			return o.Kind == object.GVK(nodePool).Kind && o.UID == nodePool.UID
 		}); !found {
 			return nil
 		}

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,15 +105,20 @@ func (r *Registration) updateNodePoolRegistrationHealth(ctx context.Context, nod
 		if err := r.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
 			return err
 		}
-		r.npState.Update(nodePool.UID, true)
-		stored := nodePool.DeepCopy()
-		if r.npState.Status(nodePool.UID) == nodepoolhealth.StatusHealthy && nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy) {
-			// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
-			// can cause races due to the fact that it fully replaces the list on a change
-			// Here, we are updating the status condition list
-			if err := r.kubeClient.Status().Patch(ctx, nodePool, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
-				return err
+		_, found := lo.Find(nodeClaim.GetOwnerReferences(), func(o metav1.OwnerReference) bool {
+			return o.UID == nodePool.UID
+		})
+		if found {
+			stored := nodePool.DeepCopy()
+			if r.npState.DryRun(nodePool.UID, true).Status() == nodepoolhealth.StatusHealthy && nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy) {
+				// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
+				// can cause races due to the fact that it fully replaces the list on a change
+				// Here, we are updating the status condition list
+				if err := r.kubeClient.Status().Patch(ctx, nodePool, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
+					return err
+				}
 			}
+			r.npState.Update(nodePool.UID, true)
 		}
 	}
 	return nil

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -519,7 +519,7 @@ var _ = Describe("Registration", func() {
 
 		// NodeClaim registration failed twice which is greater than our threshold so update the NodeRegistrationHealthy status condition
 		operatorpkg.ExpectStatusConditions(ctx, env.Client, 1*time.Minute, nodePool, status.Condition{Type: v1.ConditionTypeNodeRegistrationHealthy, Status: metav1.ConditionFalse})
-		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
+		Expect(npState.Status(nodePool.UID)).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
 		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim1, nodeClaim2)
 		ExpectNotFound(ctx, env.Client, nodeClaim1, nodeClaim2)
 
@@ -543,7 +543,7 @@ var _ = Describe("Registration", func() {
 		Expect(nodeClaim3.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue()).To(BeTrue())
 		Expect(nodeClaim3.Status.NodeName).To(Equal(node.Name))
 
-		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
+		Expect(npState.Status(nodePool.UID)).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
 		operatorpkg.ExpectStatusConditions(ctx, env.Client, 1*time.Minute, nodePool, status.Condition{
 			Type:   v1.ConditionTypeNodeRegistrationHealthy,
 			Status: metav1.ConditionFalse,

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/karpenter/pkg/operator/logging"
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -49,12 +50,15 @@ func init() {
 	log.SetLogger(logging.NopLogger)
 }
 
-var ctx context.Context
-var nodeClaimController *nodeclaimlifecycle.Controller
-var env *test.Environment
-var fakeClock *clock.FakeClock
-var cloudProvider *fake.CloudProvider
-var recorder *test.EventRecorder
+var (
+	ctx                 context.Context
+	nodeClaimController *nodeclaimlifecycle.Controller
+	env                 *test.Environment
+	fakeClock           *clock.FakeClock
+	cloudProvider       *fake.CloudProvider
+	recorder            *test.EventRecorder
+	npState             nodepoolhealth.State
+)
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -81,7 +85,8 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 
 	cloudProvider = fake.NewCloudProvider()
-	nodeClaimController = nodeclaimlifecycle.NewController(fakeClock, env.Client, cloudProvider, recorder)
+	npState = nodepoolhealth.State{}
+	nodeClaimController = nodeclaimlifecycle.NewController(fakeClock, env.Client, cloudProvider, recorder, npState)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/nodepool/registrationhealth/controller.go
+++ b/pkg/controllers/nodepool/registrationhealth/controller.go
@@ -71,12 +71,12 @@ func (c *Controller) Reconcile(ctx context.Context, nodePool *v1.NodePool) (reco
 
 	// If Karpenter restarts i.e. if the buffer for the nodePool is empty and the NodeRegistrationHealthy status condition
 	// is set to either true/false then we pre-hydrate the buffer with the existing state of the status condition
-	if c.npState.Status(string(nodePool.UID)) == nodepoolhealth.StatusUnknown {
+	if c.npState.Status(nodePool.UID) == nodepoolhealth.StatusUnknown {
 		if nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsTrue() {
-			c.npState.SetStatus(string(nodePool.UID), nodepoolhealth.StatusHealthy)
+			c.npState.SetStatus(nodePool.UID, nodepoolhealth.StatusHealthy)
 		}
 		if nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsFalse() {
-			c.npState.SetStatus(string(nodePool.UID), nodepoolhealth.StatusUnhealthy)
+			c.npState.SetStatus(nodePool.UID, nodepoolhealth.StatusUnhealthy)
 		}
 	}
 
@@ -85,7 +85,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodePool *v1.NodePool) (reco
 		nodePool.Status.NodeClassObservedGeneration != nodeClass.GetGeneration() ||
 		nodePool.Generation != nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).ObservedGeneration {
 		nodePool.StatusConditions().SetUnknown(v1.ConditionTypeNodeRegistrationHealthy)
-		c.npState.ResetStatus(string(nodePool.UID))
+		c.npState.SetStatus(nodePool.UID, nodepoolhealth.StatusUnknown)
 	}
 
 	nodePool.Status.NodeClassObservedGeneration = nodeClass.GetGeneration()

--- a/pkg/controllers/nodepool/registrationhealth/controller.go
+++ b/pkg/controllers/nodepool/registrationhealth/controller.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
+
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -41,16 +43,19 @@ import (
 type Controller struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
+	npState       nodepoolhealth.State
 }
 
 // NewController will create a controller to reset NodePool's registration health when there is an update to NodePool/NodeClass spec
-func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) *Controller {
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, npState nodepoolhealth.State) *Controller {
 	return &Controller{
 		kubeClient:    kubeClient,
 		cloudProvider: cloudProvider,
+		npState:       npState,
 	}
 }
 
+//nolint:gocyclo
 func (c *Controller) Reconcile(ctx context.Context, nodePool *v1.NodePool) (reconcile.Result, error) {
 	ctx = injection.WithControllerName(ctx, "nodepool.registrationhealth")
 
@@ -64,12 +69,25 @@ func (c *Controller) Reconcile(ctx context.Context, nodePool *v1.NodePool) (reco
 	}
 	stored := nodePool.DeepCopy()
 
-	// If NodeClass/NodePool have been updated then NodeRegistrationHealthy = Unknown
+	// If Karpenter restarts i.e. if the buffer for the nodePool is empty and the NodeRegistrationHealthy status condition
+	// is set to either true/false then we pre-hydrate the buffer with the existing state of the status condition
+	if c.npState.Status(string(nodePool.UID)) == nodepoolhealth.StatusUnknown {
+		if nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsTrue() {
+			c.npState.SetStatus(string(nodePool.UID), nodepoolhealth.StatusHealthy)
+		}
+		if nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsFalse() {
+			c.npState.SetStatus(string(nodePool.UID), nodepoolhealth.StatusUnhealthy)
+		}
+	}
+
+	// If NodeClass/NodePool have been updated then NodeRegistrationHealthy = Unknown and reset the buffer
 	if nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy) == nil ||
 		nodePool.Status.NodeClassObservedGeneration != nodeClass.GetGeneration() ||
 		nodePool.Generation != nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).ObservedGeneration {
 		nodePool.StatusConditions().SetUnknown(v1.ConditionTypeNodeRegistrationHealthy)
+		c.npState.ResetStatus(string(nodePool.UID))
 	}
+
 	nodePool.Status.NodeClassObservedGeneration = nodeClass.GetGeneration()
 	if !equality.Semantic.DeepEqual(stored, nodePool) {
 		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch

--- a/pkg/controllers/nodepool/registrationhealth/suite_test.go
+++ b/pkg/controllers/nodepool/registrationhealth/suite_test.go
@@ -107,7 +107,7 @@ var _ = Describe("RegistrationHealth", func() {
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown()).To(BeTrue())
 		Expect(nodePool.Status.NodeClassObservedGeneration).To(Equal(int64(2)))
-		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusUnknown))
+		Expect(npState.Status(nodePool.UID)).To(BeEquivalentTo(nodepoolhealth.StatusUnknown))
 	})
 	It("should set NodeRegistrationHealthy status condition on nodePool as Unknown if the nodePool is updated", func() {
 		nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "unhealthy", "unhealthy")
@@ -119,7 +119,7 @@ var _ = Describe("RegistrationHealth", func() {
 		_ = ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown()).To(BeTrue())
-		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusUnknown))
+		Expect(npState.Status(nodePool.UID)).To(BeEquivalentTo(nodepoolhealth.StatusUnknown))
 	})
 	It("should not set NodeRegistrationHealthy status condition on nodePool as Unknown if it is already set to true", func() {
 		nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy)
@@ -128,7 +128,7 @@ var _ = Describe("RegistrationHealth", func() {
 		_ = ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown()).To(BeFalse())
-		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusHealthy))
+		Expect(npState.Status(nodePool.UID)).To(BeEquivalentTo(nodepoolhealth.StatusHealthy))
 	})
 	It("should not set NodeRegistrationHealthy status condition on nodePool as Unknown if it is already set to false", func() {
 		nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "unhealthy", "unhealthy")
@@ -137,6 +137,6 @@ var _ = Describe("RegistrationHealth", func() {
 		_ = ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown()).To(BeFalse())
-		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
+		Expect(npState.Status(nodePool.UID)).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
 	})
 })

--- a/pkg/controllers/nodepool/registrationhealth/suite_test.go
+++ b/pkg/controllers/nodepool/registrationhealth/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/karpenter/pkg/controllers/nodepool/registrationhealth"
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
 
 	"github.com/awslabs/operatorpkg/object"
 	. "github.com/onsi/ginkgo/v2"
@@ -45,6 +46,7 @@ var (
 	cloudProvider *fake.CloudProvider
 	nodePool      *v1.NodePool
 	nodeClass     *v1alpha1.TestNodeClass
+	npState       nodepoolhealth.State
 )
 
 func TestAPIs(t *testing.T) {
@@ -56,7 +58,8 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	cloudProvider = fake.NewCloudProvider()
 	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
-	controller = registrationhealth.NewController(env.Client, cloudProvider)
+	npState = nodepoolhealth.State{}
+	controller = registrationhealth.NewController(env.Client, cloudProvider, npState)
 })
 var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
@@ -93,7 +96,7 @@ var _ = Describe("RegistrationHealth", func() {
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy)).To(BeNil())
 	})
-	It("should set NodeRegistrationHealthy status condition on nodePool as Unknown if the nodeClass observed generation doesn't match with that on nodePool", func() {
+	It("should set NodeRegistrationHealthy status condition on nodePool as Unknown and reset the NodeRegistrationHealthBuffer if the nodeClass observed generation doesn't match with that on nodePool", func() {
 		nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "unhealthy", "unhealthy")
 		nodePool.Status.NodeClassObservedGeneration = int64(1)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
@@ -104,6 +107,7 @@ var _ = Describe("RegistrationHealth", func() {
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown()).To(BeTrue())
 		Expect(nodePool.Status.NodeClassObservedGeneration).To(Equal(int64(2)))
+		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusUnknown))
 	})
 	It("should set NodeRegistrationHealthy status condition on nodePool as Unknown if the nodePool is updated", func() {
 		nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "unhealthy", "unhealthy")
@@ -115,6 +119,7 @@ var _ = Describe("RegistrationHealth", func() {
 		_ = ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown()).To(BeTrue())
+		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusUnknown))
 	})
 	It("should not set NodeRegistrationHealthy status condition on nodePool as Unknown if it is already set to true", func() {
 		nodePool.StatusConditions().SetTrue(v1.ConditionTypeNodeRegistrationHealthy)
@@ -123,6 +128,7 @@ var _ = Describe("RegistrationHealth", func() {
 		_ = ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown()).To(BeFalse())
+		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusHealthy))
 	})
 	It("should not set NodeRegistrationHealthy status condition on nodePool as Unknown if it is already set to false", func() {
 		nodePool.StatusConditions().SetFalse(v1.ConditionTypeNodeRegistrationHealthy, "unhealthy", "unhealthy")
@@ -131,5 +137,6 @@ var _ = Describe("RegistrationHealth", func() {
 		_ = ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
 		nodePool = ExpectExists(ctx, env.Client, nodePool)
 		Expect(nodePool.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsUnknown()).To(BeFalse())
+		Expect(npState.Status(string(nodePool.UID))).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
 	})
 })

--- a/pkg/state/nodepoolhealth/suite_test.go
+++ b/pkg/state/nodepoolhealth/suite_test.go
@@ -74,4 +74,8 @@ var _ = Describe("NodePoolHealthState", func() {
 		npState.SetStatus(npUUID2, nodepoolhealth.StatusUnknown)
 		Expect(npState.Status(npUUID2)).To(Equal(nodepoolhealth.StatusUnknown))
 	})
+	It("should create a copy of the tracker and update it and not the original tracker in case of Dry Run", func() {
+		Expect(npState.DryRun(npUUID, true).Status()).To(Equal(nodepoolhealth.StatusHealthy))
+		Expect(npState.Status(npUUID)).To(Equal(nodepoolhealth.StatusUnknown))
+	})
 })

--- a/pkg/state/nodepoolhealth/suite_test.go
+++ b/pkg/state/nodepoolhealth/suite_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodepoolhealth_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
+)
+
+var (
+	npState nodepoolhealth.State
+	npUUID  string
+)
+
+var _ = BeforeSuite(func() {
+	npUUID = string(uuid.NewUUID())
+	npState = nodepoolhealth.State{}
+})
+
+var _ = AfterEach(func() {
+	npState.ResetStatus(npUUID)
+})
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodePoolHealthState")
+}
+
+var _ = Describe("NodePoolHealthState", func() {
+	It("should expect status unknown for a new nodePool with empty buffer", func() {
+		Expect(npState.Status(npUUID)).To(BeEquivalentTo(nodepoolhealth.StatusUnknown))
+	})
+	It("should expect status healthy for a nodePool with one true entry", func() {
+		npState.Update(npUUID, true)
+		Expect(npState.Status(npUUID)).To(BeEquivalentTo(nodepoolhealth.StatusHealthy))
+	})
+	It("should expect status unhealthy for a nodePool with two false entries", func() {
+		npState.Update(npUUID, false)
+		npState.Update(npUUID, false)
+		Expect(npState.Status(npUUID)).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
+	})
+	It("should expect status unhealthy for a nodePool with two false entries and one true entry", func() {
+		npState.SetStatus(npUUID, nodepoolhealth.StatusUnhealthy)
+		npState.Update(npUUID, true)
+		Expect(npState.Status(npUUID)).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
+	})
+	It("should return the correct status in case of multiple nodepools stored in the state", func() {
+		npState.Update(npUUID, true)
+		npUUID2 := string(uuid.NewUUID())
+		npState.Update(npUUID2, false)
+		npState.Update(npUUID2, false)
+		Expect(npState.Status(npUUID)).To(BeEquivalentTo(nodepoolhealth.StatusHealthy))
+		Expect(npState.Status(npUUID2)).To(BeEquivalentTo(nodepoolhealth.StatusUnhealthy))
+		npState.ResetStatus(npUUID2)
+		Expect(npState.Status(npUUID2)).To(BeEquivalentTo(nodepoolhealth.StatusUnknown))
+	})
+})

--- a/pkg/state/nodepoolhealth/suite_test.go
+++ b/pkg/state/nodepoolhealth/suite_test.go
@@ -75,7 +75,11 @@ var _ = Describe("NodePoolHealthState", func() {
 		Expect(npState.Status(npUUID2)).To(Equal(nodepoolhealth.StatusUnknown))
 	})
 	It("should create a copy of the tracker and update it and not the original tracker in case of Dry Run", func() {
-		Expect(npState.DryRun(npUUID, true).Status()).To(Equal(nodepoolhealth.StatusHealthy))
-		Expect(npState.Status(npUUID)).To(Equal(nodepoolhealth.StatusUnknown))
+		npState.SetStatus(npUUID, nodepoolhealth.StatusHealthy)
+		npState.Update(npUUID, false)
+		Expect(npState.Status(npUUID)).To(Equal(nodepoolhealth.StatusHealthy))
+
+		Expect(npState.DryRun(npUUID, false).Status()).To(Equal(nodepoolhealth.StatusUnhealthy))
+		Expect(npState.Status(npUUID)).To(Equal(nodepoolhealth.StatusHealthy))
 	})
 })

--- a/pkg/state/nodepoolhealth/suite_test.go
+++ b/pkg/state/nodepoolhealth/suite_test.go
@@ -82,4 +82,13 @@ var _ = Describe("NodePoolHealthState", func() {
 		Expect(npState.DryRun(npUUID, false).Status()).To(Equal(nodepoolhealth.StatusUnhealthy))
 		Expect(npState.Status(npUUID)).To(Equal(nodepoolhealth.StatusHealthy))
 	})
+	It("should reset the buffer first when setting status", func() {
+		npState.Update(npUUID, false)
+		npState.Update(npUUID, false)
+		Expect(npState.Status(npUUID)).To(Equal(nodepoolhealth.StatusUnhealthy))
+
+		// This SetStatus call should first reset the buffer and then add entries to the buffer such that the status becomes healthy
+		npState.SetStatus(npUUID, nodepoolhealth.StatusHealthy)
+		Expect(npState.Status(npUUID)).To(Equal(nodepoolhealth.StatusHealthy))
+	})
 })

--- a/pkg/state/nodepoolhealth/tracker.go
+++ b/pkg/state/nodepoolhealth/tracker.go
@@ -86,8 +86,10 @@ func (t *Tracker) SetStatus(status Status) {
 	case StatusUnknown:
 		t.buffer.Reset()
 	case StatusHealthy:
+		t.buffer.Reset()
 		t.Update(true)
 	case StatusUnhealthy:
+		t.buffer.Reset()
 		for range int(BufferSize * ThresholdFalse) {
 			t.Update(false)
 		}

--- a/pkg/state/nodepoolhealth/tracker.go
+++ b/pkg/state/nodepoolhealth/tracker.go
@@ -116,3 +116,10 @@ func (s State) Update(nodePoolUID types.UID, launchStatus bool) {
 func (s State) SetStatus(nodePoolUID types.UID, status Status) {
 	s.nodePoolNodeRegistration(nodePoolUID).SetStatus(status)
 }
+
+func (s State) DryRun(nodePoolUID types.UID, launchStatus bool) *Tracker {
+	trackerCopy := NewTracker(BufferSize)
+	trackerCopy.buffer = s.nodePoolNodeRegistration(nodePoolUID).buffer
+	trackerCopy.Update(launchStatus)
+	return trackerCopy
+}

--- a/pkg/state/nodepoolhealth/tracker.go
+++ b/pkg/state/nodepoolhealth/tracker.go
@@ -119,7 +119,10 @@ func (s State) SetStatus(nodePoolUID types.UID, status Status) {
 
 func (s State) DryRun(nodePoolUID types.UID, launchStatus bool) *Tracker {
 	trackerCopy := NewTracker(BufferSize)
-	trackerCopy.buffer = s.nodePoolNodeRegistration(nodePoolUID).buffer
+	originalTracker := s.nodePoolNodeRegistration(nodePoolUID)
+	for _, item := range originalTracker.buffer.Items() {
+		trackerCopy.buffer.Insert(item)
+	}
 	trackerCopy.Update(launchStatus)
 	return trackerCopy
 }

--- a/pkg/state/nodepoolhealth/tracker.go
+++ b/pkg/state/nodepoolhealth/tracker.go
@@ -1,0 +1,122 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodepoolhealth
+
+import (
+	"sync"
+
+	"sigs.k8s.io/karpenter/pkg/utils/ringbuffer"
+)
+
+const (
+	BufferSize     = 4
+	ThresholdFalse = 0.5 // 50% of 0s for NodeRegistrationHealthy=False
+)
+
+type Status int
+
+const (
+	StatusUnknown Status = iota
+	StatusHealthy
+	StatusUnhealthy
+)
+
+type Tracker struct {
+	sync.RWMutex
+	buffer ringbuffer.Buffer[bool]
+}
+
+func NewTracker(capacity int) *Tracker {
+	return &Tracker{
+		buffer: *ringbuffer.NewBuffer[bool](capacity),
+	}
+}
+
+func (t *Tracker) Update(success bool) {
+	t.Lock()
+	defer t.Unlock()
+
+	t.buffer.Insert(success)
+}
+
+func (t *Tracker) Reset() {
+	t.Lock()
+	defer t.Unlock()
+
+	t.buffer.Reset()
+}
+
+func (t *Tracker) Status() Status {
+	t.Lock()
+	defer t.Unlock()
+
+	if t.buffer.Len() == 0 {
+		return StatusUnknown
+	}
+	// Count number of true and false
+	unhealthyCount := 0
+	for _, value := range t.buffer.GetItems() {
+		if !value {
+			unhealthyCount++
+		}
+	}
+	// Determine health status based on threshold
+	if (float64(unhealthyCount) / float64(t.buffer.Capacity())) >= ThresholdFalse {
+		return StatusUnhealthy
+	} else {
+		return StatusHealthy
+	}
+}
+
+func (t *Tracker) SetStatus(status Status) {
+	switch status {
+	case StatusUnknown:
+		t.buffer.Reset()
+	case StatusHealthy:
+		t.Update(true)
+	case StatusUnhealthy:
+		t.Update(false)
+		t.Update(false)
+	}
+}
+
+type State map[string]*Tracker
+
+func (s State) nodePoolNodeRegistration(nodepool string) *Tracker {
+	tracker, exists := s[nodepool]
+	if !exists {
+		tracker = NewTracker(BufferSize)
+		s[nodepool] = tracker
+	}
+	return tracker
+}
+
+func (s State) Status(nodePool string) Status {
+	return s.nodePoolNodeRegistration(nodePool).Status()
+}
+
+func (s State) Update(nodePool string, launchStatus bool) {
+	s.nodePoolNodeRegistration(nodePool).Update(launchStatus)
+}
+
+func (s State) SetStatus(nodePool string, status Status) {
+	s.nodePoolNodeRegistration(nodePool).SetStatus(status)
+}
+
+func (s State) ResetStatus(nodePool string) {
+	s.nodePoolNodeRegistration(nodePool).Reset()
+}

--- a/pkg/test/nodepool.go
+++ b/pkg/test/nodepool.go
@@ -58,6 +58,7 @@ func NodePool(overrides ...v1.NodePool) *v1.NodePool {
 	if override.Status.Conditions == nil {
 		override.StatusConditions().SetTrue(v1.ConditionTypeValidationSucceeded)
 		override.StatusConditions().SetTrue(v1.ConditionTypeNodeClassReady)
+		override.StatusConditions().SetUnknown(v1.ConditionTypeNodeRegistrationHealthy)
 	}
 	np := &v1.NodePool{
 		ObjectMeta: ObjectMeta(override.ObjectMeta),

--- a/pkg/utils/ringbuffer/buffer.go
+++ b/pkg/utils/ringbuffer/buffer.go
@@ -16,41 +16,37 @@ limitations under the License.
 
 package ringbuffer
 
-type Buffer[T any] struct {
-	values       []T
-	currentIndex int
+type RingBuffer[T any] struct {
+	values []T
+	head   int
 }
 
-func NewBuffer[T any](capacity int) *Buffer[T] {
-	return &Buffer[T]{
+func New[T any](capacity int) *RingBuffer[T] {
+	return &RingBuffer[T]{
 		values: make([]T, 0, capacity),
 	}
 }
 
-func (b *Buffer[T]) Insert(value T) {
+func (b *RingBuffer[T]) Insert(value T) {
 	// If buffer is not full, append the new value
 	if len(b.values) < cap(b.values) {
 		b.values = append(b.values, value)
 		return
 	}
 	// If buffer is full, replace the oldest entry
-	b.values[b.currentIndex] = value
-	b.currentIndex = (b.currentIndex + 1) % cap(b.values)
+	b.values[b.head] = value
+	b.head = (b.head + 1) % cap(b.values)
 }
 
-func (b *Buffer[T]) Len() int {
+func (b *RingBuffer[T]) Len() int {
 	return len(b.values)
 }
 
-func (b *Buffer[T]) Reset() {
+func (b *RingBuffer[T]) Reset() {
 	b.values = b.values[:0]
-	b.currentIndex = 0
+	b.head = 0
 }
 
-func (b *Buffer[T]) GetItems() []T {
+func (b *RingBuffer[T]) Items() []T {
 	return b.values
-}
-
-func (b *Buffer[T]) Capacity() int {
-	return cap(b.values)
 }

--- a/pkg/utils/ringbuffer/buffer.go
+++ b/pkg/utils/ringbuffer/buffer.go
@@ -1,0 +1,56 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ringbuffer
+
+type Buffer[T any] struct {
+	values       []T
+	currentIndex int
+}
+
+func NewBuffer[T any](capacity int) *Buffer[T] {
+	return &Buffer[T]{
+		values: make([]T, 0, capacity),
+	}
+}
+
+func (b *Buffer[T]) Insert(value T) {
+	// If buffer is not full, append the new value
+	if len(b.values) < cap(b.values) {
+		b.values = append(b.values, value)
+		return
+	}
+	// If buffer is full, replace the oldest entry
+	b.values[b.currentIndex] = value
+	b.currentIndex = (b.currentIndex + 1) % cap(b.values)
+}
+
+func (b *Buffer[T]) Len() int {
+	return len(b.values)
+}
+
+func (b *Buffer[T]) Reset() {
+	b.values = b.values[:0]
+	b.currentIndex = 0
+}
+
+func (b *Buffer[T]) GetItems() []T {
+	return b.values
+}
+
+func (b *Buffer[T]) Capacity() int {
+	return cap(b.values)
+}

--- a/pkg/utils/ringbuffer/suite_test.go
+++ b/pkg/utils/ringbuffer/suite_test.go
@@ -32,27 +32,27 @@ func TestAPIs(t *testing.T) {
 
 var _ = Describe("RingBufferUtils", func() {
 	It("should validate ring buffer functionality", func() {
-		boolBuffer := ringbuffer.NewBuffer[bool](4)
-		Expect(boolBuffer.Capacity()).To(BeEquivalentTo(4))
+		boolBuffer := ringbuffer.New[bool](4)
+		Expect(cap(boolBuffer.Items())).To(Equal(4))
 		boolBuffer.Insert(true)
-		Expect(boolBuffer.Len()).To(BeEquivalentTo(1))
-		for _, value := range boolBuffer.GetItems() {
-			Expect(value).To(BeEquivalentTo(true))
+		Expect(boolBuffer.Len()).To(Equal(1))
+		for _, value := range boolBuffer.Items() {
+			Expect(value).To(Equal(true))
 		}
 		boolBuffer.Reset()
-		Expect(boolBuffer.Len()).To(BeEquivalentTo(0))
+		Expect(boolBuffer.Len()).To(Equal(0))
 	})
 	It("should expect the oldest entry in the buffer to be replaced when the buffer is full", func() {
-		boolBuffer := ringbuffer.NewBuffer[bool](2)
+		boolBuffer := ringbuffer.New[bool](2)
 		boolBuffer.Insert(true)
 		boolBuffer.Insert(true)
-		Expect(boolBuffer.Len()).To(BeEquivalentTo(2))
-		for _, value := range boolBuffer.GetItems() {
-			Expect(value).To(BeEquivalentTo(true))
+		Expect(boolBuffer.Len()).To(Equal(2))
+		for _, value := range boolBuffer.Items() {
+			Expect(value).To(Equal(true))
 		}
 		boolBuffer.Insert(false)
-		Expect(boolBuffer.Len()).To(BeEquivalentTo(2))
-		Expect(boolBuffer.GetItems()[0]).To(BeEquivalentTo(false))
-		Expect(boolBuffer.GetItems()[1]).To(BeEquivalentTo(true))
+		Expect(boolBuffer.Len()).To(Equal(2))
+		Expect(boolBuffer.Items()[0]).To(Equal(false))
+		Expect(boolBuffer.Items()[1]).To(Equal(true))
 	})
 })

--- a/pkg/utils/ringbuffer/suite_test.go
+++ b/pkg/utils/ringbuffer/suite_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ringbuffer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/karpenter/pkg/utils/ringbuffer"
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RingBufferUtils")
+}
+
+var _ = Describe("RingBufferUtils", func() {
+	It("should validate ring buffer functionality", func() {
+		boolBuffer := ringbuffer.NewBuffer[bool](4)
+		Expect(boolBuffer.Capacity()).To(BeEquivalentTo(4))
+		boolBuffer.Insert(true)
+		Expect(boolBuffer.Len()).To(BeEquivalentTo(1))
+		for _, value := range boolBuffer.GetItems() {
+			Expect(value).To(BeEquivalentTo(true))
+		}
+		boolBuffer.Reset()
+		Expect(boolBuffer.Len()).To(BeEquivalentTo(0))
+	})
+	It("should expect the oldest entry in the buffer to be replaced when the buffer is full", func() {
+		boolBuffer := ringbuffer.NewBuffer[bool](2)
+		boolBuffer.Insert(true)
+		boolBuffer.Insert(true)
+		Expect(boolBuffer.Len()).To(BeEquivalentTo(2))
+		for _, value := range boolBuffer.GetItems() {
+			Expect(value).To(BeEquivalentTo(true))
+		}
+		boolBuffer.Insert(false)
+		Expect(boolBuffer.Len()).To(BeEquivalentTo(2))
+		Expect(boolBuffer.GetItems()[0]).To(BeEquivalentTo(false))
+		Expect(boolBuffer.GetItems()[1]).To(BeEquivalentTo(true))
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This change is intended to allow `NodeRegistrationHealthy` SC on the nodePool to be updated to `False` even if it was previously set to `True` depending on the values stored in the boolean `NodePoolNodeRegistrationBuffer`. In this implementation, the size of this buffer is `4` and if there are >=2 registration failures, we update the `NodeRegistrationHealthy` SC to `False` even if it was `True` previously. This wasn't possible in the existing implementation because once the SC was set to `True`, it could only be set to `Unknown` on updates to nodePool/nodeClass. This change allows it to go back to `False`.

**How was this change tested?**
Deployed to my dev cluster and tested. Also added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
