### PR TITLE
chore: Add locking mechanism to nodePoolRegistration State

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -77,7 +77,7 @@ func NewControllers(
 	p := provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster, clock)
 	evictionQueue := terminator.NewQueue(kubeClient, recorder)
 	disruptionQueue := disruption.NewQueue(kubeClient, recorder, cluster, clock, p)
-	npState := make(nodepoolhealth.State)
+	npState := nodepoolhealth.NewState()
 
 	controllers := []controller.Controller{
 		p, evictionQueue, disruptionQueue,

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -66,7 +66,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	garbageCollectionController = nodeclaimgarbagecollection.NewController(fakeClock, env.Client, cloudProvider)
-	nodeClaimController = nodeclaimlifcycle.NewController(fakeClock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.State{})
+	nodeClaimController = nodeclaimlifcycle.NewController(fakeClock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState())
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -66,7 +66,7 @@ type Controller struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
 	recorder      events.Recorder
-	nodePoolState nodepoolhealth.State
+	nodePoolState *nodepoolhealth.State
 
 	launch         *Launch
 	registration   *Registration
@@ -74,7 +74,7 @@ type Controller struct {
 	liveness       *Liveness
 }
 
-func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, nodePoolState nodepoolhealth.State) *Controller {
+func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, nodePoolState *nodepoolhealth.State) *Controller {
 	return &Controller{
 		kubeClient:    kubeClient,
 		cloudProvider: cloudProvider,

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -41,7 +41,7 @@ import (
 type Liveness struct {
 	clock      clock.Clock
 	kubeClient client.Client
-	npState    nodepoolhealth.State
+	npState    *nodepoolhealth.State
 }
 
 // registrationTimeout is a heuristic time that we expect the node to register within

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -44,7 +44,7 @@ import (
 type Registration struct {
 	kubeClient client.Client
 	recorder   events.Recorder
-	npState    nodepoolhealth.State
+	npState    *nodepoolhealth.State
 }
 
 func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -57,7 +57,7 @@ var (
 	fakeClock           *clock.FakeClock
 	cloudProvider       *fake.CloudProvider
 	recorder            *test.EventRecorder
-	npState             nodepoolhealth.State
+	npState             *nodepoolhealth.State
 )
 
 func TestAPIs(t *testing.T) {
@@ -85,7 +85,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 
 	cloudProvider = fake.NewCloudProvider()
-	npState = nodepoolhealth.State{}
+	npState = nodepoolhealth.NewState()
 	nodeClaimController = nodeclaimlifecycle.NewController(fakeClock, env.Client, cloudProvider, recorder, npState)
 })
 

--- a/pkg/controllers/nodepool/registrationhealth/controller.go
+++ b/pkg/controllers/nodepool/registrationhealth/controller.go
@@ -43,11 +43,11 @@ import (
 type Controller struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
-	npState       nodepoolhealth.State
+	npState       *nodepoolhealth.State
 }
 
 // NewController will create a controller to reset NodePool's registration health when there is an update to NodePool/NodeClass spec
-func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, npState nodepoolhealth.State) *Controller {
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, npState *nodepoolhealth.State) *Controller {
 	return &Controller{
 		kubeClient:    kubeClient,
 		cloudProvider: cloudProvider,

--- a/pkg/controllers/nodepool/registrationhealth/suite_test.go
+++ b/pkg/controllers/nodepool/registrationhealth/suite_test.go
@@ -46,7 +46,7 @@ var (
 	cloudProvider *fake.CloudProvider
 	nodePool      *v1.NodePool
 	nodeClass     *v1alpha1.TestNodeClass
-	npState       nodepoolhealth.State
+	npState       *nodepoolhealth.State
 )
 
 func TestAPIs(t *testing.T) {
@@ -58,7 +58,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	cloudProvider = fake.NewCloudProvider()
 	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
-	npState = nodepoolhealth.State{}
+	npState = nodepoolhealth.NewState()
 	controller = registrationhealth.NewController(env.Client, cloudProvider, npState)
 })
 var _ = AfterEach(func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The `nodepoolhealth.State` was implemented as an unsynchronized `map[types.UID]*Tracker`, causing race conditions and potential panics when multiple goroutines accessed NodePool health state concurrently.

Changes in this PR -
- Converted State to thread-safe struct by changing from map type to struct with sync.RWMutex and trackers map
- Added NewState() constructor for proper initialization
- Implemented double-checked locking in nodePoolNodeRegistration()
- Added proper synchronization i.e. RLock() protection for Status() and DryRun() read operations
- Fixed SetStatus() deadlock by using direct buffer.Insert() instead of nested Update() calls

Now we have consistent lock hierarchy: State → Tracker

**How was this change tested?**
Added tests. Tested on dev cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
