### PR TITLE
fix: allow non-churn empty nodes to be disrupted (#2206)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,83 +1,106 @@
-# See https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
+version: "2"
 run:
-  tests: true
-  timeout: 5m
   build-tags:
     - test_performance
+  tests: true
+  timeout: 5m
 linters:
   enable:
     - asciicheck
     - bidichk
-    - errorlint
     - copyloopvar
+    - errorlint
+    - gocyclo
+    - goheader
     - gosec
+    - misspell
+    - nilerr
     - revive
-    - stylecheck
+    - staticcheck
     - tparallel
     - unconvert
     - unparam
-    - gocyclo
-    - govet
-    - goimports
-    - goheader
-    - misspell
-    - nilerr
   disable:
     - prealloc
-linters-settings:
-  gocyclo:
-    min-complexity: 11
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-  revive:
+  settings:
+    gocyclo:
+      min-complexity: 11
+    goheader:
+      template: |-
+        Copyright The Kubernetes Authors.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: dot-imports
-        disabled: true
-  stylecheck:
-    dot-import-whitelist:
-      - "github.com/onsi/ginkgo/v2"
-      - "github.com/onsi/gomega"
-  misspell:
-    locale: US
-    ignore-words: []
-  goimports:
-    local-prefixes: sigs.k8s.io/karpenter
-  goheader:
-    template: |-
-      Copyright The Kubernetes Authors.
-      
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
-    skip-generated: true
+      - linters:
+          - goheader
+        path: zz_(.+)\.go
+      - linters:
+          - goheader
+        path: scheduling_benchmark_test.go
+      - path: (.+)\.go$
+        text: declaration of "(err|ctx)" shadows declaration at
+    paths:
+      - tools
+      - website
+      - hack
+      - charts
+      - designs
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   fix: true
-  exclude: ['declaration of "(err|ctx)" shadows declaration at']
-  exclude-dirs:
-    - tools
-    - website
-    - hack
-    - charts
-    - designs
-  exclude-rules:
-  - linters:
-    - goheader
-    path: 'zz_(.+)\.go'
-  - linters:
-    - goheader
-    path: 'scheduling_benchmark_test.go'
+formatters:
+  enable:
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+    goimports:
+      local-prefixes:
+        - sigs.k8s.io/karpenter
+  exclusions:
+    generated: lax
+    paths:
+      - tools
+      - website
+      - hack
+      - charts
+      - designs
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -11,7 +11,10 @@ main() {
 
 tools() {
     go install github.com/google/go-licenses@latest
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    # asciicheck is a dependency of golangci-lint that got removed so golangci changed their go.mod to use the forked version
+    # fix - https://github.com/golangci/golangci-lint/issues/6017
+    # change to latest once golangci releases new version with the fix
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@main
     go install github.com/mikefarah/yq/v4@latest
     go install github.com/google/ko@latest
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest

--- a/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml
+++ b/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: kwoknodeclasses.karpenter.kwok.sh
 spec:
   group: karpenter.kwok.sh

--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -99,7 +99,7 @@ func (c CloudProvider) Delete(ctx context.Context, nodeClaim *v1.NodeClaim) erro
 }
 
 func (c CloudProvider) Get(ctx context.Context, providerID string) (*v1.NodeClaim, error) {
-	nodeName := strings.Replace(providerID, kwokProviderPrefix, "", -1)
+	nodeName := strings.ReplaceAll(providerID, kwokProviderPrefix, "")
 	node := &corev1.Node{}
 	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
 		if errors.IsNotFound(err) {
@@ -166,7 +166,7 @@ func (c CloudProvider) getInstanceType(instanceTypeName string) (*cloudprovider.
 }
 
 func (c CloudProvider) toNode(nodeClaim *v1.NodeClaim) (*corev1.Node, error) {
-	newName := strings.Replace(namesgenerator.GetRandomName(0), "_", "-", -1)
+	newName := strings.ReplaceAll(namesgenerator.GetRandomName(0), "_", "-")
 	//nolint
 	newName = fmt.Sprintf("%s-%d", newName, rand.Uint32())
 

--- a/kwok/cloudprovider/helpers.go
+++ b/kwok/cloudprovider/helpers.go
@@ -199,7 +199,7 @@ func newInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 				Requirements: scheduling.NewRequirements(lo.Map(off.Requirements, func(req corev1.NodeSelectorRequirement, _ int) *scheduling.Requirement {
 					return scheduling.NewRequirement(req.Key, req.Operator, req.Values...)
 				})...),
-				Price:     off.Offering.Price,
+				Price:     off.Price,
 				Available: off.Available,
 			}
 		}),

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/v1/duration.go
+++ b/pkg/apis/v1/duration.go
@@ -70,7 +70,7 @@ func (d NillableDuration) MarshalJSON() ([]byte, error) {
 		return d.Raw, nil
 	}
 	if d.Duration != nil {
-		return json.Marshal(d.Duration.String())
+		return json.Marshal(d.String())
 	}
 	return json.Marshal(Never)
 }
@@ -81,7 +81,7 @@ func (d NillableDuration) ToUnstructured() interface{} {
 		return d.Raw
 	}
 	if d.Duration != nil {
-		return d.Duration.String()
+		return d.String()
 	}
 	return Never
 }

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -217,8 +217,8 @@ type NodeClaimTemplateSpec struct {
 func (in *NodeClaimTemplate) ToNodeClaim() *NodeClaim {
 	return &NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      in.ObjectMeta.Labels,
-			Annotations: in.ObjectMeta.Annotations,
+			Labels:      in.Labels,
+			Annotations: in.Annotations,
 		},
 		Spec: NodeClaimSpec{
 			Taints:                 in.Spec.Taints,

--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -182,7 +182,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 
 	// sort the instanceTypes by price before we take any actions like truncation for spot-to-spot consolidation or finding the nodeclaim
 	// that meets the minimum requirement after filteringByPrice
-	results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions = results.NewNodeClaims[0].InstanceTypeOptions.OrderByPrice(results.NewNodeClaims[0].Requirements)
+	results.NewNodeClaims[0].InstanceTypeOptions = results.NewNodeClaims[0].InstanceTypeOptions.OrderByPrice(results.NewNodeClaims[0].Requirements)
 
 	if allExistingAreSpot &&
 		results.NewNodeClaims[0].Requirements.Get(v1.CapacityTypeLabelKey).Has(v1.CapacityTypeSpot) {
@@ -201,7 +201,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 		}
 		return Command{}, pscheduling.Results{}, nil
 	}
-	if len(results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions) == 0 {
+	if len(results.NewNodeClaims[0].InstanceTypeOptions) == 0 {
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, "Can't replace with a cheaper node")...)
 		}
@@ -243,7 +243,7 @@ func (c *consolidation) computeSpotToSpotConsolidation(ctx context.Context, cand
 	// Since we are sure that the replacement nodeclaim considered for the spot candidates are spot, we will enforce it through the requirements.
 	results.NewNodeClaims[0].Requirements.Add(scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, v1.CapacityTypeSpot))
 	// All possible replacements for the current candidate compatible with spot offerings
-	results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions = results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions.Compatible(results.NewNodeClaims[0].Requirements)
+	results.NewNodeClaims[0].InstanceTypeOptions = results.NewNodeClaims[0].InstanceTypeOptions.Compatible(results.NewNodeClaims[0].Requirements)
 
 	// filterByPrice returns the instanceTypes that are lower priced than the current candidate and any error that indicates the input couldn't be filtered.
 	var err error
@@ -254,7 +254,7 @@ func (c *consolidation) computeSpotToSpotConsolidation(ctx context.Context, cand
 		}
 		return Command{}, pscheduling.Results{}, nil
 	}
-	if len(results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions) == 0 {
+	if len(results.NewNodeClaims[0].InstanceTypeOptions) == 0 {
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, "Can't replace with a cheaper node")...)
 		}
@@ -275,9 +275,9 @@ func (c *consolidation) computeSpotToSpotConsolidation(ctx context.Context, cand
 	// We check whether we have 15 cheaper instances than the current candidate instance. If this is the case, we know the following things:
 	//   1) The current candidate is not in the set of the 15 cheapest instance types and
 	//   2) There were at least 15 options cheaper than the current candidate.
-	if len(results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions) < MinInstanceTypesForSpotToSpotConsolidation {
+	if len(results.NewNodeClaims[0].InstanceTypeOptions) < MinInstanceTypesForSpotToSpotConsolidation {
 		c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, fmt.Sprintf("SpotToSpotConsolidation requires %d cheaper instance type options than the current candidate to consolidate, got %d",
-			MinInstanceTypesForSpotToSpotConsolidation, len(results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions)))...)
+			MinInstanceTypesForSpotToSpotConsolidation, len(results.NewNodeClaims[0].InstanceTypeOptions)))...)
 		return Command{}, pscheduling.Results{}, nil
 	}
 
@@ -292,10 +292,10 @@ func (c *consolidation) computeSpotToSpotConsolidation(ctx context.Context, cand
 	// Taking this to 15 types, we need to only send the 15 cheapest types in the CreateInstanceFromTypes call so that the resulting instance is always in that set of 15 and we won’t immediately consolidate.
 	if results.NewNodeClaims[0].Requirements.HasMinValues() {
 		// Here we are trying to get the max of the minimum instances required to satisfy the minimum requirement and the default 15 to cap the instances for spot-to-spot consolidation.
-		minInstanceTypes, _ := results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions.SatisfiesMinValues(results.NewNodeClaims[0].Requirements)
-		results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions = lo.Slice(results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions, 0, lo.Max([]int{MinInstanceTypesForSpotToSpotConsolidation, minInstanceTypes}))
+		minInstanceTypes, _ := results.NewNodeClaims[0].InstanceTypeOptions.SatisfiesMinValues(results.NewNodeClaims[0].Requirements)
+		results.NewNodeClaims[0].InstanceTypeOptions = lo.Slice(results.NewNodeClaims[0].InstanceTypeOptions, 0, lo.Max([]int{MinInstanceTypesForSpotToSpotConsolidation, minInstanceTypes}))
 	} else {
-		results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions = lo.Slice(results.NewNodeClaims[0].NodeClaimTemplate.InstanceTypeOptions, 0, MinInstanceTypesForSpotToSpotConsolidation)
+		results.NewNodeClaims[0].InstanceTypeOptions = lo.Slice(results.NewNodeClaims[0].InstanceTypeOptions, 0, MinInstanceTypesForSpotToSpotConsolidation)
 	}
 
 	return Command{
@@ -308,7 +308,7 @@ func (c *consolidation) computeSpotToSpotConsolidation(ctx context.Context, cand
 func getCandidatePrices(candidates []*Candidate) (float64, error) {
 	var price float64
 	for _, c := range candidates {
-		reqs := scheduling.NewLabelRequirements(c.StateNode.Labels())
+		reqs := scheduling.NewLabelRequirements(c.Labels())
 		compatibleOfferings := c.instanceType.Offerings.Compatible(reqs)
 		if len(compatibleOfferings) == 0 {
 			// It's expected that offerings may no longer exist for capacity reservations once a NodeClass stops selecting on

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -2302,7 +2302,7 @@ var _ = Describe("Consolidation", func() {
 			// and delete the old one
 			ExpectNotFound(ctx, env.Client, nodeClaims[1], nodes[1])
 		})
-		It("does not delete nodes when there is pod churn", func() {
+		It("does not delete nodes with pod churn, deletes nodes without pod churn", func() {
 			// create our RS so we can link a pod to it
 			ExpectApplied(ctx, env.Client, nodePool)
 			for i := range 2 {
@@ -2329,7 +2329,10 @@ var _ = Describe("Consolidation", func() {
 			wg.Wait()
 			Expect(err).To(Succeed())
 			Expect(results).To(Equal(pscheduling.Results{}))
-			Expect(cmd).To(Equal(disruption.Command{}))
+			Expect(cmd.Candidates()).To(HaveLen(1))
+			// the test validator manually binds a pod to nodes[0], causing it to no longer be eligible
+			Expect(cmd.Candidates()[0].StateNode.Node.Name).To(Equal(nodes[1].Name))
+			Expect(cmd.Decision()).To(Equal(disruption.DeleteDecision))
 
 			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
 

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -1818,7 +1818,7 @@ var _ = Describe("Consolidation", func() {
 				namespace := test.Namespace()
 				pdb := test.PodDisruptionBudget(test.PDBOptions{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: namespace.ObjectMeta.Name,
+						Namespace: namespace.Name,
 					},
 					Labels:         labels,
 					MaxUnavailable: fromInt(0),

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -2302,6 +2302,38 @@ var _ = Describe("Consolidation", func() {
 			// and delete the old one
 			ExpectNotFound(ctx, env.Client, nodeClaims[1], nodes[1])
 		})
+		It("does not delete nodes when there is pod churn", func() {
+			// create our RS so we can link a pod to it
+			ExpectApplied(ctx, env.Client, nodePool)
+			for i := range 2 {
+				ExpectApplied(ctx, env.Client, nodeClaims[i], nodes[i])
+			}
+
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+
+			emptyConsolidation := disruption.NewEmptiness(disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue))
+			budgets, err := disruption.BuildDisruptionBudgetMapping(ctx, cluster, fakeClock, env.Client, cloudProvider, recorder, emptyConsolidation.Reason())
+			Expect(err).To(Succeed())
+
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, emptyConsolidation.ShouldDisrupt, emptyConsolidation.Class(), queue)
+			Expect(err).To(Succeed())
+
+			// this test validator invalidates the command because it creates pod churn during validaiton
+			emptyConsolidation.Validator = NewTestEmptinessValidator(nodes, nodeClaims, nodePool, emptyConsolidation.Validator.(*disruption.EmptinessValidator), WithChurn())
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+			ExpectToWait(fakeClock, &wg)
+			cmd, results, err := emptyConsolidation.ComputeCommand(ctx, budgets, candidates...)
+			wg.Wait()
+			Expect(err).To(Succeed())
+			Expect(results).To(Equal(pscheduling.Results{}))
+			Expect(cmd).To(Equal(disruption.Command{}))
+
+			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
+
+		})
 		It("can delete nodes if another nodePool has no node template", func() {
 			// create our RS so we can link a pod to it
 			rs := test.ReplicaSet()

--- a/pkg/controllers/disruption/emptiness.go
+++ b/pkg/controllers/disruption/emptiness.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -32,12 +31,13 @@ import (
 // Emptiness is a subreconciler that deletes empty candidates.
 type Emptiness struct {
 	consolidation
+	Validator
 }
 
 func NewEmptiness(c consolidation) *Emptiness {
-	return &Emptiness{
-		consolidation: c,
-	}
+	e := &Emptiness{consolidation: c}
+	e.Validator = NewEmptinessValidator(c, e.ShouldDisrupt)
+	return e
 }
 
 // ShouldDisrupt is a predicate used to filter candidates
@@ -100,8 +100,7 @@ func (e *Emptiness) ComputeCommand(ctx context.Context, disruptionBudgetMapping 
 	case <-e.clock.After(consolidationTTL):
 	}
 
-	v := NewValidation(e.clock, e.cluster, e.kubeClient, e.provisioner, e.cloudProvider, e.recorder, e.queue, e.Reason())
-	validatedCandidates, err := v.ValidateCandidates(ctx, cmd.candidates...)
+	validCmd, err := e.Validate(ctx, cmd, consolidationTTL)
 	if err != nil {
 		if IsValidationError(err) {
 			log.FromContext(ctx).V(1).WithValues(cmd.LogValues()...).Info("abandoning empty node consolidation attempt due to pod churn, command is no longer valid")
@@ -110,15 +109,7 @@ func (e *Emptiness) ComputeCommand(ctx context.Context, disruptionBudgetMapping 
 		return Command{}, scheduling.Results{}, err
 	}
 
-	// TODO (jmdeal@): better encapsulate within validation
-	if lo.ContainsBy(validatedCandidates, func(c *Candidate) bool {
-		return len(c.reschedulablePods) != 0
-	}) {
-		log.FromContext(ctx).V(1).WithValues(cmd.LogValues()...).Info("abandoning empty node consolidation attempt due to pod churn, command is no longer valid")
-		return Command{}, scheduling.Results{}, nil
-	}
-
-	return cmd, scheduling.Results{}, nil
+	return validCmd, scheduling.Results{}, nil
 }
 
 func (e *Emptiness) Reason() v1.DisruptionReason {

--- a/pkg/controllers/disruption/emptiness_test.go
+++ b/pkg/controllers/disruption/emptiness_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package disruption_test
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -38,6 +39,68 @@ import (
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
+
+type TestEmptinessValidator struct {
+	churn      bool
+	nodes      []*corev1.Node
+	nodeClaims []*v1.NodeClaim
+	nodePool   *v1.NodePool
+	emptiness  *disruption.EmptinessValidator
+}
+
+type TestEmptinessValidatorOption func(*TestEmptinessValidator)
+
+func WithChurn() TestEmptinessValidatorOption {
+	return func(v *TestEmptinessValidator) {
+		v.churn = true
+	}
+}
+
+func NewTestEmptinessValidator(nodes []*corev1.Node, nodeClaims []*v1.NodeClaim, nodePool *v1.NodePool, e *disruption.EmptinessValidator, opts ...TestEmptinessValidatorOption) disruption.Validator {
+	v := &TestEmptinessValidator{
+		nodes:      nodes,
+		nodeClaims: nodeClaims,
+		nodePool:   nodePool,
+		emptiness:  e,
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}
+
+func (t *TestEmptinessValidator) Validate(ctx context.Context, cmd disruption.Command, _ time.Duration) (disruption.Command, error) {
+	var pods []*corev1.Pod
+	if t.churn {
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, t.nodes, t.nodeClaims)
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		// Simulate churn
+		pods = test.Pods(1, test.PodOptions{
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					// 100m * 10 = 1 vCPU. This should be less than the largest node capacity.
+					corev1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				"app": "test",
+			},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         lo.ToPtr(true),
+						BlockOwnerDeletion: lo.ToPtr(true),
+					},
+				}}})
+		ExpectApplied(ctx, env.Client, pods[0])
+		ExpectManualBinding(ctx, env.Client, pods[0], t.nodes[0])
+	}
+	return t.emptiness.Validate(ctx, cmd, 0)
+}
 
 var _ = Describe("Emptiness", func() {
 	var nodePool *v1.NodePool

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -192,7 +192,7 @@ func filterOutSameType(newNodeClaim *scheduling.NodeClaim, consolidate []*Candid
 	// get the price of the cheapest node that we currently are considering deleting indexed by instance type
 	for _, c := range consolidate {
 		existingInstanceTypes.Insert(c.instanceType.Name)
-		compatibleOfferings := c.instanceType.Offerings.Compatible(scheduler.NewLabelRequirements(c.StateNode.Labels()))
+		compatibleOfferings := c.instanceType.Offerings.Compatible(scheduler.NewLabelRequirements(c.Labels()))
 		if len(compatibleOfferings) == 0 {
 			continue
 		}

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -38,10 +38,13 @@ const MultiNodeConsolidationType = "multi"
 
 type MultiNodeConsolidation struct {
 	consolidation
+	Validator
 }
 
 func NewMultiNodeConsolidation(consolidation consolidation) *MultiNodeConsolidation {
-	return &MultiNodeConsolidation{consolidation: consolidation}
+	m := &MultiNodeConsolidation{consolidation: consolidation}
+	m.Validator = NewConsolidationValidator(consolidation, m.ShouldDisrupt)
+	return m
 }
 
 func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) (Command, scheduling.Results, error) {
@@ -96,7 +99,7 @@ func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, disruptionB
 		return cmd, scheduling.Results{}, nil
 	}
 
-	if err := NewValidation(m.clock, m.cluster, m.kubeClient, m.provisioner, m.cloudProvider, m.recorder, m.queue, m.Reason()).IsValid(ctx, cmd, consolidationTTL); err != nil {
+	if cmd, err = m.Validate(ctx, cmd, consolidationTTL); err != nil {
 		if IsValidationError(err) {
 			log.FromContext(ctx).V(1).WithValues(cmd.LogValues()...).Info("abandoning multi-node consolidation attempt due to pod churn, command is no longer valid")
 			return Command{}, scheduling.Results{}, nil

--- a/pkg/controllers/disruption/orchestration/queue.go
+++ b/pkg/controllers/disruption/orchestration/queue.go
@@ -195,7 +195,7 @@ func (q *Queue) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	}
 
 	// Get command from queue. This waits until queue is non-empty.
-	cmd, shutdown := q.TypedRateLimitingInterface.Get()
+	cmd, shutdown := q.Get()
 	if shutdown {
 		panic("unexpected failure, disruption queue has shut down")
 	}
@@ -207,8 +207,8 @@ func (q *Queue) Reconcile(ctx context.Context) (reconcile.Result, error) {
 			// store the error that is causing us to fail, so we can bubble it up later if this times out.
 			cmd.lastError = err
 			// mark this item as done processing. This is necessary so that the RLI is able to add the item back in.
-			q.TypedRateLimitingInterface.Done(cmd)
-			q.TypedRateLimitingInterface.AddRateLimited(cmd)
+			q.Done(cmd)
+			q.AddRateLimited(cmd)
 			return reconcile.Result{RequeueAfter: singleton.RequeueImmediately}, nil
 		}
 		// If the command failed, bail on the action.
@@ -341,8 +341,8 @@ func (q *Queue) HasAny(ids ...string) bool {
 // Remove fully clears the queue of all references of a hash/command
 func (q *Queue) Remove(cmd *Command) {
 	// mark this item as done processing. This is necessary so that the RLI is able to add the item back in.
-	q.TypedRateLimitingInterface.Done(cmd)
-	q.TypedRateLimitingInterface.Forget(cmd)
+	q.Done(cmd)
+	q.Forget(cmd)
 	q.cluster.UnmarkForDeletion(lo.Map(cmd.candidates, func(s *state.StateNode, _ int) string { return s.ProviderID() })...)
 	// Remove all candidates linked to the command
 	q.mu.Lock()

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -140,6 +140,10 @@ func (c Command) Decision() Decision {
 	}
 }
 
+func (c Command) Candidates() []*Candidate {
+	return c.candidates
+}
+
 func (c Command) LogValues() []any {
 	podCount := lo.Reduce(c.candidates, func(_ int, cd *Candidate, _ int) int { return len(cd.reschedulablePods) }, 0)
 

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/samber/lo"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -147,6 +148,32 @@ func (c *ConsolidationValidator) isValid(ctx context.Context, cmd Command, valid
 		return err
 	}
 	return nil
+}
+
+func (e *EmptinessValidator) validateCandidates(ctx context.Context, candidates ...*Candidate) ([]*Candidate, error) {
+	validatedCandidates, err := GetCandidates(ctx, e.cluster, e.kubeClient, e.recorder, e.clock, e.cloudProvider, e.filter, GracefulDisruptionClass, e.queue)
+	if err != nil {
+		return nil, fmt.Errorf("constructing validation candidates, %w", err)
+	}
+	validatedCandidates = mapCandidates(candidates, validatedCandidates)
+	if len(validatedCandidates) == 0 {
+		return nil, NewValidationError(fmt.Errorf("%d candidates are no longer valid", len(candidates)))
+	}
+	disruptionBudgetMapping, err := BuildDisruptionBudgetMapping(ctx, e.cluster, e.clock, e.kubeClient, e.cloudProvider, e.recorder, e.reason)
+	if err != nil {
+		return nil, fmt.Errorf("building disruption budgets, %w", err)
+	}
+
+	if valid := lo.Filter(validatedCandidates, func(cn *Candidate, _ int) bool {
+		if e.cluster.IsNodeNominated(cn.ProviderID()) || disruptionBudgetMapping[cn.NodePool.Name] == 0 {
+			return false
+		}
+		disruptionBudgetMapping[cn.NodePool.Name]--
+		return true
+	}); len(valid) > 0 {
+		return valid, nil
+	}
+	return nil, NewValidationError(fmt.Errorf("a candidate failed validation because it was nominated for a pod or would violate disruption budgets"))
 }
 
 // ValidateCandidates gets the current representation of the provided candidates and ensures that they are all still valid.

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"k8s.io/utils/clock"
@@ -50,60 +49,101 @@ func IsValidationError(err error) bool {
 	return errors.As(err, &validationError)
 }
 
+type Validator interface {
+	Validate(context.Context, Command, time.Duration) (Command, error)
+}
+
 // Validation is used to perform validation on a consolidation command.  It makes an assumption that when re-used, all
 // of the commands passed to IsValid were constructed based off of the same consolidation state.  This allows it to
 // skip the validation TTL for all but the first command.
-type Validation struct {
-	start         time.Time
+type validation struct {
 	clock         clock.Clock
 	cluster       *state.Cluster
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
 	provisioner   *provisioning.Provisioner
-	once          sync.Once
 	recorder      events.Recorder
 	queue         *orchestration.Queue
 	reason        v1.DisruptionReason
+	filter        CandidateFilter
 }
 
-func NewValidation(clk clock.Clock, cluster *state.Cluster, kubeClient client.Client, provisioner *provisioning.Provisioner,
-	cp cloudprovider.CloudProvider, recorder events.Recorder, queue *orchestration.Queue, reason v1.DisruptionReason) *Validation {
-	return &Validation{
-		clock:         clk,
-		cluster:       cluster,
-		kubeClient:    kubeClient,
-		provisioner:   provisioner,
-		cloudProvider: cp,
-		recorder:      recorder,
-		queue:         queue,
-		reason:        reason,
+type EmptinessValidator struct {
+	validation
+}
+
+func NewEmptinessValidator(c consolidation, filter CandidateFilter) *EmptinessValidator {
+	return &EmptinessValidator{
+		validation: validation{
+			clock:         c.clock,
+			cluster:       c.cluster,
+			kubeClient:    c.kubeClient,
+			provisioner:   c.provisioner,
+			cloudProvider: c.cloudProvider,
+			recorder:      c.recorder,
+			queue:         c.queue,
+			reason:        v1.DisruptionReasonEmpty,
+			filter:        filter,
+		},
 	}
 }
 
-func (v *Validation) IsValid(ctx context.Context, cmd Command, validationPeriod time.Duration) error {
-	var err error
-	v.once.Do(func() {
-		v.start = v.clock.Now()
-	})
+func (e *EmptinessValidator) Validate(ctx context.Context, cmd Command, _ time.Duration) (Command, error) {
+	validatedCandidates, err := e.validateCandidates(ctx, cmd.candidates...)
+	if err != nil {
+		return Command{}, err
+	}
+	cmd.candidates = validatedCandidates
+	return cmd, nil
+}
 
-	waitDuration := validationPeriod - v.clock.Since(v.start)
-	if waitDuration > 0 {
+type ConsolidationValidator struct {
+	validation
+}
+
+func NewConsolidationValidator(c consolidation, filter CandidateFilter) *ConsolidationValidator {
+	return &ConsolidationValidator{
+		validation: validation{
+			clock:         c.clock,
+			cluster:       c.cluster,
+			kubeClient:    c.kubeClient,
+			provisioner:   c.provisioner,
+			cloudProvider: c.cloudProvider,
+			recorder:      c.recorder,
+			queue:         c.queue,
+			reason:        v1.DisruptionReasonUnderutilized,
+			filter:        filter,
+		},
+	}
+}
+
+func (c *ConsolidationValidator) Validate(ctx context.Context, cmd Command, validationPeriod time.Duration) (Command, error) {
+	if err := c.isValid(ctx, cmd, validationPeriod); err != nil {
+		return Command{}, err
+	}
+	return cmd, nil
+}
+
+func (c *ConsolidationValidator) isValid(ctx context.Context, cmd Command, validationPeriod time.Duration) error {
+	var err error
+	// TODO: see if this check can be removed, as written, consolidation tests begin hanging with its removal
+	if validationPeriod > 0 {
 		select {
 		case <-ctx.Done():
 			return errors.New("context canceled")
-		case <-v.clock.After(waitDuration):
+		case <-c.clock.After(validationPeriod):
 		}
 	}
-	validatedCandidates, err := v.ValidateCandidates(ctx, cmd.candidates...)
+	validatedCandidates, err := c.validateCandidates(ctx, cmd.candidates...)
 	if err != nil {
 		return err
 	}
-	if err := v.ValidateCommand(ctx, cmd, validatedCandidates); err != nil {
+	if err := c.validateCommand(ctx, cmd, validatedCandidates); err != nil {
 		return err
 	}
 	// Revalidate candidates after validating the command. This mitigates the chance of a race condition outlined in
 	// the following GitHub issue: https://github.com/kubernetes-sigs/karpenter/issues/1167.
-	if _, err = v.ValidateCandidates(ctx, validatedCandidates...); err != nil {
+	if _, err = c.validateCandidates(ctx, validatedCandidates...); err != nil {
 		return err
 	}
 	return nil
@@ -117,9 +157,9 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command, validationPeriod 
 //	c. It must still be disruptable without violating node disruption budgets
 //
 // If these conditions are met for all candidates, ValidateCandidates returns a slice with the updated representations.
-func (v *Validation) ValidateCandidates(ctx context.Context, candidates ...*Candidate) ([]*Candidate, error) {
+func (v *validation) validateCandidates(ctx context.Context, candidates ...*Candidate) ([]*Candidate, error) {
 	// GracefulDisruptionClass is hardcoded here because ValidateCandidates is only used for consolidation disruption. All consolidation disruption is graceful disruption.
-	validatedCandidates, err := GetCandidates(ctx, v.cluster, v.kubeClient, v.recorder, v.clock, v.cloudProvider, v.ShouldDisrupt, GracefulDisruptionClass, v.queue)
+	validatedCandidates, err := GetCandidates(ctx, v.cluster, v.kubeClient, v.recorder, v.clock, v.cloudProvider, v.filter, GracefulDisruptionClass, v.queue)
 	if err != nil {
 		return nil, fmt.Errorf("constructing validation candidates, %w", err)
 	}
@@ -147,13 +187,8 @@ func (v *Validation) ValidateCandidates(ctx context.Context, candidates ...*Cand
 	return validatedCandidates, nil
 }
 
-// ShouldDisrupt is a predicate used to filter candidates
-func (v *Validation) ShouldDisrupt(_ context.Context, c *Candidate) bool {
-	return c.NodePool.Spec.Disruption.ConsolidateAfter.Duration != nil && c.NodeClaim.StatusConditions().Get(v1.ConditionTypeConsolidatable).IsTrue()
-}
-
 // ValidateCommand validates a command for a Method
-func (v *Validation) ValidateCommand(ctx context.Context, cmd Command, candidates []*Candidate) error {
+func (v *validation) validateCommand(ctx context.Context, cmd Command, candidates []*Candidate) error {
 	// None of the chosen candidate are valid for execution, so retry
 	if len(candidates) == 0 {
 		return NewValidationError(fmt.Errorf("no candidates"))

--- a/pkg/controllers/metrics/nodepool/controller.go
+++ b/pkg/controllers/metrics/nodepool/controller.go
@@ -96,14 +96,14 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	nodePool := &v1.NodePool{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, nodePool); err != nil {
 		if errors.IsNotFound(err) {
-			c.metricStore.Delete(req.NamespacedName.String())
+			c.metricStore.Delete(req.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 	if !nodepoolutils.IsManaged(nodePool, c.cloudProvider) {
 		return reconcile.Result{}, nil
 	}
-	c.metricStore.Update(req.NamespacedName.String(), buildMetrics(nodePool))
+	c.metricStore.Update(req.String(), buildMetrics(nodePool))
 	// periodically update our metrics per nodepool even if nothing has changed
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -211,7 +211,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	pod := &corev1.Pod{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, pod); err != nil {
 		if errors.IsNotFound(err) {
-			c.pendingPods.Delete(req.NamespacedName.String())
+			c.pendingPods.Delete(req.String())
 			// Delete the unstarted metric since the pod is deleted
 			PodUnstartedTimeSeconds.Delete(map[string]string{
 				podName:      req.Name,
@@ -221,7 +221,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				podName:      req.Name,
 				podNamespace: req.Namespace,
 			})
-			c.unscheduledPods.Delete(req.NamespacedName.String())
+			c.unscheduledPods.Delete(req.String())
 			// Delete the unbound metric since the pod is deleted
 			PodUnboundTimeSeconds.Delete(map[string]string{
 				podName:      req.Name,
@@ -235,7 +235,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 				podName:      req.Name,
 				podNamespace: req.Namespace,
 			})
-			c.metricStore.Delete(req.NamespacedName.String())
+			c.metricStore.Delete(req.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -170,7 +170,7 @@ func (c *Controller) findUnhealthyConditions(node *corev1.Node) (nc *corev1.Node
 }
 
 func (c *Controller) annotateTerminationGracePeriod(ctx context.Context, nodeClaim *v1.NodeClaim) error {
-	if expirationTimeString, exists := nodeClaim.ObjectMeta.Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]; exists {
+	if expirationTimeString, exists := nodeClaim.Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]; exists {
 		expirationTime, err := time.Parse(time.RFC3339, expirationTimeString)
 		if err == nil && expirationTime.Before(c.clock.Now()) {
 			return nil
@@ -179,7 +179,7 @@ func (c *Controller) annotateTerminationGracePeriod(ctx context.Context, nodeCla
 
 	stored := nodeClaim.DeepCopy()
 	terminationTime := c.clock.Now().Format(time.RFC3339)
-	nodeClaim.ObjectMeta.Annotations = lo.Assign(nodeClaim.ObjectMeta.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: terminationTime})
+	nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: terminationTime})
 
 	if !equality.Semantic.DeepEqual(stored, nodeClaim) {
 		if err := c.kubeClient.Patch(ctx, nodeClaim, client.MergeFrom(stored)); err != nil {

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Node Health", func() {
 			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(v1.NodeClaimTerminationTimestampAnnotationKey, fakeClock.Now().Format(time.RFC3339)))
 		})
 		It("should not respect termination grace period if set on the nodepool", func() {
-			nodeClaim.ObjectMeta.Annotations = lo.Assign(nodeClaim.ObjectMeta.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: fakeClock.Now().Add(120 * time.Minute).Format(time.RFC3339)})
+			nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: fakeClock.Now().Add(120 * time.Minute).Format(time.RFC3339)})
 			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
 				Type:   "BadNode",
 				Status: corev1.ConditionFalse,
@@ -189,7 +189,7 @@ var _ = Describe("Node Health", func() {
 		})
 		It("should not update termination grace period if set before the current time", func() {
 			terminationTime := fakeClock.Now().Add(-3 * time.Minute).Format(time.RFC3339)
-			nodeClaim.ObjectMeta.Annotations = lo.Assign(nodeClaim.ObjectMeta.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: terminationTime})
+			nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: terminationTime})
 			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
 				Type:   "BadNode",
 				Status: corev1.ConditionFalse,

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -276,7 +276,7 @@ func (c *Controller) nodeTerminationTime(node *corev1.Node, nodeClaims ...*v1.No
 	if len(nodeClaims) == 0 {
 		return nil, nil
 	}
-	expirationTimeString, exists := nodeClaims[0].ObjectMeta.Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]
+	expirationTimeString, exists := nodeClaims[0].Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]
 	if !exists {
 		return nil, nil
 	}

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -147,20 +147,20 @@ func (q *Queue) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	// Check if the queue is empty. client-go recommends not using this function to gate the subsequent
 	// get call, but since we're popping items off the queue synchronously, there should be no synchonization
 	// issues.
-	if q.TypedRateLimitingInterface.Len() == 0 {
+	if q.Len() == 0 {
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 	// Get pod from queue. This waits until queue is non-empty.
-	item, shutdown := q.TypedRateLimitingInterface.Get()
+	item, shutdown := q.Get()
 	if shutdown {
 		return reconcile.Result{}, fmt.Errorf("EvictionQueue is broken and has shutdown")
 	}
 
-	defer q.TypedRateLimitingInterface.Done(item)
+	defer q.Done(item)
 
 	// Evict the pod
 	if q.Evict(ctx, item) {
-		q.TypedRateLimitingInterface.Forget(item)
+		q.Forget(item)
 		q.mu.Lock()
 		q.set.Delete(item)
 		q.mu.Unlock()
@@ -168,7 +168,7 @@ func (q *Queue) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	}
 
 	// Requeue pod if eviction failed
-	q.TypedRateLimitingInterface.AddRateLimited(item)
+	q.AddRateLimited(item)
 	return reconcile.Result{RequeueAfter: singleton.RequeueImmediately}, nil
 }
 

--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -135,7 +135,7 @@ func instanceTypeNotFound(its []*cloudprovider.InstanceType, nodeClaim *v1.NodeC
 }
 
 // Eligible fields for drift are described in the docs
-// https://karpenter.sh/docs/concepts/deprovisioning/#drift
+// https://karpenter.sh/docs/concepts/disruption/#drift
 func areStaticFieldsDrifted(nodePool *v1.NodePool, nodeClaim *v1.NodeClaim) cloudprovider.DriftReason {
 	nodePoolHash, foundNodePoolHash := nodePool.Annotations[v1.NodePoolHashAnnotationKey]
 	nodePoolHashVersion, foundNodePoolHashVersion := nodePool.Annotations[v1.NodePoolHashVersionAnnotationKey]

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -447,7 +447,7 @@ var _ = Describe("Drift", func() {
 					},
 				},
 			}
-			nodeClaim.ObjectMeta.Annotations[v1.NodePoolHashAnnotationKey] = nodePool.Hash()
+			nodeClaim.Annotations[v1.NodePoolHashAnnotationKey] = nodePool.Hash()
 		})
 		// We need to test each all the fields on the NodePool when we expect the field to be drifted
 		// This will also test that the NodePool fields can be hashed.
@@ -477,14 +477,14 @@ var _ = Describe("Drift", func() {
 			Entry("TerminationGracePeriod", v1.NodePool{Spec: v1.NodePoolSpec{Template: v1.NodeClaimTemplate{Spec: v1.NodeClaimTemplateSpec{TerminationGracePeriod: &metav1.Duration{Duration: 100 * time.Minute}}}}}),
 		)
 		It("should not return drifted if karpenter.sh/nodepool-hash annotation is not present on the NodePool", func() {
-			nodePool.ObjectMeta.Annotations = map[string]string{}
+			nodePool.Annotations = map[string]string{}
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 			ExpectObjectReconciled(ctx, env.Client, nodeClaimDisruptionController, nodeClaim)
 			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)).To(BeNil())
 		})
 		It("should not return drifted if karpenter.sh/nodepool-hash annotation is not present on the NodeClaim", func() {
-			nodeClaim.ObjectMeta.Annotations = map[string]string{
+			nodeClaim.Annotations = map[string]string{
 				v1.NodePoolHashVersionAnnotationKey: v1.NodePoolHashVersion,
 			}
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
@@ -493,11 +493,11 @@ var _ = Describe("Drift", func() {
 			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)).To(BeNil())
 		})
 		It("should not return drifted if the NodeClaim's karpenter.sh/nodepool-hash-version annotation does not match the NodePool's", func() {
-			nodePool.ObjectMeta.Annotations = map[string]string{
+			nodePool.Annotations = map[string]string{
 				v1.NodePoolHashAnnotationKey:        "test-hash-1",
 				v1.NodePoolHashVersionAnnotationKey: "test-version-1",
 			}
-			nodeClaim.ObjectMeta.Annotations = map[string]string{
+			nodeClaim.Annotations = map[string]string{
 				v1.NodePoolHashAnnotationKey:        "test-hash-2",
 				v1.NodePoolHashVersionAnnotationKey: "test-version-2",
 			}
@@ -507,7 +507,7 @@ var _ = Describe("Drift", func() {
 			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted)).To(BeNil())
 		})
 		It("should not return drifted if karpenter.sh/nodepool-hash-version annotation is not present on the NodeClaim", func() {
-			nodeClaim.ObjectMeta.Annotations = map[string]string{
+			nodeClaim.Annotations = map[string]string{
 				v1.NodePoolHashAnnotationKey: "test-hash-111111111",
 			}
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)

--- a/pkg/controllers/nodeclaim/expiration/suite_test.go
+++ b/pkg/controllers/nodeclaim/expiration/suite_test.go
@@ -173,13 +173,13 @@ var _ = Describe("Expiration", func() {
 		nodeClaim.Spec.ExpireAfter = v1.MustParseNillableDuration("200s")
 		ExpectApplied(ctx, env.Client, nodeClaim, node)
 
-		fakeClock.SetTime(nodeClaim.CreationTimestamp.Time.Add(time.Second * 100))
+		fakeClock.SetTime(nodeClaim.CreationTimestamp.Add(time.Second * 100))
 
 		result := ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
 		Expect(result.RequeueAfter).To(BeNumerically("~", time.Second*100, time.Second))
 	})
 	It("shouldn't expire the same NodeClaim multiple times", func() {
-		nodeClaim.ObjectMeta.Finalizers = append(nodeClaim.ObjectMeta.Finalizers, "test-finalizer")
+		nodeClaim.Finalizers = append(nodeClaim.Finalizers, "test-finalizer")
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 
 		// step forward to make the node expired

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -254,14 +254,14 @@ func (c *Controller) finalize(ctx context.Context, nodeClaim *v1.NodeClaim) (rec
 
 func (c *Controller) ensureTerminationGracePeriodTerminationTimeAnnotation(ctx context.Context, nodeClaim *v1.NodeClaim) error {
 	// if the expiration annotation is already set, we don't need to do anything
-	if _, exists := nodeClaim.ObjectMeta.Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]; exists {
+	if _, exists := nodeClaim.Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]; exists {
 		return nil
 	}
 
 	// In Kubernetes, every object has a terminationGracePeriodSeconds, defaulted to and un-changeable from 0. There is an additional TerminationGracePeriodSeconds in the PodSpec which can be configured.
 	// We use the kubernetes object TerminationGracePeriod to infer that the DeletionTimestamp is always equal to the time the NodeClaim is deleted.
 	// This should not be confused with the NodeClaim.spec.terminationGracePeriod field introduced in Karpenter Custom Resources.
-	if nodeClaim.Spec.TerminationGracePeriod != nil && !nodeClaim.ObjectMeta.DeletionTimestamp.IsZero() {
+	if nodeClaim.Spec.TerminationGracePeriod != nil && !nodeClaim.DeletionTimestamp.IsZero() {
 		terminationTimeString := nodeClaim.DeletionTimestamp.Time.Add(nodeClaim.Spec.TerminationGracePeriod.Duration).Format(time.RFC3339)
 		return c.annotateTerminationGracePeriodTerminationTime(ctx, nodeClaim, terminationTimeString)
 	}
@@ -271,7 +271,7 @@ func (c *Controller) ensureTerminationGracePeriodTerminationTimeAnnotation(ctx c
 
 func (c *Controller) annotateTerminationGracePeriodTerminationTime(ctx context.Context, nodeClaim *v1.NodeClaim, terminationTime string) error {
 	stored := nodeClaim.DeepCopy()
-	nodeClaim.ObjectMeta.Annotations = lo.Assign(nodeClaim.ObjectMeta.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: terminationTime})
+	nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{v1.NodeClaimTerminationTimestampAnnotationKey: terminationTime})
 
 	// We use client.MergeFromWithOptimisticLock because patching a terminationGracePeriod annotation
 	// can cause races with the health controller, as that controller sets the current time as the terminationGracePeriod annotation

--- a/pkg/controllers/nodeclaim/lifecycle/termination_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/termination_test.go
@@ -322,12 +322,12 @@ var _ = Describe("Termination", func() {
 		ExpectExists(ctx, env.Client, node)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 
-		_, annotationExists := nodeClaim.ObjectMeta.Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]
+		_, annotationExists := nodeClaim.Annotations[v1.NodeClaimTerminationTimestampAnnotationKey]
 		Expect(annotationExists).To(BeTrue())
 	})
 	It("should not change the annotation if the NodeClaim has a terminationGracePeriod and the annotation already exists", func() {
 		nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
-		nodeClaim.ObjectMeta.Annotations = map[string]string{
+		nodeClaim.Annotations = map[string]string{
 			v1.NodeClaimTerminationTimestampAnnotationKey: "2024-04-01T12:00:00-05:00",
 		}
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -129,7 +129,7 @@ func (n *NodeClaim) Add(ctx context.Context, pod *corev1.Pod, podData *PodData) 
 	nodeClaimRequirements.Add(podData.Requirements.Values()...)
 
 	// Check Topology Requirements
-	topologyRequirements, err := n.topology.AddRequirements(pod, n.NodeClaimTemplate.Spec.Taints, podData.StrictRequirements, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
+	topologyRequirements, err := n.topology.AddRequirements(pod, n.Spec.Taints, podData.StrictRequirements, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func (n *NodeClaim) Add(ctx context.Context, pod *corev1.Pod, podData *PodData) 
 	n.InstanceTypeOptions = remaining
 	n.Spec.Resources.Requests = requests
 	n.Requirements = nodeClaimRequirements
-	n.topology.Record(pod, n.NodeClaim.Spec.Taints, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
+	n.topology.Record(pod, n.Spec.Taints, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
 	n.hostPortUsage.Add(pod, hostPorts)
 	n.releaseReservedOfferings(n.reservedOfferings, reservedOfferings)
 	n.reservedOfferings = reservedOfferings

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -278,7 +278,7 @@ func (r Results) TruncateInstanceTypes(maxInstanceTypes int) Results {
 			// Check if the truncated InstanceTypeOptions in each NewNodeClaim from the results still satisfy the minimum requirements
 			// If number of InstanceTypes in the NodeClaim cannot satisfy the minimum requirements, add its Pods to error map with reason.
 			for _, pod := range newNodeClaim.Pods {
-				r.PodErrors[pod] = fmt.Errorf("pod didn’t schedule because NodePool %q couldn’t meet minValues requirements, %w", newNodeClaim.NodeClaimTemplate.NodePoolName, err)
+				r.PodErrors[pod] = fmt.Errorf("pod didn’t schedule because NodePool %q couldn’t meet minValues requirements, %w", newNodeClaim.NodePoolName, err)
 			}
 		} else {
 			validNewNodeClaims = append(validNewNodeClaims, newNodeClaim)

--- a/pkg/test/cachesyncingclient.go
+++ b/pkg/test/cachesyncingclient.go
@@ -49,7 +49,7 @@ func (c *CacheSyncingClient) Create(ctx context.Context, obj client.Object, opts
 		return err
 	}
 	_ = retry.Do(func() error {
-		if err := c.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			return fmt.Errorf("getting object, %w", err)
 		}
 		return nil
@@ -62,7 +62,7 @@ func (c *CacheSyncingClient) Delete(ctx context.Context, obj client.Object, opts
 		return err
 	}
 	_ = retry.Do(func() error {
-		if err := c.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if errors.IsNotFound(err) {
 				return nil
 			}
@@ -106,10 +106,10 @@ func (c *CacheSyncingClient) DeleteAllOf(ctx context.Context, obj client.Object,
 
 	_ = retry.Do(func() error {
 		listOptions := []client.ListOption{client.Limit(1)}
-		if options.ListOptions.Namespace != "" {
-			listOptions = append(listOptions, client.InNamespace(options.ListOptions.Namespace))
+		if options.Namespace != "" {
+			listOptions = append(listOptions, client.InNamespace(options.Namespace))
 		}
-		if err := c.Client.List(ctx, metaList, listOptions...); err != nil {
+		if err := c.List(ctx, metaList, listOptions...); err != nil {
 			return fmt.Errorf("listing objects, %w", err)
 		}
 		if len(metaList.Items) != 0 {

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -139,7 +139,7 @@ func NewEnvironment(options ...option.Function[EnvironmentOptions]) *Environment
 	opts := option.Resolve(options...)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	version := version.MustParseSemantic(strings.Replace(env.WithDefaultString("K8S_VERSION", "1.32.x"), ".x", ".0", -1))
+	version := version.MustParseSemantic(strings.ReplaceAll(env.WithDefaultString("K8S_VERSION", "1.32.x"), ".x", ".0"))
 	environment := envtest.Environment{Scheme: scheme.Scheme, CRDs: opts.crds}
 	if version.Minor() >= 21 && version.Minor() < 32 {
 		// PodAffinityNamespaceSelector is used for label selectors in pod affinities.  If the feature-gate is turned off,

--- a/pkg/test/v1alpha1/crds/karpenter.test.sh_testnodeclasses.yaml
+++ b/pkg/test/v1alpha1/crds/karpenter.test.sh_testnodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: testnodeclasses.karpenter.test.sh
 spec:
   group: karpenter.test.sh

--- a/pkg/utils/disruption/disruption.go
+++ b/pkg/utils/disruption/disruption.go
@@ -38,7 +38,7 @@ func LifetimeRemaining(clock clock.Clock, nodePool *v1.NodePool, nodeClaim *v1.N
 	remaining := 1.0
 	if nodeClaim.Spec.ExpireAfter.Duration != nil {
 		ageInSeconds := clock.Since(nodeClaim.CreationTimestamp.Time).Seconds()
-		totalLifetimeSeconds := nodeClaim.Spec.ExpireAfter.Duration.Seconds()
+		totalLifetimeSeconds := nodeClaim.Spec.ExpireAfter.Seconds()
 		lifetimeRemainingSeconds := totalLifetimeSeconds - ageInSeconds
 		remaining = lo.Clamp(lifetimeRemainingSeconds/totalLifetimeSeconds, 0.0, 1.0)
 	}

--- a/pkg/utils/pdb/pdb.go
+++ b/pkg/utils/pdb/pdb.go
@@ -89,7 +89,7 @@ func (l Limits) isEvictable(pod *v1.Pod, evictionBlocker evictionBlocker) (clien
 		return client.ObjectKey{}, true
 	}
 	for _, pdb := range l {
-		if pdb.key.Namespace == pod.ObjectMeta.Namespace {
+		if pdb.key.Namespace == pod.Namespace {
 			if pdb.selector.Matches(labels.Set(pod.Labels)) {
 
 				// if the PDB policy is set to allow evicting unhealthy pods, then it won't stop us from
@@ -148,11 +148,7 @@ func newPdb(pdb policyv1.PodDisruptionBudget) (*pdbItem, error) {
 	if err != nil {
 		return nil, err
 	}
-	canAlwaysEvictUnhealthyPods := false
-
-	if pdb.Spec.UnhealthyPodEvictionPolicy != nil && *pdb.Spec.UnhealthyPodEvictionPolicy == policyv1.AlwaysAllow {
-		canAlwaysEvictUnhealthyPods = true
-	}
+	canAlwaysEvictUnhealthyPods := pdb.Spec.UnhealthyPodEvictionPolicy != nil && *pdb.Spec.UnhealthyPodEvictionPolicy == policyv1.AlwaysAllow
 
 	return &pdbItem{
 		key:                client.ObjectKeyFromObject(&pdb),

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -101,7 +101,7 @@ func IsProvisionable(pod *corev1.Pod) bool {
 // - Has the `karpenter.sh/do-not-disrupt` annotation
 // - Is an actively running pod
 func IsDisruptable(pod *corev1.Pod) bool {
-	return !(IsActive(pod) && HasDoNotDisrupt(pod))
+	return !IsActive(pod) || !HasDoNotDisrupt(pod)
 }
 
 // FailedToSchedule ensures that the kube-scheduler has seen this pod and has intentionally
@@ -164,7 +164,7 @@ func IsOwnedByNode(pod *corev1.Pod) bool {
 
 func IsOwnedBy(pod *corev1.Pod, gvks []schema.GroupVersionKind) bool {
 	for _, ignoredOwner := range gvks {
-		for _, owner := range pod.ObjectMeta.OwnerReferences {
+		for _, owner := range pod.OwnerReferences {
 			if owner.APIVersion == ignoredOwner.GroupVersion().String() && owner.Kind == ignoredOwner.Kind {
 				return true
 			}

--- a/test/pkg/debug/node.go
+++ b/test/pkg/debug/node.go
@@ -49,11 +49,11 @@ func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (
 	n := &corev1.Node{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, n); err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Printf("[DELETED %s] NODE %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+			fmt.Printf("[DELETED %s] NODE %s\n", time.Now().Format(time.RFC3339), req.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	fmt.Printf("[CREATED/UPDATED %s] NODE %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.Name, c.GetInfo(ctx, n))
+	fmt.Printf("[CREATED/UPDATED %s] NODE %s %s\n", time.Now().Format(time.RFC3339), req.Name, c.GetInfo(ctx, n))
 	return reconcile.Result{}, nil
 }
 

--- a/test/pkg/debug/nodeclaim.go
+++ b/test/pkg/debug/nodeclaim.go
@@ -47,11 +47,11 @@ func (c *NodeClaimController) Reconcile(ctx context.Context, req reconcile.Reque
 	nc := &v1.NodeClaim{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, nc); err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Printf("[DELETED %s] NODECLAIM %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+			fmt.Printf("[DELETED %s] NODECLAIM %s\n", time.Now().Format(time.RFC3339), req.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	fmt.Printf("[CREATED/UPDATED %s] NODECLAIM %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.Name, c.GetInfo(nc))
+	fmt.Printf("[CREATED/UPDATED %s] NODECLAIM %s %s\n", time.Now().Format(time.RFC3339), req.Name, c.GetInfo(nc))
 	return reconcile.Result{}, nil
 }
 

--- a/test/pkg/debug/pod.go
+++ b/test/pkg/debug/pod.go
@@ -50,11 +50,11 @@ func (c *PodController) Reconcile(ctx context.Context, req reconcile.Request) (r
 	p := &v1.Pod{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, p); err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Printf("[DELETED %s] POD %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+			fmt.Printf("[DELETED %s] POD %s\n", time.Now().Format(time.RFC3339), req.String())
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	fmt.Printf("[CREATED/UPDATED %s] POD %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String(), c.GetInfo(p))
+	fmt.Printf("[CREATED/UPDATED %s] POD %s %s\n", time.Now().Format(time.RFC3339), req.String(), c.GetInfo(p))
 	return reconcile.Result{}, nil
 }
 

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -45,7 +45,7 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/operator"
-	. "sigs.k8s.io/karpenter/pkg/utils/testing" //nolint:stylecheck
+	. "sigs.k8s.io/karpenter/pkg/utils/testing" //nolint:stylecheck,staticcheck
 	"sigs.k8s.io/karpenter/test/pkg/debug"
 )
 

--- a/test/suites/perf/scheduling_test.go
+++ b/test/suites/perf/scheduling_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Performance", func() {
 			env.EventuallyExpectHealthyPodCount(labelSelector, replicas)
 
 			env.TimeIntervalCollector.Start("Drift")
-			nodePool.Spec.Template.ObjectMeta.Labels = lo.Assign(nodePool.Spec.Template.ObjectMeta.Labels, map[string]string{
+			nodePool.Spec.Template.Labels = lo.Assign(nodePool.Spec.Template.Labels, map[string]string{
 				"test-drift": "true",
 			})
 			env.ExpectUpdated(nodePool)
@@ -133,7 +133,7 @@ var _ = Describe("Performance", func() {
 			env.EventuallyExpectHealthyPodCountWithTimeout(10*time.Minute, labelSelector, totalReplicas)
 
 			env.TimeIntervalCollector.Start("Drift")
-			nodePool.Spec.Template.ObjectMeta.Labels = lo.Assign(nodePool.Spec.Template.ObjectMeta.Labels, map[string]string{
+			nodePool.Spec.Template.Labels = lo.Assign(nodePool.Spec.Template.Labels, map[string]string{
 				"test-drift": "true",
 			})
 			env.ExpectUpdated(nodePool)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Cherry picks "fix: allow non-churn empty nodes to be disrupted (#2206)" and upgrades golangci-lint (similar to #2485)

**How was this change tested?**
`make toolchain` and `make presubmit`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
