### PR TITLE
fix: upgrade Go to 1.25.5 to resolve GO-2025-4155 vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0


### PR DESCRIPTION
## What problem does this PR solve?

Closes #2686 

Resolves security vulnerability GO-2025-4155 in Go's `crypto/x509` package by upgrading from Go 1.25.3 to 1.25.5.

## What is the vulnerability?

GO-2025-4155 affects `crypto/x509.HostnameError.Error()` and can lead to excessive resource consumption when printing error strings for host certificate validation.

**Vulnerability Details**: https://pkg.go.dev/vuln/GO-2025-4155

**Affected Code**: `pkg/controllers/nodepool/validation/controller.go:58:114`

## Changes Made

- Updated `go.mod`: `go 1.25.3` → `go 1.25.5`
- Ran `go mod tidy` (no dependency changes required)
- Verified fix with `make vulncheck` (passes with no vulnerabilities)

## Testing

Before:
```
Vulnerability #1: GO-2025-4155
    Found in: crypto/x509@go1.25.4
    Fixed in: crypto/x509@go1.25.5
```

After:
```
No vulnerabilities found.
```

## Checklist

- [x] Updated Go version in `go.mod`
- [x] Ran `go mod tidy`
- [x] Verified with `make vulncheck`
- [x] No code changes required (standard library fix only)