### PR TITLE
fix: Update label for deleted node

### DIFF
--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Termination", func() {
 			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
 
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			Expect(node.Labels[corev1.LabelNodeExcludeBalancers]).Should(Equal("karpenter"))
+			Expect(node.Labels[corev1.LabelNodeExcludeBalancers]).Should(Equal("true"))
 		})
 		It("should not evict pods that tolerate karpenter disruption taint with equal operator", func() {
 			podEvict := test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -70,7 +70,7 @@ func (t *Terminator) Taint(ctx context.Context, node *corev1.Node, taint corev1.
 	// https://github.com/aws/aws-node-termination-handler/issues/316
 	// https://github.com/aws/karpenter/pull/2518
 	node.Labels = lo.Assign(node.Labels, map[string]string{
-		corev1.LabelNodeExcludeBalancers: "karpenter",
+		corev1.LabelNodeExcludeBalancers: "true",
 	})
 	if !equality.Semantic.DeepEqual(node, stored) {
 		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch


### PR DESCRIPTION
fix: Change the label added on the deleted node

Description

When a node is marked to be deleted by Karpenter, the label value for Kubernetes exclude from loadbalancers is set to karpenter, instead of usual value of true. This causes the node to become  a part of the load balancer group.

How was this change tested?

Update the change in our forked repository and soaked and tested.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
