### PR TITLE
allow consolidation from 3->2 nodes

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -163,7 +163,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 	}
 
 	// we're not going to turn a single node into multiple candidates
-	if len(results.NewNodeClaims) != 1 {
+	if len(results.NewNodeClaims) > len(candidates) {
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, fmt.Sprintf("Can't remove without creating %d candidates", len(results.NewNodeClaims)))...)
 		}


### PR DESCRIPTION
feat: allow consolidation from 3->2 nodes

**Description**

multinodeconsolidation reuses `consolidation` which seems to be built for singlenodeconsolidation,
since it should be perfectly valid to go from 3->2 nodes (or other combinations, as long as it's less)
for example 3 12xl nodes -> 2 16xl nodes

**How was this change tested?** ran it against our test cluster and seems to be doing a bit better, no longer seeing it stop on 3->2 cases

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
