### PR TITLE
feat: add flags for changing leader election lease duration, renew deadline, retry period

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -163,6 +163,9 @@ func NewOperator(o ...option.Function[Options]) (context.Context, *Operator) {
 		LeaderElectionReleaseOnCancel: true,
 		LeaderElectionConfig:          leaderConfig,
 		LeaderElectionLabels:          opts.LeaderElectionLabels,
+		LeaseDuration:                 &options.FromContext(ctx).LeaderElectionLeaseDuration,
+		RenewDeadline:                 &options.FromContext(ctx).LeaderElectionRenewDeadline,
+		RetryPeriod:                   &options.FromContext(ctx).LeaderElectionRetryPeriod,
 		Metrics: server.Options{
 			BindAddress: fmt.Sprintf(":%d", options.FromContext(ctx).MetricsPort),
 		},

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -75,6 +75,9 @@ type Options struct {
 	DisableClusterStateObservability bool
 	LeaderElectionName               string
 	LeaderElectionNamespace          string
+	LeaderElectionLeaseDuration      time.Duration
+	LeaderElectionRenewDeadline      time.Duration
+	LeaderElectionRetryPeriod        time.Duration
 	MemoryLimit                      int64
 	CPURequests                      int64
 	LogLevel                         string
@@ -118,6 +121,9 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.BoolVarWithEnv(&o.DisableClusterStateObservability, "disable-cluster-state-observability", "DISABLE_CLUSTER_STATE_OBSERVABILITY", false, "Disable cluster state metrics and events")
 	fs.StringVar(&o.LeaderElectionName, "leader-election-name", env.WithDefaultString("LEADER_ELECTION_NAME", "karpenter-leader-election"), "Leader election name to create and monitor the lease if running outside the cluster")
 	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", env.WithDefaultString("LEADER_ELECTION_NAMESPACE", ""), "Leader election namespace to create and monitor the lease if running outside the cluster")
+	fs.DurationVar(&o.LeaderElectionLeaseDuration, "leader-election-lease-duration", env.WithDefaultDuration("LEADER_ELECTION_LEASE_DURATION", 15*time.Second), "The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.")
+	fs.DurationVar(&o.LeaderElectionRenewDeadline, "leader-election-renew-deadline", env.WithDefaultDuration("LEADER_ELECTION_RENEW_DEADLINE", 10*time.Second), "The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than the lease duration. This is only applicable if leader election is enabled.")
+	fs.DurationVar(&o.LeaderElectionRetryPeriod, "leader-election-retry-period", env.WithDefaultDuration("LEADER_ELECTION_RETRY_PERIOD", 2*time.Second), "The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.")
 	fs.Int64Var(&o.MemoryLimit, "memory-limit", env.WithDefaultInt64("MEMORY_LIMIT", -1), "Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value.")
 	fs.Int64Var(&o.CPURequests, "cpu-requests", env.WithDefaultInt64("CPU_REQUESTS", 1000), "CPU requests in millicores on the container running the controller.")
 	fs.StringVar(&o.LogLevel, "log-level", env.WithDefaultString("LOG_LEVEL", "info"), "Log verbosity level. Can be one of 'debug', 'info', or 'error'")

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -55,6 +55,9 @@ var _ = Describe("Options", func() {
 		"DISABLE_LEADER_ELECTION",
 		"DISABLE_CLUSTER_STATE_OBSERVABILITY",
 		"LEADER_ELECTION_NAMESPACE",
+		"LEADER_ELECTION_LEASE_DURATION",
+		"LEADER_ELECTION_RENEW_DEADLINE",
+		"LEADER_ELECTION_RETRY_PERIOD",
 		"MEMORY_LIMIT",
 		"LOG_LEVEL",
 		"LOG_OUTPUT_PATHS",
@@ -110,6 +113,9 @@ var _ = Describe("Options", func() {
 				DisableClusterStateObservability: lo.ToPtr(false),
 				LeaderElectionName:               lo.ToPtr("karpenter-leader-election"),
 				LeaderElectionNamespace:          lo.ToPtr(""),
+				LeaderElectionLeaseDuration:      lo.ToPtr(15 * time.Second),
+				LeaderElectionRenewDeadline:      lo.ToPtr(10 * time.Second),
+				LeaderElectionRetryPeriod:        lo.ToPtr(2 * time.Second),
 				MemoryLimit:                      lo.ToPtr[int64](-1),
 				LogLevel:                         lo.ToPtr("info"),
 				LogOutputPaths:                   lo.ToPtr("stdout"),
@@ -144,6 +150,9 @@ var _ = Describe("Options", func() {
 				"--disable-cluster-state-observability=true",
 				"--leader-election-name=karpenter-controller",
 				"--leader-election-namespace=karpenter",
+				"--leader-election-lease-duration=60s",
+				"--leader-election-renew-deadline=40s",
+				"--leader-election-retry-period=20s",
 				"--memory-limit", "0",
 				"--log-level", "debug",
 				"--log-output-paths", "/etc/k8s/test",
@@ -166,6 +175,9 @@ var _ = Describe("Options", func() {
 				DisableClusterStateObservability: lo.ToPtr(true),
 				LeaderElectionName:               lo.ToPtr("karpenter-controller"),
 				LeaderElectionNamespace:          lo.ToPtr("karpenter"),
+				LeaderElectionLeaseDuration:      lo.ToPtr(60 * time.Second),
+				LeaderElectionRenewDeadline:      lo.ToPtr(40 * time.Second),
+				LeaderElectionRetryPeriod:        lo.ToPtr(20 * time.Second),
 				MemoryLimit:                      lo.ToPtr[int64](0),
 				LogLevel:                         lo.ToPtr("debug"),
 				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
@@ -196,6 +208,9 @@ var _ = Describe("Options", func() {
 			os.Setenv("DISABLE_CLUSTER_STATE_OBSERVABILITY", "true")
 			os.Setenv("LEADER_ELECTION_NAME", "karpenter-controller")
 			os.Setenv("LEADER_ELECTION_NAMESPACE", "karpenter")
+			os.Setenv("LEADER_ELECTION_LEASE_DURATION", "45s")
+			os.Setenv("LEADER_ELECTION_RENEW_DEADLINE", "30s")
+			os.Setenv("LEADER_ELECTION_RETRY_PERIOD", "15s")
 			os.Setenv("MEMORY_LIMIT", "0")
 			os.Setenv("LOG_LEVEL", "debug")
 			os.Setenv("LOG_OUTPUT_PATHS", "/etc/k8s/test")
@@ -222,6 +237,9 @@ var _ = Describe("Options", func() {
 				DisableClusterStateObservability: lo.ToPtr(true),
 				LeaderElectionName:               lo.ToPtr("karpenter-controller"),
 				LeaderElectionNamespace:          lo.ToPtr("karpenter"),
+				LeaderElectionLeaseDuration:      lo.ToPtr(45 * time.Second),
+				LeaderElectionRenewDeadline:      lo.ToPtr(30 * time.Second),
+				LeaderElectionRetryPeriod:        lo.ToPtr(15 * time.Second),
 				MemoryLimit:                      lo.ToPtr[int64](0),
 				LogLevel:                         lo.ToPtr("debug"),
 				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
@@ -280,6 +298,9 @@ var _ = Describe("Options", func() {
 				DisableClusterStateObservability: lo.ToPtr(true),
 				LeaderElectionName:               lo.ToPtr("karpenter-leader-election"),
 				LeaderElectionNamespace:          lo.ToPtr(""),
+				LeaderElectionLeaseDuration:      lo.ToPtr(15 * time.Second),
+				LeaderElectionRenewDeadline:      lo.ToPtr(10 * time.Second),
+				LeaderElectionRetryPeriod:        lo.ToPtr(2 * time.Second),
 				MemoryLimit:                      lo.ToPtr[int64](0),
 				LogLevel:                         lo.ToPtr("debug"),
 				LogOutputPaths:                   lo.ToPtr("/etc/k8s/test"),
@@ -382,6 +403,9 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.KubeClientBurst).To(Equal(optsB.KubeClientBurst))
 	Expect(optsA.EnableProfiling).To(Equal(optsB.EnableProfiling))
 	Expect(optsA.DisableLeaderElection).To(Equal(optsB.DisableLeaderElection))
+	Expect(optsA.LeaderElectionLeaseDuration).To(Equal(optsB.LeaderElectionLeaseDuration))
+	Expect(optsA.LeaderElectionRenewDeadline).To(Equal(optsB.LeaderElectionRenewDeadline))
+	Expect(optsA.LeaderElectionRetryPeriod).To(Equal(optsB.LeaderElectionRetryPeriod))
 	Expect(optsA.DisableClusterStateObservability).To(Equal(optsB.DisableClusterStateObservability))
 	Expect(optsA.MemoryLimit).To(Equal(optsB.MemoryLimit))
 	Expect(optsA.LogLevel).To(Equal(optsB.LogLevel))

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -38,6 +38,9 @@ type OptionsFields struct {
 	DisableClusterStateObservability *bool
 	LeaderElectionName               *string
 	LeaderElectionNamespace          *string
+	LeaderElectionLeaseDuration      *time.Duration
+	LeaderElectionRenewDeadline      *time.Duration
+	LeaderElectionRetryPeriod        *time.Duration
 	MemoryLimit                      *int64
 	CPURequests                      *int64
 	LogLevel                         *string
@@ -76,6 +79,9 @@ func Options(overrides ...OptionsFields) *options.Options {
 		EnableProfiling:                  lo.FromPtrOr(opts.EnableProfiling, false),
 		DisableLeaderElection:            lo.FromPtrOr(opts.DisableLeaderElection, false),
 		DisableClusterStateObservability: lo.FromPtrOr(opts.DisableClusterStateObservability, false),
+		LeaderElectionLeaseDuration:      lo.FromPtrOr(opts.LeaderElectionLeaseDuration, 15*time.Second),
+		LeaderElectionRenewDeadline:      lo.FromPtrOr(opts.LeaderElectionRenewDeadline, 10*time.Second),
+		LeaderElectionRetryPeriod:        lo.FromPtrOr(opts.LeaderElectionRetryPeriod, 2*time.Second),
 		MemoryLimit:                      lo.FromPtrOr(opts.MemoryLimit, -1),
 		CPURequests:                      lo.FromPtrOr(opts.CPURequests, 5000), // use 5 threads to enforce parallelism
 		LogLevel:                         lo.FromPtrOr(opts.LogLevel, ""),


### PR DESCRIPTION

**Description**
We've been seeing slow lease updates in our very loaded clusters that lead to a ton of container restarts. We've made changes to relax the lease settings on other kube components, but I found no such settings available for karpenter.

This adds 3 configurable flags/env vars to control leader election:
- lease duration: `leader-election-lease-duration`, `LEADER_ELECTION_LEASE_DURATION`, default 15s
- renew deadline: `leader-election-renew-deadline`, `LEADER_ELECTION_RENEW_DEADLINE`, default 10s
- retry period: `leader-election-retry-period`, `LEADER_ELECTION_RETRY_PERIOD`, default 2s

Defaults are taken from the controller defaults, so no change to existing behavior. Descriptions are copied from other kube components with these settings.

**How was this change tested?**
I deployed this patch into our own cluster with extra logging to ensure the (higher than default) values were taken and verified that the slow lease updates and sporadic container restarts went away

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
