### PR TITLE
fix: allow timing variance in rate limiting test

### DIFF
--- a/pkg/events/suite_test.go
+++ b/pkg/events/suite_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Rate Limiting", func() {
 		for i := 0; i < 100; i++ {
 			eventRecorder.Publish(schedulingevents.NominatePodEvent(PodWithUID(), NodeWithUID(), NodeClaimWithUID()))
 		}
-		Expect(internalRecorder.Calls(schedulingevents.NominatePodEvent(PodWithUID(), NodeWithUID(), NodeClaimWithUID()).Reason)).To(Equal(10))
+		Expect(internalRecorder.Calls(schedulingevents.NominatePodEvent(PodWithUID(), NodeWithUID(), NodeClaimWithUID()).Reason)).To(Or(Equal(10), Equal(11))) // 11 can slip through due to timing before rate limiter kicks in
 	})
 	It("should allow many events over time due to smoothed rate limiting", func() {
 		for i := 0; i < 3; i++ {


### PR DESCRIPTION
The rate limiting test asserts exactly 10 events pass through during a burst, but due to token bucket timing variance in CI, sometimes 11 events slip through before the limiter kicks in.

Fixes flaky test: `Rate Limiting - should only create max-burst when many events are created quickly`

Known flakes:
- https://github.com/kubernetes-sigs/karpenter/actions/runs/20119840106/attempts/1