### PR TITLE
chore: fix typos in comments and documentation

### DIFF
--- a/designs/spot-consolidation.md
+++ b/designs/spot-consolidation.md
@@ -14,7 +14,7 @@ All consolidation actions contain an inherent tradeoff between price and availab
 
 Karpenter will replace a spot node with a cheaper spot node for both single and multi-node consolidation. Cheaper spot instance types are selected with the `price-capacity-optimized` strategy and often the cheapest spot instance type is not launched due to the likelihood of interruption. Karpenter would replace spot node for single-node consolidation only if there are more than 15 potential replacement spot instance types. Also, Karpenter would have to limit its flexibility to this threshold while launching replacements with consolidation to avoid repeat interruptions, e.g. "walking down the ladder". Since on-demand capacity uses the lowest price strategy, its behavior is unaffected if these rules are applied equally to both spot and on-demand launches.
 
-Minimum flexibility of 15 spot instance types is decided after an analysis done on the flexiblity of AWS customers request in the launch path. Karpenter does not have the same instance type flexibility requirement for multi-node spot-to-spot consolidations (many nodes to 1 node) since doing so without requiring flexibility won't lead to "race to the bottom" scenarios. It is also to prevent inconsistent behavior between consolidation of mixed capacity type [od,spot] to [spot] and spot capacity type [spot,spot] to [spot] since we already support mixed capacity type multi-node consolidation to spot today without any additional conditions.
+Minimum flexibility of 15 spot instance types is decided after an analysis done on the flexibility of AWS customers request in the launch path. Karpenter does not have the same instance type flexibility requirement for multi-node spot-to-spot consolidations (many nodes to 1 node) since doing so without requiring flexibility won't lead to "race to the bottom" scenarios. It is also to prevent inconsistent behavior between consolidation of mixed capacity type [od,spot] to [spot] and spot capacity type [spot,spot] to [spot] since we already support mixed capacity type multi-node consolidation to spot today without any additional conditions.
 
 Finally, a limit for the number of instance types in the launch path is placed only on consolidation instead of the entire launch path in the provisioning loop in order to unblock scenarios where a user doesn't have enough flexibility with spot specified in their NodePool. As a result, their initial launch would succeed but would get no consolidations after their initial launch.
 
@@ -45,7 +45,7 @@ See appendix for examples.
 * 👍 Extensible to new methods of capacity allocation, since Karpenter core is now completely agnostic to spot
 * 👍 Prevents consolidation from interrupting workloads for marginal improvement
 * 👎 During a spot capacity crunch, if many capacity pools within a price range are unhealthy, the customer may get interrupted soon after the consolidation. This is exacerbated if the customer cannot tolerate instance type diversity. 
-* 👎 Tuning this value to migitage both marginal-improvement-churn and lowest-price-regression is challenging, and desired values may conflict.
+* 👎 Tuning this value to mitigate both marginal-improvement-churn and lowest-price-regression is challenging, and desired values may conflict.
 
 Note: Regardless of the decision made to solve the spot consolidation problem, we’d likely want to implement a price improvement in the future to prevent consolidation from interrupting nodes to make marginal improvements.
 

--- a/designs/v1-api.md
+++ b/designs/v1-api.md
@@ -220,7 +220,7 @@ Given this, we should update our `apiVersion` field in the `nodeClassRef` to be 
 
 **Category:** Stability
 
-`spec.resource.requests` is part of the NodeClaim API and is set by the Karpenter controller when creating new NodeClaim resources from the scheduling loop. This field describes the required resource requests cacluated from the summation of pod resource requests needed to run against a new instance that we launch. This field is also used to establish Karpenter initialization, where we rely on the presence of requested resources in the newly created Node before we will allow the Karpenter disruption controller to disrupt the node.
+`spec.resource.requests` is part of the NodeClaim API and is set by the Karpenter controller when creating new NodeClaim resources from the scheduling loop. This field describes the required resource requests calculated from the summation of pod resource requests needed to run against a new instance that we launch. This field is also used to establish Karpenter initialization, where we rely on the presence of requested resources in the newly created Node before we will allow the Karpenter disruption controller to disrupt the node.
 
 We are currently templating every field from the NodeClaim API onto the NodePool `spec.template` (in the same way that a Deployment templates every field from Pod). Validation currently blocks users from setting resource requests in the NodePool, since the field does not make any sense in that context.
 

--- a/pkg/controllers/disruption/queue_test.go
+++ b/pkg/controllers/disruption/queue_test.go
@@ -41,9 +41,11 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
 
-var nodeClaim1, nodeClaim2 *v1.NodeClaim
-var nodePool *v1.NodePool
-var node1, node2 *corev1.Node
+var (
+	nodeClaim1, nodeClaim2 *v1.NodeClaim
+	nodePool               *v1.NodePool
+	node1, node2           *corev1.Node
+)
 
 var _ = Describe("Queue", func() {
 	BeforeEach(func() {
@@ -334,7 +336,7 @@ var _ = Describe("Queue", func() {
 			// And expect the nodeClaim and node to be deleted
 			ExpectNotFound(ctx, env.Client, nodeClaim1, node1)
 		})
-		It("should finish two commands in order as replacements are intialized", func() {
+		It("should finish two commands in order as replacements are initialized", func() {
 			ExpectApplied(ctx, env.Client, nodePool, nodeClaim1, node1, nodeClaim2, node2)
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node1, node2}, []*v1.NodeClaim{nodeClaim1, nodeClaim2})
 			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -86,7 +86,8 @@ func (c *Candidate) OwnedByStaticNodePool() bool {
 
 //nolint:gocyclo
 func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events.Recorder, clk clock.Clock, node *state.StateNode, pdbs pdb.Limits,
-	nodePoolMap map[string]*v1.NodePool, nodePoolToInstanceTypesMap map[string]map[string]*cloudprovider.InstanceType, queue *Queue, disruptionClass string) (*Candidate, error) {
+	nodePoolMap map[string]*v1.NodePool, nodePoolToInstanceTypesMap map[string]map[string]*cloudprovider.InstanceType, queue *Queue, disruptionClass string,
+) (*Candidate, error) {
 	var err error
 	var pods []*corev1.Pod
 	// If the orchestration queue is already considering a candidate we want to disrupt, don't consider it a candidate.
@@ -137,7 +138,7 @@ type Replacement struct {
 	*scheduling.NodeClaim
 
 	Name string
-	// Use a bool track if a node has already been initialized so we can fire metrics for intialization once.
+	// Use a bool track if a node has already been initialized so we can fire metrics for initialization once.
 	// This intentionally does not capture nodes that go initialized then go NotReady after as other pods can
 	// schedule to this node as well.
 	Initialized bool


### PR DESCRIPTION
Fixes #N/A

**Description**
Fixed several typos found in code comments and design documents.

**Changes**
- **pkg/controllers/disruption/queue_test.go**: `intialized` → `initialized`
- **pkg/controllers/disruption/types.go**: `intialization` → `initialization`
- **pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go**: `doens't` → `doesn't`
- **designs/v1-api.md**: `cacluated` → `calculated`
- **designs/spot-consolidation.md**: `flexiblity` → `flexibility`, `migitage` → `mitigate`

**Testing**
- No functional changes
- All typos are in comments or documentation only

**Checklist**
- [x] Fixed typos in code comments
- [x] Fixed typos in design documents
- [x] No code logic changes