### PR TITLE
chore: check the error on the provisioner scheduling round and launch

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -4405,7 +4405,8 @@ var _ = Describe("Consolidation", func() {
 				pods = append(pods, pod)
 			}
 			ExpectApplied(ctx, env.Client, rs, nodePool)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, lo.Map(pods, func(p *corev1.Pod, _ int) *corev1.Pod { return p.DeepCopy() })...)
+			_, err := ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, lo.Map(pods, func(p *corev1.Pod, _ int) *corev1.Pod { return p.DeepCopy() })...)
+			Expect(err).ToNot(HaveOccurred())
 
 			nodeClaims := ExpectNodeClaims(ctx, env.Client)
 			Expect(nodeClaims).To(HaveLen(1))
@@ -4418,7 +4419,8 @@ var _ = Describe("Consolidation", func() {
 			// Mark the node for deletion and re-trigger reconciliation
 			oldNodeName := nodes[0].Name
 			cluster.MarkForDeletion(nodes[0].Spec.ProviderID)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, lo.Map(pods, func(p *corev1.Pod, _ int) *corev1.Pod { return p.DeepCopy() })...)
+			_, err = ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, lo.Map(pods, func(p *corev1.Pod, _ int) *corev1.Pod { return p.DeepCopy() })...)
+			Expect(err).ToNot(HaveOccurred())
 
 			// Make sure that the cluster state is aware of the current node state
 			nodes = ExpectNodes(ctx, env.Client)

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2417,7 +2417,8 @@ var _ = Context("Scheduling", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			pod := test.UnschedulablePod(opts)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			_, err := ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			Expect(err).ToNot(HaveOccurred())
 			var nodes corev1.NodeList
 			Expect(env.Client.List(ctx, &nodes)).To(Succeed())
 			Expect(nodes.Items).To(HaveLen(1))
@@ -2425,7 +2426,8 @@ var _ = Context("Scheduling", func() {
 
 			pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodScheduled, Reason: corev1.PodReasonUnschedulable, Status: corev1.ConditionFalse}}
 			ExpectApplied(ctx, env.Client, pod)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			_, err = ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(env.Client.List(ctx, &nodes)).To(Succeed())
 			// shouldn't create a second node
 			Expect(nodes.Items).To(HaveLen(1))
@@ -2668,7 +2670,8 @@ var _ = Context("Scheduling", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			initialPod := test.UnschedulablePod(opts)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
+			_, err := ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
+			Expect(err).ToNot(HaveOccurred())
 			ExpectNotScheduled(ctx, env.Client, initialPod)
 
 			// should launch a single node
@@ -2678,7 +2681,8 @@ var _ = Context("Scheduling", func() {
 
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 			secondPod := test.UnschedulablePod(opts)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, secondPod)
+			_, err = ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, secondPod)
+			Expect(err).ToNot(HaveOccurred())
 			ExpectNotScheduled(ctx, env.Client, secondPod)
 			// shouldn't create a second node as it can bind to the existingNodes node
 			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
@@ -2700,7 +2704,8 @@ var _ = Context("Scheduling", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool)
 			initialPod := test.UnschedulablePod(opts)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
+			_, err := ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
+			Expect(err).ToNot(HaveOccurred())
 			ExpectNotScheduled(ctx, env.Client, initialPod)
 
 			// should launch a single node
@@ -2720,7 +2725,8 @@ var _ = Context("Scheduling", func() {
 
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 			secondPod := test.UnschedulablePod(opts)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, secondPod)
+			_, err = ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, secondPod)
+			Expect(err).ToNot(HaveOccurred())
 			ExpectNotScheduled(ctx, env.Client, secondPod)
 			// shouldn't create a second node as it can bind to the existingNodes node
 			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
@@ -2742,7 +2748,8 @@ var _ = Context("Scheduling", func() {
 				}},
 			}, 2)
 			ExpectApplied(ctx, env.Client, nodePool)
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pods[0])
+			_, err := ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pods[0])
+			Expect(err).ToNot(HaveOccurred())
 			var nodeList corev1.NodeList
 			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 			for i := range nodeList.Items {
@@ -2751,7 +2758,8 @@ var _ = Context("Scheduling", func() {
 			// the second pod can schedule against the in-flight node, but for that to work we need to be careful
 			// in how we fulfill the self-affinity by taking the existing node's domain as a preference over any
 			// random viable domain
-			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pods[1])
+			_, err = ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pods[1])
+			Expect(err).ToNot(HaveOccurred())
 			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 			Expect(nodeList.Items).To(HaveLen(1))
 		})

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -516,7 +516,8 @@ var _ = Describe("Provisioning", func() {
 
 		// Provision without a binding since some pods will already be bound
 		// Should all schedule to the new node, ignoring the old node
-		bindings := ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, test.UnschedulablePod(), test.UnschedulablePod())
+		bindings, err := ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, test.UnschedulablePod(), test.UnschedulablePod())
+		Expect(err).ToNot(HaveOccurred())
 		nodes := &corev1.NodeList{}
 		Expect(env.Client.List(ctx, nodes)).To(Succeed())
 		Expect(len(nodes.Items)).To(Equal(2))


### PR DESCRIPTION

**Description**
achieve TODOS in 
https://github.com/kubernetes-sigs/karpenter/blob/3c00d41c0e290b1cac96efcb6a125c8b3d95b236/pkg/test/expectations/expectations.go#L328
https://github.com/kubernetes-sigs/karpenter/blob/3c00d41c0e290b1cac96efcb6a125c8b3d95b236/pkg/test/expectations/expectations.go#L336
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
