### PR TITLE
fix: add kubebuilder markers for non-breaking kube-api-linter issues

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -175,6 +175,7 @@ spec:
                     type: object
                   maxItems: 100
                   type: array
+                  x-kubernetes-list-type: atomic
                   x-kubernetes-validations:
                     - message: requirements with operator 'In' must have a value defined
                       rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
@@ -197,7 +198,7 @@ spec:
                   type: object
                 startupTaints:
                   description: |-
-                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    startupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
                     within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
                     daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
                     purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
@@ -234,8 +235,9 @@ spec:
                       - key
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
                 taints:
-                  description: Taints will be applied to the NodeClaim's node.
+                  description: taints will be applied to the NodeClaim's node.
                   items:
                     description: |-
                       The node this Taint is attached to has the "effect" on
@@ -269,6 +271,7 @@ spec:
                       - key
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
                 terminationGracePeriod:
                   description: |-
                     TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
@@ -367,6 +370,9 @@ spec:
                       - type
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 imageID:
                   description: ImageID is an identifier for the image that runs on the node
                   type: string

--- a/kwok/charts/crds/karpenter.sh_nodeoverlays.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeoverlays.yaml
@@ -80,7 +80,7 @@ spec:
                   type: string
                 requirements:
                   description: |-
-                    Requirements constrain when this NodeOverlay is applied during scheduling simulations.
+                    requirements constrain when this NodeOverlay is applied during scheduling simulations.
                     These requirements can match:
                     - Well-known labels (e.g., node.kubernetes.io/instance-type, karpenter.sh/nodepool)
                     - Custom labels from NodePool's spec.template.labels
@@ -131,6 +131,7 @@ spec:
                     type: object
                   maxItems: 100
                   type: array
+                  x-kubernetes-list-type: atomic
                   x-kubernetes-validations:
                     - message: requirements with operator 'NotIn' must have a value defined
                       rule: 'self.all(x, x.operator == ''NotIn'' ? x.values.size() != 0 : true)'
@@ -213,6 +214,9 @@ spec:
                       - type
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
               type: object
           required:
             - spec

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -112,7 +112,7 @@ spec:
                             type: string
                           reasons:
                             description: |-
-                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
                               Otherwise, this will apply to each reason defined.
                               allowed reasons are Underutilized, Empty, and Drifted.
                             items:
@@ -124,6 +124,7 @@ spec:
                               type: string
                             maxItems: 50
                             type: array
+                            x-kubernetes-list-type: set
                           schedule:
                             description: |-
                               Schedule specifies when a budget begins being active, following
@@ -137,6 +138,7 @@ spec:
                         type: object
                       maxItems: 50
                       type: array
+                      x-kubernetes-list-type: atomic
                       x-kubernetes-validations:
                         - message: '''schedule'' must be set with ''duration'''
                           rule: self.all(x, has(x.schedule) == has(x.duration))
@@ -197,22 +199,24 @@ spec:
                           additionalProperties:
                             type: string
                           description: |-
-                            Annotations is an unstructured key value map stored with a resource that may be
+                            annotations is an unstructured key value map stored with a resource that may be
                             set by external tools to store and retrieve arbitrary metadata. They are not
                             queryable and should be preserved when modifying objects.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                           type: object
+                          x-kubernetes-map-type: granular
                         labels:
                           additionalProperties:
                             type: string
                             maxLength: 63
                             pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                           description: |-
-                            Map of string keys and values that can be used to organize and categorize
+                            labels is a map of string keys and values that can be used to organize and categorize
                             (scope and select) objects. May match selectors of replication controllers
                             and services.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                           type: object
+                          x-kubernetes-map-type: atomic
                           maxProperties: 100
                           x-kubernetes-validations:
                             - message: label domain "karpenter.sh" is restricted
@@ -330,6 +334,7 @@ spec:
                             type: object
                           maxItems: 100
                           type: array
+                          x-kubernetes-list-type: atomic
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined
                               rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
@@ -339,7 +344,7 @@ spec:
                               rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
                         startupTaints:
                           description: |-
-                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            startupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
                             within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
                             daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
                             purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
@@ -376,8 +381,9 @@ spec:
                               - key
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         taints:
-                          description: Taints will be applied to the NodeClaim's node.
+                          description: taints will be applied to the NodeClaim's node.
                           items:
                             description: |-
                               The node this Taint is attached to has the "effect" on
@@ -411,6 +417,7 @@ spec:
                               - key
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         terminationGracePeriod:
                           description: |-
                             TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
@@ -515,6 +522,9 @@ spec:
                       - type
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 nodeClassObservedGeneration:
                   description: |-
                     NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -173,6 +173,7 @@ spec:
                     type: object
                   maxItems: 100
                   type: array
+                  x-kubernetes-list-type: atomic
                   x-kubernetes-validations:
                     - message: requirements with operator 'In' must have a value defined
                       rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
@@ -195,7 +196,7 @@ spec:
                   type: object
                 startupTaints:
                   description: |-
-                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    startupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
                     within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
                     daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
                     purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
@@ -232,8 +233,9 @@ spec:
                       - key
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
                 taints:
-                  description: Taints will be applied to the NodeClaim's node.
+                  description: taints will be applied to the NodeClaim's node.
                   items:
                     description: |-
                       The node this Taint is attached to has the "effect" on
@@ -267,6 +269,7 @@ spec:
                       - key
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
                 terminationGracePeriod:
                   description: |-
                     TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
@@ -365,6 +368,9 @@ spec:
                       - type
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 imageID:
                   description: ImageID is an identifier for the image that runs on the node
                   type: string

--- a/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
@@ -80,7 +80,7 @@ spec:
                   type: string
                 requirements:
                   description: |-
-                    Requirements constrain when this NodeOverlay is applied during scheduling simulations.
+                    requirements constrain when this NodeOverlay is applied during scheduling simulations.
                     These requirements can match:
                     - Well-known labels (e.g., node.kubernetes.io/instance-type, karpenter.sh/nodepool)
                     - Custom labels from NodePool's spec.template.labels
@@ -131,6 +131,7 @@ spec:
                     type: object
                   maxItems: 100
                   type: array
+                  x-kubernetes-list-type: atomic
                   x-kubernetes-validations:
                     - message: requirements with operator 'NotIn' must have a value defined
                       rule: 'self.all(x, x.operator == ''NotIn'' ? x.values.size() != 0 : true)'
@@ -213,6 +214,9 @@ spec:
                       - type
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
               type: object
           required:
             - spec

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -112,7 +112,7 @@ spec:
                             type: string
                           reasons:
                             description: |-
-                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
                               Otherwise, this will apply to each reason defined.
                               allowed reasons are Underutilized, Empty, and Drifted.
                             items:
@@ -124,6 +124,7 @@ spec:
                               type: string
                             maxItems: 50
                             type: array
+                            x-kubernetes-list-type: set
                           schedule:
                             description: |-
                               Schedule specifies when a budget begins being active, following
@@ -137,6 +138,7 @@ spec:
                         type: object
                       maxItems: 50
                       type: array
+                      x-kubernetes-list-type: atomic
                       x-kubernetes-validations:
                         - message: '''schedule'' must be set with ''duration'''
                           rule: self.all(x, has(x.schedule) == has(x.duration))
@@ -197,22 +199,24 @@ spec:
                           additionalProperties:
                             type: string
                           description: |-
-                            Annotations is an unstructured key value map stored with a resource that may be
+                            annotations is an unstructured key value map stored with a resource that may be
                             set by external tools to store and retrieve arbitrary metadata. They are not
                             queryable and should be preserved when modifying objects.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                           type: object
+                          x-kubernetes-map-type: granular
                         labels:
                           additionalProperties:
                             type: string
                             maxLength: 63
                             pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                           description: |-
-                            Map of string keys and values that can be used to organize and categorize
+                            labels is a map of string keys and values that can be used to organize and categorize
                             (scope and select) objects. May match selectors of replication controllers
                             and services.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                           type: object
+                          x-kubernetes-map-type: atomic
                           maxProperties: 100
                           x-kubernetes-validations:
                             - message: label domain "karpenter.sh" is restricted
@@ -328,6 +332,7 @@ spec:
                             type: object
                           maxItems: 100
                           type: array
+                          x-kubernetes-list-type: atomic
                           x-kubernetes-validations:
                             - message: requirements with operator 'In' must have a value defined
                               rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
@@ -337,7 +342,7 @@ spec:
                               rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
                         startupTaints:
                           description: |-
-                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            startupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
                             within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
                             daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
                             purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
@@ -374,8 +379,9 @@ spec:
                               - key
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         taints:
-                          description: Taints will be applied to the NodeClaim's node.
+                          description: taints will be applied to the NodeClaim's node.
                           items:
                             description: |-
                               The node this Taint is attached to has the "effect" on
@@ -409,6 +415,7 @@ spec:
                               - key
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         terminationGracePeriod:
                           description: |-
                             TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
@@ -513,6 +520,9 @@ spec:
                       - type
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 nodeClassObservedGeneration:
                   description: |-
                     NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -25,24 +25,25 @@ import (
 
 // NodeClaimSpec describes the desired state of the NodeClaim
 type NodeClaimSpec struct {
-	//nolint:kubeapilinter
-	// Taints will be applied to the NodeClaim's node.
+	// taints will be applied to the NodeClaim's node.
 	// +optional
+	// +listType=atomic
 	Taints []v1.Taint `json:"taints,omitempty"`
-	//nolint:kubeapilinter
-	// StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+	// startupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
 	// within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
 	// daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
 	// purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
 	// +optional
+	// +listType=atomic
 	StartupTaints []v1.Taint `json:"startupTaints,omitempty"`
-	//nolint:kubeapilinter
 	// Requirements are layered with GetLabels and applied to every node.
 	// +kubebuilder:validation:XValidation:message="requirements with operator 'In' must have a value defined",rule="self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
 	// +kubebuilder:validation:XValidation:message="requirements operator 'Gt', 'Lt', 'Gte', or 'Lte' must have a single positive integer value",rule="self.all(x, (x.operator == 'Gt' || x.operator == 'Lt' || x.operator == 'Gte' || x.operator == 'Lte') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
 	// +kubebuilder:validation:XValidation:message="requirements with 'minValues' must have at least that many values specified in the 'values' field",rule="self.all(x, (x.operator == 'In' && has(x.minValues)) ? x.values.size() >= x.minValues : true)"
 	// +kubebuilder:validation:MaxItems:=100
 	// +required
+	// +listType=atomic
+	//nolint:kubeapilinter
 	Requirements []NodeSelectorRequirementWithMinValues `json:"requirements" hash:"ignore"`
 	//nolint:kubeapilinter
 	// Resources models the resource requirements for the NodeClaim to launch

--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -57,9 +57,11 @@ type NodeClaimStatus struct {
 	// Allocatable is the estimated allocatable capacity of the node
 	// +optional
 	Allocatable v1.ResourceList `json:"allocatable,omitempty"`
-	//nolint:kubeapilinter
 	// Conditions contains signals for health and readiness
 	// +optional
+	// +listType=map
+	// +listMapKey=type
+	//nolint:kubeapilinter
 	Conditions []status.Condition `json:"conditions,omitempty"`
 	//nolint:kubeapilinter
 	// LastPodEventTime is updated with the last time a pod was scheduled

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -99,7 +99,6 @@ type Disruption struct {
 	// +kubebuilder:validation:Enum:={WhenEmpty,WhenEmptyOrUnderutilized}
 	// +optional
 	ConsolidationPolicy ConsolidationPolicy `json:"consolidationPolicy,omitempty"`
-	//nolint:kubeapilinter
 	// Budgets is a list of Budgets.
 	// If there are multiple active budgets, Karpenter uses
 	// the most restrictive value. If left undefined,
@@ -108,18 +107,20 @@ type Disruption struct {
 	// +kubebuilder:default:={{nodes: "10%"}}
 	// +kubebuilder:validation:MaxItems=50
 	// +optional
+	// +listType=atomic
+	//nolint:kubeapilinter
 	Budgets []Budget `json:"budgets,omitempty" hash:"ignore"`
 }
 
 // Budget defines when Karpenter will restrict the
 // number of Node Claims that can be terminating simultaneously.
 type Budget struct {
-	//nolint:kubeapilinter
-	// Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+	// reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
 	// Otherwise, this will apply to each reason defined.
 	// allowed reasons are Underutilized, Empty, and Drifted.
 	// +kubebuilder:validation:MaxItems=50
 	// +optional
+	// +listType=set
 	Reasons []DisruptionReason `json:"reasons,omitempty"`
 	//nolint:kubeapilinter
 	// Nodes dictates the maximum number of NodeClaims owned by this NodePool
@@ -197,24 +198,25 @@ type NodeClaimTemplate struct {
 // NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
 // users are not able to set resource requests in the NodePool.
 type NodeClaimTemplateSpec struct {
-	//nolint:kubeapilinter
-	// Taints will be applied to the NodeClaim's node.
+	// taints will be applied to the NodeClaim's node.
 	// +optional
+	// +listType=atomic
 	Taints []v1.Taint `json:"taints,omitempty"`
-	//nolint:kubeapilinter
-	// StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+	// startupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
 	// within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
 	// daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
 	// purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
 	// +optional
+	// +listType=atomic
 	StartupTaints []v1.Taint `json:"startupTaints,omitempty"`
-	//nolint:kubeapilinter
 	// Requirements are layered with GetLabels and applied to every node.
 	// +kubebuilder:validation:XValidation:message="requirements with operator 'In' must have a value defined",rule="self.all(x, x.operator == 'In' ? x.values.size() != 0 : true)"
 	// +kubebuilder:validation:XValidation:message="requirements operator 'Gt', 'Lt', 'Gte', or 'Lte' must have a single positive integer value",rule="self.all(x, (x.operator == 'Gt' || x.operator == 'Lt' || x.operator == 'Gte' || x.operator == 'Lte') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
 	// +kubebuilder:validation:XValidation:message="requirements with 'minValues' must have at least that many values specified in the 'values' field",rule="self.all(x, (x.operator == 'In' && has(x.minValues)) ? x.values.size() >= x.minValues : true)"
 	// +kubebuilder:validation:MaxItems:=100
 	// +required
+	// +listType=atomic
+	//nolint:kubeapilinter
 	Requirements []NodeSelectorRequirementWithMinValues `json:"requirements" hash:"ignore"`
 	//nolint:kubeapilinter
 	// NodeClassRef is a reference to an object that defines provider specific configuration
@@ -271,20 +273,20 @@ func (in *NodeClaimTemplate) ToNodeClaim() *NodeClaim {
 }
 
 type ObjectMeta struct {
-	//nolint:kubeapilinter
-	// Map of string keys and values that can be used to organize and categorize
+	// labels is a map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 	// +optional
+	// +mapType=atomic
 	Labels map[string]string `json:"labels,omitempty"`
 
-	//nolint:kubeapilinter
-	// Annotations is an unstructured key value map stored with a resource that may be
+	// annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
 	// +optional
+	// +mapType=granular
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 

--- a/pkg/apis/v1/nodepool_status.go
+++ b/pkg/apis/v1/nodepool_status.go
@@ -47,9 +47,11 @@ type NodePoolStatus struct {
 	// the actual NodeClass Generation, NodeRegistrationHealthy status condition on the NodePool will be reset
 	// +optional
 	NodeClassObservedGeneration int64 `json:"nodeClassObservedGeneration,omitempty"`
-	//nolint:kubeapilinter
 	// Conditions contains signals for health and readiness
 	// +optional
+	// +listType=map
+	// +listMapKey=type
+	//nolint:kubeapilinter
 	Conditions []status.Condition `json:"conditions,omitempty"`
 }
 

--- a/pkg/apis/v1alpha1/nodeoverlay.go
+++ b/pkg/apis/v1alpha1/nodeoverlay.go
@@ -57,8 +57,7 @@ func (r NodeSelectorRequirement) AsNodeSelectorRequirement() corev1.NodeSelector
 }
 
 type NodeOverlaySpec struct {
-	//nolint:kubeapilinter
-	// Requirements constrain when this NodeOverlay is applied during scheduling simulations.
+	// requirements constrain when this NodeOverlay is applied during scheduling simulations.
 	// These requirements can match:
 	// - Well-known labels (e.g., node.kubernetes.io/instance-type, karpenter.sh/nodepool)
 	// - Custom labels from NodePool's spec.template.labels
@@ -67,6 +66,7 @@ type NodeOverlaySpec struct {
 	// +kubebuilder:validation:XValidation:message="requirements operator 'Gt', 'Lt', 'Gte' or 'Lte' must have a single positive integer value",rule="self.all(x, (x.operator == 'Gt' || x.operator == 'Lt' || x.operator == 'Gte' || x.operator == 'Lte') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)"
 	// +kubebuilder:validation:MaxItems:=100
 	// +required
+	// +listType=atomic
 	Requirements []NodeSelectorRequirement `json:"requirements,omitempty"`
 	//nolint:kubeapilinter
 	// PriceAdjustment specifies the price change for matching instance types. Accepts either:

--- a/pkg/apis/v1alpha1/nodeoverlay_status.go
+++ b/pkg/apis/v1alpha1/nodeoverlay_status.go
@@ -28,10 +28,12 @@ const (
 
 // NodeOverlayStatus defines the observed state of NodeOverlay
 type NodeOverlayStatus struct {
-	//nolint:kubeapilinter
 	// Conditions contains signals for health and readiness
 	// +optional
-	Conditions []status.Condition `json:"conditions,omitempty"` //nolint:kubeapilinter
+	// +listType=map
+	// +listMapKey=type
+	//nolint:kubeapilinter
+	Conditions []status.Condition `json:"conditions,omitempty"`
 }
 
 func (in *NodeOverlay) StatusConditions() status.ConditionSet {


### PR DESCRIPTION
https://github.com/kubernetes-sigs/karpenter/issues/2419

## Summary
This PR addresses non-breaking kube-api-linter issues identified in #2618 by adding appropriate kubebuilder markers to API field definitions.

## Changes
### Added kubebuilder markers:
- **List fields**: Added `+listType=atomic` to `Taints`, `StartupTaints`, `Requirements`, and `Budgets`
- **List fields**: Added `+listType=set` to `Reasons` (no duplicates allowed)
- **List fields**: Added `+listType=map` with `+listMapKey=type` to `Conditions` (indexed by type)
- **Map fields**: Added `+mapType=atomic` to `Labels`
- **Map fields**: Added `+mapType=granular` to `Annotations`

### Retained `//nolint:kubeapilinter` for:
- Embedded fields (`metav1.ObjectMeta`, `Status`, etc.)
- Pointer types (`*NodeClassReference`, `*metav1.Duration`, etc.)
- Primitive fields in Status structs
- Fields with design constraints requiring breaking changes

## Testing
All changes are non-breaking and only add metadata markers that don't affect runtime behavior or API compatibility.

Related to #2618