### PR TITLE
docs: clarify OCI provider is provided by Zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Karpenter is a multi-cloud project with implementations by the following cloud p
 - [GCP](https://github.com/cloudpilot-ai/karpenter-provider-gcp)
 - [IBM Cloud](https://github.com/kubernetes-sigs/karpenter-provider-ibm-cloud)
 - [Proxmox](https://github.com/sergelogvinov/karpenter-provider-proxmox)
-- [Oracle Cloud Infrastructure (OCI)](https://github.com/zoom/karpenter-oci)
+- [Oracle Cloud Infrastructure (OCI) - Provided by Zoom](https://github.com/zoom/karpenter-oci)
 
 ## Community, discussion, contribution, and support
 


### PR DESCRIPTION
Fixes #2572

**Description**
Updated the README to clarify that the Oracle Cloud Infrastructure (OCI) provider is maintained by Zoom, not an official Oracle offering. Changed the listing from "Oracle Cloud Infrastructure (OCI)" to "Oracle Cloud Infrastructure (OCI) - Provided by Zoom" to avoid confusion while Oracle develops their official Karpenter provider.

**How was this change tested?**
Documentation-only change, no testing required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.