### PR TITLE
fix: add check for deleted nodepools in cluster cost

### DIFF
--- a/pkg/controllers/state/informer/pricing.go
+++ b/pkg/controllers/state/informer/pricing.go
@@ -63,6 +63,9 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 		return reconciler.Result{}, err
 	}
 
+	// Remove Deleted NodePools from Cluster Cost Mapping
+	c.clusterCost.CheckForDeletedNodePools(npl)
+
 	// Add a fake wide open nodepool to capture manually created nodeclaims
 	npl.Items = append(npl.Items, v1.NodePool{ObjectMeta: metav1.ObjectMeta{UID: types.UID("manual")}})
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2793

**Description** 
* Fixes a memory leak in cluster cost mapping where deleted NodePools are never removed from the mapping (if they are deleted before NodeClaims for that NodePool)

**How was this change tested?**
* make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
