### PR TITLE
docs: clarify expireAfter behavior and interaction with disruption budgets

### DIFF
--- a/designs/disruption-controls-by-reason.md
+++ b/designs/disruption-controls-by-reason.md
@@ -14,7 +14,9 @@ See further breakdown of some additional scenarios towards the bottom of the doc
 ## Clarifying the requirements and behavior 
 **Reason and Budget Definition:** Users should be able to define an reason and a corresponding budget(s).
 **Supported Reasons:** All disruption Reasons affected by the current Budgets implementation (Underutilized, Empty, Drifted) should be supported. 
-**Default Behavior for Unspecified Reasons:** Budgets should continue to support a default behavior for all disruption reasons. 
+**Default Behavior for Unspecified Reasons:** Budgets should continue to support a default behavior for all disruption reasons.
+
+> **Note on Expiration**: Budgets can control `Drifted`, `Empty`, and `Underutilized` disruption reasons. However, the `Expired` disruption reason (controlled by `expireAfter`) is not subject to budget restrictions as it uses [Forceful Expiration](./forceful-expiration.md). When a node reaches its `expireAfter` deadline, it will be disrupted regardless of budget settings. Conversely, if you have budgets that allow other disruption reasons (e.g., `Drifted`), nodes may be terminated before reaching their `expireAfter` deadline. See the [Forceful Expiration design document](./forceful-expiration.md#important-considerations-for-expireafter) for more details. 
 
 # API Design
 ### Approach A: List Approach With Multiple Reasons per Budget - Recommended


### PR DESCRIPTION
Fixes #2530

**Description**

This PR improves documentation to clarify the behavior of `expireAfter` and its interaction with disruption budgets, addressing confusion reported in issue #2530.

**Problem**
Users were confused about `expireAfter` behavior, mistakenly believing it enforces a minimum node lifetime. In reality, while `expireAfter` sets a maximum node lifetime (ceiling) that triggers forceful expiration, other disruption reasons (Drift, Underutilization, Emptiness) can terminate nodes earlier if allowed by budgets.

**Changes**
- Added "Important Considerations for `expireAfter`" section to forceful-expiration.md explaining:
  - `expireAfter` is a maximum lifetime (ceiling), not a minimum guarantee
  - How other disruption reasons interact with expiration
  - Concrete example showing AMI drift can override `expireAfter` deadline
  - Best practices for enforcing strict node lifetimes
- Added clarifying note to disruption-controls-by-reason.md about:
  - Which disruption reasons are controlled by budgets (Drifted, Empty, Underutilized)
  - Expired reason bypasses budgets (forceful expiration)
  - Cross-reference to forceful-expiration.md for details

**Key Points Clarified**
1. `expireAfter` guarantees nodes won't live *beyond* the specified duration
2. Other disruption mechanisms may terminate nodes *before* that time
3. Expired nodes bypass disruption budgets and `do-not-disrupt` annotations
4. Budget-controlled disruption reasons (Drift, etc.) can terminate nodes earlier than `expireAfter`

**How was this change tested?**
- Verified documentation accuracy against implementation in:
  - `pkg/controllers/nodeclaim/expiration/controller.go` (forceful expiration logic)
  - `pkg/controllers/disruption/controller.go` (disruption method ordering)
  - `pkg/apis/v1/nodepool.go` (DisruptionReason constants)
- Confirmed expiration controller operates independently without budget checks
- Validated example YAML configuration against CRD schema

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.