### PR TITLE
feat: Add random shuffles in multi-node consolidation

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -163,7 +163,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 		}, nil
 	}
 
-	// we're not going to turn a single node into multiple candidates
+	// we're not going to turn one or more nodes into multiple candidates
 	if len(results.NewNodeClaims) != 1 {
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, fmt.Sprintf("Can't remove without creating %d candidates", len(results.NewNodeClaims)))...)

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -205,7 +205,7 @@ func BuildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 		nodePoolInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, np)
 		if err != nil {
 			if nodeoverlay.IsUnevaluatedNodePoolError(err) {
-				log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Error(err, "skipping, node overlies are not applied")
+				log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Error(err, "skipping, node overlays are not applied")
 				continue
 			}
 			// don't error out on building the node pool, we just won't be able to handle any nodes that

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -88,6 +88,7 @@ type Options struct {
 	MinValuesPolicy                  MinValuesPolicy
 	IgnoreDRARequests                bool // NOTE: This flag will be removed once formal DRA support is GA in Karpenter.
 	FeatureGates                     FeatureGates
+	MultiNodeRandomizedShuffleLimit  int64
 }
 
 type FlagSet struct {
@@ -129,6 +130,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, and StaticCapacity.")
+	fs.Int64Var(&o.MultiNodeRandomizedShuffleLimit, "multi-node-randomized-shuffle-limit", env.WithDefaultInt64("MULTI_NODE_RANDOMIZED_SHUFFLE_LIMIT", 0), "The number of times to randomly shuffle the candidates when computing multi-node consolidation. A higher number increases the chance of finding a valid consolidation but increases compute time.")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2434

**Description**

The current algorithm doesn't deal well with:
- Multiple mutually exclusive NodePools
- Nodes spread across AZs with topologySpreadConstraints
as it orders the Nodes, and then all consolidations must be of a consecutive sequence.

This preserves the existing behaviour as a default, but then can optionally shuffle the order in order to attempt to find other consolidation opportunities.

**How was this change tested?**

I've been using karpenter-provider-aws per [the docs](https://karpenter.sh/docs/contributing/development-guide/#locally) with the karpenter dependency replaced locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
