### PR TITLE
test: use random name in registration test to prevent flakes

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -598,10 +598,11 @@ var _ = Describe("Registration", func() {
 		})
 	})
 	It("should not update NodeRegistrationHealthy status condition if nodePool owning the nodeClaim is deleted", func() {
+		nodePoolName := test.RandomName()
 		nodePool = test.NodePool(
 			v1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-nodepool",
+					Name: nodePoolName,
 				},
 			},
 		)
@@ -631,7 +632,7 @@ var _ = Describe("Registration", func() {
 		nodePool = test.NodePool(
 			v1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-nodepool",
+					Name: nodePoolName,
 				},
 			},
 		)


### PR DESCRIPTION
## Problem

The registration test `should not update NodeRegistrationHealthy status condition if nodePool owning the nodeClaim is deleted` uses a hardcoded `"test-nodepool"` name. This causes intermittent failures when:
- Tests run in parallel and another test creates/deletes a NodePool with the same name
- Async garbage collection deletes the NodePool before the test expects

## Flake evidence

```
[FAILED] Expected success, but got an error:
    nodepools.karpenter.sh "test-nodepool" not found
```

Seen in: [#2718](https://github.com/kubernetes-sigs/karpenter/actions/runs/20311265541)

## Fix

Use `test.RandomName()` to generate a unique NodePool name for each test run.