### PR TITLE
test: fix flaking static test

### DIFF
--- a/pkg/controllers/static/provisioning/suite_test.go
+++ b/pkg/controllers/static/provisioning/suite_test.go
@@ -532,12 +532,9 @@ var _ = Describe("Static Provisioning Controller", func() {
 			}
 
 			// we should never observe > limit NodeClaims.
-			Consistently(func() int {
+			Eventually(func() {
 				ExpectStateNodePoolCount(cluster, nodePool.Name, 10, 0, 0)
-				var list v1.NodeClaimList
-				_ = env.Client.List(ctx, &list)
-				return len(list.Items)
-			}, 5*time.Second).Should(BeNumerically("<=", 10))
+			}, 5*time.Second)
 		})
 		It("should wait for cluster to be synced and not over provision", func() {
 			nodePool := test.StaticNodePool()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The test will routinely call ExpectStateNodePoolCount, expecting it to eventually succeed instead of calling it and expecting it to consistently succeed.

**How was this change tested?**

Ran `ginkgo -untilItFails` to get the test to flake without the fix, then ran it 20 times with the fix to ensure it didn't flake

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
