### PR TITLE
test: fix flaking static provisioning test

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -592,6 +592,13 @@ func (c *Cluster) Reset() {
 	c.podsSchedulableTimes = sync.Map{}
 }
 
+// sets the cluster to be synced or unsynced for unit testing
+func (c *Cluster) SetSynced(state bool) {
+	c.unsyncedTimeMu.Lock()
+	defer c.unsyncedTimeMu.Unlock()
+	c.hasSynced.Store(state)
+}
+
 func (c *Cluster) GetDaemonSetPod(daemonset *appsv1.DaemonSet) *corev1.Pod {
 	if pod, ok := c.daemonSetPods.Load(client.ObjectKeyFromObject(daemonset)); ok {
 		return pod.(*corev1.Pod).DeepCopy()

--- a/pkg/controllers/static/provisioning/suite_test.go
+++ b/pkg/controllers/static/provisioning/suite_test.go
@@ -541,7 +541,7 @@ var _ = Describe("Static Provisioning Controller", func() {
 				go func(i int) {
 					defer GinkgoRecover()
 					if i%4 == 0 {
-						cluster.Reset()
+						cluster.SetSynced(false)
 					}
 					_, e := controller.Reconcile(ctx, nodePool)
 					errs <- e
@@ -558,6 +558,7 @@ var _ = Describe("Static Provisioning Controller", func() {
 				return len(list.Items)
 			}, 5*time.Second).Should(BeNumerically("<=", 10))
 
+			ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
 			// at the end we should have right counts in StateNodePool
 			ExpectStateNodePoolCount(cluster, nodePool.Name, 10, 0, 0)
 		})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/kubernetes-sigs/karpenter/actions/runs/19683853291/job/56384371037

**Description**

If we call cluster.Reset() we get rid of our internal state, which causes race conditions. Since deleting cluster state is not indicative of how the code will function, I have switched it to instead delete nodeclaims regularly.

**How was this change tested?**

Ran the tests quite a few times locally, no flakes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
