### PR TITLE
ci: integrate kube-api-linter into CI workflow

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,6 @@
+version: v2.6.1
+name: golangci-lint-kube-api-linter
+destination: ./bin
+plugins:
+- module: 'sigs.k8s.io/kube-api-linter'
+  version: 'v0.0.0-20251106172841-33e0e4392883'

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ go.work
 go.work.sum
 report.json
 *__debug_*
+bin/
 
 # Common in OSs and IDEs
 .idea

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
     - gocyclo
     - goheader
     - gosec
+    - kubeapilinter
     - misspell
     - nilerr
     - revive
@@ -23,6 +24,13 @@ linters:
   disable:
     - prealloc
   settings:
+    custom:
+      kubeapilinter:
+        type: "module"
+        description: Kube API Linter lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters: {}
+          lintersConfig: {}
     gocyclo:
       min-complexity: 11
     goheader:
@@ -70,6 +78,9 @@ linters:
         path: scheduling_benchmark_test.go
       - path: (.+)\.go$
         text: declaration of "(err|ctx)" shadows declaration at
+      - path-except: pkg/apis/
+        linters:
+          - kubeapilinter
     paths:
       - tools
       - website
@@ -81,6 +92,8 @@ linters:
       - examples$
 issues:
   fix: true
+  fix-by-linter:
+    - kubeapilinter: false
 formatters:
   enable:
     - goimports

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ verify: ## Verify code. Includes codegen, docgen, dependencies, linting, formatt
 	hack/boilerplate.sh
 	go vet ./...
 	cd kwok/charts && helm-docs
-	golangci-lint run
+	./bin/golangci-lint-kube-api-linter run
 	@git diff --quiet ||\
 		{ echo "New file modification detected in the Git working tree. Please check in before commit."; git --no-pager diff --name-only | uniq | awk '{print "  - " $$0}'; \
 		if [ "${CI}" = true ]; then\

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -25,6 +25,9 @@ tools() {
     go install github.com/rhysd/actionlint/cmd/actionlint@latest
     go install github.com/mattn/goveralls@latest
 
+    # Build golangci-lint with kube-api-linter plugin
+    golangci-lint custom
+
     if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then
         echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\${GOPATH:-\$HOME/go}/bin\"'."
     fi

--- a/pkg/apis/v1/duration.go
+++ b/pkg/apis/v1/duration.go
@@ -31,11 +31,11 @@ const Never = "Never"
 // marshaling to YAML and JSON. It uses the value "Never" to signify
 // that the duration is disabled and sets the inner duration as nil
 type NillableDuration struct {
-	*time.Duration
+	*time.Duration //nolint:kubeapilinter
 
 	// Raw is used to ensure we remarshal the NillableDuration in the same format it was specified.
 	// This ensures tools like Flux and ArgoCD don't mistakenly detect drift due to our conversion webhooks.
-	Raw []byte `hash:"ignore"`
+	Raw []byte `hash:"ignore"` //nolint:kubeapilinter
 }
 
 func MustParseNillableDuration(val string) NillableDuration {

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -25,15 +25,18 @@ import (
 
 // NodeClaimSpec describes the desired state of the NodeClaim
 type NodeClaimSpec struct {
+	//nolint:kubeapilinter
 	// Taints will be applied to the NodeClaim's node.
 	// +optional
 	Taints []v1.Taint `json:"taints,omitempty"`
+	//nolint:kubeapilinter
 	// StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
 	// within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
 	// daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
 	// purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
 	// +optional
 	StartupTaints []v1.Taint `json:"startupTaints,omitempty"`
+	//nolint:kubeapilinter
 	// Requirements are layered with GetLabels and applied to every node.
 	// +kubebuilder:validation:XValidation:message="requirements with operator 'In' must have a value defined",rule="self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
 	// +kubebuilder:validation:XValidation:message="requirements operator 'Gt' or 'Lt' must have a single positive integer value",rule="self.all(x, (x.operator == 'Gt' || x.operator == 'Lt') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
@@ -41,12 +44,15 @@ type NodeClaimSpec struct {
 	// +kubebuilder:validation:MaxItems:=100
 	// +required
 	Requirements []NodeSelectorRequirementWithMinValues `json:"requirements" hash:"ignore"`
+	//nolint:kubeapilinter
 	// Resources models the resource requirements for the NodeClaim to launch
 	// +optional
 	Resources ResourceRequirements `json:"resources,omitempty" hash:"ignore"`
+	//nolint:kubeapilinter
 	// NodeClassRef is a reference to an object that defines provider specific configuration
 	// +required
 	NodeClassRef *NodeClassReference `json:"nodeClassRef"`
+	//nolint:kubeapilinter
 	// TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 	//
 	// Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
@@ -80,6 +86,7 @@ type NodeClaimSpec struct {
 // and minValues that represent the requirement to have at least that many values.
 type NodeSelectorRequirementWithMinValues struct {
 	v1.NodeSelectorRequirement `json:",inline"`
+	//nolint:kubeapilinter
 	// This field is ALPHA and can be dropped or replaced at any time
 	// MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
 	// +kubebuilder:validation:Minimum:=1
@@ -91,20 +98,24 @@ type NodeSelectorRequirementWithMinValues struct {
 // ResourceRequirements models the required resources for the NodeClaim to launch
 // Ths will eventually be transformed into v1.ResourceRequirements when we support resources.limits
 type ResourceRequirements struct {
+	//nolint:kubeapilinter
 	// Requests describes the minimum required resources for the NodeClaim to launch
 	// +optional
 	Requests v1.ResourceList `json:"requests,omitempty"`
 }
 
 type NodeClassReference struct {
+	//nolint:kubeapilinter
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
 	// +kubebuilder:validation:XValidation:rule="self != ''",message="kind may not be empty"
 	// +required
 	Kind string `json:"kind"`
+	//nolint:kubeapilinter
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	// +kubebuilder:validation:XValidation:rule="self != ''",message="name may not be empty"
 	// +required
 	Name string `json:"name"`
+	//nolint:kubeapilinter
 	// API version of the referent
 	// +kubebuilder:validation:XValidation:rule="self != ''",message="group may not be empty"
 	// +kubebuilder:validation:Pattern=`^[^/]*$`
@@ -140,12 +151,13 @@ type Provider = runtime.RawExtension
 // +kubebuilder:printcolumn:name="Drifted",type="string",JSONPath=".status.conditions[?(@.type==\"Drifted\")].status",priority=1,description=""
 type NodeClaim struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitempty"` //nolint:kubeapilinter
 
+	//nolint:kubeapilinter
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec is immutable"
 	// +required
 	Spec   NodeClaimSpec   `json:"spec"`
-	Status NodeClaimStatus `json:"status,omitempty"`
+	Status NodeClaimStatus `json:"status,omitempty"` //nolint:kubeapilinter
 }
 
 // NodeClaimList contains a list of NodeClaims

--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -37,24 +37,31 @@ const (
 
 // NodeClaimStatus defines the observed state of NodeClaim
 type NodeClaimStatus struct {
+	//nolint:kubeapilinter
 	// NodeName is the name of the corresponding node object
 	// +optional
 	NodeName string `json:"nodeName,omitempty"`
+	//nolint:kubeapilinter
 	// ProviderID of the corresponding node object
 	// +optional
 	ProviderID string `json:"providerID,omitempty"`
+	//nolint:kubeapilinter
 	// ImageID is an identifier for the image that runs on the node
 	// +optional
 	ImageID string `json:"imageID,omitempty"`
+	//nolint:kubeapilinter
 	// Capacity is the estimated full capacity of the node
 	// +optional
 	Capacity v1.ResourceList `json:"capacity,omitempty"`
+	//nolint:kubeapilinter
 	// Allocatable is the estimated allocatable capacity of the node
 	// +optional
 	Allocatable v1.ResourceList `json:"allocatable,omitempty"`
+	//nolint:kubeapilinter
 	// Conditions contains signals for health and readiness
 	// +optional
 	Conditions []status.Condition `json:"conditions,omitempty"`
+	//nolint:kubeapilinter
 	// LastPodEventTime is updated with the last time a pod was scheduled
 	// or removed from the node. A pod going terminal or terminating
 	// is also considered as removed.

--- a/pkg/apis/v1/nodeclaim_validation.go
+++ b/pkg/apis/v1/nodeclaim_validation.go
@@ -57,8 +57,8 @@ var (
 )
 
 type taintKeyEffect struct {
-	OwnerKey string
-	Effect   v1.TaintEffect
+	OwnerKey string         //nolint:kubeapilinter
+	Effect   v1.TaintEffect //nolint:kubeapilinter
 }
 
 func (in *NodeClaimTemplateSpec) validateTaints() (errs error) {

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -40,18 +40,22 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || (!has(self.limits) || size(self.limits) == 0 || (size(self.limits) == 1 && 'nodes' in self.limits))",message="only 'limits.nodes' is supported on static NodePools"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || !has(self.weight)",message="'weight' is not supported on static NodePools"
 type NodePoolSpec struct {
+	//nolint:kubeapilinter
 	// Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
 	// NodeClaims launched from this NodePool will often be further constrained than the template specifies.
 	// +required
 	Template NodeClaimTemplate `json:"template"`
+	//nolint:kubeapilinter
 	// Disruption contains the parameters that relate to Karpenter's disruption logic
 	// +kubebuilder:default:={consolidateAfter: "0s"}
 	// +optional
 	Disruption Disruption `json:"disruption"`
+	//nolint:kubeapilinter
 	// Limits define a set of bounds for provisioning capacity.
 	// Limits other than limits.nodes is not supported when replicas is set.
 	// +optional
 	Limits Limits `json:"limits,omitempty"`
+	//nolint:kubeapilinter
 	// Weight is the priority given to the nodepool during scheduling. A higher
 	// numerical weight indicates that this nodepool will be ordered
 	// ahead of other nodepools with lower weights. A nodepool with no weight
@@ -61,6 +65,7 @@ type NodePoolSpec struct {
 	// +kubebuilder:validation:Maximum:=100
 	// +optional
 	Weight *int32 `json:"weight,omitempty"`
+	//nolint:kubeapilinter
 	// Replicas is the desired number of nodes for the NodePool. When specified, the NodePool will
 	// maintain this fixed number of replicas rather than scaling based on pod demand.
 	// When replicas is set:
@@ -76,6 +81,7 @@ type NodePoolSpec struct {
 }
 
 type Disruption struct {
+	//nolint:kubeapilinter
 	// ConsolidateAfter is the duration the controller will wait
 	// before attempting to terminate nodes that are underutilized.
 	// Refer to ConsolidationPolicy for how underutilization is considered.
@@ -85,6 +91,7 @@ type Disruption struct {
 	// +kubebuilder:validation:Schemaless
 	// +required
 	ConsolidateAfter NillableDuration `json:"consolidateAfter"`
+	//nolint:kubeapilinter
 	// ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
 	// algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
 	// When replicas is set, ConsolidationPolicy is simply ignored
@@ -92,6 +99,7 @@ type Disruption struct {
 	// +kubebuilder:validation:Enum:={WhenEmpty,WhenEmptyOrUnderutilized}
 	// +optional
 	ConsolidationPolicy ConsolidationPolicy `json:"consolidationPolicy,omitempty"`
+	//nolint:kubeapilinter
 	// Budgets is a list of Budgets.
 	// If there are multiple active budgets, Karpenter uses
 	// the most restrictive value. If left undefined,
@@ -106,12 +114,14 @@ type Disruption struct {
 // Budget defines when Karpenter will restrict the
 // number of Node Claims that can be terminating simultaneously.
 type Budget struct {
+	//nolint:kubeapilinter
 	// Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
 	// Otherwise, this will apply to each reason defined.
 	// allowed reasons are Underutilized, Empty, and Drifted.
 	// +kubebuilder:validation:MaxItems=50
 	// +optional
 	Reasons []DisruptionReason `json:"reasons,omitempty"`
+	//nolint:kubeapilinter
 	// Nodes dictates the maximum number of NodeClaims owned by this NodePool
 	// that can be terminating at once. This is calculated by counting nodes that
 	// have a deletion timestamp set, or are actively being deleted by Karpenter.
@@ -122,6 +132,7 @@ type Budget struct {
 	// +kubebuilder:validation:Pattern:="^((100|[0-9]{1,2})%|[0-9]+)$"
 	// +kubebuilder:default:="10%"
 	Nodes string `json:"nodes" hash:"ignore"`
+	//nolint:kubeapilinter
 	// Schedule specifies when a budget begins being active, following
 	// the upstream cronjob syntax. If omitted, the budget is always active.
 	// Timezones are not supported.
@@ -129,6 +140,7 @@ type Budget struct {
 	// +kubebuilder:validation:Pattern:=`^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$`
 	// +optional
 	Schedule *string `json:"schedule,omitempty" hash:"ignore"`
+	//nolint:kubeapilinter
 	// Duration determines how long a Budget is active since each Schedule hit.
 	// Only minutes and hours are accepted, as cron does not work in seconds.
 	// If omitted, the budget is always active.
@@ -175,7 +187,8 @@ func (l Limits) ExceededBy(resources v1.ResourceList) error {
 }
 
 type NodeClaimTemplate struct {
-	ObjectMeta `json:"metadata,omitempty"`
+	ObjectMeta `json:"metadata,omitempty"` //nolint:kubeapilinter
+	//nolint:kubeapilinter
 	// +required
 	Spec NodeClaimTemplateSpec `json:"spec"`
 }
@@ -184,15 +197,18 @@ type NodeClaimTemplate struct {
 // NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
 // users are not able to set resource requests in the NodePool.
 type NodeClaimTemplateSpec struct {
+	//nolint:kubeapilinter
 	// Taints will be applied to the NodeClaim's node.
 	// +optional
 	Taints []v1.Taint `json:"taints,omitempty"`
+	//nolint:kubeapilinter
 	// StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
 	// within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
 	// daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
 	// purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
 	// +optional
 	StartupTaints []v1.Taint `json:"startupTaints,omitempty"`
+	//nolint:kubeapilinter
 	// Requirements are layered with GetLabels and applied to every node.
 	// +kubebuilder:validation:XValidation:message="requirements with operator 'In' must have a value defined",rule="self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
 	// +kubebuilder:validation:XValidation:message="requirements operator 'Gt' or 'Lt' must have a single positive integer value",rule="self.all(x, (x.operator == 'Gt' || x.operator == 'Lt') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
@@ -200,11 +216,13 @@ type NodeClaimTemplateSpec struct {
 	// +kubebuilder:validation:MaxItems:=100
 	// +required
 	Requirements []NodeSelectorRequirementWithMinValues `json:"requirements" hash:"ignore"`
+	//nolint:kubeapilinter
 	// NodeClassRef is a reference to an object that defines provider specific configuration
 	// +kubebuilder:validation:XValidation:rule="self.group == oldSelf.group",message="nodeClassRef.group is immutable"
 	// +kubebuilder:validation:XValidation:rule="self.kind == oldSelf.kind",message="nodeClassRef.kind is immutable"
 	// +required
 	NodeClassRef *NodeClassReference `json:"nodeClassRef"`
+	//nolint:kubeapilinter
 	// TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
 	//
 	// Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
@@ -253,6 +271,7 @@ func (in *NodeClaimTemplate) ToNodeClaim() *NodeClaim {
 }
 
 type ObjectMeta struct {
+	//nolint:kubeapilinter
 	// Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
@@ -260,6 +279,7 @@ type ObjectMeta struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
+	//nolint:kubeapilinter
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
@@ -283,11 +303,12 @@ type ObjectMeta struct {
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.nodes
 type NodePool struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitempty"` //nolint:kubeapilinter
 
+	//nolint:kubeapilinter
 	// +required
 	Spec   NodePoolSpec   `json:"spec"`
-	Status NodePoolStatus `json:"status,omitempty"`
+	Status NodePoolStatus `json:"status,omitempty"` //nolint:kubeapilinter
 }
 
 // We need to bump the NodePoolHashVersion when we make an update to the NodePool CRD under these conditions:

--- a/pkg/apis/v1/nodepool_status.go
+++ b/pkg/apis/v1/nodepool_status.go
@@ -33,17 +33,21 @@ const (
 
 // NodePoolStatus defines the observed state of NodePool
 type NodePoolStatus struct {
+	//nolint:kubeapilinter
 	// Resources is the list of resources that have been provisioned.
 	// +optional
 	Resources v1.ResourceList `json:"resources,omitempty"`
+	//nolint:kubeapilinter
 	// Nodes is the count of nodes associated with this NodePool
 	// +kubebuilder:default:=0
 	// +optional
 	Nodes *int64 `json:"nodes"`
+	//nolint:kubeapilinter
 	// NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match
 	// the actual NodeClass Generation, NodeRegistrationHealthy status condition on the NodePool will be reset
 	// +optional
 	NodeClassObservedGeneration int64 `json:"nodeClassObservedGeneration,omitempty"`
+	//nolint:kubeapilinter
 	// Conditions contains signals for health and readiness
 	// +optional
 	Conditions []status.Condition `json:"conditions,omitempty"`

--- a/pkg/apis/v1alpha1/nodeoverlay.go
+++ b/pkg/apis/v1alpha1/nodeoverlay.go
@@ -25,6 +25,7 @@ import (
 )
 
 type NodeOverlaySpec struct {
+	//nolint:kubeapilinter
 	// Requirements constrain when this NodeOverlay is applied during scheduling simulations.
 	// These requirements can match:
 	// - Well-known labels (e.g., node.kubernetes.io/instance-type, karpenter.sh/nodepool)
@@ -35,22 +36,26 @@ type NodeOverlaySpec struct {
 	// +kubebuilder:validation:MaxItems:=100
 	// +required
 	Requirements []v1.NodeSelectorRequirement `json:"requirements,omitempty"`
+	//nolint:kubeapilinter
 	// PriceAdjustment specifies the price change for matching instance types. Accepts either:
 	// - A fixed price modifier (e.g., -0.5, 1.2)
 	// - A percentage modifier (e.g., +10% for increase, -15% for decrees)
 	// +kubebuilder:validation:Pattern=`^(([+-]{1}(\d*\.?\d+))|(\+{1}\d*\.?\d+%)|(^(-\d{1,2}(\.\d+)?%)$)|(-100%))$`
 	// +optional
 	PriceAdjustment *string `json:"priceAdjustment,omitempty"`
+	//nolint:kubeapilinter
 	// Price specifies amount for an instance types that match the specified labels. Users can override prices using a signed float representing the price override
 	// +kubebuilder:validation:Pattern=`^\d+(\.\d+)?$`
 	// +optional
 	Price *string `json:"price,omitempty"`
+	//nolint:kubeapilinter
 	// Capacity adds extended resources only, and does not replace any existing resources.
 	// These extended resources are appended to the node's existing resource list.
 	// Note: This field does not modify or override standard resources like cpu, memory, ephemeral-storage, or pods.
 	// +kubebuilder:validation:XValidation:message="invalid resource restricted",rule="self.all(x, !(x in ['cpu', 'memory', 'ephemeral-storage', 'pods']))"
 	// +optional
 	Capacity v1.ResourceList `json:"capacity,omitempty"`
+	//nolint:kubeapilinter
 	// Weight defines the priority of this NodeOverlay when overriding node attributes.
 	// NodeOverlays with higher numerical weights take precedence over those with lower weights.
 	// If no weight is specified, the NodeOverlay is treated as having a weight of 0.
@@ -69,12 +74,14 @@ type NodeOverlaySpec struct {
 // +kubebuilder:printcolumn:name="Weight",type="integer",JSONPath=".spec.weight",priority=1,description=""
 // +kubebuilder:subresource:status
 type NodeOverlay struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	//nolint:kubeapilinter
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	//nolint:kubeapilinter
 	// +kubebuilder:validation:XValidation:message="cannot set both 'price' and 'priceAdjustment'",rule="!has(self.price) || !has(self.priceAdjustment)"
 	Spec   NodeOverlaySpec   `json:"spec"`
-	Status NodeOverlayStatus `json:"status,omitempty"`
+	Status NodeOverlayStatus `json:"status,omitempty"` //nolint:kubeapilinter
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/v1alpha1/nodeoverlay_status.go
+++ b/pkg/apis/v1alpha1/nodeoverlay_status.go
@@ -28,9 +28,10 @@ const (
 
 // NodeOverlayStatus defines the observed state of NodeOverlay
 type NodeOverlayStatus struct {
+	//nolint:kubeapilinter
 	// Conditions contains signals for health and readiness
 	// +optional
-	Conditions []status.Condition `json:"conditions,omitempty"`
+	Conditions []status.Condition `json:"conditions,omitempty"` //nolint:kubeapilinter
 }
 
 func (in *NodeOverlay) StatusConditions() status.ConditionSet {


### PR DESCRIPTION
## What
Integrate kube-api-linter into the CI workflow to enforce Kubernetes API conventions and best practices.

## Why
#2419

To ensure our Kubernetes-like APIs follow API conventions and best practices automatically during development and CI.

## How
- Added `.custom-gcl.yml` to configure golangci-lint custom plugin with kube-api-linter
- Configured `.golangci.yaml` to enable kubeapilinter, applying it only to `pkg/apis/` directory
- Updated `Makefile` to run kube-api-linter as part of the verify target
- Modified `hack/toolchain.sh` to build golangci-lint with kube-api-linter plugin
- Added `bin/` to `.gitignore` for the locally built linter binary

## Testing
- Verified that `make verify` runs successfully with kube-api-linter enabled
- Confirmed linter only runs on API-related code in `pkg/apis/`

## Note
When running `./bin/golangci-lint-kube-api-linter run` locally, 42 existing issues were detected across the codebase. These pre-existing issues will be addressed in follow-up PRs. This PR focuses on integrating the linter into CI to prevent new violations going forward.