### PR TITLE
fix: close race condition for tests

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -582,7 +582,7 @@ func (c *Cluster) Reset() {
 	c.nodes = map[string]*StateNode{}
 	c.nodeNameToProviderID = map[string]string{}
 	c.nodeClaimNameToProviderID = map[string]string{}
-	c.NodePoolState = NewNodePoolState()
+	c.NodePoolState.Reset()
 	c.nodePoolResources = map[string]corev1.ResourceList{}
 	c.bindings = map[types.NamespacedName]string{}
 	c.antiAffinityPods = sync.Map{}

--- a/pkg/controllers/state/statenodepool.go
+++ b/pkg/controllers/state/statenodepool.go
@@ -210,3 +210,11 @@ func (n *NodePoolState) ensureNodePoolEntry(np string) {
 		n.nodePoolNameToNodePoolLimit[np] = &atomic.Int64{}
 	}
 }
+
+func (n *NodePoolState) Reset() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.nodePoolNameToNodeClaimState = make(map[string]NodeClaimState)
+	n.nodeClaimNameToNodePoolName = make(map[string]string)
+	n.nodePoolNameToNodePoolLimit = make(map[string]*atomic.Int64)
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

Data race in presubmits: https://github.com/kubernetes-sigs/karpenter/actions/runs/19520770854/job/55883533852

**Description**

The data race comes from a read to the cluster object here: https://github.com/kubernetes-sigs/karpenter/blob/main/pkg/controllers/static/provisioning/controller.go#L93

**How was this change tested?**

make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
