### PR TITLE
fix: kube-api-linter needs to be built prior to running

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,6 +1,5 @@
 version: v2.6.1
 name: golangci-lint-kube-api-linter
-destination: ./bin
 plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
   version: 'v0.0.0-20251106172841-33e0e4392883'

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ verify: ## Verify code. Includes codegen, docgen, dependencies, linting, formatt
 	@perl -i -pe 's/sets.Set/sets.Set[string]/g' pkg/scheduling/zz_generated.deepcopy.go
 	hack/boilerplate.sh
 	go vet ./...
+	golangci-lint-kube-api-linter run
 	cd kwok/charts && helm-docs
-	./bin/golangci-lint-kube-api-linter run
 	@git diff --quiet ||\
 		{ echo "New file modification detected in the Git working tree. Please check in before commit."; git --no-pager diff --name-only | uniq | awk '{print "  - " $$0}'; \
 		if [ "${CI}" = true ]; then\

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -25,12 +25,12 @@ tools() {
     go install github.com/rhysd/actionlint/cmd/actionlint@latest
     go install github.com/mattn/goveralls@latest
 
-    # Build golangci-lint with kube-api-linter plugin
-    golangci-lint custom
-
     if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then
         echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\${GOPATH:-\$HOME/go}/bin\"'."
     fi
+    
+    # Build golangci-lint with kube-api-linter plugin
+    golangci-lint custom --destination ${GOBIN:-$(go env GOPATH)/bin} 
 }
 
 kubebuilder() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Presubmits are flaking everywhere due to kube-api-linter not getting built during `make verify`

This could be changed by adding a step to the presubmit workflow to run `golangci-lint custom`

**How was this change tested?**

Removed a nolint:

```
➜  karpenter-testing-fork git:(fix-kube-api-linter) ✗ make verify
go mod tidy
go generate ./...
hack/validation/taint.sh
hack/validation/requirements.sh
hack/validation/labels.sh
hack/validation/status.sh
cp -r pkg/apis/crds kwok/charts
hack/kwok/requirements.sh
hack/dependabot.sh
hack/boilerplate.sh
go vet ./...
golangci-lint custom
./bin/golangci-lint-kube-api-linter run
WARN [runner/nolint_filter] Found unknown linters in //nolint directives: stylecheck 
pkg/apis/v1/duration.go:34:2: jsontags: embedded field NillableDuration.*time.Duration is missing json tag (kubeapilinter)
        *time.Duration
        ^
1 issues:
* kubeapilinter: 1
make: *** [verify] Error 1

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
