### PR TITLE
docs: fix timezone link formatting for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Bi-weekly meetings alternating between Thursdays @ 9:00 PT ([convert to your tim
 Weekly meetings alternating between repositories and time slots. Please check the calendar invite for specific dates:
 
 **kubernetes-sigs/karpenter**:
-- Alternating Mondays @ 9:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=Seattle)) and @ 15:00 PT [convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=Seattle) monthly
+- Alternating Mondays @ 9:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=Seattle)) and @ 15:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=Seattle)) monthly
 
 **aws/karpenter-provider-aws**:
-- Alternating Mondays @ 9:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=Seattle)) and @ 15:00 PT [convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=Seattle) monthly
+- Alternating Mondays @ 9:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=Seattle)) and @ 15:00 PT ([convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=Seattle)) monthly
 
 #### Meeting Resources
 - **Zoom Link**: [Join Meeting](https://zoom.us/j/95618088729) (password: 77777)


### PR DESCRIPTION
**Description**

I'm adding these parenthesis to match the format of the surrounding timezone links.

This is my first PR, I'll use it to sign my CLA as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<img width="618" height="373" alt="Screenshot 2025-12-26 at 10 01 05 AM" src="https://github.com/user-attachments/assets/9251d69b-59e5-4090-822a-52247117757e" />
