### PR TITLE
fix: remove requirements clone in topology domain scheduling

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topologydomaingroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologydomaingroup.go
@@ -24,6 +24,7 @@ import (
 
 // topologyDomainAttributes stores attributes associated with a topology domain (the map key), such as the taints and
 // requirements that yield that domain.
+// NOTE the requirements field is shared across topologyDomainAttributes and should not be mutated
 type topologyDomainAttributes struct {
 	taints       [][]v1.Taint
 	requirements []scheduling.Requirements
@@ -58,7 +59,7 @@ func (t TopologyDomainGroup) Insert(domain string, requirements scheduling.Requi
 		entry.taints = append(entry.taints, taints)
 	}
 
-	entry.requirements = append(entry.requirements, requirements.Clone())
+	entry.requirements = append(entry.requirements, requirements)
 }
 
 // ForEachDomain calls f on each domain tracked by the topology group. The provided filter determines which domains

--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -70,15 +70,6 @@ func NewLabelRequirements(labels map[string]string) Requirements {
 	return requirements
 }
 
-// Clone returns a deep copy of the requirements set.
-func (r Requirements) Clone() Requirements {
-	clone := NewRequirements()
-	for key, requirement := range r {
-		clone[key] = requirement.DeepCopy()
-	}
-	return clone
-}
-
 // NewPodRequirements constructs requirements from a pod and treats any preferred requirements as required.
 func NewPodRequirements(pod *corev1.Pod) Requirements {
 	return newPodRequirements(pod, podRequirementTypeAll)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2779 

**Description**
* remove clone of requirements during topology domain scheduling to reduce memory consumption
  * Note: this is safe to do as TopologyDomainGroup requirements are not mutated and therefore can be shared

**How was this change tested?**
* memory usage graphs during scheduling across versions
<img width="2308" height="1296" alt="mem drawio" src="https://github.com/user-attachments/assets/79ce5991-d883-4703-bc7e-5dcb11cbf591" />

* v.1.8.1 pprof shows large allocations due to Requirement deep copies
   * cardinality is `Every NodePool × Every InstanceType × Every Domain in Every Topology Group` 
<img width="307" height="558" alt="Screenshot 2026-01-13 at 5 40 46 PM" src="https://github.com/user-attachments/assets/a0b31a2c-82ef-4669-8c4d-0a5434283284" />




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
