### PR TITLE
ci:  add CI jobs to publish karpenter-kwow image and helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,8 +43,6 @@ jobs:
           gh release upload "$TAG" karpenter.intoto.json
 
   publish-kwok-image:
-    env:
-      TAG: ${{ github.ref_name }}
     permissions:
       contents: read
       packages: write
@@ -70,13 +68,16 @@ jobs:
           username: ${{ github.actor }}
           password: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Set VERSION to env
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Publish KWOK image
         run: |
-          KO_DOCKER_REPO="ghcr.io/${{ github.repository }}/karpenter-kwok" ko publish ./kwok --bare -t "$TAG"
+          KO_DOCKER_REPO="ghcr.io/${{ github.repository }}/karpenter-kwok" ko publish ./kwok --bare -t "$VERSION"
 
   publish-kwok-chart:
-    env:
-      TAG: ${{ github.ref_name }}
     permissions:
       contents: read
       packages: write
@@ -97,6 +98,11 @@ jobs:
           username: ${{ github.actor }}
           password: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Set VERSION to env
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Package KWOK chart
         id: pkg
         run: |
@@ -108,11 +114,10 @@ jobs:
             rm -f "$SRC/crds/karpenter.kwok.sh_kwoknodeclasses.yaml"
             cp "${{ github.workspace }}/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml" "$SRC/crds/karpenter.kwok.sh_kwoknodeclasses.yaml"
           fi
-
           # Use the release tag as the chart version
-          helm package "$SRC" --version "$TAG"
-          echo "saved chart to path: ${{ github.workspace }}/karpenter-kwok-$TAG.tgz"
+          helm package "$SRC" --version "$VERSION"
+          echo "saved chart to path: ${{ github.workspace }}/karpenter-kwok-$VERSION.tgz"
 
       - name: Push KWOK chart to GHCR (OCI)
         run: |
-          helm push "${{ github.workspace }}/karpenter-kwok-$TAG.tgz" "oci://ghcr.io/${{ github.repository }}/charts"
+          helm push "${{ github.workspace }}/karpenter-kwok-$VERSION.tgz" "oci://ghcr.io/${{ github.repository }}/charts"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,3 +41,78 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "$TAG" karpenter.intoto.json
+
+  publish-kwok-image:
+    env:
+      TAG: ${{ github.ref_name }}
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Set up ko
+        uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Publish KWOK image
+        run: |
+          KO_DOCKER_REPO="ghcr.io/${{ github.repository }}/karpenter-kwok" ko publish ./kwok --bare -t "$TAG"
+
+  publish-kwok-chart:
+    env:
+      TAG: ${{ github.ref_name }}
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Package KWOK chart
+        id: pkg
+        run: |
+          set -euo pipefail
+          SRC="${{ github.workspace }}/kwok/charts"
+
+          if [[ -f "${{ github.workspace }}/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml" && -L "${{ github.workspace }}/kwok/charts/crds/karpenter.kwok.sh_kwoknodeclasses.yaml" ]]; then
+            echo "replacing karpenter.kwok.sh_kwoknodeclasses.yaml CRD symlink with the real file"
+            rm -f "$SRC/crds/karpenter.kwok.sh_kwoknodeclasses.yaml"
+            cp "${{ github.workspace }}/kwok/apis/crds/karpenter.kwok.sh_kwoknodeclasses.yaml" "$SRC/crds/karpenter.kwok.sh_kwoknodeclasses.yaml"
+          fi
+
+          # Use the release tag as the chart version
+          helm package "$SRC" --version "$TAG"
+          echo "saved chart to path: ${{ github.workspace }}/karpenter-kwok-$TAG.tgz"
+
+      - name: Push KWOK chart to GHCR (OCI)
+        run: |
+          helm push "${{ github.workspace }}/karpenter-kwok-$TAG.tgz" "oci://ghcr.io/${{ github.repository }}/charts"

--- a/kwok/charts/Chart.yaml
+++ b/kwok/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: karpenter
+name: karpenter-kwok
 description: A Helm chart for Karpenter's KwoK Provider, integrated with https://github.com/kubernetes-sigs/kwok.
 type: application
 version: 0.35.0

--- a/kwok/charts/README.md
+++ b/kwok/charts/README.md
@@ -1,4 +1,4 @@
-# karpenter
+# karpenter-kwok
 
 A Helm chart for Karpenter's KwoK Provider, integrated with https://github.com/kubernetes-sigs/kwok.
 


### PR DESCRIPTION
**Description**
Currently there is no way of using karpenter kwok image and helm chart outside of this repo. 

This PR add two jobs to release.yaml:
- publish-kwok-image: builds and publishes the KWOK container image to GHCR using ko  to ghcr.io/<repo>/karpenter-kwok:$TAG.
- publish-kwok-chart: packages the KWOK Helm chart and pushes it to GHCR (OCI). Packages the chart using the release tag as the chart version. 

There is a symlink file in `karpenter/kwok/charts/crds/karpenter.kwok.sh_kwoknodeclasses.yaml` helm build does not resolve symlinks, I've added copy of real file as a step in the action. 

Proposed names and paths: 
- image: `ghcr.io/kubernetes-sigs/karpenter/karpenter-kwok` 
- chart: `oci://ghcr.io/kubernetes-sigs/karpenter/charts/karpenter-kwok`



**How was this change tested?**
In my repository - I've pushed images and chart, then tested them locally. Check them out here:
https://github.com/zamai?tab=packages&repo_name=karpenter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
