### PR TITLE
feat: Add Pod Disruption Schedule

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -49,6 +49,8 @@ const (
 // Karpenter specific annotations
 const (
 	DoNotDisruptAnnotationKey                  = apis.Group + "/do-not-disrupt"
+	DisruptionScheduleAnnotationKey            = apis.Group + "/disruption-schedule"
+	DisruptionScheduleDurationAnnotationKey    = apis.Group + "/disruption-schedule-duration"
 	ProviderCompatibilityAnnotationKey         = apis.CompatibilityGroup + "/provider"
 	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"
 	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"

--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -137,7 +137,7 @@ func (c *consolidation) sortCandidates(candidates []*Candidate) []*Candidate {
 func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	var err error
 	// Run scheduling simulation to compute consolidation option
-	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, candidates...)
+	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, c.clock, candidates...)
 	if err != nil {
 		// if a candidate node is now deleting, just retry
 		if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -103,7 +103,7 @@ func NewMethods(clk clock.Clock, cluster *state.Cluster, kubeClient client.Clien
 		// Terminate and create replacement for drifted NodeClaims in Static NodePool
 		NewStaticDrift(cluster, provisioner, cp),
 		// Terminate any NodeClaims that have drifted from provisioning specifications, allowing the pods to reschedule.
-		NewDrift(kubeClient, cluster, provisioner, recorder),
+		NewDrift(clk, kubeClient, cluster, provisioner, recorder),
 		// Attempt to identify multiple NodeClaims that we can consolidate simultaneously to reduce pod churn
 		NewMultiNodeConsolidation(c),
 		// And finally fall back our single NodeClaim consolidation to further reduce cluster cost.

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -1010,7 +1010,7 @@ var _ = Describe("Drift", func() {
 			for _, nc := range nodeClaims {
 				nc.StatusConditions().SetTrue(v1.ConditionTypeDrifted)
 			}
-			drift := disruption.NewDrift(env.Client, cluster, prov, recorder)
+			drift := disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder)
 
 			ExpectApplied(ctx, env.Client, staticNp, nodeClaims[0], nodeClaims[1], nodes[0], nodes[1])
 

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -49,7 +49,7 @@ import (
 var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 
 //nolint:gocyclo
-func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *state.Cluster, provisioner *provisioning.Provisioner,
+func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *state.Cluster, provisioner *provisioning.Provisioner, clk clock.Clock,
 	candidates ...*Candidate,
 ) (scheduling.Results, error) {
 	candidateNames := sets.NewString(lo.Map(candidates, func(t *Candidate, i int) string { return t.Name() })...)
@@ -83,13 +83,13 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	}
 	for _, n := range candidates {
 		currentlyReschedulablePods := lo.Filter(n.reschedulablePods, func(p *corev1.Pod, _ int) bool {
-			return pdbs.IsCurrentlyReschedulable(p)
+			return pdbs.IsCurrentlyReschedulable(p, clk)
 		})
 		pods = append(pods, currentlyReschedulablePods...)
 	}
 
 	// We get the pods that are on nodes that are deleting
-	deletingNodePods, err := deletingNodes.CurrentlyReschedulablePods(ctx, kubeClient)
+	deletingNodePods, err := deletingNodes.CurrentlyReschedulablePods(ctx, kubeClient, clk)
 	if err != nil {
 		return scheduling.Results{}, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
 	}

--- a/pkg/controllers/disruption/queue_test.go
+++ b/pkg/controllers/disruption/queue_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Queue", func() {
 
 			stateNode := ExpectStateNodeExists(cluster, node1)
 			cmd := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},
@@ -132,7 +132,7 @@ var _ = Describe("Queue", func() {
 			}
 
 			cmd := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},
@@ -157,7 +157,7 @@ var _ = Describe("Queue", func() {
 			}
 
 			cmd := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},
@@ -188,7 +188,7 @@ var _ = Describe("Queue", func() {
 			}
 
 			cmd := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},
@@ -218,7 +218,7 @@ var _ = Describe("Queue", func() {
 			}
 
 			cmd := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},
@@ -271,7 +271,7 @@ var _ = Describe("Queue", func() {
 			}
 
 			cmd := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},
@@ -315,7 +315,7 @@ var _ = Describe("Queue", func() {
 			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
 
 			cmd := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},
@@ -352,7 +352,7 @@ var _ = Describe("Queue", func() {
 			}}
 
 			cmd := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},
@@ -361,7 +361,7 @@ var _ = Describe("Queue", func() {
 			}
 			Expect(queue.StartCommand(ctx, cmd)).To(BeNil())
 			cmd2 := &disruption.Command{
-				Method:            disruption.NewDrift(env.Client, cluster, prov, recorder),
+				Method:            disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 				CreationTimestamp: fakeClock.Now(),
 				ID:                uuid.New(),
 				Results:           scheduling.Results{},

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, stateNode, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(Succeed())
 
-		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, candidate)
+		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, fakeClock, candidate)
 		Expect(err).To(Succeed())
 		Expect(results.PodErrors[pod]).To(BeNil())
 	})
@@ -1879,7 +1879,7 @@ var _ = Describe("Candidate Filtering", func() {
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
-		cmd := &disruption.Command{Method: disruption.NewDrift(env.Client, cluster, prov, recorder), Results: pscheduling.Results{}, Candidates: []*disruption.Candidate{{StateNode: cluster.DeepCopyNodes()[0], NodePool: nodePool}}, Replacements: nil}
+		cmd := &disruption.Command{Method: disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder), Results: pscheduling.Results{}, Candidates: []*disruption.Candidate{{StateNode: cluster.DeepCopyNodes()[0], NodePool: nodePool}}, Replacements: nil}
 		Expect(queue.StartCommand(ctx, cmd))
 
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, fakeClock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -111,7 +111,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	}
 	// We only care if instanceType in non-empty consolidation to do price-comparison.
 	instanceType := instanceTypeMap[node.Labels()[corev1.LabelInstanceTypeStable]]
-	if pods, err = node.ValidatePodsDisruptable(ctx, kubeClient, pdbs); err != nil {
+	if pods, err = node.ValidatePodsDisruptable(ctx, kubeClient, pdbs, clk); err != nil {
 		// If the NodeClaim has a TerminationGracePeriod set and the disruption class is eventual, the node should be
 		// considered a candidate even if there's a pod that will block eviction. Other error types should still cause
 		// failure creating the candidate.

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -259,7 +259,7 @@ func (v *validation) validateCommand(ctx context.Context, cmd Command, candidate
 	if len(candidates) == 0 {
 		return NewValidationError(fmt.Errorf("no candidates"))
 	}
-	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, candidates...)
+	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, v.clock, candidates...)
 	if err != nil {
 		return fmt.Errorf("simluating scheduling, %w", err)
 	}

--- a/pkg/controllers/disruption/validation_test.go
+++ b/pkg/controllers/disruption/validation_test.go
@@ -51,7 +51,7 @@ func NewMethodsWithNopValidator() []disruption.Method {
 	return []disruption.Method{
 		emptiness,
 		disruption.NewStaticDrift(cluster, prov, cloudProvider),
-		disruption.NewDrift(env.Client, cluster, prov, recorder),
+		disruption.NewDrift(fakeClock, env.Client, cluster, prov, recorder),
 		multiNodeConsolidation,
 		singleNodeConsolidation,
 	}

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -109,7 +109,7 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 	for _, group := range podGroups {
 		if len(group) > 0 {
 			// Only add pods to the eviction queue that haven't been evicted yet
-			t.evictionQueue.Add(lo.Filter(group, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p) })...)
+			t.evictionQueue.Add(lo.Filter(group, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p, t.clock) })...)
 			return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", lo.SumBy(podGroups, func(pods []*corev1.Pod) int { return len(pods) })))
 		}
 	}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -329,7 +329,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	// We do this after getting the pending pods so that we undershoot if pods are
 	// actively migrating from a node that is being deleted
 	// NOTE: The assumption is that these nodes are cordoned and no additional pods will schedule to them
-	deletingNodePods, err := nodes.Deleting().CurrentlyReschedulablePods(ctx, p.kubeClient)
+	deletingNodePods, err := nodes.Deleting().CurrentlyReschedulablePods(ctx, p.kubeClient, p.clock)
 	if err != nil {
 		return scheduler.Results{}, err
 	}

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -147,7 +148,7 @@ func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (
 }
 
 // GetCurrentlyReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
-func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
+func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client, clk clock.Clock, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
 	pods, err := GetPods(ctx, kubeClient, nodes...)
 	if err != nil {
 		return nil, fmt.Errorf("listing pods, %w", err)
@@ -159,7 +160,7 @@ func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client
 	}
 
 	return lo.Filter(pods, func(p *corev1.Pod, _ int) bool {
-		return pdbs.IsCurrentlyReschedulable(p)
+		return pdbs.IsCurrentlyReschedulable(p, clk)
 	}), nil
 }
 

--- a/pkg/utils/pod/schedule.go
+++ b/pkg/utils/pod/schedule.go
@@ -1,0 +1,119 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+const (
+	// DefaultDisruptionScheduleDuration is the default duration for a disruption schedule window
+	// when the duration annotation is not specified.
+	DefaultDisruptionScheduleDuration = "1h"
+)
+
+// DisruptionScheduleResult holds the result of evaluating a pod's disruption schedule.
+type DisruptionScheduleResult struct {
+	// HasSchedule indicates whether the pod has a disruption schedule annotation.
+	HasSchedule bool
+	// IsActive indicates whether disruption is currently allowed.
+	// True if: no schedule is set, schedule is active, or schedule is invalid (fail-open).
+	IsActive bool
+	// InvalidSchedule indicates the cron expression was invalid.
+	InvalidSchedule bool
+	// InvalidDuration indicates the duration was invalid.
+	InvalidDuration bool
+	// ErrorMessage contains details about any parsing errors.
+	ErrorMessage string
+}
+
+// EvaluateDisruptionSchedule checks if a pod's disruption schedule allows disruption at the current time.
+// It returns a result indicating whether the pod can be disrupted and any parsing errors.
+//
+// Behavior:
+//   - If no schedule annotation is set, returns HasSchedule=false, IsActive=true (always disruptable)
+//   - If schedule is invalid, returns IsActive=true (fail-open) with InvalidSchedule=true
+//   - If duration is invalid, returns IsActive=true (fail-open) with InvalidDuration=true
+//   - If current time is within the schedule window, returns IsActive=true
+//   - If current time is outside the schedule window, returns IsActive=false
+func EvaluateDisruptionSchedule(pod *corev1.Pod, clk clock.Clock) DisruptionScheduleResult {
+	if pod.Annotations == nil {
+		return DisruptionScheduleResult{HasSchedule: false, IsActive: true}
+	}
+
+	scheduleStr := pod.Annotations[v1.DisruptionScheduleAnnotationKey]
+	if scheduleStr == "" {
+		return DisruptionScheduleResult{HasSchedule: false, IsActive: true}
+	}
+
+	// Parse duration (default to 1h if not specified)
+	durationStr := pod.Annotations[v1.DisruptionScheduleDurationAnnotationKey]
+	if durationStr == "" {
+		durationStr = DefaultDisruptionScheduleDuration
+	}
+
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil || duration <= 0 {
+		return DisruptionScheduleResult{
+			HasSchedule:     true,
+			IsActive:        true, // fail-open
+			InvalidDuration: true,
+			ErrorMessage:    fmt.Sprintf("invalid duration %q: %v", durationStr, err),
+		}
+	}
+
+	// Parse cron schedule (standard 5-field format, UTC timezone)
+	// Follows the same pattern as Budget.IsActive() in pkg/apis/v1/nodepool.go
+	schedule, err := cron.ParseStandard(fmt.Sprintf("TZ=UTC %s", scheduleStr))
+	if err != nil {
+		return DisruptionScheduleResult{
+			HasSchedule:     true,
+			IsActive:        true, // fail-open
+			InvalidSchedule: true,
+			ErrorMessage:    fmt.Sprintf("invalid cron schedule %q: %v", scheduleStr, err),
+		}
+	}
+
+	// Check if current time is within the disruption window.
+	// Walk back in time by the duration and check if the next schedule hit is before now.
+	// If the last schedule hit is within the duration window, disruption is active.
+	now := clk.Now().UTC()
+	checkPoint := now.Add(-duration)
+	nextHit := schedule.Next(checkPoint)
+	isActive := !nextHit.After(now)
+
+	return DisruptionScheduleResult{
+		HasSchedule: true,
+		IsActive:    isActive,
+	}
+}
+
+// IsWithinDisruptionSchedule returns true if the pod can be disrupted based on its schedule.
+// Returns true if:
+//   - No schedule annotation is set (always disruptable)
+//   - Schedule is set and current time is within the window
+//   - Schedule is invalid (fail-open behavior)
+func IsWithinDisruptionSchedule(pod *corev1.Pod, clk clock.Clock) bool {
+	return EvaluateDisruptionSchedule(pod, clk).IsActive
+}

--- a/pkg/utils/pod/schedule_test.go
+++ b/pkg/utils/pod/schedule_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clock "k8s.io/utils/clock/testing"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/utils/pod"
+)
+
+func TestSchedule(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pod Schedule")
+}
+
+var _ = Describe("IsDisruptable", func() {
+	var fakeClock *clock.FakeClock
+	var testPod *corev1.Pod
+
+	BeforeEach(func() {
+		fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 17, 2, 30, 0, 0, time.UTC))
+		testPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		}
+	})
+
+	It("should return true for pods without any disruption annotations", func() {
+		Expect(pod.IsDisruptable(testPod, fakeClock)).To(BeTrue())
+	})
+
+	It("should return false for pods with do-not-disrupt annotation", func() {
+		testPod.Annotations = map[string]string{
+			v1.DoNotDisruptAnnotationKey: "true",
+		}
+		Expect(pod.IsDisruptable(testPod, fakeClock)).To(BeFalse())
+	})
+
+	It("should return true for terminal pods even with do-not-disrupt annotation", func() {
+		testPod.Annotations = map[string]string{
+			v1.DoNotDisruptAnnotationKey: "true",
+		}
+		testPod.Status.Phase = corev1.PodSucceeded
+		Expect(pod.IsDisruptable(testPod, fakeClock)).To(BeTrue())
+	})
+
+	It("should return false when outside disruption schedule window", func() {
+		// Set clock to a time outside the Saturday 2 AM window
+		fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 17, 10, 0, 0, 0, time.UTC))
+		testPod.Annotations = map[string]string{
+			v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+			v1.DisruptionScheduleDurationAnnotationKey: "4h",
+		}
+		Expect(pod.IsDisruptable(testPod, fakeClock)).To(BeFalse())
+	})
+
+	It("should return true when inside disruption schedule window", func() {
+		testPod.Annotations = map[string]string{
+			v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+			v1.DisruptionScheduleDurationAnnotationKey: "4h",
+		}
+		Expect(pod.IsDisruptable(testPod, fakeClock)).To(BeTrue())
+	})
+
+	It("do-not-disrupt should take precedence over schedule", func() {
+		// Even with an active schedule, do-not-disrupt blocks disruption
+		testPod.Annotations = map[string]string{
+			v1.DoNotDisruptAnnotationKey:               "true",
+			v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+			v1.DisruptionScheduleDurationAnnotationKey: "4h",
+		}
+		Expect(pod.IsDisruptable(testPod, fakeClock)).To(BeFalse())
+	})
+})
+
+var _ = Describe("DisruptionSchedule", func() {
+	var fakeClock *clock.FakeClock
+	var testPod *corev1.Pod
+
+	BeforeEach(func() {
+		// Set the time to Saturday 2 AM UTC (within typical maintenance window)
+		// June 17, 2000 is a Saturday
+		fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 17, 2, 30, 0, 0, time.UTC))
+		testPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+		}
+	})
+
+	Context("EvaluateDisruptionSchedule", func() {
+		It("should return HasSchedule=false and IsActive=true when no annotations exist", func() {
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeFalse())
+			Expect(result.IsActive).To(BeTrue())
+		})
+
+		It("should return HasSchedule=false and IsActive=true when schedule annotation is empty", func() {
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey: "",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeFalse())
+			Expect(result.IsActive).To(BeTrue())
+		})
+
+		It("should return IsActive=true when current time is within the schedule window", func() {
+			// Schedule: 2 AM on Saturdays, duration: 4h
+			// Current time: Saturday 2:30 AM (within window)
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+				v1.DisruptionScheduleDurationAnnotationKey: "4h",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeTrue())
+			Expect(result.InvalidSchedule).To(BeFalse())
+			Expect(result.InvalidDuration).To(BeFalse())
+		})
+
+		It("should return IsActive=false when current time is outside the schedule window", func() {
+			// Schedule: 2 AM on Saturdays, duration: 1h
+			// Current time: Saturday 2:30 AM (outside 1h window that ended at 3 AM)
+			// Actually wait, 2:30 AM is still within the window from 2 AM to 3 AM
+			// Let's set the clock to 4 AM which is definitely outside
+			fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 17, 4, 0, 0, 0, time.UTC))
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+				v1.DisruptionScheduleDurationAnnotationKey: "1h",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeFalse())
+		})
+
+		It("should return IsActive=true and InvalidSchedule=true for invalid cron expression (fail-open)", func() {
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "invalid-cron",
+				v1.DisruptionScheduleDurationAnnotationKey: "1h",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeTrue()) // fail-open
+			Expect(result.InvalidSchedule).To(BeTrue())
+			Expect(result.ErrorMessage).To(ContainSubstring("invalid cron schedule"))
+		})
+
+		It("should return IsActive=true and InvalidDuration=true for invalid duration (fail-open)", func() {
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+				v1.DisruptionScheduleDurationAnnotationKey: "not-a-duration",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeTrue()) // fail-open
+			Expect(result.InvalidDuration).To(BeTrue())
+			Expect(result.ErrorMessage).To(ContainSubstring("invalid duration"))
+		})
+
+		It("should return IsActive=true and InvalidDuration=true for negative duration (fail-open)", func() {
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+				v1.DisruptionScheduleDurationAnnotationKey: "-1h",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeTrue()) // fail-open
+			Expect(result.InvalidDuration).To(BeTrue())
+		})
+
+		It("should use default duration of 1h when duration annotation is not specified", func() {
+			// Schedule: 2 AM on Saturdays (default duration: 1h)
+			// Current time: Saturday 2:30 AM (within 1h window)
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey: "0 2 * * 6",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeTrue())
+
+			// Move clock past 1h window
+			fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 17, 3, 30, 0, 0, time.UTC))
+			result = pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.IsActive).To(BeFalse())
+		})
+
+		It("should handle @daily schedule shorthand", func() {
+			// @daily means 0 0 * * * (midnight every day)
+			// Set clock to just after midnight
+			fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 17, 0, 30, 0, 0, time.UTC))
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "@daily",
+				v1.DisruptionScheduleDurationAnnotationKey: "1h",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeTrue())
+		})
+
+		It("should handle @weekly schedule shorthand", func() {
+			// @weekly means 0 0 * * 0 (midnight on Sunday)
+			// Set clock to Sunday midnight + 30 min
+			// June 18, 2000 is a Sunday
+			fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 18, 0, 30, 0, 0, time.UTC))
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "@weekly",
+				v1.DisruptionScheduleDurationAnnotationKey: "2h",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeTrue())
+		})
+
+		It("should always evaluate schedule in UTC", func() {
+			// The clock is in a non-UTC timezone, but schedule should be evaluated in UTC
+			fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 17, 2, 30, 0, 0, time.FixedZone("UTC+5", 5*3600)))
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+				v1.DisruptionScheduleDurationAnnotationKey: "4h",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			// The schedule is evaluated in UTC. At 2:30 AM in UTC+5, it's 9:30 PM UTC on Friday
+			// which is outside the Saturday 2 AM window
+			Expect(result.HasSchedule).To(BeTrue())
+			Expect(result.IsActive).To(BeFalse())
+		})
+
+		It("should handle overlapping schedule windows correctly", func() {
+			// Set up a schedule that runs every hour for 2 hours (always active)
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "0 * * * *",
+				v1.DisruptionScheduleDurationAnnotationKey: "2h",
+			}
+			result := pod.EvaluateDisruptionSchedule(testPod, fakeClock)
+			Expect(result.IsActive).To(BeTrue())
+		})
+	})
+
+	Context("IsWithinDisruptionSchedule", func() {
+		It("should return true when no schedule is set", func() {
+			Expect(pod.IsWithinDisruptionSchedule(testPod, fakeClock)).To(BeTrue())
+		})
+
+		It("should return true when within schedule window", func() {
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+				v1.DisruptionScheduleDurationAnnotationKey: "4h",
+			}
+			Expect(pod.IsWithinDisruptionSchedule(testPod, fakeClock)).To(BeTrue())
+		})
+
+		It("should return false when outside schedule window", func() {
+			fakeClock = clock.NewFakeClock(time.Date(2000, time.June, 17, 10, 0, 0, 0, time.UTC))
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey:         "0 2 * * 6",
+				v1.DisruptionScheduleDurationAnnotationKey: "4h",
+			}
+			Expect(pod.IsWithinDisruptionSchedule(testPod, fakeClock)).To(BeFalse())
+		})
+
+		It("should return true for invalid schedule (fail-open)", func() {
+			testPod.Annotations = map[string]string{
+				v1.DisruptionScheduleAnnotationKey: "invalid",
+			}
+			Expect(pod.IsWithinDisruptionSchedule(testPod, fakeClock)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1719 <!-- issue number -->
Related to #2744 (RFC)

**Description**
This is a renewal of https://github.com/kubernetes-sigs/karpenter/pull/1720 and adds the ability to define a pod disruption schedule at the pod-level which behaves somewhat akin to nodepool disruption budgets.

Note: This was mostly AI generated but I have reviewed and understand the implementation. I've built a custom controller that runs alongside Karpenter with similar logic and have previously added this functionality in #1720.

**How was this change tested?**
Add tests and will run inside a real cluster and update this comment with validation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
