### PR TITLE
fix: use test.RandomName() to prevent test name collisions

### DIFF
--- a/pkg/apis/v1/nodeclaim_validation_cel_test.go
+++ b/pkg/apis/v1/nodeclaim_validation_cel_test.go
@@ -18,9 +18,7 @@ package v1_test
 
 import (
 	"strconv"
-	"strings"
 
-	"github.com/Pallinder/go-randomdata"
 	"github.com/awslabs/operatorpkg/object"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,7 +42,7 @@ var _ = Describe("Validation", func() {
 			Skip("CEL Validation is for 1.25>")
 		}
 		nodeClaim = &NodeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			ObjectMeta: metav1.ObjectMeta{Name: test.RandomName()},
 			Spec: NodeClaimSpec{
 				NodeClassRef: &NodeClassReference{
 					Group: "karpenter.test.sh",

--- a/pkg/apis/v1/nodepool_budgets_test.go
+++ b/pkg/apis/v1/nodepool_budgets_test.go
@@ -18,10 +18,8 @@ package v1_test
 
 import (
 	"math"
-	"strings"
 	"time"
 
-	"github.com/Pallinder/go-randomdata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -29,6 +27,7 @@ import (
 	clock "k8s.io/utils/clock/testing"
 
 	. "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/test"
 )
 
 var _ = Describe("Budgets", func() {
@@ -85,7 +84,7 @@ var _ = Describe("Budgets", func() {
 			},
 		}
 		nodePool = &NodePool{
-			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			ObjectMeta: metav1.ObjectMeta{Name: test.RandomName()},
 			Spec: NodePoolSpec{
 				Disruption: Disruption{
 					Budgets: budgets,

--- a/pkg/apis/v1/nodepool_default_test.go
+++ b/pkg/apis/v1/nodepool_default_test.go
@@ -17,10 +17,8 @@ limitations under the License.
 package v1_test
 
 import (
-	"strings"
 	"time"
 
-	"github.com/Pallinder/go-randomdata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -30,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/test"
 )
 
 var _ = Describe("CEL/Default", func() {
@@ -37,7 +36,7 @@ var _ = Describe("CEL/Default", func() {
 
 	BeforeEach(func() {
 		nodePool = &NodePool{
-			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			ObjectMeta: metav1.ObjectMeta{Name: test.RandomName()},
 			Spec: NodePoolSpec{
 				Template: NodeClaimTemplate{
 					Spec: NodeClaimTemplateSpec{

--- a/pkg/apis/v1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1/nodepool_validation_cel_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	. "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/test"
 )
 
 var _ = Describe("CEL/Validation", func() {
@@ -45,7 +46,7 @@ var _ = Describe("CEL/Validation", func() {
 			Skip("CEL Validation is for 1.25>")
 		}
 		nodePool = &NodePool{
-			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			ObjectMeta: metav1.ObjectMeta{Name: test.RandomName()},
 			Spec: NodePoolSpec{
 				Template: NodeClaimTemplate{
 					Spec: NodeClaimTemplateSpec{

--- a/pkg/apis/v1alpha1/nodeoverlay_validation_test.go
+++ b/pkg/apis/v1alpha1/nodeoverlay_validation_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	. "sigs.k8s.io/karpenter/pkg/apis/v1alpha1"
+	"sigs.k8s.io/karpenter/pkg/test"
 )
 
 var _ = Describe("CEL/Validation", func() {
@@ -38,7 +39,7 @@ var _ = Describe("CEL/Validation", func() {
 
 	BeforeEach(func() {
 		nodeOverlay = &NodeOverlay{
-			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			ObjectMeta: metav1.ObjectMeta{Name: test.RandomName()},
 			Spec: NodeOverlaySpec{
 				Requirements: []corev1.NodeSelectorRequirement{
 					{


### PR DESCRIPTION
Tests were using `randomdata.SillyName()` directly for resource names, which can produce duplicate names when tests run in parallel or cleanup is async. This caused flaky 'already exists' errors like:

- `nodepools.karpenter.sh "slothcerulean" already exists`
- `nodepools.karpenter.sh "antelopewinter" already exists`

`test.RandomName()` appends a sequential counter and random suffix to ensure uniqueness.

Fixes flakes in PRs #2710, #2642, #2673, #2678