### PR TITLE
fix: initialize npMap in metrics cost controller to prevent nil map panic

### DIFF
--- a/pkg/controllers/metrics/cluster/controller.go
+++ b/pkg/controllers/metrics/cluster/controller.go
@@ -60,6 +60,7 @@ func NewController(client client.Client, clusterCost *cost.ClusterCost) *Control
 	return &Controller{
 		client:      client,
 		clusterCost: clusterCost,
+		npMap:       make(map[string]*v1.NodePool),
 	}
 }
 

--- a/pkg/controllers/metrics/cluster/suite_test.go
+++ b/pkg/controllers/metrics/cluster/suite_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/metrics/cluster"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var clusterController *cluster.Controller
+var ctx context.Context
+var env *test.Environment
+var clusterCost *cost.ClusterCost
+var cp *fake.CloudProvider
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ClusterMetrics")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...))
+	cp = fake.NewCloudProvider()
+	clusterCost = cost.NewClusterCost(ctx, cp, env.Client)
+	clusterController = cluster.NewController(env.Client, clusterCost)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("Controller", func() {
+	It("should not panic when reconciling with nodepools", func() {
+		nodePool := test.NodePool()
+		ExpectApplied(ctx, env.Client, nodePool)
+
+		// This should not panic due to nil map
+		_, err := clusterController.Reconcile(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
fix: Initialize npMap in metrics cost controller to prevent nil map panic. Fixes issue introduced in commit a1357ee7 (PR #2584)

**Description**
- Add unit test to reproduce nil map panic in metrics.cost controller
- Initialize npMap field in NewController constructor
- Fixes crash on every reconciliation attempt

**How was this change tested?**
Simulations and local unit tests crashed before the fix, and unit tests pass after the fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
