### PR TITLE
feat(limits): support NodePool node limits

### DIFF
--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -359,11 +360,12 @@ func (in *StateNode) Capacity() corev1.ResourceList {
 					ret[resourceName] = quantity
 				}
 			}
-			return ret
+			// A StateNode will always have a capacity of 1 node.
+			return lo.Assign(ret, corev1.ResourceList{resources.Node: resource.MustParse("1")})
 		}
-		return in.NodeClaim.Status.Capacity
+		return lo.Assign(in.NodeClaim.Status.Capacity, corev1.ResourceList{resources.Node: resource.MustParse("1")})
 	}
-	return in.Node.Status.Capacity
+	return lo.Assign(in.Node.Status.Capacity, corev1.ResourceList{resources.Node: resource.MustParse("1")})
 }
 
 func (in *StateNode) Allocatable() corev1.ResourceList {


### PR DESCRIPTION
Fixes: https://github.com/issues/created?issue=kubernetes-sigs%7Ckarpenter%7C2657, #732 

**Description**
This PR attempts to allow NodePool Node limits to work in the same behaviour as CPU and memory nodepool limits, and properly limit the resource from being created over the limit _specifically_ during provisioning.

See the original issue for more details.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
