### PR TITLE
fix: deflake termination tests by using injected clock

### DIFF
--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -732,7 +732,7 @@ var _ = Describe("Termination", func() {
 		It("should preemptively delete pods to satisfy their terminationGracePeriodSeconds", func() {
 			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
 			nodeClaim.Annotations = map[string]string{
-				v1.NodeClaimTerminationTimestampAnnotationKey: time.Now().Add(nodeClaim.Spec.TerminationGracePeriod.Duration).Format(time.RFC3339),
+				v1.NodeClaimTerminationTimestampAnnotationKey: fakeClock.Now().Add(nodeClaim.Spec.TerminationGracePeriod.Duration).Format(time.RFC3339),
 			}
 			pod := test.Pod(test.PodOptions{
 				NodeName: node.Name,
@@ -757,7 +757,7 @@ var _ = Describe("Termination", func() {
 		It("should only delete pods when their terminationGracePeriodSeconds is less than the the node's remaining terminationGracePeriod", func() {
 			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
 			nodeClaim.Annotations = map[string]string{
-				v1.NodeClaimTerminationTimestampAnnotationKey: time.Now().Add(nodeClaim.Spec.TerminationGracePeriod.Duration).Format(time.RFC3339),
+				v1.NodeClaimTerminationTimestampAnnotationKey: fakeClock.Now().Add(nodeClaim.Spec.TerminationGracePeriod.Duration).Format(time.RFC3339),
 			}
 			pod := test.Pod(test.PodOptions{
 				NodeName: node.Name,


### PR DESCRIPTION
## Description

The termination tests were flaky because they used `time.Now()` to set the `NodeClaimTerminationTimestampAnnotationKey` while the controller uses the injected `fakeClock`. In CI environments with timing jitter, this mismatch could cause test failures.

This fix uses `fakeClock.Now()` for the annotation timestamps so the test timing is consistent with the controller's clock.

First observed: https://github.com/kubernetes-sigs/karpenter/actions/runs/20975167016/job/60288077617?pr=2781

## Changes

- Use `fakeClock.Now()` instead of `time.Now()` in two termination tests

## Testing

```
go test ./pkg/controllers/node/termination/... -v -count=100
```