### PR TITLE
fix: nodepool crd definition should explicitly say replicas field as alpha

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -182,6 +182,7 @@ spec:
                           * disruption.consolidateAfter
                       - Only limits.nodes is supported; other resource limits (e.g., CPU, memory) must not be specified.
                       - Weight is not supported.
+                    Note: This field is alpha.
                   format: int64
                   minimum: 0
                   type: integer

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -182,6 +182,7 @@ spec:
                           * disruption.consolidateAfter
                       - Only limits.nodes is supported; other resource limits (e.g., CPU, memory) must not be specified.
                       - Weight is not supported.
+                    Note: This field is alpha.
                   format: int64
                   minimum: 0
                   type: integer

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -69,6 +69,7 @@ type NodePoolSpec struct {
 	//       * disruption.consolidateAfter
 	//   - Only limits.nodes is supported; other resource limits (e.g., CPU, memory) must not be specified.
 	//   - Weight is not supported.
+	// Note: This field is alpha.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
 	Replicas *int64 `json:"replicas,omitempty"`


### PR DESCRIPTION
fix: nodepool crd definition should explicitly say replicas field as alpha

Fixes #N/A 

**Description**
make presubmit

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
