### PR TITLE
test: Should revert the use of test.CreateDeploymentOptions in the regressi…

### DIFF
--- a/test/suites/regression/chaos_test.go
+++ b/test/suites/regression/chaos_test.go
@@ -60,10 +60,15 @@ var _ = Describe("Chaos", func() {
 			nodePool.Spec.Disruption.ConsolidateAfter = v1.MustParseNillableDuration("0s")
 
 			numPods := 1
-			dep := test.Deployment(test.CreateDeploymentOptions("my-app", int32(numPods), "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(map[string]string{"app": "my-app"}),
-				test.WithTerminationGracePeriod(0)))
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "my-app"},
+					},
+					TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+				},
+			})
 			// Start a controller that adds taints to nodes after creation
 			Expect(startTaintAdder(ctx, env.Config)).To(Succeed())
 			startNodeCountMonitor(ctx, env.Client)
@@ -85,10 +90,15 @@ var _ = Describe("Chaos", func() {
 			nodePool.Spec.Disruption.ConsolidationPolicy = v1.ConsolidationPolicyWhenEmpty
 			nodePool.Spec.Disruption.ConsolidateAfter = v1.MustParseNillableDuration("30s")
 			numPods := 1
-			dep := test.Deployment(test.CreateDeploymentOptions("my-app", int32(numPods), "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(map[string]string{"app": "my-app"}),
-				test.WithTerminationGracePeriod(0)))
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "my-app"},
+					},
+					TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+				},
+			})
 			// Start a controller that adds taints to nodes after creation
 			Expect(startTaintAdder(ctx, env.Config)).To(Succeed())
 			startNodeCountMonitor(ctx, env.Client)

--- a/test/suites/regression/drift_test.go
+++ b/test/suites/regression/drift_test.go
@@ -48,11 +48,18 @@ var _ = Describe("Drift", Ordered, func() {
 		numPods = 1
 		label = map[string]string{"app": "large-app"}
 		// Add pods with a do-not-disrupt annotation so that we can check node metadata before we disrupt
-		dep = test.Deployment(test.CreateDeploymentOptions("large-app", int32(numPods), "100m", "128Mi",
-			test.WithNoResourceRequests(),
-			test.WithLabels(label),
-			test.WithDoNotDisrupt(),
-			test.WithTerminationGracePeriod(0)))
+		dep = test.Deployment(test.DeploymentOptions{
+			Replicas: int32(numPods),
+			PodOptions: test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: label,
+					Annotations: map[string]string{
+						v1.DoNotDisruptAnnotationKey: "true",
+					},
+				},
+				TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+			},
+		})
 		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 	})
 	Context("Budgets", func() {
@@ -62,11 +69,23 @@ var _ = Describe("Drift", Ordered, func() {
 				Nodes: "50%",
 			}}
 			var numPods int32 = 3
-			dep = test.Deployment(test.CreateDeploymentOptions("large-app", numPods, "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(label),
-				test.WithDoNotDisrupt(),
-				test.WithPodAntiAffinityHostname()))
+			dep = test.Deployment(test.DeploymentOptions{
+				Replicas: numPods,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1.DoNotDisruptAnnotationKey: "true",
+						},
+						Labels: label,
+					},
+					PodAntiRequirements: []corev1.PodAffinityTerm{{
+						TopologyKey: corev1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: label,
+						},
+					}},
+				},
+			})
 			selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 			env.ExpectCreated(nodeClass, nodePool, dep)
 
@@ -103,21 +122,27 @@ var _ = Describe("Drift", Ordered, func() {
 				Nodes: "50%",
 			}}
 			var numPods int32 = 9
-			customConstraints := []corev1.TopologySpreadConstraint{
-				{
-					MaxSkew:           3,
-					TopologyKey:       corev1.LabelHostname,
-					WhenUnsatisfiable: corev1.DoNotSchedule,
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: label,
+			dep = test.Deployment(test.DeploymentOptions{
+				Replicas: numPods,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1.DoNotDisruptAnnotationKey: "true",
+						},
+						Labels: label,
+					},
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:           3,
+							TopologyKey:       corev1.LabelHostname,
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: label,
+							},
+						},
 					},
 				},
-			}
-			dep = test.Deployment(test.CreateDeploymentOptions("large-app", numPods, "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(label),
-				test.WithDoNotDisrupt(),
-				test.WithTopologySpreadConstraints(customConstraints)))
+			})
 			selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 			env.ExpectCreated(nodeClass, nodePool, dep)
 
@@ -170,10 +195,20 @@ var _ = Describe("Drift", Ordered, func() {
 			// Create a 5 pod deployment with hostname inter-pod anti-affinity to ensure each pod is placed on a unique node
 			numPods = 5
 			selector = labels.SelectorFromSet(appLabels)
-			deployment := test.Deployment(test.CreateDeploymentOptions("large-app", int32(numPods), "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(appLabels),
-				test.WithPodAntiAffinityHostname()))
+			deployment := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: appLabels,
+					},
+					PodAntiRequirements: []corev1.PodAffinityTerm{{
+						TopologyKey: corev1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: appLabels,
+						},
+					}},
+				},
+			})
 
 			env.ExpectCreated(nodeClass, nodePool, deployment)
 
@@ -390,10 +425,18 @@ var _ = Describe("Drift", Ordered, func() {
 
 			// launch a new nodeClaim
 			var numPods int32 = 2
-			dep := test.Deployment(test.CreateDeploymentOptions("inflate", 2, "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(map[string]string{"app": "inflate"}),
-				test.WithPodAntiAffinityHostname()))
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: 2,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "inflate"}},
+					PodAntiRequirements: []corev1.PodAffinityTerm{{
+						TopologyKey: corev1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "inflate"},
+						}},
+					},
+				},
+			})
 			// Expect only a single node to get tainted due to default disruption budgets
 			nodePool.Spec.Disruption = v1.Disruption{}
 			env.ExpectCreated(dep, nodeClass, nodePool)
@@ -430,10 +473,18 @@ var _ = Describe("Drift", Ordered, func() {
 		It("should not disrupt a drifted node if the replacement node registers but never initialized", func() {
 			// launch a new nodeClaim
 			var numPods int32 = 2
-			dep := test.Deployment(test.CreateDeploymentOptions("inflate", 2, "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(map[string]string{"app": "inflate"}),
-				test.WithPodAntiAffinityHostname()))
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: 2,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "inflate"}},
+					PodAntiRequirements: []corev1.PodAffinityTerm{{
+						TopologyKey: corev1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "inflate"},
+						}},
+					},
+				},
+			})
 			// Expect only a single node to get tainted due to default disruption budgets
 			nodePool.Spec.Disruption = v1.Disruption{}
 			env.ExpectCreated(dep, nodeClass, nodePool)
@@ -478,21 +529,30 @@ var _ = Describe("Drift", Ordered, func() {
 			// Create a deployment that contains a readiness probe that will never succeed
 			// This way, the pod will bind to the node, but the PodDisruptionBudget will never go healthy
 			var numPods int32 = 2
-			readinessProbe := &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Port: intstr.FromInt32(80),
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: 2,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app":                 "inflate",
+							"kwok.x-k8s.io/stage": "unhealthy",
+						},
+					},
+					PodAntiRequirements: []corev1.PodAffinityTerm{{
+						TopologyKey: corev1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "inflate"},
+						}},
+					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Port: intstr.FromInt32(80),
+							},
+						},
 					},
 				},
-			}
-			dep := test.Deployment(test.CreateDeploymentOptions("inflate", 2, "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(map[string]string{
-					"app":                 "inflate",
-					"kwok.x-k8s.io/stage": "unhealthy",
-				}),
-				test.WithPodAntiAffinityHostname(),
-				test.WithReadinessProbe(readinessProbe)))
+			})
 			selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 			minAvailable := intstr.FromInt32(numPods - 1)
 			pdb := test.PodDisruptionBudget(test.PDBOptions{

--- a/test/suites/regression/expiration_test.go
+++ b/test/suites/regression/expiration_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package integration_test
 
 import (
+	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -36,10 +38,15 @@ var _ = Describe("Expiration", func() {
 	var numPods int
 	BeforeEach(func() {
 		numPods = 1
-		dep = test.Deployment(test.CreateDeploymentOptions("my-app", int32(numPods), "100m", "128Mi",
-			test.WithNoResourceRequests(),
-			test.WithLabels(map[string]string{"app": "my-app"}),
-			test.WithTerminationGracePeriod(0)))
+		dep = test.Deployment(test.DeploymentOptions{
+			Replicas: int32(numPods),
+			PodOptions: test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "my-app"},
+				},
+				TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+			},
+		})
 		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 	})
 	It("should expire the node after the expiration is reached", func() {

--- a/test/suites/regression/integration_test.go
+++ b/test/suites/regression/integration_test.go
@@ -67,8 +67,17 @@ var _ = Describe("Integration", func() {
 				},
 			})
 			numPods := 1
-			dep = test.Deployment(test.CreateDeploymentOptions("large-app", int32(numPods), "100m", "4",
-				test.WithLabels(map[string]string{"app": "large-app"})))
+			dep = test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "large-app"},
+					},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4")},
+					},
+				},
+			})
 		})
 		It("should account for LimitRange Default on daemonSet pods for resources", func() {
 			limitrange.Spec.Limits = []corev1.LimitRangeItem{
@@ -151,16 +160,33 @@ var _ = Describe("Integration", func() {
 	Describe("Utilization", Label(debug.NoWatch), Label(debug.NoEvents), func() {
 		It("should provision one pod per node", func() {
 			label := map[string]string{"app": "large-app"}
-			// Calculate dynamic CPU requirement
-			dsOverhead := env.GetDaemonSetOverhead(nodePool)
-			base := lo.ToPtr(resource.MustParse("1800m"))
-			base.Sub(*dsOverhead.Cpu())
-			cpuRequest := base.String()
-
-			deployment := test.Deployment(test.CreateDeploymentOptions("large-app", 100, cpuRequest, "128Mi",
-				test.WithLabels(label),
-				test.WithDoNotDisrupt(),
-				test.WithPodAntiAffinityHostname()))
+			deployment := test.Deployment(test.DeploymentOptions{
+				Replicas: 100,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1.DoNotDisruptAnnotationKey: "true",
+						},
+						Labels: label,
+					},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: func() resource.Quantity {
+								dsOverhead := env.GetDaemonSetOverhead(nodePool)
+								base := lo.ToPtr(resource.MustParse("1800m"))
+								base.Sub(*dsOverhead.Cpu())
+								return *base
+							}(),
+						},
+					},
+					PodAntiRequirements: []corev1.PodAffinityTerm{{
+						TopologyKey: corev1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: label,
+						},
+					}},
+				},
+			})
 
 			env.ExpectCreated(nodeClass, nodePool, deployment)
 			env.EventuallyExpectHealthyPodCountWithTimeout(time.Minute*10, labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
@@ -310,11 +336,20 @@ var _ = Describe("Integration", func() {
 				}
 				numPods = 1
 				// Add pods with a do-not-disrupt annotation so that we can check node metadata before we disrupt
-				dep = test.Deployment(test.CreateDeploymentOptions("my-app", int32(numPods), "100m", "128Mi",
-					test.WithNoResourceRequests(),
-					test.WithLabels(map[string]string{"app": "my-app"}),
-					test.WithDoNotDisrupt(),
-					test.WithTerminationGracePeriod(0)))
+				dep = test.Deployment(test.DeploymentOptions{
+					Replicas: int32(numPods),
+					PodOptions: test.PodOptions{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "my-app",
+							},
+							Annotations: map[string]string{
+								v1.DoNotDisruptAnnotationKey: "true",
+							},
+						},
+						TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+					},
+				})
 				selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 			})
 			DescribeTable("Conditions", func(unhealthyCondition corev1.NodeCondition) {

--- a/test/suites/regression/perf_test.go
+++ b/test/suites/regression/perf_test.go
@@ -23,6 +23,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -34,15 +37,35 @@ var _ = Describe("Performance", func() {
 
 	Context("Provisioning", func() {
 		It("should do simple provisioning", func() {
-			deployment := test.Deployment(test.CreateDeploymentOptions("test-app", int32(replicas), "1", "128Mi",
-				test.WithLabels(testLabels)))
+			deployment := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(replicas),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: testLabels,
+					},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				}})
 			env.ExpectCreated(deployment)
 			env.ExpectCreated(nodePool, nodeClass)
 			env.EventuallyExpectHealthyPodCount(labelSelector, replicas)
 		})
 		It("should do simple provisioning and simple drift", func() {
-			deployment := test.Deployment(test.CreateDeploymentOptions("test-app", int32(replicas), "1", "128Mi",
-				test.WithLabels(testLabels)))
+			deployment := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(replicas),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: testLabels,
+					},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				}})
 			env.ExpectCreated(deployment)
 			env.ExpectCreated(nodePool, nodeClass)
 			env.EventuallyExpectHealthyPodCount(labelSelector, replicas)

--- a/test/suites/regression/termination_test.go
+++ b/test/suites/regression/termination_test.go
@@ -47,9 +47,14 @@ var _ = Describe("Termination", func() {
 			nodePool.Spec.Disruption.ConsolidateAfter = karpv1.MustParseNillableDuration("0s")
 
 			numPods = 1
-			dep = test.Deployment(test.CreateDeploymentOptions("large-app", int32(numPods), "100m", "128Mi",
-				test.WithNoResourceRequests(),
-				test.WithLabels(map[string]string{"app": "large-app"})))
+			dep = test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "large-app"},
+					},
+				},
+			})
 			selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
 		})
 		Context("Budgets", func() {
@@ -100,7 +105,7 @@ var _ = Describe("Termination", func() {
 			nodePool.Spec.Disruption.ConsolidateAfter = karpv1.MustParseNillableDuration("10s")
 
 			const numPods = 1
-			deployment := test.Deployment(test.CreateDeploymentOptions("test-app", numPods, "100m", "128Mi", test.WithNoResourceRequests()))
+			deployment := test.Deployment(test.DeploymentOptions{Replicas: numPods})
 
 			By("kicking off provisioning for a deployment")
 			env.ExpectCreated(nodeClass, nodePool, deployment)


### PR DESCRIPTION

**Description**
Regression tests in downstream repos were failing due to the test.CreateDeploymentOptions helper function not quite replicating the deployment options used in the regression test suite in some cases. This PR reverts the regression test deployment changes for now, can revisit test.CreateDeploymentOptions at some point later if needed. 
**How was this change tested?**
Make verify + submission tests. Will work with Andrew to check that this fixes the regression test failures tied to test.CreateDeploymentOptions. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
