### PR TITLE
chore: Retracting release v1.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 )
 
 retract (
+	v1.8.1 // has a bug that prevents Karpenter from scheduling pods with specific topologySpreadConstraint configurations - https://github.com/kubernetes-sigs/karpenter/issues/2785
 	v0.100.101-test // accidentally published testing version
 	v0.35.3 // accidentally published incomplete patch release
 	v0.34.4 // accidentally published incomplete patch release


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/kubernetes-sigs/karpenter/issues/2779

**Description**
This change is meant for retracting the v1.8.1 release which has a bug that causes increased memory usage - https://github.com/kubernetes-sigs/karpenter/issues/2779

**How was this change tested?**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
