### PR TITLE
feat: Add prometheus metrics for nodepool disruption decisions performed, active disruptions

### DIFF
--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -151,6 +151,10 @@ var _ = Describe("Drift", func() {
 				metrics.NodePoolLabel: nodePool.Name,
 				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
 			})
+			ExpectMetricGaugeValue(disruption.NodePoolNodesConsumingBudgets, 0, map[string]string{
+				metrics.NodePoolLabel: nodePool.Name,
+				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+			})
 		})
 		It("should disrupt 3 nodes, taking into account commands in progress", func() {
 			nodeClaims, nodes = test.NodeClaimsAndNodes(numNodes, v1.NodeClaim{
@@ -321,6 +325,16 @@ var _ = Describe("Drift", func() {
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 10, map[string]string{
 				metrics.ReasonLabel: "drifted",
 			})
+			for _, np := range nps {
+				ExpectMetricCounterValue(disruption.NodepoolDecisionsPerformed, 1, map[string]string{
+					metrics.NodePoolLabel: np.Name,
+					metrics.ReasonLabel:   "drifted",
+				})
+				ExpectMetricGaugeValue(disruption.NodePoolNodesConsumingBudgets, 0, map[string]string{
+					metrics.NodePoolLabel: nodePool.Name,
+					metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				})
+			}
 		})
 	})
 	Context("Drift", func() {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -271,6 +271,9 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 		NodePoolAllowedDisruptions.Set(float64(allowedDisruptions), map[string]string{
 			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
 		})
+		NodePoolNodesConsumingBudgets.Set(float64(disrupting[nodePool.Name]), map[string]string{
+			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+		})
 		if numNodes[nodePool.Name] != 0 && allowedDisruptions == 0 {
 			recorder.Publish(disruptionevents.NodePoolBlockedForDisruptionReason(nodePool, reason))
 		}

--- a/pkg/controllers/disruption/metrics.go
+++ b/pkg/controllers/disruption/metrics.go
@@ -58,6 +58,16 @@ var (
 		},
 		[]string{decisionLabel, metrics.ReasonLabel, ConsolidationTypeLabel},
 	)
+	NodepoolDecisionsPerformed = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: voluntaryDisruptionSubsystem,
+			Name:      "decisions_by_nodepool_total",
+			Help:      "Number of disruption decisions performed by nodepool. Labeled by nodepool name, disruption decision, reason, and consolidation type.",
+		},
+		[]string{metrics.NodePoolLabel, decisionLabel, metrics.ReasonLabel, ConsolidationTypeLabel},
+	)
 	EligibleNodes = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
 		prometheus.GaugeOpts{
@@ -95,6 +105,16 @@ var (
 			Subsystem: metrics.NodePoolSubsystem,
 			Name:      "allowed_disruptions",
 			Help:      "The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.",
+		},
+		[]string{metrics.NodePoolLabel, metrics.ReasonLabel},
+	)
+	NodePoolNodesConsumingBudgets = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.NodePoolSubsystem,
+			Name:      "nodes_consuming_budgets",
+			Help:      "The number of nodes consuming the budget of a nodepool at a point in time. Labeled by NodePool.",
 		},
 		[]string{metrics.NodePoolLabel, metrics.ReasonLabel},
 	)

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -163,6 +163,7 @@ var _ = AfterEach(func() {
 
 	// Reset the metrics collectors
 	disruption.DecisionsPerformedTotal.Reset()
+	disruption.NodepoolDecisionsPerformed.Reset()
 })
 
 var _ = Describe("Simulate Scheduling", func() {
@@ -1941,6 +1942,11 @@ var _ = Describe("Metrics", func() {
 			"decision":          "delete",
 			metrics.ReasonLabel: "empty",
 		})
+		ExpectMetricCounterValue(disruption.NodepoolDecisionsPerformed, 1, map[string]string{
+			metrics.NodePoolLabel: nodePool.Name,
+			"decision":            "delete",
+			metrics.ReasonLabel:   "empty",
+		})
 	})
 	It("should fire metrics for single node delete disruption", func() {
 		nodeClaims, nodes = nodeClaims[:2], nodes[:2]
@@ -1966,6 +1972,11 @@ var _ = Describe("Metrics", func() {
 			"decision":          "delete",
 			metrics.ReasonLabel: "drifted",
 		})
+		ExpectMetricCounterValue(disruption.NodepoolDecisionsPerformed, 1, map[string]string{
+			metrics.NodePoolLabel: nodePool.Name,
+			"decision":            "delete",
+			metrics.ReasonLabel:   "drifted",
+		})
 	})
 	It("should fire metrics for single node replace disruption", func() {
 		nodeClaim, node := nodeClaims[0], nodes[0]
@@ -1989,6 +2000,11 @@ var _ = Describe("Metrics", func() {
 			"decision":          "replace",
 			metrics.ReasonLabel: "drifted",
 		})
+		ExpectMetricCounterValue(disruption.NodepoolDecisionsPerformed, 1, map[string]string{
+			metrics.NodePoolLabel: nodePool.Name,
+			"decision":            "replace",
+			metrics.ReasonLabel:   "drifted",
+		})
 	})
 	It("should fire metrics for multi-node empty disruption", func() {
 		ExpectApplied(ctx, env.Client, nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodeClaims[2], nodes[2], nodePool)
@@ -2000,6 +2016,12 @@ var _ = Describe("Metrics", func() {
 			"decision":           "delete",
 			metrics.ReasonLabel:  "empty",
 			"consolidation_type": "empty",
+		})
+		ExpectMetricCounterValue(disruption.NodepoolDecisionsPerformed, 1, map[string]string{
+			metrics.NodePoolLabel: nodePool.Name,
+			"decision":            "delete",
+			metrics.ReasonLabel:   "empty",
+			"consolidation_type":  "empty",
 		})
 	})
 	It("should fire metrics for multi-node delete disruption", func() {
@@ -2035,6 +2057,12 @@ var _ = Describe("Metrics", func() {
 			"decision":           "delete",
 			metrics.ReasonLabel:  "underutilized",
 			"consolidation_type": "multi",
+		})
+		ExpectMetricCounterValue(disruption.NodepoolDecisionsPerformed, 1, map[string]string{
+			metrics.NodePoolLabel: nodePool.Name,
+			"decision":            "delete",
+			metrics.ReasonLabel:   "underutilized",
+			"consolidation_type":  "multi",
 		})
 	})
 	It("should fire metrics for multi-node replace disruption", func() {
@@ -2090,6 +2118,12 @@ var _ = Describe("Metrics", func() {
 			"decision":           "replace",
 			metrics.ReasonLabel:  "underutilized",
 			"consolidation_type": "multi",
+		})
+		ExpectMetricCounterValue(disruption.NodepoolDecisionsPerformed, 1, map[string]string{
+			metrics.NodePoolLabel: nodePool.Name,
+			"decision":            "replace",
+			metrics.ReasonLabel:   "underutilized",
+			"consolidation_type":  "multi",
 		})
 	})
 	It("should stop multi-node consolidation after context deadline is reached", func() {


### PR DESCRIPTION
Fixes N/A

**Description**

Adds two new prometheus metrics:

* `karpenter_nodepools_decisions`
* `karpenter_nodepools_active_disruptions`

`karpenter_nodepools_decisions` tracks the same actions as `karpenter_voluntary_disruptions_decisions_total`, but with an extra dimension for the nodepool. As a result, the total count of `karpenter_nodepools_decisions` may be greater than `karpenter_voluntary_disruptions_decisions_total` when 1 decision spans more than 1 nodepool. 

`karpenter_nodepools_active_disruptions` tracks the active number of terminating nodeclaims in each nodepool, which is useful to compare against the existing metric `karpenter_nodepools_allowed_disruptions`. 

This change allows us to track how disrupted individual nodepools are, and measure the consolidation in individual nodepools over time.

**How was this change tested?**

`make presubmit` and tested in our clusters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
