### PR TITLE
fix: over provisioning static nodeclaims during controller crashes

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -897,3 +897,8 @@ func (c *Cluster) triggerConsolidationOnChange(old, new *StateNode) {
 		return
 	}
 }
+
+// HasSynced returns whether the cluster state has been synchronized at least once.
+func (c *Cluster) HasSynced() bool {
+	return c.hasSynced.Load()
+}

--- a/pkg/controllers/static/deprovisioning/controller.go
+++ b/pkg/controllers/static/deprovisioning/controller.go
@@ -79,6 +79,8 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1.NodePool) (reconcile.
 		return reconcile.Result{}, nil
 	}
 
+	// We dont have to wait for cluster sync as we cannot really have internal state representing more NodeClaims than actual
+	// During controller crashes we gradually populate our cluster/NodePoolState, as and when we populate we delete NC if we are over-provisioned
 	runningNodeClaims, _, _ := c.cluster.NodePoolState.GetNodeCount(np.Name)
 	desiredReplicas := lo.FromPtr(np.Spec.Replicas)
 	// To avoid race conditions between deprovisioning and the disruption controller,


### PR DESCRIPTION
Fixes over provisioning of NodeClaims during controller crashes.


**Description**

Since we use local Cluster NodePoolState to account for limits, if during provisioning controller dies then the next leader would need to wait until cluster state is populated to avoid over-provisioning of resources. 

We dont need to sync on cluster state for deprovisioning as we gradually populate NodePoolState and look at the replicas to delete NC when over-provisioned.

**How was this change tested?**

UT and tested by rolling and restarting karpenter to check if we overprovision resources.
Even tested deprovisioning case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
