### PR TITLE
chore: bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Seeing a couple of PRs failing vulncheck with the following message.
```
Standard library
    Found in: net/url@go1.25.5
    Fixed in: net/url@go1.25.6
```
So updated go.mod: go 1.25.5 to go 1.25.6.

**How was this change tested?**
Ran go mod tidy (no dependency changes required).
Verified fix with make vulncheck (passes with no vulnerabilities).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
