### PR TITLE
feat: add configurable additional labels to NodePool metrics

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -111,7 +111,7 @@ func NewControllers(
 	if !options.FromContext(ctx).DisableClusterStateObservability {
 		controllers = append(controllers,
 			metricspod.NewController(kubeClient, cluster),
-			metricsnodepool.NewController(kubeClient, cloudProvider, clusterCost),
+			metricsnodepool.NewController(ctx, kubeClient, cloudProvider, clusterCost),
 			metricsnode.NewController(cluster),
 			status.NewController[*v1.NodeClaim](
 				kubeClient,

--- a/pkg/controllers/metrics/nodepool/controller.go
+++ b/pkg/controllers/metrics/nodepool/controller.go
@@ -174,11 +174,7 @@ func makeLabels(ctx context.Context, nodePool *v1.NodePool, resourceTypeName str
 
 	// Add values for additional labels from CLI flags
 	for _, labelKey := range opts.AdditionalNodePoolMetricLabels {
-		if value, ok := nodePool.Labels[labelKey]; ok {
-			labels[labelKey] = value
-		} else {
-			labels[labelKey] = ""
-		}
+		labels[labelKey] = nodePool.Labels[labelKey]
 	}
 
 	return labels

--- a/pkg/controllers/metrics/nodepool/suite_test.go
+++ b/pkg/controllers/metrics/nodepool/suite_test.go
@@ -56,7 +56,9 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
 	cp = fake.NewCloudProvider()
 	cc = cost.NewClusterCost(ctx, cp, env.Client)
-	ctx = options.ToContext(ctx, test.Options())
+	ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+		AdditionalNodePoolMetricLabels: []string{"capacity_type", "zone", "architecture"},
+	}))
 	nodePoolController = nodepool.NewController(ctx, env.Client, cp, cc)
 })
 

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -163,13 +163,13 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 	o.MinValuesPolicy = MinValuesPolicy(o.minValuesPolicyRaw)
 
 	// Parse comma-separated additional nodepool metric labels
-	if o.rawAdditionalNodePoolMetricLabels != "" {
-		o.AdditionalNodePoolMetricLabels = lo.Map(strings.Split(o.rawAdditionalNodePoolMetricLabels, ","), func(s string, _ int) string {
-			return strings.TrimSpace(s)
-		})
-	} else {
-		o.AdditionalNodePoolMetricLabels = []string{}
-	}
+	o.AdditionalNodePoolMetricLabels = lo.FilterMap(
+		strings.Split(o.rawAdditionalNodePoolMetricLabels, ","),
+		func(s string, _ int) (string, bool) {
+			trimmed := strings.TrimSpace(s)
+			return trimmed, trimmed != ""
+		},
+	)
 
 	return nil
 }

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -132,7 +132,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, and StaticCapacity.")
-	fs.StringVar(&o.rawAdditionalNodePoolMetricLabels, "additional-nodepool-metric-labels", env.WithDefaultString("ADDITIONAL_NODEPOOL_METRIC_LABELS", "capacity_type,zone,architecture"), "Comma-separated list of additional labels to include in NodePool metrics (karpenter_nodepools_limit and karpenter_nodepools_usage)")
+	fs.StringVar(&o.rawAdditionalNodePoolMetricLabels, "additional-nodepool-metric-labels", env.WithDefaultString("ADDITIONAL_NODEPOOL_METRIC_LABELS", ""), "Comma-separated list of additional labels to include in NodePool metrics (karpenter_nodepools_limit and karpenter_nodepools_usage)")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -65,29 +66,31 @@ type FeatureGates struct {
 
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
 type Options struct {
-	ServiceName                      string
-	MetricsPort                      int
-	HealthProbePort                  int
-	KubeClientQPS                    int
-	KubeClientBurst                  int
-	EnableProfiling                  bool
-	DisableLeaderElection            bool
-	DisableClusterStateObservability bool
-	LeaderElectionName               string
-	LeaderElectionNamespace          string
-	MemoryLimit                      int64
-	CPURequests                      int64
-	LogLevel                         string
-	LogOutputPaths                   string
-	LogErrorOutputPaths              string
-	BatchMaxDuration                 time.Duration
-	BatchIdleDuration                time.Duration
-	preferencePolicyRaw              string
-	PreferencePolicy                 PreferencePolicy
-	minValuesPolicyRaw               string
-	MinValuesPolicy                  MinValuesPolicy
-	IgnoreDRARequests                bool // NOTE: This flag will be removed once formal DRA support is GA in Karpenter.
-	FeatureGates                     FeatureGates
+	ServiceName                       string
+	MetricsPort                       int
+	HealthProbePort                   int
+	KubeClientQPS                     int
+	KubeClientBurst                   int
+	EnableProfiling                   bool
+	DisableLeaderElection             bool
+	DisableClusterStateObservability  bool
+	LeaderElectionName                string
+	LeaderElectionNamespace           string
+	MemoryLimit                       int64
+	CPURequests                       int64
+	LogLevel                          string
+	LogOutputPaths                    string
+	LogErrorOutputPaths               string
+	BatchMaxDuration                  time.Duration
+	BatchIdleDuration                 time.Duration
+	preferencePolicyRaw               string
+	PreferencePolicy                  PreferencePolicy
+	minValuesPolicyRaw                string
+	MinValuesPolicy                   MinValuesPolicy
+	IgnoreDRARequests                 bool // NOTE: This flag will be removed once formal DRA support is GA in Karpenter.
+	FeatureGates                      FeatureGates
+	rawAdditionalNodePoolMetricLabels string
+	AdditionalNodePoolMetricLabels    []string
 }
 
 type FlagSet struct {
@@ -129,6 +132,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, and StaticCapacity.")
+	fs.StringVar(&o.rawAdditionalNodePoolMetricLabels, "additional-nodepool-metric-labels", env.WithDefaultString("ADDITIONAL_NODEPOOL_METRIC_LABELS", "capacity_type,zone,architecture"), "Comma-separated list of additional labels to include in NodePool metrics (karpenter_nodepools_limit and karpenter_nodepools_usage)")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {
@@ -157,6 +161,16 @@ func (o *Options) Parse(fs *FlagSet, args ...string) error {
 	o.FeatureGates = gates
 	o.PreferencePolicy = PreferencePolicy(o.preferencePolicyRaw)
 	o.MinValuesPolicy = MinValuesPolicy(o.minValuesPolicyRaw)
+
+	// Parse comma-separated additional nodepool metric labels
+	if o.rawAdditionalNodePoolMetricLabels != "" {
+		o.AdditionalNodePoolMetricLabels = lo.Map(strings.Split(o.rawAdditionalNodePoolMetricLabels, ","), func(s string, _ int) string {
+			return strings.TrimSpace(s)
+		})
+	} else {
+		o.AdditionalNodePoolMetricLabels = []string{}
+	}
+
 	return nil
 }
 

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -49,6 +49,7 @@ type OptionsFields struct {
 	BatchIdleDuration                *time.Duration
 	IgnoreDRARequests                *bool
 	FeatureGates                     FeatureGates
+	AdditionalNodePoolMetricLabels   []string
 }
 
 type FeatureGates struct {
@@ -93,5 +94,6 @@ func Options(overrides ...OptionsFields) *options.Options {
 			NodeOverlay:             lo.FromPtrOr(opts.FeatureGates.NodeOverlay, false),
 			StaticCapacity:          lo.FromPtrOr(opts.FeatureGates.StaticCapacity, false),
 		},
+		AdditionalNodePoolMetricLabels: lo.Ternary(len(opts.AdditionalNodePoolMetricLabels) > 0, opts.AdditionalNodePoolMetricLabels, []string{"capacity_type", "zone", "architecture"}),
 	}
 }

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -94,6 +94,6 @@ func Options(overrides ...OptionsFields) *options.Options {
 			NodeOverlay:             lo.FromPtrOr(opts.FeatureGates.NodeOverlay, false),
 			StaticCapacity:          lo.FromPtrOr(opts.FeatureGates.StaticCapacity, false),
 		},
-		AdditionalNodePoolMetricLabels: lo.Ternary(len(opts.AdditionalNodePoolMetricLabels) > 0, opts.AdditionalNodePoolMetricLabels, []string{"capacity_type", "zone", "architecture"}),
+		AdditionalNodePoolMetricLabels: opts.AdditionalNodePoolMetricLabels,
 	}
 }


### PR DESCRIPTION
## What problem does this PR solve?

Closes #2221

Allows users to customize which NodePool labels are included in NodePool metrics (`karpenter_nodepools_limit` and `karpenter_nodepools_usage`), enabling better observability for custom attributes like capacity type, availability zone, and architecture.

## How does this PR solve the problem?

### Implementation approach

Added a CLI flag `--additional-nodepool-metric-labels` (environment variable: `ADDITIONAL_NODEPOOL_METRIC_LABELS`) that accepts a comma-separated list of label keys to include in NodePool metrics.

**Default behavior**: No additional labels (empty by default). Users must explicitly configure which labels to include.

### Key design decisions

1. **CLI flag instead of annotations**: Satisfies Prometheus constraint that all time series for a metric must have identical label keys. Label keys are fixed at startup when metrics are registered.

2. **Deferred initialization**: Follows the same pattern as Node metrics controller - metrics are declared as package variables but initialized in `initializeMetrics()` called from `NewController()`. This ensures options are available when building the label key set.

3. **Empty string for missing labels**: If a NodePool doesn't have a specified label, the metric uses an empty string `""` for that label value. This maintains consistent label keys across all NodePools while allowing flexibility.

4. **No defaults**: By not providing default labels, this PR stays focused on providing the capability without making assumptions about which labels exist on users' NodePools.

### Example usage

```bash
# No additional labels (default)
karpenter

# Add custom labels for capacity type, zone, and architecture
karpenter --additional-nodepool-metric-labels=capacity_type,zone,architecture

# Or use environment variable
export ADDITIONAL_NODEPOOL_METRIC_LABELS=environment,team,version
karpenter
```

With a NodePool:
```
apiVersion: karpenter.sh/v1
kind: NodePool
metadata:
  name: production-spot
  labels:
    capacity_type: spot
    zone: us-east-1a
    architecture: amd64
spec:
  limits:
    cpu: "1000"
```

When configured with --additional-nodepool-metric-labels=capacity_type,zone,architecture, produces metrics:
```
karpenter_nodepools_limit{nodepool="production-spot",resource_type="cpu",capacity_type="spot",zone="us-east-1a",architecture="amd64"} 1000
```

Without the flag, produces metrics:
```
karpenter_nodepools_limit{nodepool="production-spot",resource_type="cpu"} 1000
```

## Testing

- Added comprehensive test coverage in suite_test.go:
  - Verifies additional labels are included in metrics when configured
  - Validates empty string behavior for missing labels
  - All 6 tests passing

## Checklist

- Added CLI flag with empty default
- Implemented deferred metric initialization
- Updated controller wiring to pass context
- Added test helper support
- Comprehensive test coverage (6/6 passing)
- Follows existing Node metrics pattern for consistency