### PR TITLE
Test: Log timing metrics for Scheduler.Add() 

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -488,7 +488,7 @@ func (s *Scheduler) updateCachedPodData(p *corev1.Pod) {
 func (s *Scheduler) add(ctx context.Context, pod *corev1.Pod) error {
 	// Timing and metrics block
 	start := time.Now()
-	numNodesInBatch := -1
+	numNodesInCluster := -1
 	numPodsInBatch := -1
 	numPodsInCluster := -1
 	numTopologyGroups := -1
@@ -500,7 +500,7 @@ func (s *Scheduler) add(ctx context.Context, pod *corev1.Pod) error {
 			"karpenter-timing: scheduler.add complete",
 			"function", "scheduling.scheduler.add()",
 			"timestamp", start.Format(time.RFC3339),
-			"num_nodes_in_batch", numNodesInBatch,
+			"num_nodes_in_cluster", numNodesInCluster,
 			"num_pods_in_batch", numPodsInBatch,
 			"num_pods_in_cluster", numPodsInCluster,
 			"num_topology_groups", numTopologyGroups,
@@ -510,8 +510,8 @@ func (s *Scheduler) add(ctx context.Context, pod *corev1.Pod) error {
 		)
 	}()
 
-	// Capture scheduling batch metrics
-	numNodesInBatch = len(s.existingNodes)
+	// Capture scheduling cluster metrics
+	numNodesInCluster = len(s.existingNodes)
 
 	// Count pods in current scheduling batch
 	numPodsInBatch = 0

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -255,6 +255,13 @@ func (c *Cluster) DeepCopyNodes() StateNodes {
 	})
 }
 
+// PodCount returns the total number of bound pods tracked in the cluster state
+func (c *Cluster) PodCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.bindings)
+}
+
 // IsNodeNominated returns true if the given node was expected to have a pod bound to it during a recent scheduling
 // batch
 func (c *Cluster) IsNodeNominated(providerID string) bool {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

**Description**

## Metrics We're Collecting

I'm analyzing the latency of the `scheduler.add()`, i.e. the time it takes for a single pod to find a node home. I'm trying to collect some log metrics for this analysis and I've got conflicting numbers when comparing them with prometheus metrics during simple ~100k pod scale-up/down tests. Quite a bit different, for example the number of nodes reached almost 5k in prom, while only ~2.5k here. Maybe I'm missing something, but just wanted to get some eyes to see if what I'm collecting is sensible.

Added timing logs to `scheduler.add()` with the following metrics:

1. **`num_nodes_in_cluster`** - Number of existing nodes in cluster state
2. **`num_pods_in_batch`** - Number of pods in current scheduling batch
3. **`num_pods_in_cluster`** - Total pods in cluster (NEW - using new `PodCount()` method)
4. **`num_topology_groups`** - Number of topology groups
5. **`num_inverse_topology_groups`** - Number of inverse topology groups
6. **`num_topology_keys`** - Number of topology keys
7. **`duration_ms`** - Scheduling operation duration

## Example Output

```json
{
  "msg": "karpenter-timing: scheduler.add complete",
  "num_nodes_in_cluster": 45,
  "num_pods_in_batch": 120,
  "num_pods_in_cluster": 5420,
  "num_topology_groups": 3,
  "num_inverse_topology_groups": 2,
  "num_topology_keys": 1,
  "duration_ms": 42.5
}
```

## Questions

**Are we collecting these metrics correctly?** Specifically:
- Is `num_nodes` actually the total cluster node count of the cluster struct?
- Does `num_pods_in_batch` represent what we think it does?
- Should we be capturing any additional metrics for scale testing?

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
