### PR TITLE
feat: allow configuring MultiNodeConsolidationTimeoutDuration

### DIFF
--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/awslabs/operatorpkg/option"
 	"github.com/samber/lo"
@@ -29,10 +28,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	scheduler "sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
-const MultiNodeConsolidationTimeoutDuration = 1 * time.Minute
 const MultiNodeConsolidationType = "multi"
 
 type MultiNodeConsolidation struct {
@@ -127,7 +126,7 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 
 	lastSavedCommand := Command{}
 	// Set a timeout
-	timeoutCtx, cancel := context.WithTimeout(ctx, MultiNodeConsolidationTimeoutDuration)
+	timeoutCtx, cancel := context.WithTimeout(ctx, options.FromContext(ctx).MultiNodeConsolidationTimeout)
 	defer cancel()
 	for min <= max {
 		mid := (min + max) / 2

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -2170,7 +2170,7 @@ var _ = Describe("Metrics", func() {
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[0], nodes[1], nodes[2]}, []*v1.NodeClaim{nodeClaims[0], nodeClaims[1], nodeClaims[2]})
 		// create timeout in the past
-		timeoutCtx, cancel := context.WithTimeout(ctx, -disruption.MultiNodeConsolidationTimeoutDuration)
+		timeoutCtx, cancel := context.WithTimeout(ctx, -time.Minute)
 		defer cancel()
 
 		ExpectSingletonReconciled(timeoutCtx, disruptionController)

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -83,6 +83,7 @@ type Options struct {
 	LogErrorOutputPaths              string
 	BatchMaxDuration                 time.Duration
 	BatchIdleDuration                time.Duration
+	MultiNodeConsolidationTimeout    time.Duration
 	preferencePolicyRaw              string
 	PreferencePolicy                 PreferencePolicy
 	minValuesPolicyRaw               string
@@ -127,6 +128,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.LogErrorOutputPaths, "log-error-output-paths", env.WithDefaultString("LOG_ERROR_OUTPUT_PATHS", "stderr"), "Optional comma separated paths for logging error output")
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
+	fs.DurationVar(&o.MultiNodeConsolidationTimeout, "multi-node-consolidation-timeout", env.WithDefaultDuration("MULTI_NODE_CONSOLIDATION_TIMEOUT", time.Minute), "The timeout for multi-node consolidation. The longer this is, the more time Karpenter has to find a valid multi-node consolidation but at the cost of increased disruption latency.")
 	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -48,6 +48,7 @@ type OptionsFields struct {
 	MinValuesPolicy                  *options.MinValuesPolicy
 	BatchMaxDuration                 *time.Duration
 	BatchIdleDuration                *time.Duration
+	MultiNodeConsolidationTimeout    *time.Duration
 	IgnoreDRARequests                *bool
 	FeatureGates                     FeatureGates
 }
@@ -85,6 +86,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		LogErrorOutputPaths:              lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),
 		BatchMaxDuration:                 lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
 		BatchIdleDuration:                lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
+		MultiNodeConsolidationTimeout:    lo.FromPtrOr(opts.MultiNodeConsolidationTimeout, time.Minute),
 		PreferencePolicy:                 lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
 		MinValuesPolicy:                  lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
 		IgnoreDRARequests:                lo.FromPtrOr(opts.IgnoreDRARequests, true),


### PR DESCRIPTION
Fixes #1733 #2826 

**Description**

This PR adds the flag `MultiNodeConsolidationTimeout` in CLI making it configurable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
