### PR TITLE
refactor(utils/node): Remove Get prefix from getter functions to follow Go conventions

### DIFF
--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -257,7 +257,7 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 		// If the node satisfies one of the following, we subtract it from the allowed disruptions.
 		// 1. Has a NotReady conditiion
 		// 2. Is marked as disrupting
-		if cond := nodeutils.GetCondition(node.Node, corev1.NodeReady); cond.Status != corev1.ConditionTrue || node.MarkedForDeletion() {
+		if cond := nodeutils.Condition(node.Node, corev1.NodeReady); cond.Status != corev1.ConditionTrue || node.MarkedForDeletion() {
 			disrupting[nodePool]++
 		}
 	}

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -86,7 +86,7 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 				}
 
 				for _, oldCond := range oldNode.Status.Conditions {
-					newCond := nodeutils.GetCondition(newNode, oldCond.Type)
+					newCond := nodeutils.Condition(newNode, oldCond.Type)
 					// Return true if any of these conditions are met:
 					// 1. Condition type no longer exists in new node
 					// 2. Transition time has changed
@@ -191,7 +191,7 @@ func (c *Controller) findUnhealthyConditions(node *corev1.Node) (nc *corev1.Node
 	requeueTime := time.Time{}
 	for _, policy := range c.cloudProvider.RepairPolicies() {
 		// check the status and the type on the condition
-		nodeCondition := nodeutils.GetCondition(node, policy.ConditionType)
+		nodeCondition := nodeutils.Condition(node, policy.ConditionType)
 		if nodeCondition.Status == policy.ConditionStatus {
 			terminationTime := nodeCondition.LastTransitionTime.Add(policy.TolerationDuration)
 			// Determine requeue time
@@ -245,7 +245,7 @@ func (c *Controller) areNodesHealthy(ctx context.Context, opts ...client.ListOpt
 	}
 	unhealthyNodeCount := lo.CountBy(nodeList.Items, func(node corev1.Node) bool {
 		_, found := lo.Find(c.cloudProvider.RepairPolicies(), func(policy cloudprovider.RepairPolicy) bool {
-			nodeCondition := nodeutils.GetCondition(lo.ToPtr(node), policy.ConditionType)
+			nodeCondition := nodeutils.Condition(lo.ToPtr(node), policy.ConditionType)
 			return nodeCondition.Status == policy.ConditionStatus
 		})
 		return found

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -116,7 +116,7 @@ func (c *Controller) finalize(ctx context.Context, node *corev1.Node) (reconcile
 	// associated node. We do a check on the Ready condition of the node since, even though the CloudProvider says the
 	// instance is not around, we know that the kubelet process is still running if the Node Ready condition is true.
 	// Similar logic to: https://github.com/kubernetes/kubernetes/blob/3a75a8c8d9e6a1ebd98d8572132e675d4980f184/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go#L144
-	if nodeutils.GetCondition(node, corev1.NodeReady).Status != corev1.ConditionTrue {
+	if nodeutils.Condition(node, corev1.NodeReady).Status != corev1.ConditionTrue {
 		if _, err = c.cloudProvider.Get(ctx, node.Spec.ProviderID); err != nil {
 			if cloudprovider.IsNodeClaimNotFoundError(err) {
 				return reconcile.Result{}, c.removeFinalizer(ctx, node)
@@ -294,7 +294,7 @@ func (c *Controller) hasTerminationGracePeriodElapsed(nodeTerminationTime *time.
 }
 
 func (c *Controller) pendingVolumeAttachments(ctx context.Context, node *corev1.Node) ([]*storagev1.VolumeAttachment, error) {
-	volumeAttachments, err := nodeutils.GetVolumeAttachments(ctx, c.kubeClient, node)
+	volumeAttachments, err := nodeutils.VolumeAttachments(ctx, c.kubeClient, node)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func filterVolumeAttachments(ctx context.Context, kubeClient client.Client, node
 		return volumeAttachments, nil
 	}
 	// Create list of non-drain-able Pods associated with Node
-	pods, err := nodeutils.GetPods(ctx, kubeClient, node)
+	pods, err := nodeutils.Pods(ctx, kubeClient, node)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -94,7 +94,7 @@ func (t *Terminator) Taint(ctx context.Context, node *corev1.Node, taint corev1.
 // Drain evicts pods from the node and returns true when all pods are evicted
 // https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeriodExpirationTime *time.Time) error {
-	pods, err := nodeutils.GetPods(ctx, t.kubeClient, node)
+	pods, err := nodeutils.Pods(ctx, t.kubeClient, node)
 	if err != nil {
 		return fmt.Errorf("listing pods on node, %w", err)
 	}

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -97,7 +97,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 		// We do a check on the Ready condition of the node since, even though the CloudProvider says the instance
 		// is not around, we know that the kubelet process is still running if the Node Ready condition is true
 		// Similar logic to: https://github.com/kubernetes/kubernetes/blob/3a75a8c8d9e6a1ebd98d8572132e675d4980f184/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go#L144
-		if node != nil && nodeutils.GetCondition(node, corev1.NodeReady).Status == corev1.ConditionTrue {
+		if node != nil && nodeutils.Condition(node, corev1.NodeReady).Status == corev1.ConditionTrue {
 			return
 		}
 		if err := c.kubeClient.Delete(ctx, nodeClaims[i]); err != nil {

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -57,7 +57,7 @@ func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim)
 		nodeClaim.StatusConditions().SetUnknownWithReason(v1.ConditionTypeInitialized, "NodeNotFound", "Node not registered with cluster")
 		return reconcile.Result{}, nil //nolint:nilerr
 	}
-	if nodeutils.GetCondition(node, corev1.NodeReady).Status != corev1.ConditionTrue {
+	if nodeutils.Condition(node, corev1.NodeReady).Status != corev1.ConditionTrue {
 		nodeClaim.StatusConditions().SetUnknownWithReason(v1.ConditionTypeInitialized, "NodeNotReady", "Node status is NotReady")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -176,7 +176,7 @@ func (p *Provisioner) CreateNodeClaims(ctx context.Context, nodeClaims []*schedu
 func (p *Provisioner) GetPendingPods(ctx context.Context) ([]*corev1.Pod, error) {
 	// filter for provisionable pods first, so we don't check for validity/PVCs on pods we won't provision anyway
 	// (e.g. those owned by daemonsets)
-	pods, err := nodeutils.GetProvisionablePods(ctx, p.kubeClient)
+	pods, err := nodeutils.ProvisionablePods(ctx, p.kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("listing pods, %w", err)
 	}

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -192,7 +192,7 @@ func (in *StateNode) Pods(ctx context.Context, kubeClient client.Client) ([]*cor
 	if in.Node == nil {
 		return nil, nil
 	}
-	return nodeutils.GetPods(ctx, kubeClient, in.Node)
+	return nodeutils.Pods(ctx, kubeClient, in.Node)
 }
 
 // ValidateNodeDisruptable returns an error if the StateNode cannot be disrupted
@@ -259,7 +259,7 @@ func (in *StateNode) CurrentlyReschedulablePods(ctx context.Context, kubeClient 
 	if in.Node == nil {
 		return nil, nil
 	}
-	return nodeutils.GetCurrentlyReschedulablePods(ctx, kubeClient, in.Node)
+	return nodeutils.CurrentlyReschedulablePods(ctx, kubeClient, in.Node)
 }
 
 func (in *StateNode) HostName() string {
@@ -555,7 +555,6 @@ func ClearNodeClaimsCondition(ctx context.Context, kubeClient client.Client, con
 			errs[i] = client.IgnoreNotFound(err)
 			return
 		}
-
 	})
 	return multierr.Combine(errs...)
 }

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -99,8 +99,8 @@ func IgnoreDuplicateNodeClaimError(err error) error {
 	return nil
 }
 
-// GetPods grabs all pods that are currently bound to the passed nodes
-func GetPods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
+// Pods grabs all pods that are currently bound to the passed nodes
+func Pods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
 	var pods []*corev1.Pod
 	for _, node := range nodes {
 		var podList corev1.PodList
@@ -114,8 +114,8 @@ func GetPods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Nod
 	return pods, nil
 }
 
-// GetNodeClaims grabs all NodeClaims with a providerID that matches the provided Node
-func GetNodeClaims(ctx context.Context, kubeClient client.Client, node *corev1.Node) ([]*v1.NodeClaim, error) {
+// NodeClaims grabs all NodeClaims with a providerID that matches the provided Node
+func NodeClaims(ctx context.Context, kubeClient client.Client, node *corev1.Node) ([]*v1.NodeClaim, error) {
 	// Nodes without providerID should not match any NodeClaims to prevent false positives
 	// with NodeClaims that also have empty providerIDs (e.g., during NodeClaim creation)
 	if node.Spec.ProviderID == "" {
@@ -133,7 +133,7 @@ func GetNodeClaims(ctx context.Context, kubeClient client.Client, node *corev1.N
 //  1. No v1.NodeClaims match the corev1.Node's providerID
 //  2. Multiple v1.NodeClaims match the corev1.Node's providerID
 func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (*v1.NodeClaim, error) {
-	nodeClaims, err := GetNodeClaims(ctx, c, node)
+	nodeClaims, err := NodeClaims(ctx, c, node)
 	if err != nil {
 		return nil, err
 	}
@@ -146,9 +146,9 @@ func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (
 	return nodeClaims[0], nil
 }
 
-// GetCurrentlyReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
-func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
-	pods, err := GetPods(ctx, kubeClient, nodes...)
+// CurrentlyReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
+func CurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
+	pods, err := Pods(ctx, kubeClient, nodes...)
 	if err != nil {
 		return nil, fmt.Errorf("listing pods, %w", err)
 	}
@@ -163,8 +163,8 @@ func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client
 	}), nil
 }
 
-// GetProvisionablePods grabs all the pods from the passed nodes that satisfy the IsProvisionable criteria
-func GetProvisionablePods(ctx context.Context, kubeClient client.Client) ([]*corev1.Pod, error) {
+// ProvisionablePods grabs all the pods from the passed nodes that satisfy the IsProvisionable criteria
+func ProvisionablePods(ctx context.Context, kubeClient client.Client) ([]*corev1.Pod, error) {
 	var podList corev1.PodList
 	if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": ""}); err != nil {
 		return nil, fmt.Errorf("listing pods, %w", err)
@@ -174,8 +174,8 @@ func GetProvisionablePods(ctx context.Context, kubeClient client.Client) ([]*cor
 	}), nil
 }
 
-// GetVolumeAttachments grabs all volumeAttachments associated with the passed node
-func GetVolumeAttachments(ctx context.Context, kubeClient client.Client, node *corev1.Node) ([]*storagev1.VolumeAttachment, error) {
+// VolumeAttachments grabs all volumeAttachments associated with the passed node
+func VolumeAttachments(ctx context.Context, kubeClient client.Client, node *corev1.Node) ([]*storagev1.VolumeAttachment, error) {
 	var volumeAttachmentList storagev1.VolumeAttachmentList
 	if err := kubeClient.List(ctx, &volumeAttachmentList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
 		return nil, fmt.Errorf("listing volumeAttachments, %w", err)
@@ -183,7 +183,7 @@ func GetVolumeAttachments(ctx context.Context, kubeClient client.Client, node *c
 	return lo.ToSlicePtr(volumeAttachmentList.Items), nil
 }
 
-func GetCondition(n *corev1.Node, match corev1.NodeConditionType) corev1.NodeCondition {
+func Condition(n *corev1.Node, match corev1.NodeConditionType) corev1.NodeCondition {
 	for _, condition := range n.Status.Conditions {
 		if condition.Type == match {
 			return condition

--- a/pkg/utils/node/suite_test.go
+++ b/pkg/utils/node/suite_test.go
@@ -66,7 +66,7 @@ var _ = Describe("NodeUtils", func() {
 		testNode = test.NodeClaimLinkedNode(nodeClaim)
 		ExpectApplied(ctx, env.Client, testNode, nodeClaim)
 
-		nodeClaims, err := nodeutils.GetNodeClaims(ctx, env.Client, testNode)
+		nodeClaims, err := nodeutils.NodeClaims(ctx, env.Client, testNode)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeClaims).To(HaveLen(1))
 		for _, nc := range nodeClaims {
@@ -79,7 +79,7 @@ var _ = Describe("NodeUtils", func() {
 		})
 		ExpectApplied(ctx, env.Client, testNode, nodeClaim)
 
-		nodeClaims, err := nodeutils.GetNodeClaims(ctx, env.Client, testNode)
+		nodeClaims, err := nodeutils.NodeClaims(ctx, env.Client, testNode)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeClaims).To(HaveLen(0))
 	})
@@ -89,7 +89,7 @@ var _ = Describe("NodeUtils", func() {
 		})
 		ExpectApplied(ctx, env.Client, testNode, nodeClaim)
 
-		nodeClaims, err := nodeutils.GetNodeClaims(ctx, env.Client, testNode)
+		nodeClaims, err := nodeutils.NodeClaims(ctx, env.Client, testNode)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeClaims).To(HaveLen(0))
 	})

--- a/test/pkg/debug/node.go
+++ b/test/pkg/debug/node.go
@@ -59,8 +59,8 @@ func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (
 }
 
 func (c *NodeController) GetInfo(ctx context.Context, n *corev1.Node) string {
-	pods, _ := nodeutils.GetPods(ctx, c.kubeClient, n)
-	return fmt.Sprintf("ready=%s schedulable=%t initialized=%s pods=%d taints=%v", nodeutils.GetCondition(n, corev1.NodeReady).Status, !n.Spec.Unschedulable, n.Labels[v1.NodeInitializedLabelKey], len(pods), n.Spec.Taints)
+	pods, _ := nodeutils.Pods(ctx, c.kubeClient, n)
+	return fmt.Sprintf("ready=%s schedulable=%t initialized=%s pods=%d taints=%v", nodeutils.Condition(n, corev1.NodeReady).Status, !n.Spec.Unschedulable, n.Labels[v1.NodeInitializedLabelKey], len(pods), n.Spec.Taints)
 }
 
 func (c *NodeController) Register(ctx context.Context, m manager.Manager) error {

--- a/test/suites/regression/chaos_test.go
+++ b/test/suites/regression/chaos_test.go
@@ -179,7 +179,7 @@ func startNodeCountMonitor(ctx context.Context, kubeClient client.Client) {
 			list := &corev1.NodeList{}
 			if err := kubeClient.List(ctx, list, client.HasLabels{test.DiscoveryLabel}); err == nil {
 				readyCount := lo.CountBy(list.Items, func(n corev1.Node) bool {
-					return nodeutils.GetCondition(&n, corev1.NodeReady).Status == corev1.ConditionTrue
+					return nodeutils.Condition(&n, corev1.NodeReady).Status == corev1.ConditionTrue
 				})
 				fmt.Printf("[NODE COUNT] CURRENT: %d | READY: %d | CREATED: %d | DELETED: %d\n", len(list.Items), readyCount, createdNodes.Load(), deletedNodes.Load())
 			}


### PR DESCRIPTION
Fixes #N/A

**Summary**
This PR removes the `Get` prefix from getter functions in `pkg/utils/node` to align with Effective Go and Kubernetes API naming conventions.

**Motivation**
According to [Effective Go](https://go.dev/doc/effective_go#Getters):

> **Go doesn't provide automatic support for getters and setters. There's nothing wrong with providing getters and setters yourself, and it's often appropriate to do so, but it's neither idiomatic nor necessary to put Get into the getter's name.**
> 
> If you have a field called `owner` (lower case, unexported), the getter method should be called `Owner` (upper case, exported), not `GetOwner`. The use of upper-case names for export provides the hook to discriminate the field from the method.

This convention is also consistent with Kubernetes API conventions which prefer concise, declarative naming.

**Changes**
The following functions have been renamed:
- `GetPods` → `Pods`
- `GetNodeClaims` → `NodeClaims`
- `GetCondition` → `Condition`
- `GetCurrentlyReschedulablePods` → `CurrentlyReschedulablePods`
- `GetProvisionablePods` → `ProvisionablePods`
- `GetVolumeAttachments` → `VolumeAttachments`

All usages have been updated across **13 files**:
- Core definition: `pkg/utils/node/node.go`
- Controllers: termination, health, disruption, provisioning, nodeclaim lifecycle
- State management: `pkg/controllers/state/statenode.go`
- Tests: unit tests and regression tests

**Testing**
- Existing unit tests pass with renamed functions
- No functional changes, only naming convention updates
- All call sites have been updated to use new names

**References**
- [Effective Go - Getters](https://go.dev/doc/effective_go#Getters)
- [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)

Part of addressing Effective Go and Kubernetes API convention compliance across the codebase.