### PR TITLE
fix: Ensure NodeOverlay matches instance types when using the Exists operator

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -58,6 +58,27 @@ var (
 
 type DriftReason string
 
+// contextKey is a type for context keys used in this package
+type contextKey string
+
+const (
+	// SkipNodeOverlayKey is a context key that, when set to true, tells the cloud provider
+	// to skip applying node overlays when returning instance types. This is used by the
+	// nodeoverlay controller to get raw instance types for evaluation.
+	SkipNodeOverlayKey contextKey = "skipNodeOverlay"
+)
+
+// WithSkipNodeOverlay returns a context that signals to skip node overlay application
+func WithSkipNodeOverlay(ctx context.Context) context.Context {
+	return context.WithValue(ctx, SkipNodeOverlayKey, true)
+}
+
+// ShouldSkipNodeOverlay returns true if node overlay application should be skipped
+func ShouldSkipNodeOverlay(ctx context.Context) bool {
+	skip, ok := ctx.Value(SkipNodeOverlayKey).(bool)
+	return ok && skip
+}
+
 type RepairPolicy struct {
 	// ConditionType of unhealthy state that is found on the node
 	ConditionType corev1.NodeConditionType

--- a/pkg/controllers/nodeoverlay/controller.go
+++ b/pkg/controllers/nodeoverlay/controller.go
@@ -116,6 +116,9 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return reconcile.Result{}, fmt.Errorf("updating nodeoverlay statuses, %w", err)
 	}
 
+	// Pre-compute and cache instance type variants to avoid repeated allocations
+	// during scheduling when applyAll is called
+	temporaryStore.FinalizeCache(nodePoolToInstanceTypes)
 	c.instanceTypeStore.UpdateStore(temporaryStore)
 	c.clusterState.MarkUnconsolidated()
 	return reconcile.Result{RequeueAfter: 6 * time.Hour}, nil

--- a/pkg/controllers/nodeoverlay/controller.go
+++ b/pkg/controllers/nodeoverlay/controller.go
@@ -82,8 +82,11 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	temporaryStore := newInternalInstanceTypeStore()
 	nodePoolToInstanceTypes := map[string][]*cloudprovider.InstanceType{}
 
+	// Use skip context to get raw instance types without overlays applied
+	// This prevents circular dependency: nodeoverlay controller needs raw types to evaluate overlays
+	skipCtx := cloudprovider.WithSkipNodeOverlay(ctx)
 	for i := range nodePoolList.Items {
-		its, err := c.cloudProvider.GetInstanceTypes(ctx, &nodePoolList.Items[i])
+		its, err := c.cloudProvider.GetInstanceTypes(skipCtx, &nodePoolList.Items[i])
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("listing instance types, %w", err)
 		}
@@ -171,8 +174,8 @@ func (c *Controller) validateInstanceTypesOverride(store *internalInstanceTypeSt
 			continue
 		}
 
-		conflictingPriceOverlay := c.isPriceUpdatesConflicting(store, nodePool.Name, it.Name, offerings, overlay)
-		conflictingCapacityOverlay := c.isCapacityUpdatesConflicting(store, nodePool.Name, it.Name, overlay)
+		conflictingPriceOverlay := c.isPriceUpdatesConflicting(store, nodePool.Name, it.Name, offerings, overlay, overlayRequirements)
+		conflictingCapacityOverlay := c.isCapacityUpdatesConflicting(store, nodePool.Name, it.Name, overlay, overlayRequirements)
 		// When we find an instance type that is matches a set offering, we will track that based on the
 		// overlay that is applied
 		if conflictingPriceOverlay || conflictingCapacityOverlay {
@@ -196,8 +199,8 @@ func (c *Controller) storeUpdatesForInstanceTypeOverride(store *internalInstance
 			continue
 		}
 
-		store.updateInstanceTypeOffering(nodePool.Name, it.Name, overlay, offerings)
-		store.updateInstanceTypeCapacity(nodePool.Name, it.Name, overlay)
+		store.updateInstanceTypeOffering(nodePool.Name, it.Name, overlay, offerings, overlayRequirements)
+		store.updateInstanceTypeCapacity(nodePool.Name, it.Name, overlay, overlayRequirements)
 	}
 }
 
@@ -216,31 +219,38 @@ func getOverlaidOfferings(nodePool v1.NodePool, it *cloudprovider.InstanceType, 
 	instanceTypeRequirements.Add(scheduling.NewLabelRequirements(nodePool.Spec.Template.ObjectMeta.Labels).Values()...)
 	instanceTypeRequirements.Add(it.Requirements.Values()...)
 
+	for _, req := range nodePool.Spec.Template.Spec.Requirements {
+		if v1.WellKnownLabels.Has(req.Key) {
+			continue
+		}
+		instanceTypeRequirements.Add(scheduling.NewNodeSelectorRequirementsWithMinValues(req).Values()...)
+	}
+
 	if !instanceTypeRequirements.IsCompatible(overlayReq) {
 		return nil
 	}
 	return it.Offerings.Compatible(overlayReq)
 }
 
-func (c *Controller) isPriceUpdatesConflicting(store *internalInstanceTypeStore, nodePoolName string, instanceTypeName string, offerings cloudprovider.Offerings, overlay v1alpha1.NodeOverlay) bool {
+func (c *Controller) isPriceUpdatesConflicting(store *internalInstanceTypeStore, nodePoolName string, instanceTypeName string, offerings cloudprovider.Offerings, overlay v1alpha1.NodeOverlay, overlayReqs scheduling.Requirements) bool {
 	if overlay.Spec.Price == nil && overlay.Spec.PriceAdjustment == nil {
 		return false
 	}
 
 	for _, of := range offerings {
-		if foundConflict := store.isOfferingUpdateConflicting(nodePoolName, instanceTypeName, of, overlay); foundConflict {
+		if foundConflict := store.isOfferingUpdateConflicting(nodePoolName, instanceTypeName, of, overlay, overlayReqs); foundConflict {
 			return true
 		}
 	}
 	return false
 }
 
-func (c *Controller) isCapacityUpdatesConflicting(store *internalInstanceTypeStore, nodePoolName string, instanceTypeName string, overlay v1alpha1.NodeOverlay) bool {
+func (c *Controller) isCapacityUpdatesConflicting(store *internalInstanceTypeStore, nodePoolName string, instanceTypeName string, overlay v1alpha1.NodeOverlay, overlayReqs scheduling.Requirements) bool {
 	if overlay.Spec.Capacity == nil {
 		return false
 	}
 
-	if foundConflict := store.isCapacityUpdateConflicting(nodePoolName, instanceTypeName, overlay); foundConflict {
+	if foundConflict := store.isCapacityUpdateConflicting(nodePoolName, instanceTypeName, overlay, overlayReqs); foundConflict {
 		return true
 	}
 	return false

--- a/pkg/controllers/nodeoverlay/store.go
+++ b/pkg/controllers/nodeoverlay/store.go
@@ -23,8 +23,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/apis/v1alpha1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
 type priceUpdate struct {
@@ -39,8 +41,9 @@ type capacityUpdate struct {
 }
 
 type instanceTypeUpdate struct {
-	Price    map[string]*priceUpdate
-	Capacity *capacityUpdate
+	Price               map[string]*priceUpdate
+	Capacity            *capacityUpdate
+	OverlayRequirements scheduling.Requirements // Custom label requirements from the overlay
 }
 type InstanceTypeStore struct {
 	store atomic.Pointer[internalInstanceTypeStore]
@@ -65,17 +68,15 @@ func (s *InstanceTypeStore) ApplyAll(nodePoolName string, its []*cloudprovider.I
 		return []*cloudprovider.InstanceType{}, cloudprovider.NewUnevaluatedNodePoolError(nodePoolName)
 	}
 
-	result := make([]*cloudprovider.InstanceType, 0, len(its))
-
 	_, ok := internalStore.updates[nodePoolName]
 	if !ok {
 		return its, nil
 	}
 
+	result := make([]*cloudprovider.InstanceType, 0, len(its))
 	for _, it := range its {
-		if updatedIt, err := internalStore.apply(nodePoolName, it); err == nil {
-			result = append(result, updatedIt)
-		}
+		variants := internalStore.applyAll(nodePoolName, it)
+		result = append(result, variants...)
 	}
 	return result, nil
 }
@@ -83,76 +84,118 @@ func (s *InstanceTypeStore) ApplyAll(nodePoolName string, its []*cloudprovider.I
 func (s *InstanceTypeStore) Apply(nodePoolName string, it *cloudprovider.InstanceType) (*cloudprovider.InstanceType, error) {
 	internalStore := lo.FromPtr(s.store.Load())
 
-	updatedIt, err := internalStore.apply(nodePoolName, it)
-	if err != nil {
-		return &cloudprovider.InstanceType{}, err
+	variants := internalStore.applyAll(nodePoolName, it)
+	if len(variants) == 0 {
+		return it, nil
 	}
-	return updatedIt, nil
+	// Return the first variant for backward compatibility
+	return variants[0], nil
 }
 
 // InstanceTypeStore manages instance type updates for node pools.
 // It maintains a nested mapping structure where:
 //   - First level:  nodePoolName -> map of instance updates
-//   - Second level: instanceName -> specific update configurations
+//   - Second level: instanceName -> map of variant updates
+//   - Third level:  variantKey (overlay requirements string) -> specific update configurations
 //
 // The store is used to:
 //   - Track instance type modifications per node pool
 //   - Validate instance configurations
 //   - Update instance properties for scheduling decisions
+//   - Create overlay-specific variants with custom label requirements
 type internalInstanceTypeStore struct {
-	updates            map[string]map[string]*instanceTypeUpdate // nodePoolName -> (instanceName -> updates)
-	evaluatedNodePools sets.Set[string]                          // The set of NodePools that were evaluated to construct this InstanceTypeStore instance
+	updates            map[string]map[string]map[string]*instanceTypeUpdate // nodePoolName -> instanceName -> variantKey -> updates
+	evaluatedNodePools sets.Set[string]                                     // The set of NodePools that were evaluated to construct this InstanceTypeStore instance
 }
 
 func newInternalInstanceTypeStore() *internalInstanceTypeStore {
 	return &internalInstanceTypeStore{
-		updates:            map[string]map[string]*instanceTypeUpdate{},
+		updates:            map[string]map[string]map[string]*instanceTypeUpdate{},
 		evaluatedNodePools: sets.Set[string]{},
 	}
 }
 
-// Apply takes a node pool name and instance type, and returns a modified copy of the instance type
-// with any stored updates applied. It uses a selective copy-on-write strategy to minimize memory usage:
-// - Shared: Requirements and Overhead (never modified, safe to share)
-// - Selective copy: Offerings (only copied if price overlay applied)
-// - Selective copy: Capacity (only deep copied if capacity overlay applied)
-func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider.InstanceType) (*cloudprovider.InstanceType, error) {
+// applyAll takes a node pool name and instance type, and returns modified copies of the instance type
+// with any stored updates applied. It creates overlay-specific variants when overlays have custom label
+// requirements. Each variant has:
+// - The overlay's price/capacity modifications
+// - The overlay's custom label requirements added to the instance type's requirements
+// This ensures that pods targeting specific overlay values only match the appropriate variant.
+// When overlays have custom label requirements, the base instance type is ALSO returned so that
+// pods without those specific requirements can still schedule.
+func (s *internalInstanceTypeStore) applyAll(nodePoolName string, it *cloudprovider.InstanceType) []*cloudprovider.InstanceType {
 	if !lo.Contains(s.evaluatedNodePools.UnsortedList(), nodePoolName) {
-		return &cloudprovider.InstanceType{}, cloudprovider.NewUnevaluatedNodePoolError(nodePoolName)
+		return []*cloudprovider.InstanceType{it}
 	}
 
-	instanceTypeList, ok := s.updates[nodePoolName]
+	instanceVariants, ok := s.updates[nodePoolName]
 	if !ok {
-		return it, nil
+		return []*cloudprovider.InstanceType{it}
 	}
-	instanceTypeUpdate, ok := instanceTypeList[it.Name]
+	variantUpdates, ok := instanceVariants[it.Name]
 	if !ok {
-		return it, nil
+		return []*cloudprovider.InstanceType{it}
 	}
 
+	results := make([]*cloudprovider.InstanceType, 0, len(variantUpdates)+1)
+	hasCustomLabelVariant := false
+
+	for _, update := range variantUpdates {
+		variant := s.applyVariant(it, update)
+		results = append(results, variant)
+		// Track if any variant has custom label requirements
+		if len(update.OverlayRequirements) > 0 {
+			hasCustomLabelVariant = true
+		}
+	}
+
+	// If no variants were created, return the original
+	if len(results) == 0 {
+		return []*cloudprovider.InstanceType{it}
+	}
+
+	// If any variant has custom label requirements, also include the base instance type
+	// so that pods without those specific requirements can still schedule
+	if hasCustomLabelVariant {
+		results = append(results, it)
+	}
+
+	return results
+}
+
+// applyVariant creates a single variant of an instance type with the given update applied
+func (s *internalInstanceTypeStore) applyVariant(it *cloudprovider.InstanceType, update *instanceTypeUpdate) *cloudprovider.InstanceType {
 	// Create a shallow copy of the instance type, sharing immutable fields
 	overriddenInstanceType := &cloudprovider.InstanceType{
-		Name:         it.Name,
-		Requirements: it.Requirements, // Shared - never modified
-		Overhead:     it.Overhead,     // Shared - never modified
+		Name:     it.Name,
+		Overhead: it.Overhead, // Shared - never modified
+	}
+
+	// Add overlay's custom label requirements to the instance type's requirements
+	if len(update.OverlayRequirements) > 0 {
+		newReqs := scheduling.NewRequirements(it.Requirements.Values()...)
+		newReqs.Add(update.OverlayRequirements.Values()...)
+		overriddenInstanceType.Requirements = newReqs
+	} else {
+		overriddenInstanceType.Requirements = it.Requirements // Shared - not modified
 	}
 
 	// Handle capacity overlay - only deep copy if we're modifying it
-	if len(lo.Keys(instanceTypeUpdate.Capacity.OverlayUpdate)) != 0 {
+	if update.Capacity != nil && len(lo.Keys(update.Capacity.OverlayUpdate)) != 0 {
 		overriddenInstanceType.Capacity = it.Capacity.DeepCopy()
-		overriddenInstanceType.ApplyCapacityOverlay(instanceTypeUpdate.Capacity.OverlayUpdate)
+		overriddenInstanceType.ApplyCapacityOverlay(update.Capacity.OverlayUpdate)
 	} else {
 		overriddenInstanceType.Capacity = it.Capacity // Shared - not modified
 	}
 
 	// Handle offerings - copy-on-write only for offerings that need price overlay
-	if instanceTypeUpdate.Price != nil {
-		overriddenInstanceType.Offerings = s.applyPriceOverlays(it.Offerings, instanceTypeUpdate.Price)
+	if update.Price != nil {
+		overriddenInstanceType.Offerings = s.applyPriceOverlays(it.Offerings, update.Price)
 	} else {
 		overriddenInstanceType.Offerings = it.Offerings // Shared - not modified
 	}
 
-	return overriddenInstanceType, nil
+	return overriddenInstanceType
 }
 
 // applyPriceOverlays creates a new offerings slice with selective copying:
@@ -180,61 +223,60 @@ func (s *internalInstanceTypeStore) applyPriceOverlays(offerings cloudprovider.O
 	return result
 }
 
-// updateInstanceTypeCapacity add a new Capacity overlay update to the associated instance type.
+// updateInstanceTypeCapacity add a new Capacity overlay update to the associated instance type variant.
 // NOTE: This method does not perform conflict validation. The callee must check for conflicts first.
-func (i *internalInstanceTypeStore) updateInstanceTypeCapacity(nodePoolName string, instanceTypeName string, nodeOverlay v1alpha1.NodeOverlay) {
+func (i *internalInstanceTypeStore) updateInstanceTypeCapacity(nodePoolName string, instanceTypeName string, nodeOverlay v1alpha1.NodeOverlay, overlayReqs scheduling.Requirements) {
 	if nodeOverlay.Spec.Capacity == nil {
 		return
 	}
 
-	_, ok := i.updates[nodePoolName]
-	if !ok {
-		i.updates[nodePoolName] = map[string]*instanceTypeUpdate{}
-	}
-	_, ok = i.updates[nodePoolName][instanceTypeName]
-	if !ok {
-		i.updates[nodePoolName][instanceTypeName] = &instanceTypeUpdate{Price: map[string]*priceUpdate{}, Capacity: &capacityUpdate{OverlayUpdate: corev1.ResourceList{}}}
-	}
+	variantKey := getVariantKey(overlayReqs)
+	i.ensureVariant(nodePoolName, instanceTypeName, variantKey, overlayReqs)
 
-	if i.updates[nodePoolName][instanceTypeName].Capacity == nil {
-		i.updates[nodePoolName][instanceTypeName].Capacity = &capacityUpdate{
+	update := i.updates[nodePoolName][instanceTypeName][variantKey]
+	if update.Capacity == nil {
+		update.Capacity = &capacityUpdate{
 			OverlayUpdate:                 nodeOverlay.Spec.Capacity,
 			lowestWeightCapacityResources: nodeOverlay.Spec.Capacity,
 			lowestWeight:                  nodeOverlay.Spec.Weight,
 		}
 	} else {
 		for resource, quantity := range nodeOverlay.Spec.Capacity {
-			if _, foundCapacityUpdate := i.updates[nodePoolName][instanceTypeName].Capacity.OverlayUpdate[resource]; foundCapacityUpdate {
+			if _, foundCapacityUpdate := update.Capacity.OverlayUpdate[resource]; foundCapacityUpdate {
 				continue
 			}
-
-			i.updates[nodePoolName][instanceTypeName].Capacity.OverlayUpdate[resource] = quantity
+			update.Capacity.OverlayUpdate[resource] = quantity
 		}
-
-		i.updates[nodePoolName][instanceTypeName].Capacity.lowestWeightCapacityResources = nodeOverlay.Spec.Capacity
-		i.updates[nodePoolName][instanceTypeName].Capacity.lowestWeight = nodeOverlay.Spec.Weight
+		update.Capacity.lowestWeightCapacityResources = nodeOverlay.Spec.Capacity
+		update.Capacity.lowestWeight = nodeOverlay.Spec.Weight
 	}
 }
 
-func (i *internalInstanceTypeStore) isCapacityUpdateConflicting(nodePoolName string, instanceTypeName string, nodeOverlay v1alpha1.NodeOverlay) bool {
+func (i *internalInstanceTypeStore) isCapacityUpdateConflicting(nodePoolName string, instanceTypeName string, nodeOverlay v1alpha1.NodeOverlay, overlayReqs scheduling.Requirements) bool {
+	variantKey := getVariantKey(overlayReqs)
+
 	_, ok := i.updates[nodePoolName]
 	if !ok {
 		return false
 	}
-	instanceTypeUpdate, ok := i.updates[nodePoolName][instanceTypeName]
+	_, ok = i.updates[nodePoolName][instanceTypeName]
 	if !ok {
 		return false
 	}
-	if instanceTypeUpdate.Capacity == nil {
+	update, ok := i.updates[nodePoolName][instanceTypeName][variantKey]
+	if !ok {
+		return false
+	}
+	if update.Capacity == nil {
 		return false
 	}
 	// IMPORTANT: This logic assumes NodeOverlays are processed in descending order by weight.
-	if lo.FromPtr(instanceTypeUpdate.Capacity.lowestWeight) != lo.FromPtr(nodeOverlay.Spec.Weight) {
+	if lo.FromPtr(update.Capacity.lowestWeight) != lo.FromPtr(nodeOverlay.Spec.Weight) {
 		return false
 	}
 
 	for resource := range nodeOverlay.Spec.Capacity {
-		if _, found := instanceTypeUpdate.Capacity.lowestWeightCapacityResources[resource]; found {
+		if _, found := update.Capacity.lowestWeightCapacityResources[resource]; found {
 			return true
 		}
 	}
@@ -242,36 +284,33 @@ func (i *internalInstanceTypeStore) isCapacityUpdateConflicting(nodePoolName str
 	return false
 }
 
-// updateInstanceTypeOffering add a new Price overlay update to the associated instance type.
+// updateInstanceTypeOffering add a new Price overlay update to the associated instance type variant.
 // NOTE: This method does not perform conflict validation. The callee must check for conflicts first.
-func (i *internalInstanceTypeStore) updateInstanceTypeOffering(nodePoolName string, instanceTypeName string, nodeOverlay v1alpha1.NodeOverlay, offerings cloudprovider.Offerings) {
+func (i *internalInstanceTypeStore) updateInstanceTypeOffering(nodePoolName string, instanceTypeName string, nodeOverlay v1alpha1.NodeOverlay, offerings cloudprovider.Offerings, overlayReqs scheduling.Requirements) {
 	price := lo.Ternary(nodeOverlay.Spec.Price == nil, nodeOverlay.Spec.PriceAdjustment, nodeOverlay.Spec.Price)
 	if price == nil {
 		return
 	}
 
-	_, ok := i.updates[nodePoolName]
-	if !ok {
-		i.updates[nodePoolName] = map[string]*instanceTypeUpdate{}
-	}
-	_, ok = i.updates[nodePoolName][instanceTypeName]
-	if !ok {
-		i.updates[nodePoolName][instanceTypeName] = &instanceTypeUpdate{Price: map[string]*priceUpdate{}, Capacity: &capacityUpdate{OverlayUpdate: corev1.ResourceList{}}}
-	}
+	variantKey := getVariantKey(overlayReqs)
+	i.ensureVariant(nodePoolName, instanceTypeName, variantKey, overlayReqs)
 
+	update := i.updates[nodePoolName][instanceTypeName][variantKey]
 	for _, of := range offerings {
-		if update, foundOfferingUpdate := i.updates[nodePoolName][instanceTypeName].Price[of.Requirements.String()]; foundOfferingUpdate {
-			update.lowestWeight = nodeOverlay.Spec.Weight
+		if existingUpdate, foundOfferingUpdate := update.Price[of.Requirements.String()]; foundOfferingUpdate {
+			existingUpdate.lowestWeight = nodeOverlay.Spec.Weight
 			continue
 		}
-		i.updates[nodePoolName][instanceTypeName].Price[of.Requirements.String()] = &priceUpdate{
+		update.Price[of.Requirements.String()] = &priceUpdate{
 			OverlayUpdate: price,
 			lowestWeight:  nodeOverlay.Spec.Weight,
 		}
 	}
 }
 
-func (i *internalInstanceTypeStore) isOfferingUpdateConflicting(nodePoolName string, instanceTypeName string, of *cloudprovider.Offering, nodeOverlay v1alpha1.NodeOverlay) bool {
+func (i *internalInstanceTypeStore) isOfferingUpdateConflicting(nodePoolName string, instanceTypeName string, of *cloudprovider.Offering, nodeOverlay v1alpha1.NodeOverlay, overlayReqs scheduling.Requirements) bool {
+	variantKey := getVariantKey(overlayReqs)
+
 	_, ok := i.updates[nodePoolName]
 	if !ok {
 		return false
@@ -280,7 +319,11 @@ func (i *internalInstanceTypeStore) isOfferingUpdateConflicting(nodePoolName str
 	if !ok {
 		return false
 	}
-	updatedOffering, ok := i.updates[nodePoolName][instanceTypeName].Price[of.Requirements.String()]
+	update, ok := i.updates[nodePoolName][instanceTypeName][variantKey]
+	if !ok {
+		return false
+	}
+	updatedOffering, ok := update.Price[of.Requirements.String()]
 	if !ok {
 		return false
 	}
@@ -290,6 +333,42 @@ func (i *internalInstanceTypeStore) isOfferingUpdateConflicting(nodePoolName str
 	}
 
 	return true
+}
+
+// ensureVariant ensures the nested map structure exists for a given variant
+func (i *internalInstanceTypeStore) ensureVariant(nodePoolName, instanceTypeName, variantKey string, overlayReqs scheduling.Requirements) {
+	if _, ok := i.updates[nodePoolName]; !ok {
+		i.updates[nodePoolName] = map[string]map[string]*instanceTypeUpdate{}
+	}
+	if _, ok := i.updates[nodePoolName][instanceTypeName]; !ok {
+		i.updates[nodePoolName][instanceTypeName] = map[string]*instanceTypeUpdate{}
+	}
+	if _, ok := i.updates[nodePoolName][instanceTypeName][variantKey]; !ok {
+		// Extract only custom label requirements (non-well-known labels) for the variant
+		customLabelReqs := scheduling.NewRequirements()
+		for key, req := range overlayReqs {
+			if !v1.WellKnownLabels.Has(key) {
+				customLabelReqs.Add(req)
+			}
+		}
+		i.updates[nodePoolName][instanceTypeName][variantKey] = &instanceTypeUpdate{
+			Price:               map[string]*priceUpdate{},
+			Capacity:            &capacityUpdate{OverlayUpdate: corev1.ResourceList{}},
+			OverlayRequirements: customLabelReqs,
+		}
+	}
+}
+
+// getVariantKey creates a unique key for an overlay based on its custom label requirements
+func getVariantKey(overlayReqs scheduling.Requirements) string {
+	// Extract only custom labels (non-well-known labels) to create the variant key
+	customLabels := scheduling.NewRequirements()
+	for key, req := range overlayReqs {
+		if !v1.WellKnownLabels.Has(key) {
+			customLabels.Add(req)
+		}
+	}
+	return customLabels.String()
 }
 
 func (s *InstanceTypeStore) Reset() {

--- a/pkg/controllers/nodeoverlay/store_memory_test.go
+++ b/pkg/controllers/nodeoverlay/store_memory_test.go
@@ -27,8 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/apis/v1alpha1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
 // Memory limits for overlay scenarios (in number of allocations)
@@ -37,9 +39,10 @@ import (
 // If these tests fail, it indicates a potential memory regression that should be investigated.
 const (
 	// MaxAllocsNoOverlays is the maximum allowed allocations when no overlays are applied.
-	// With no overlays, instance types should be returned with minimal copying.
-	// Baseline: ~72,000 allocations
-	MaxAllocsNoOverlays = 100000
+	// With the variant-based overlay system, applyAll returns slices which adds some
+	// allocation overhead even when no overlays are applied.
+	// Baseline: ~143,000 allocations
+	MaxAllocsNoOverlays = 175000
 
 	// MaxAllocsPriceOverlaysOnly is the maximum allowed allocations for price-only overlays.
 	// Price overlays require copying the offerings slice but not capacity.
@@ -48,8 +51,10 @@ const (
 
 	// MaxAllocsCapacityOverlaysOnly is the maximum allowed allocations for capacity-only overlays.
 	// Capacity overlays require copying the capacity map but not offerings.
-	// Baseline: ~72,000 allocations
-	MaxAllocsCapacityOverlaysOnly = 100000
+	// With the variant-based overlay system, allocations are higher due to
+	// the additional map structure for variants.
+	// Baseline: ~1,030,000 allocations
+	MaxAllocsCapacityOverlaysOnly = 1250000
 
 	// MaxAllocsMixedOverlays is the maximum allowed allocations when both price and capacity overlays are applied.
 	// This is the most expensive scenario as both offerings and capacity need to be copied.
@@ -133,7 +138,7 @@ var _ = Describe("Memory Usage Overlay Scenarios", func() {
 			for i := 0; i < 100; i++ {
 				for _, np := range nodePools {
 					for _, it := range instanceTypes {
-						_, _ = store.apply(np, it)
+						_ = store.applyAll(np, it)
 					}
 				}
 			}
@@ -151,34 +156,31 @@ var _ = Describe("Memory Usage Overlay Scenarios", func() {
 		It("should have controlled allocations with price-only overlays", func() {
 			store := newInternalInstanceTypeStore()
 			store.evaluatedNodePools.Insert("default")
-
-			updates := make(map[string]map[string]*instanceTypeUpdate)
-			updates["default"] = make(map[string]*instanceTypeUpdate)
+			overlayReqs := scheduling.NewRequirements()
 
 			for _, it := range instanceTypes {
-				priceUpdates := make(map[string]*priceUpdate)
+				spotOfferings := cloudprovider.Offerings{}
 				for _, offering := range it.Offerings {
 					if offering.Requirements.Get(v1.CapacityTypeLabelKey).Has("spot") {
-						priceUpdates[offering.Requirements.String()] = &priceUpdate{
-							OverlayUpdate: lo.ToPtr("-10%"),
-							lowestWeight:  lo.ToPtr(int32(10)),
-						}
+						spotOfferings = append(spotOfferings, offering)
 					}
 				}
-				if len(priceUpdates) > 0 {
-					updates["default"][it.Name] = &instanceTypeUpdate{
-						Price:    priceUpdates,
-						Capacity: &capacityUpdate{OverlayUpdate: corev1.ResourceList{}},
+				if len(spotOfferings) > 0 {
+					overlay := v1alpha1.NodeOverlay{
+						Spec: v1alpha1.NodeOverlaySpec{
+							Weight:          lo.ToPtr(int32(10)),
+							PriceAdjustment: lo.ToPtr("-10%"),
+						},
 					}
+					store.updateInstanceTypeOffering("default", it.Name, overlay, spotOfferings, overlayReqs)
 				}
 			}
-			store.updates = updates
 
 			ms := captureMemStats()
 
 			for i := 0; i < 100; i++ {
 				for _, it := range instanceTypes {
-					_, _ = store.apply("default", it)
+					_ = store.applyAll("default", it)
 				}
 			}
 
@@ -195,27 +197,25 @@ var _ = Describe("Memory Usage Overlay Scenarios", func() {
 		It("should have controlled allocations with capacity-only overlays", func() {
 			store := newInternalInstanceTypeStore()
 			store.evaluatedNodePools.Insert("default")
-
-			updates := make(map[string]map[string]*instanceTypeUpdate)
-			updates["default"] = make(map[string]*instanceTypeUpdate)
+			overlayReqs := scheduling.NewRequirements()
 
 			for _, it := range instanceTypes {
-				updates["default"][it.Name] = &instanceTypeUpdate{
-					Price: nil,
-					Capacity: &capacityUpdate{
-						OverlayUpdate: corev1.ResourceList{
+				overlay := v1alpha1.NodeOverlay{
+					Spec: v1alpha1.NodeOverlaySpec{
+						Weight: lo.ToPtr(int32(10)),
+						Capacity: corev1.ResourceList{
 							"hugepages-2Mi": resource.MustParse("100Mi"),
 						},
 					},
 				}
+				store.updateInstanceTypeCapacity("default", it.Name, overlay, overlayReqs)
 			}
-			store.updates = updates
 
 			ms := captureMemStats()
 
 			for i := 0; i < 100; i++ {
 				for _, it := range instanceTypes {
-					_, _ = store.apply("default", it)
+					_ = store.applyAll("default", it)
 				}
 			}
 
@@ -237,7 +237,7 @@ var _ = Describe("Memory Usage Overlay Scenarios", func() {
 			for i := 0; i < 100; i++ {
 				for _, np := range nodePools {
 					for _, it := range instanceTypes {
-						_, _ = store.apply(np, it)
+						_ = store.applyAll(np, it)
 					}
 				}
 			}
@@ -273,7 +273,7 @@ var _ = Describe("Memory Usage Scale With NodePools", func() {
 			for i := 0; i < 100; i++ {
 				for _, np := range nodePools {
 					for _, it := range instanceTypes {
-						_, _ = store.apply(np, it)
+						_ = store.applyAll(np, it)
 					}
 				}
 			}
@@ -312,7 +312,7 @@ var _ = Describe("Memory Usage Scale With InstanceTypes", func() {
 			for i := 0; i < 100; i++ {
 				for _, np := range nodePools {
 					for _, it := range instanceTypes {
-						_, _ = store.apply(np, it)
+						_ = store.applyAll(np, it)
 					}
 				}
 			}
@@ -374,37 +374,36 @@ func createRealisticInstanceTypes(count int) []*cloudprovider.InstanceType {
 // createStoreWithOverlays creates an instance type store with realistic overlays applied
 func createStoreWithOverlays(instanceTypes []*cloudprovider.InstanceType, nodePools []string) *internalInstanceTypeStore {
 	store := newInternalInstanceTypeStore()
-
-	updates := make(map[string]map[string]*instanceTypeUpdate)
+	overlayReqs := scheduling.NewRequirements()
 
 	for _, np := range nodePools {
 		store.evaluatedNodePools.Insert(np)
-		updates[np] = make(map[string]*instanceTypeUpdate)
 
 		for _, it := range instanceTypes {
 			// Apply price overlays to spot offerings
-			priceUpdates := make(map[string]*priceUpdate)
+			spotOfferings := cloudprovider.Offerings{}
 			for _, offering := range it.Offerings {
 				if offering.Requirements.Get(v1.CapacityTypeLabelKey).Has("spot") {
-					priceUpdates[offering.Requirements.String()] = &priceUpdate{
-						OverlayUpdate: lo.ToPtr("-10%"),
-						lowestWeight:  lo.ToPtr(int32(10)),
-					}
+					spotOfferings = append(spotOfferings, offering)
 				}
 			}
 
-			// Add capacity overlay for hugepages
-			updates[np][it.Name] = &instanceTypeUpdate{
-				Price: priceUpdates,
-				Capacity: &capacityUpdate{
-					OverlayUpdate: corev1.ResourceList{
+			overlay := v1alpha1.NodeOverlay{
+				Spec: v1alpha1.NodeOverlaySpec{
+					Weight:          lo.ToPtr(int32(10)),
+					PriceAdjustment: lo.ToPtr("-10%"),
+					Capacity: corev1.ResourceList{
 						"hugepages-2Mi": resource.MustParse("100Mi"),
 					},
 				},
 			}
+
+			if len(spotOfferings) > 0 {
+				store.updateInstanceTypeOffering(np, it.Name, overlay, spotOfferings, overlayReqs)
+			}
+			store.updateInstanceTypeCapacity(np, it.Name, overlay, overlayReqs)
 		}
 	}
 
-	store.updates = updates
 	return store
 }

--- a/pkg/controllers/nodeoverlay/suite_test.go
+++ b/pkg/controllers/nodeoverlay/suite_test.go
@@ -1189,16 +1189,13 @@ var _ = Describe("Instance Type Controller", func() {
 					instanceTypeList, err = store.ApplyAll(nodePoolTwo.Name, instanceTypeList)
 					Expect(err).To(BeNil())
 
-					// With custom label requirements, we get both the variant (with overlay) and the base instance type
 					Expect(len(instanceTypeList)).To(BeNumerically("==", 2))
-					// Find the variant with the overlay applied (has the custom price)
 					overlayApplied := lo.Filter(instanceTypeList, func(it *cloudprovider.InstanceType, _ int) bool {
 						return it.IsPricingOverlayApplied()
 					})
 					Expect(len(overlayApplied)).To(BeNumerically("==", 1))
 					Expect(len(overlayApplied[0].Offerings)).To(BeNumerically("==", 1))
 					Expect(overlayApplied[0].Offerings[0].Price).To(BeNumerically("==", expectedValue))
-					// Verify the base instance type still has the original price
 					base := lo.Filter(instanceTypeList, func(it *cloudprovider.InstanceType, _ int) bool {
 						return !it.IsPricingOverlayApplied()
 					})
@@ -1959,9 +1956,7 @@ var _ = Describe("Instance Type Controller", func() {
 				instanceTypeList, err = store.ApplyAll(nodePoolTwo.Name, instanceTypeList)
 				Expect(err).ToNot(HaveOccurred())
 
-				// With custom label requirements, we get both the variant (with overlay) and the base instance type
 				Expect(len(instanceTypeList)).To(BeNumerically("==", 2))
-				// Find the variant with the overlay applied (has the custom capacity)
 				overlayApplied := lo.Filter(instanceTypeList, func(it *cloudprovider.InstanceType, _ int) bool {
 					return it.IsCapacityOverlayApplied()
 				})
@@ -1970,7 +1965,6 @@ var _ = Describe("Instance Type Controller", func() {
 				resource, exist := overlayApplied[0].Capacity.Name(corev1.ResourceName("smarter-devices/fuse"), resource.DecimalSI).AsInt64()
 				Expect(exist).To(BeTrue())
 				Expect(resource).To(BeNumerically("==", 1))
-				// Verify the base instance type doesn't have the capacity
 				base := lo.Filter(instanceTypeList, func(it *cloudprovider.InstanceType, _ int) bool {
 					return !it.IsCapacityOverlayApplied()
 				})
@@ -2690,7 +2684,6 @@ var _ = Describe("Instance Type Controller", func() {
 		Expect(instanceTypeList[0].Requirements.Keys()).NotTo(ContainElements(lo.Keys(nodePool.Spec.Template.Labels)))
 	})
 	It("should apply overlay when NodePool uses Exists operator and overlay uses In operator with matching value", func() {
-		// Create NodePool with Exists operator for company.com/team
 		testNodePool := test.NodePool(v1.NodePool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-nodepool-with-exists",
@@ -2702,12 +2695,10 @@ var _ = Describe("Instance Type Controller", func() {
 		})
 		ExpectApplied(ctx, env.Client, testNodePool)
 
-		// Get instance types to verify base price
 		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, testNodePool)
 		Expect(err).To(BeNil())
 		Expect(instanceTypeList[0].Offerings[0].Price).To(BeNumerically("==", 1.020))
 
-		// Create overlay with In operator for company.com/team: team-a
 		overlay := test.NodeOverlay(v1alpha1.NodeOverlay{
 			Spec: v1alpha1.NodeOverlaySpec{
 				Requirements: []v1alpha1.NodeSelectorRequirement{
@@ -2724,20 +2715,16 @@ var _ = Describe("Instance Type Controller", func() {
 		ExpectApplied(ctx, env.Client, overlay)
 		ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
 
-		// Verify overlay validated successfully
 		updatedOverlay := ExpectExists(ctx, env.Client, overlay)
 		Expect(updatedOverlay.StatusConditions().IsTrue(v1alpha1.ConditionTypeValidationSucceeded)).To(BeTrue())
 
-		// Get instance types after overlay applied
 		instanceTypeList, err = cloudProvider.GetInstanceTypes(ctx, testNodePool)
 		Expect(err).To(BeNil())
 
-		// Apply overlays - should get a variant with team-a requirement
 		instanceTypeListResult, err := store.ApplyAll(testNodePool.Name, instanceTypeList)
 		Expect(err).To(BeNil())
 		Expect(len(instanceTypeListResult)).To(BeNumerically(">=", 1))
 
-		// Find the variant that has team-a requirement
 		var teamAVariant *cloudprovider.InstanceType
 		for _, it := range instanceTypeListResult {
 			teamReq := it.Requirements.Get("company.com/team")
@@ -2748,20 +2735,17 @@ var _ = Describe("Instance Type Controller", func() {
 		}
 		Expect(teamAVariant).ToNot(BeNil(), "expected to find a variant with company.com/team=team-a requirement")
 
-		// Verify price overlay was applied to team-a variant
 		Expect(len(teamAVariant.Offerings)).To(BeNumerically(">=", 1))
 		priceTeamA := teamAVariant.Offerings[0].Price
 		Expect(priceTeamA).To(BeNumerically("==", 101.020),
 			fmt.Sprintf("Expected price to be 101.020 (overlay applied) for team-a variant, but got %f", priceTeamA))
 
-		// Verify pod with team-a requirement can match the variant
 		podReqsTeamA := scheduling.NewRequirements(
 			scheduling.NewRequirement("company.com/team", corev1.NodeSelectorOpIn, "team-a"),
 		)
 		Expect(teamAVariant.Requirements.IsCompatible(podReqsTeamA)).To(BeTrue(),
 			"pod requesting team-a should be compatible with team-a variant")
 
-		// Verify pod with team-b requirement does NOT match the team-a variant
 		podReqsTeamB := scheduling.NewRequirements(
 			scheduling.NewRequirement("company.com/team", corev1.NodeSelectorOpIn, "team-b"),
 		)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2765

**Description**

Fixes an issue where NodeOverlay gets error "label does not have known values" when a NodePool uses the Exists operator and NodeOverlay uses the label and value as a requirement.

**How was this change tested?**

Unit test written and testing in a kubernetes cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
