### PR TITLE
chore: use structured logging for errors

### DIFF
--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -209,7 +209,7 @@ func BuildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 			}
 			// don't error out on building the node pool, we just won't be able to handle any nodes that
 			// were created by it
-			log.FromContext(ctx).Error(err, fmt.Sprintf("failed listing instance types for %s", np.Name))
+			log.FromContext(ctx).Error(err, "failed listing instance types", "nodepool", np.Name)
 			continue
 		}
 		if len(nodePoolInstanceTypes) == 0 {


### PR DESCRIPTION
**Description**
[structured logging](https://stackify.com/what-is-structured-logging-and-why-developers-need-it/) helps filter or exclude the same type of error, but it's harder when every error is different

**Todo**
if this is acceptable then find all the other .Error calls and convert them

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
