### PR TITLE
chore: add grace period for newly published vulnerabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ deflake: ## Run randomized, racing tests until the test fails to catch flakes
 		./pkg/...
 
 vulncheck: ## Verify code vulnerabilities
-	@go tool govulncheck ./pkg/...
+	@hack/vulncheck.sh
 
 licenses: download ## Verifies dependency licenses
 	! go tool go-licenses csv ./... | grep -v -e 'MIT' -e 'Apache-2.0' -e 'BSD-3-Clause' -e 'BSD-2-Clause' -e 'ISC' -e 'MPL-2.0'

--- a/hack/vulncheck.sh
+++ b/hack/vulncheck.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Wrapper for govulncheck with grace period for newly published vulnerabilities
+set -euo pipefail
+
+GRACE_HOURS="${VULN_GRACE_PERIOD_HOURS:-48}"
+OUTPUT=$(mktemp)
+trap "rm -f $OUTPUT" EXIT
+
+go tool govulncheck -json ./pkg/... > "$OUTPUT" 2>&1 || true
+
+# Parse and check publish dates
+python3 - "$OUTPUT" "$GRACE_HOURS" << 'EOF'
+import json, sys, datetime
+output_file, grace_hours = sys.argv[1], int(sys.argv[2])
+cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=grace_hours)
+
+with open(output_file) as f:
+    content = f.read()
+
+# Parse JSON stream
+objects, depth, start = [], 0, 0
+for i, c in enumerate(content):
+    if c == '{':
+        if depth == 0: start = i
+        depth += 1
+    elif c == '}':
+        depth -= 1
+        if depth == 0:
+            try: objects.append(json.loads(content[start:i+1]))
+            except: pass
+
+findings = [o for o in objects if o.get("finding")]
+if not findings:
+    print("No vulnerabilities found.")
+    sys.exit(0)
+
+osv_map = {e["osv"]["id"]: e["osv"] for e in objects if e.get("osv")}
+seen, blocking = set(), []
+
+for f in findings:
+    vuln_id = f["finding"]["osv"]
+    if vuln_id in seen: continue
+    seen.add(vuln_id)
+    published = osv_map.get(vuln_id, {}).get("published", "")
+    if published:
+        pub_dt = datetime.datetime.fromisoformat(published.replace("Z", "+00:00"))
+        if pub_dt > cutoff:
+            print(f"⚠️  {vuln_id}: within {grace_hours}h grace period (published {published})")
+            continue
+    blocking.append(vuln_id)
+
+if blocking:
+    print(f"❌ Blocking: {blocking}")
+    sys.exit(1)
+print("✅ All vulnerabilities within grace period")
+EOF


### PR DESCRIPTION
chore: add grace period for newly published vulnerabilities

## Description

Adds a 48h grace period wrapper for govulncheck. Vulnerabilities
published within the grace period warn but don't block CI, allowing
time for fixed Go versions to become available in GitHub Actions.

Set VULN_GRACE_PERIOD_HOURS to customize (default: 48).

## Prompts

| Prompt | Action |
|--------|--------|
| Run make vulncheck | Identified GO-2025-4155 vulnerability |
| is there a way to put a grace period | Added grace period wrapper |

## Testing

- make vulncheck passes with GO-2025-4155 in grace period
- Vulnerabilities older than 48h still block