### PR TITLE
feat: Add option to enabled warmup when leader election is used

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -184,7 +184,7 @@ func NewOperator(o ...option.Function[Options]) (context.Context, *Operator) {
 			// EnableWarmup allows controllers to start their sources (watches/informers) before leader election
 			// is won. This pre-populates caches and improves leader failover time. Only effective when leader
 			// election is enabled, so we only set it when both conditions are true.
-			EnableWarmup: lo.ToPtr(!options.FromContext(ctx).DisableLeaderElection && options.FromContext(ctx).EnableControllerWarmup),
+			EnableWarmup: lo.ToPtr(!options.FromContext(ctx).DisableLeaderElection && !options.FromContext(ctx).DisableControllerWarmup),
 		},
 	}
 	if options.FromContext(ctx).EnableProfiling {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -71,7 +71,7 @@ type Options struct {
 	KubeClientQPS                    int
 	KubeClientBurst                  int
 	EnableProfiling                  bool
-	EnableControllerWarmup           bool
+	DisableControllerWarmup          bool
 	DisableLeaderElection            bool
 	DisableClusterStateObservability bool
 	LeaderElectionName               string
@@ -115,7 +115,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.IntVar(&o.KubeClientQPS, "kube-client-qps", env.WithDefaultInt("KUBE_CLIENT_QPS", 200), "The smoothed rate of qps to kube-apiserver")
 	fs.IntVar(&o.KubeClientBurst, "kube-client-burst", env.WithDefaultInt("KUBE_CLIENT_BURST", 300), "The maximum allowed burst of queries to the kube-apiserver")
 	fs.BoolVarWithEnv(&o.EnableProfiling, "enable-profiling", "ENABLE_PROFILING", false, "Enable the profiling on the metric endpoint")
-	fs.BoolVarWithEnv(&o.EnableControllerWarmup, "enable-controller-warmup", "ENABLE_CONTROLLER_WARMUP", false, "Enable controller warmup to start controller sources before leader election is won. This pre-populates caches and improves leader failover time.")
+	fs.BoolVarWithEnv(&o.DisableControllerWarmup, "disable-controller-warmup", "DISABLE_CONTROLLER_WARMUP", true, "Disable controller warmup which starts controller sources before leader election is won. Controller warmup pre-populates caches and improves leader failover time.")
 	fs.BoolVarWithEnv(&o.DisableLeaderElection, "disable-leader-election", "DISABLE_LEADER_ELECTION", false, "Disable the leader election client before executing the main loop. Disable when running replicated components for high availability is not desired.")
 	fs.BoolVarWithEnv(&o.DisableClusterStateObservability, "disable-cluster-state-observability", "DISABLE_CLUSTER_STATE_OBSERVABILITY", false, "Disable cluster state metrics and events")
 	fs.StringVar(&o.LeaderElectionName, "leader-election-name", env.WithDefaultString("LEADER_ELECTION_NAME", "karpenter-leader-election"), "Leader election name to create and monitor the lease if running outside the cluster")

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Options", func() {
 		"KUBE_CLIENT_QPS",
 		"KUBE_CLIENT_BURST",
 		"ENABLE_PROFILING",
-		"ENABLE_CONTROLLER_WARMUP",
+		"DISABLE_CONTROLLER_WARMUP",
 		"DISABLE_LEADER_ELECTION",
 		"DISABLE_CLUSTER_STATE_OBSERVABILITY",
 		"LEADER_ELECTION_NAMESPACE",
@@ -107,7 +107,7 @@ var _ = Describe("Options", func() {
 				KubeClientQPS:                    lo.ToPtr(200),
 				KubeClientBurst:                  lo.ToPtr(300),
 				EnableProfiling:                  lo.ToPtr(false),
-				EnableControllerWarmup:           lo.ToPtr(false),
+				DisableControllerWarmup:          lo.ToPtr(true),
 				DisableLeaderElection:            lo.ToPtr(false),
 				DisableClusterStateObservability: lo.ToPtr(false),
 				LeaderElectionName:               lo.ToPtr("karpenter-leader-election"),
@@ -142,7 +142,7 @@ var _ = Describe("Options", func() {
 				"--kube-client-qps", "0",
 				"--kube-client-burst", "0",
 				"--enable-profiling",
-				"--enable-controller-warmup",
+				"--disable-controller-warmup=false",
 				"--disable-leader-election=true",
 				"--disable-cluster-state-observability=true",
 				"--leader-election-name=karpenter-controller",
@@ -165,7 +165,7 @@ var _ = Describe("Options", func() {
 				KubeClientQPS:                    lo.ToPtr(0),
 				KubeClientBurst:                  lo.ToPtr(0),
 				EnableProfiling:                  lo.ToPtr(true),
-				EnableControllerWarmup:           lo.ToPtr(true),
+				DisableControllerWarmup:          lo.ToPtr(false),
 				DisableLeaderElection:            lo.ToPtr(true),
 				DisableClusterStateObservability: lo.ToPtr(true),
 				LeaderElectionName:               lo.ToPtr("karpenter-controller"),
@@ -196,7 +196,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("KUBE_CLIENT_QPS", "0")
 			os.Setenv("KUBE_CLIENT_BURST", "0")
 			os.Setenv("ENABLE_PROFILING", "true")
-			os.Setenv("ENABLE_CONTROLLER_WARMUP", "true")
+			os.Setenv("DISABLE_CONTROLLER_WARMUP", "false")
 			os.Setenv("DISABLE_LEADER_ELECTION", "true")
 			os.Setenv("DISABLE_CLUSTER_STATE_OBSERVABILITY", "true")
 			os.Setenv("LEADER_ELECTION_NAME", "karpenter-controller")
@@ -223,7 +223,7 @@ var _ = Describe("Options", func() {
 				KubeClientQPS:                    lo.ToPtr(0),
 				KubeClientBurst:                  lo.ToPtr(0),
 				EnableProfiling:                  lo.ToPtr(true),
-				EnableControllerWarmup:           lo.ToPtr(true),
+				DisableControllerWarmup:          lo.ToPtr(false),
 				DisableLeaderElection:            lo.ToPtr(true),
 				DisableClusterStateObservability: lo.ToPtr(true),
 				LeaderElectionName:               lo.ToPtr("karpenter-controller"),
@@ -253,7 +253,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("KUBE_CLIENT_QPS", "0")
 			os.Setenv("KUBE_CLIENT_BURST", "0")
 			os.Setenv("ENABLE_PROFILING", "true")
-			os.Setenv("ENABLE_CONTROLLER_WARMUP", "true")
+			os.Setenv("DISABLE_CONTROLLER_WARMUP", "false")
 			os.Setenv("DISABLE_LEADER_ELECTION", "true")
 			os.Setenv("DISABLE_CLUSTER_STATE_OBSERVABILITY", "true")
 			os.Setenv("MEMORY_LIMIT", "0")
@@ -283,7 +283,7 @@ var _ = Describe("Options", func() {
 				KubeClientQPS:                    lo.ToPtr(0),
 				KubeClientBurst:                  lo.ToPtr(0),
 				EnableProfiling:                  lo.ToPtr(true),
-				EnableControllerWarmup:           lo.ToPtr(true),
+				DisableControllerWarmup:          lo.ToPtr(false),
 				DisableLeaderElection:            lo.ToPtr(true),
 				DisableClusterStateObservability: lo.ToPtr(true),
 				LeaderElectionName:               lo.ToPtr("karpenter-leader-election"),
@@ -389,7 +389,7 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.KubeClientQPS).To(Equal(optsB.KubeClientQPS))
 	Expect(optsA.KubeClientBurst).To(Equal(optsB.KubeClientBurst))
 	Expect(optsA.EnableProfiling).To(Equal(optsB.EnableProfiling))
-	Expect(optsA.EnableControllerWarmup).To(Equal(optsB.EnableControllerWarmup))
+	Expect(optsA.DisableControllerWarmup).To(Equal(optsB.DisableControllerWarmup))
 	Expect(optsA.DisableLeaderElection).To(Equal(optsB.DisableLeaderElection))
 	Expect(optsA.DisableClusterStateObservability).To(Equal(optsB.DisableClusterStateObservability))
 	Expect(optsA.MemoryLimit).To(Equal(optsB.MemoryLimit))

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -34,7 +34,7 @@ type OptionsFields struct {
 	KubeClientQPS                    *int
 	KubeClientBurst                  *int
 	EnableProfiling                  *bool
-	EnableControllerWarmup           *bool
+	DisableControllerWarmup          *bool
 	DisableLeaderElection            *bool
 	DisableClusterStateObservability *bool
 	LeaderElectionName               *string
@@ -75,7 +75,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		KubeClientQPS:                    lo.FromPtrOr(opts.KubeClientQPS, 200),
 		KubeClientBurst:                  lo.FromPtrOr(opts.KubeClientBurst, 300),
 		EnableProfiling:                  lo.FromPtrOr(opts.EnableProfiling, false),
-		EnableControllerWarmup:           lo.FromPtrOr(opts.EnableControllerWarmup, false),
+		DisableControllerWarmup:          lo.FromPtrOr(opts.DisableControllerWarmup, true),
 		DisableLeaderElection:            lo.FromPtrOr(opts.DisableLeaderElection, false),
 		DisableClusterStateObservability: lo.FromPtrOr(opts.DisableClusterStateObservability, false),
 		MemoryLimit:                      lo.FromPtrOr(opts.MemoryLimit, -1),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Add option to enable controller runtime warm up when leader election is used. Warm up allows non-leader pods to warm up k8s cache and watch for events hydrating the informer cache even when it isn't the leader. This allows faster fail over (don't have to hydrate informer after leader changes).

**How was this change tested?**
- Ran with the change. Follower memory didn't increase dramatically (note that this is simply the informer cache, any subsequent caches that is built after pod is created isn't ran until it becomes leader)
- Attempted to force a leader election by killing the leader and making sure follower comes up normally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
