### PR TITLE
test: fix flaking provisioning large replica test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/pkg/controllers/static/provisioning/suite_test.go
+++ b/pkg/controllers/static/provisioning/suite_test.go
@@ -495,7 +495,7 @@ var _ = Describe("Static Provisioning Controller", func() {
 				nodeClaims := &v1.NodeClaimList{}
 				Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
 				return len(nodeClaims.Items)
-			}, ).WithTimeout(40 * time.Second).Should(Equal(numNodeClaims))
+			}).WithTimeout(40 * time.Second).Should(Equal(numNodeClaims))
 			ExpectStateNodePoolCount(cluster, nodePool.Name, numNodeClaims, 0, 0)
 		})
 		It("handles concurrent reconciliation without exceeding NodePool limits", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes: https://github.com/kubernetes-sigs/karpenter/actions/runs/19681142380/job/56375210769?pr=2626

**Description**

Occasionally, the server side nodeclaim name generation will fail to create a unique name. Ordinarily, this would be retried. In our tests, it isn't. This retries the reconciler like it would in practice to prevent flakes

**How was this change tested?**

make presubmit a bunch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
