### PR TITLE
fix: deflake nomination test by using injected clock

### DIFF
--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -93,7 +93,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	if queue.HasAny(node.ProviderID()) {
 		return nil, fmt.Errorf("candidate is already being disrupted")
 	}
-	if err = node.ValidateNodeDisruptable(); err != nil {
+	if err = node.ValidateNodeDisruptable(clk); err != nil {
 		// Only emit an event if the NodeClaim is not nil, ensuring that we only emit events for Karpenter-managed nodes
 		if node.NodeClaim != nil {
 			recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, pretty.Sentence(err.Error()))...)

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -262,7 +262,7 @@ func (c *Cluster) IsNodeNominated(providerID string) bool {
 	defer c.mu.RUnlock()
 
 	if n, ok := c.nodes[providerID]; ok {
-		return n.Nominated()
+		return n.Nominated(c.clock)
 	}
 	return false
 }
@@ -273,7 +273,7 @@ func (c *Cluster) NominateNodeForPod(ctx context.Context, providerID string) {
 	defer c.mu.Unlock()
 
 	if n, ok := c.nodes[providerID]; ok {
-		n.Nominate(ctx) // extends nomination window if already nominated
+		n.Nominate(ctx, c.clock) // extends nomination window if already nominated
 	}
 }
 

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -199,7 +200,7 @@ func (in *StateNode) Pods(ctx context.Context, kubeClient client.Client) ([]*cor
 // ValidateNodeDisruptable takes in a recorder to emit events on the nodeclaims when the state node is not a candidate
 //
 //nolint:gocyclo
-func (in *StateNode) ValidateNodeDisruptable() error {
+func (in *StateNode) ValidateNodeDisruptable(clk clock.Clock) error {
 	if in.NodeClaim == nil {
 		return fmt.Errorf("node isn't managed by karpenter")
 	}
@@ -213,7 +214,7 @@ func (in *StateNode) ValidateNodeDisruptable() error {
 		return fmt.Errorf("node is deleting or marked for deletion")
 	}
 	// skip the node if it is nominated by a recent provisioning pass to be the target of a pending pod.
-	if in.Nominated() {
+	if in.Nominated(clk) {
 		return fmt.Errorf("node is nominated for a pending pod")
 	}
 	if in.Annotations()[v1.DoNotDisruptAnnotationKey] == "true" {
@@ -428,12 +429,12 @@ func (in *StateNode) Deleted() bool {
 		(in.Node != nil && in.NodeClaim == nil && !in.Node.DeletionTimestamp.IsZero())
 }
 
-func (in *StateNode) Nominate(ctx context.Context) {
-	in.nominatedUntil = metav1.Time{Time: time.Now().Add(nominationWindow(ctx))}
+func (in *StateNode) Nominate(ctx context.Context, clk clock.Clock) {
+	in.nominatedUntil = metav1.Time{Time: clk.Now().Add(nominationWindow(ctx))}
 }
 
-func (in *StateNode) Nominated() bool {
-	return in.nominatedUntil.After(time.Now())
+func (in *StateNode) Nominated(clk clock.Clock) bool {
+	return in.nominatedUntil.After(clk.Now())
 }
 
 func (in *StateNode) Managed() bool {

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1008,11 +1008,11 @@ var _ = Describe("Node Resource Level", func() {
 		cluster.NominateNodeForPod(ctx, node.Spec.ProviderID)
 
 		// Expect that the node is now nominated
-		Expect(ExpectStateNodeExists(cluster, node).Nominated()).To(BeTrue())
-		time.Sleep(time.Second * 10) // nomination window is 20s so it should still be nominated
-		Expect(ExpectStateNodeExists(cluster, node).Nominated()).To(BeTrue())
-		time.Sleep(time.Second * 11) // past 20s, node should no longer be nominated
-		Expect(ExpectStateNodeExists(cluster, node).Nominated()).To(BeFalse())
+		Expect(ExpectStateNodeExists(cluster, node).Nominated(fakeClock)).To(BeTrue())
+		fakeClock.Step(time.Second * 10) // nomination window is 20s so it should still be nominated
+		Expect(ExpectStateNodeExists(cluster, node).Nominated(fakeClock)).To(BeTrue())
+		fakeClock.Step(time.Second * 11) // past 20s, node should no longer be nominated
+		Expect(ExpectStateNodeExists(cluster, node).Nominated(fakeClock)).To(BeFalse())
 	})
 	It("should handle a node changing from no providerID to registering a providerID", func() {
 		node := test.Node()


### PR DESCRIPTION
## Description

The nomination test was flaky because `Nominate()` and `Nominated()` used `time.Now()` directly while the test used `time.Sleep()` for real-time delays. In CI environments with timing jitter, the 21-second sleep could sometimes not exceed the 20-second nomination window.

This fix passes the clock as a parameter to `Nominate()` and `Nominated()` so nomination timing uses the test's fake clock instead of real time.

Note: We cannot store `clock.Clock` in `StateNode` because it has `+k8s:deepcopy-gen=true` and controller-gen cannot generate DeepCopy for interface types.

## Changes
- Update `Nominate(ctx, clk)` and `Nominated(clk)` to accept clock parameter
- Update `ValidateNodeDisruptable(clk)` to pass clock to `Nominated()`
- Update callers in `Cluster` to pass `c.clock`
- Replace `time.Sleep()` with `fakeClock.Step()` in test

## Testing

```
go test ./pkg/controllers/state/... -v
go test ./pkg/controllers/disruption/... -v
```

All tests pass. The nomination test now runs instantly instead of sleeping for 21 seconds.