### PR TITLE
docs: fix typo "decrees" → "decrease" in price adjustment descriptions

### DIFF
--- a/designs/node-overlay.md
+++ b/designs/node-overlay.md
@@ -72,7 +72,7 @@ spec:
 
 **Price Adjustment:** Define a pricing adjustment for instance types that match the specified labels. Users can adjust prices using either:
 - A signed float representing the price adjustment
-- A percentage of the original price (e.g., +10% for increase, -15% for decrees)
+- A percentage of the original price (e.g., +10% for increase, -15% for decrease)
 
 *Karpenter is currency-agnostic, so while these examples use USD, the same principles apply to all currencies.*
 

--- a/kwok/charts/crds/karpenter.sh_nodeoverlays.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeoverlays.yaml
@@ -75,7 +75,7 @@ spec:
                   description: |-
                     PriceAdjustment specifies the price change for matching instance types. Accepts either:
                     - A fixed price modifier (e.g., -0.5, 1.2)
-                    - A percentage modifier (e.g., +10% for increase, -15% for decrees)
+                    - A percentage modifier (e.g., +10% for increase, -15% for decrease)
                   pattern: ^(([+-]{1}(\d*\.?\d+))|(\+{1}\d*\.?\d+%)|(^(-\d{1,2}(\.\d+)?%)$)|(-100%))$
                   type: string
                 requirements:

--- a/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
@@ -75,7 +75,7 @@ spec:
                   description: |-
                     PriceAdjustment specifies the price change for matching instance types. Accepts either:
                     - A fixed price modifier (e.g., -0.5, 1.2)
-                    - A percentage modifier (e.g., +10% for increase, -15% for decrees)
+                    - A percentage modifier (e.g., +10% for increase, -15% for decrease)
                   pattern: ^(([+-]{1}(\d*\.?\d+))|(\+{1}\d*\.?\d+%)|(^(-\d{1,2}(\.\d+)?%)$)|(-100%))$
                   type: string
                 requirements:

--- a/pkg/apis/v1alpha1/nodeoverlay.go
+++ b/pkg/apis/v1alpha1/nodeoverlay.go
@@ -71,7 +71,7 @@ type NodeOverlaySpec struct {
 	//nolint:kubeapilinter
 	// PriceAdjustment specifies the price change for matching instance types. Accepts either:
 	// - A fixed price modifier (e.g., -0.5, 1.2)
-	// - A percentage modifier (e.g., +10% for increase, -15% for decrees)
+	// - A percentage modifier (e.g., +10% for increase, -15% for decrease)
 	// +kubebuilder:validation:Pattern=`^(([+-]{1}(\d*\.?\d+))|(\+{1}\d*\.?\d+%)|(^(-\d{1,2}(\.\d+)?%)$)|(-100%))$`
 	// +optional
 	PriceAdjustment *string `json:"priceAdjustment,omitempty"`


### PR DESCRIPTION
Fixes #N/A

**Summary**
Fixed a typo where "decrees" was used instead of "decrease" in price adjustment documentation across 4 files.

**Changes**
The documentation described price modifiers as "+10% for increase, -15% for decrees", where "decrees" (meaning commands/orders) was incorrectly used instead of "decrease" (meaning reduction).

Files Modified:
- `pkg/apis/crds/karpenter.sh_nodeoverlays.yaml`
- `pkg/apis/v1alpha1/nodeoverlay.go`
- `designs/node-overlay.md`
- `kwok/charts/crds/karpenter.sh_nodeoverlays.yaml`

**Type of Change**
- [x] Documentation fix
- [x] Typo correction