### PR TITLE
test: fix static provisioning cluster sync test flake

### DIFF
--- a/pkg/controllers/static/provisioning/suite_test.go
+++ b/pkg/controllers/static/provisioning/suite_test.go
@@ -560,6 +560,8 @@ var _ = Describe("Static Provisioning Controller", func() {
 				return len(list.Items)
 			}, 5*time.Second).Should(BeNumerically("<=", 10))
 
+			// Ensure cluster is synced before final reconcile
+			cluster.SetSynced(true)
 			ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
 			// at the end we should have right counts in StateNodePool
 			ExpectStateNodePoolCount(cluster, nodePool.Name, 10, 0, 0)


### PR DESCRIPTION
## Problem

The test `should wait for cluster to be synced and not over provision` runs 50 parallel reconciles while randomly setting `cluster.SetSynced(false)`. The final assertion expects 10 NodeClaims via `ExpectStateNodePoolCount(cluster, nodePool.Name, 10, 0, 0)`.

However, if the cluster is still unsynced from a previous goroutine when `ExpectObjectReconciled` runs, the final reconcile won't create the remaining NodeClaims, causing the test to fail with:

```
Expected <int>: 5 to equal <int>: 10
```

## Flake evidence

Seen in 4 PRs:
- [#2683](https://github.com/kubernetes-sigs/karpenter/actions/runs/19909080750)
- [#2670](https://github.com/kubernetes-sigs/karpenter/actions/runs/19798868290)
- [#2586](https://github.com/kubernetes-sigs/karpenter/actions/runs/19250130799)
- [#2676](https://github.com/kubernetes-sigs/karpenter/actions/runs/19841470169)

## Fix

Explicitly set `cluster.SetSynced(true)` before the final reconcile to ensure deterministic behavior.