### PR TITLE
feat: add a nodepool cost metric 2

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -1066,6 +1066,7 @@ var _ = Describe("Consolidation", func() {
 				corev1.LabelTopologyZone:       mostExpSpotOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
 			})
 
+			ExpectSingletonReconciled(ctx, pricingController)
 			rs := test.ReplicaSet()
 			ExpectApplied(ctx, env.Client, rs)
 			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
@@ -1180,6 +1181,7 @@ var _ = Describe("Consolidation", func() {
 				v1.CapacityTypeLabelKey:        spotOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
 				corev1.LabelTopologyZone:       spotOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
 			})
+			ExpectSingletonReconciled(ctx, pricingController)
 
 			rs := test.ReplicaSet()
 			ExpectApplied(ctx, env.Client, rs)
@@ -1715,6 +1717,7 @@ var _ = Describe("Consolidation", func() {
 				node = lo.Ternary(spotToSpot, spotNode, node)
 				// Add these spot instance with this special condition to cloud provider instancetypes
 				cloudProvider.InstanceTypes = append(cloudProvider.InstanceTypes, lo.Ternary(spotToSpot, spotInstances, onDemandInstances)...)
+				ExpectSingletonReconciled(ctx, pricingController)
 
 				rs := test.ReplicaSet()
 				ExpectApplied(ctx, env.Client, rs)
@@ -2229,6 +2232,7 @@ var _ = Describe("Consolidation", func() {
 				currentInstance,
 				replacementInstance,
 			}
+			ExpectSingletonReconciled(ctx, pricingController)
 
 			// create our RS so we can link a pod to it
 			rs := test.ReplicaSet()
@@ -2317,6 +2321,7 @@ var _ = Describe("Consolidation", func() {
 				currentInstance,
 				replacementInstance,
 			}
+			ExpectSingletonReconciled(ctx, pricingController)
 
 			// create our RS so we can link a pod to it
 			rs := test.ReplicaSet()
@@ -2917,6 +2922,7 @@ var _ = Describe("Consolidation", func() {
 				defaultInstanceType,
 				smallInstanceType,
 			}
+			ExpectSingletonReconciled(ctx, pricingController)
 			// create our RS so we can link a pod to it
 			rs := test.ReplicaSet()
 			ExpectApplied(ctx, env.Client, rs)
@@ -4468,6 +4474,7 @@ var _ = Describe("Consolidation", func() {
 					v1alpha1.LabelReservationID: mostExpensiveReservationID,
 				}),
 			})
+			ExpectSingletonReconciled(ctx, pricingController)
 			reservedNodeClaim, reservedNode = test.NodeClaimAndNode(v1.NodeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
 
 	"sigs.k8s.io/karpenter/pkg/metrics"
 
@@ -63,8 +64,10 @@ import (
 
 var ctx context.Context
 var env *test.Environment
+var clusterCost *cost.ClusterCost
 var cluster *state.Cluster
 var disruptionController *disruption.Controller
+var pricingController *informer.PricingController
 var prov *provisioning.Provisioner
 var cloudProvider *fake.CloudProvider
 var nodeStateController *informer.NodeController
@@ -92,9 +95,11 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	fakeClock = clock.NewFakeClock(time.Now())
+	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)
+	pricingController = informer.NewPricingController(env.Client, cloudProvider, clusterCost)
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	nodeStateController = informer.NewNodeController(env.Client, cluster)
-	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster)
+	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 	recorder = test.NewEventRecorder()
 	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, fakeClock)
 	queue = disruption.NewQueue(env.Client, recorder, cluster, fakeClock, prov)
@@ -107,6 +112,8 @@ var _ = AfterSuite(func() {
 var _ = BeforeEach(func() {
 	cloudProvider.Reset()
 	cloudProvider.InstanceTypes = fake.InstanceTypesAssorted()
+	clusterCost.Reset()
+	ExpectSingletonReconciled(ctx, pricingController)
 
 	recorder.Reset() // Reset the events that we captured during the run
 
@@ -578,6 +585,7 @@ var _ = Describe("Disruption Taints", func() {
 			currentInstance,
 			replacementInstance,
 		}
+		ExpectSingletonReconciled(ctx, pricingController)
 		nodePool.Spec.Disruption.ConsolidateAfter.Duration = lo.ToPtr(time.Duration(0))
 		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
 		ExpectApplied(ctx, env.Client, nodeClaim, nodePool)
@@ -952,8 +960,7 @@ var _ = Describe("Candidate Filtering", func() {
 				},
 			},
 		})
-		// Don't apply the NodePool
-		ExpectApplied(ctx, env.Client, nodeClaim, node)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 		pod := test.Pod(test.PodOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{

--- a/pkg/controllers/metrics/nodepool/suite_test.go
+++ b/pkg/controllers/metrics/nodepool/suite_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	"sigs.k8s.io/karpenter/pkg/controllers/metrics/nodepool"
 	"sigs.k8s.io/karpenter/pkg/metrics"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
@@ -42,6 +43,7 @@ var nodePoolController *nodepool.Controller
 var ctx context.Context
 var env *test.Environment
 var cp *fake.CloudProvider
+var cc *cost.ClusterCost
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -52,7 +54,8 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
 	cp = fake.NewCloudProvider()
-	nodePoolController = nodepool.NewController(env.Client, cp)
+	cc = cost.NewClusterCost(ctx, cp, env.Client)
+	nodePoolController = nodepool.NewController(env.Client, cp, cc)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/nodeoverlay/controller.go
+++ b/pkg/controllers/nodeoverlay/controller.go
@@ -115,6 +115,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 
 	c.instanceTypeStore.UpdateStore(temporaryStore)
 	c.clusterState.MarkUnconsolidated()
+
 	return reconcile.Result{RequeueAfter: 6 * time.Hour}, nil
 }
 

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -59,6 +59,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 	pscheduling "sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
@@ -69,6 +70,7 @@ var ctx context.Context
 var prov *provisioning.Provisioner
 var env *test.Environment
 var fakeClock *clock.FakeClock
+var clusterCost *cost.ClusterCost
 var cluster *state.Cluster
 var cloudProvider *fake.CloudProvider
 var nodeStateController *informer.NodeController
@@ -95,9 +97,10 @@ var _ = BeforeSuite(func() {
 	// set these on the cloud provider, so we can manipulate them if needed
 	cloudProvider.InstanceTypes = instanceTypes
 	fakeClock = clock.NewFakeClock(time.Now())
+	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	nodeStateController = informer.NewNodeController(env.Client, cluster)
-	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster)
+	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 	podStateController = informer.NewPodController(env.Client, cluster)
 	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, fakeClock)
 	podController = provisioning.NewPodController(env.Client, prov, cluster)

--- a/pkg/controllers/state/informer/pricing.go
+++ b/pkg/controllers/state/informer/pricing.go
@@ -1,0 +1,122 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/awslabs/operatorpkg/reconciler"
+	"github.com/awslabs/operatorpkg/singleton"
+	"github.com/samber/lo"
+	"go.uber.org/multierr"
+	"k8s.io/apimachinery/pkg/types"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
+)
+
+// This whole pricing controller only exists because CP's surface InstanceType information
+// via a poll-method. Long term, this controller should likely be removed in favor of refactoring the
+// cloudprovider interface to a push model for instance type information:
+// https://github.com/kubernetes-sigs/karpenter/issues/2605
+type PricingController struct {
+	client        client.Client
+	cloudProvider cloudprovider.CloudProvider
+	clusterCost   *cost.ClusterCost
+	npOfMap       map[types.NamespacedName]map[cost.OfferingKey]float64
+}
+
+func NewPricingController(client client.Client, cloudProvider cloudprovider.CloudProvider, clusterCost *cost.ClusterCost) *PricingController {
+	return &PricingController{
+		client:        client,
+		cloudProvider: cloudProvider,
+		clusterCost:   clusterCost,
+	}
+}
+
+func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, error) {
+	npl := &v1.NodePoolList{}
+	err := c.client.List(ctx, npl)
+	if err != nil {
+		return reconciler.Result{}, err
+	}
+
+	newNpOfMap := make(map[types.NamespacedName]map[cost.OfferingKey]float64)
+	var errs error
+	for _, np := range npl.Items {
+		oldOfs, exists := c.npOfMap[client.ObjectKeyFromObject(&np)]
+		newIts, err := c.cloudProvider.GetInstanceTypes(ctx, &np)
+		if err != nil {
+			errs = multierr.Append(errs, err)
+			continue
+		}
+
+		newNpOfMap[client.ObjectKeyFromObject(&np)] = make(map[cost.OfferingKey]float64)
+
+		for _, it := range newIts {
+			for _, o := range it.Offerings {
+				offeringKey := cost.OfferingKey{InstanceName: it.Name, Zone: o.Zone(), CapacityType: o.CapacityType()}
+				newNpOfMap[client.ObjectKeyFromObject(&np)][offeringKey] = o.Price
+			}
+		}
+
+		if exists && equal(oldOfs, newNpOfMap[client.ObjectKeyFromObject(&np)]) {
+			continue
+		}
+		c.clusterCost.UpdateOfferings(ctx, &np, newIts)
+	}
+	if errs != nil {
+		return reconciler.Result{}, fmt.Errorf("refreshing pricing info, %w", errs)
+	}
+	c.npOfMap = newNpOfMap
+
+	return reconciler.Result{RequeueAfter: 1 * time.Hour}, nil
+}
+
+func equal(oldOfs map[cost.OfferingKey]float64, newOfs map[cost.OfferingKey]float64) bool {
+	if len(lo.Values(oldOfs)) != len(newOfs) {
+		return false
+	}
+	for newOf, newPrice := range newOfs {
+		oldPrice, exists := oldOfs[newOf]
+		if !exists {
+			return false
+		}
+		if oldPrice != newPrice {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *PricingController) Name() string {
+	return "state.pricing"
+}
+
+func (c *PricingController) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		WatchesRawSource(singleton.Source()).
+		Complete(singleton.AsReconciler(c))
+}

--- a/pkg/controllers/static/deprovisioning/suite_test.go
+++ b/pkg/controllers/static/deprovisioning/suite_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
 	static "sigs.k8s.io/karpenter/pkg/controllers/static/deprovisioning"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
@@ -56,6 +57,7 @@ var (
 	controller               *static.Controller
 	env                      *test.Environment
 	nodeClaimStateController *informer.NodeClaimController
+	clusterCost              *cost.ClusterCost
 )
 
 type failingClient struct {
@@ -80,11 +82,12 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	fakeClock = clock.NewFakeClock(time.Now())
+	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	nodeController = informer.NewNodeController(env.Client, cluster)
 	daemonsetController = informer.NewDaemonSetController(env.Client, cluster)
 	controller = static.NewController(env.Client, cluster, cloudProvider, fakeClock)
-	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster)
+	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 })
 
 var _ = BeforeEach(func() {

--- a/pkg/controllers/static/provisioning/suite_test.go
+++ b/pkg/controllers/static/provisioning/suite_test.go
@@ -44,6 +44,7 @@ import (
 	static "sigs.k8s.io/karpenter/pkg/controllers/static/provisioning"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
@@ -72,6 +73,7 @@ var (
 	env                      *test.Environment
 	nodeClaimStateController *informer.NodeClaimController
 	prov                     *provisioning.Provisioner
+	clusterCost              *cost.ClusterCost
 )
 
 func TestAPIs(t *testing.T) {
@@ -86,11 +88,12 @@ var _ = BeforeSuite(func() {
 	cloudProvider = fake.NewCloudProvider()
 	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, fakeClock)
 	fakeClock = clock.NewFakeClock(time.Now())
+	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	nodeController = informer.NewNodeController(env.Client, cluster)
 	daemonsetController = informer.NewDaemonSetController(env.Client, cluster)
 	controller = static.NewController(env.Client, cluster, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, prov, fakeClock)
-	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster)
+	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 })
 
 var _ = BeforeEach(func() {

--- a/pkg/state/cost/cost.go
+++ b/pkg/state/cost/cost.go
@@ -1,0 +1,388 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cost
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
+	"github.com/awslabs/operatorpkg/serrors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/metrics"
+)
+
+// NecessaryLabels defines the set of required Kubernetes labels that must be present
+// on NodeClaim objects for cost tracking to function properly.
+var NecessaryLabels = []string{corev1.LabelInstanceTypeStable, v1.CapacityTypeLabelKey, corev1.LabelTopologyZone, v1.NodePoolLabelKey}
+
+var (
+	CostTrackingErrorsTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.NodePoolSubsystem,
+			Name:      "cost_tracker_errors_total",
+			Help:      "Number of errors encountered during cost tracking operations. Labeled by nodepool and nodeclaim.",
+		},
+		[]string{
+			metrics.NodePoolLabel,
+		},
+	)
+)
+
+// ClusterCost tracks the cost of compute resources across all NodePools in a cluster.
+// This is an alpha-level component and its API may change without notice.
+//
+// The ClusterCost maintains real-time cost information by:
+// - Tracking NodeClaim additions and removals
+// - Managing instance type offerings and their prices
+// - Calculating aggregate costs per NodePool and cluster-wide
+//
+// All operations are thread-safe through internal locking mechanisms.
+type ClusterCost struct {
+	sync.RWMutex
+	npCostMap map[string]*NodePoolCost // nodepool.Name -> NodePoolCost
+	// nodeClaimSet tracks which NodeClaims are currently being monitored for cost
+	nodeClaimMap map[types.NamespacedName]NodeClaimMetaData // nodeClaim object key -> NodeClaimMetaData
+
+	cloudProvider cloudprovider.CloudProvider
+	client        client.Client
+}
+
+// NodePoolCost represents the cost tracking information for a single NodePool.
+// It maintains the current cost, available instance types, and count of active offerings.
+type NodePoolCost struct {
+	cost float64
+	// offeringCounts tracks how many instances of each offering type are currently active
+	offeringCounts map[OfferingKey]OfferingCount
+}
+
+// OfferingKey uniquely identifies a specific compute offering by its zone,
+// capacity type (e.g., spot/on-demand), and instance type name.
+// This is not a hard invariant
+type OfferingKey struct {
+	Zone, CapacityType, InstanceName string
+}
+
+// OfferingCount tracks the number and cost of instances for a specific offering.
+type OfferingCount struct {
+	Count int
+	Price float64 // Price of the offering, not Price * count
+}
+
+type NodeClaimMetaData struct {
+	NodePoolName string
+	NodeClaimKey OfferingKey
+}
+
+// NewClusterCost creates and initializes a new ClusterCost instance for tracking
+// compute costs across the cluster. It requires a cloud provider for accessing
+// instance type and pricing information, and a Kubernetes client for NodePool loofferingKeyups.
+func NewClusterCost(ctx context.Context, cloudProvider cloudprovider.CloudProvider, client client.Client) *ClusterCost {
+	return &ClusterCost{
+		npCostMap:     make(map[string]*NodePoolCost),
+		nodeClaimMap:  make(map[types.NamespacedName]NodeClaimMetaData),
+		cloudProvider: cloudProvider,
+		client:        client,
+	}
+}
+
+// UpdateOfferings updates the available instance types and their pricing information
+// for a specific NodePool. This method is typically called when NodePool configurations
+// change or when cloud provider pricing information is refreshed.
+//
+// Returns an error if instance type information cannot be updated or if cost
+// recalculation fails.
+func (cc *ClusterCost) UpdateOfferings(ctx context.Context, np *v1.NodePool, instanceTypes []*cloudprovider.InstanceType) {
+	cc.Lock()
+	defer cc.Unlock()
+	cc.internalUpdateOfferings(np, instanceTypes)
+}
+
+func (cc *ClusterCost) internalNodepoolUpdate(ctx context.Context, np *v1.NodePool) error {
+	instanceTypes, err := cc.cloudProvider.GetInstanceTypes(ctx, np)
+	if err != nil {
+		return fmt.Errorf("failed to get instance types for nodepool %q, %w", np.Name, err)
+	}
+	cc.internalUpdateOfferings(np, instanceTypes)
+	return nil
+}
+
+func (cc *ClusterCost) internalUpdateOfferings(np *v1.NodePool, instanceTypes []*cloudprovider.InstanceType) {
+	npCost, exists := cc.npCostMap[np.Name]
+
+	if !exists {
+		cc.createNewNodePoolCost(np.Name, instanceTypes)
+	} else {
+		instanceTypes = lo.Filter(instanceTypes, func(it *cloudprovider.InstanceType, _ int) bool {
+			return it != nil
+		})
+		newMap := map[OfferingKey]OfferingCount{}
+		for _, it := range instanceTypes {
+			for _, o := range it.Offerings {
+				offeringKey := OfferingKey{InstanceName: it.Name, Zone: o.Zone(), CapacityType: o.CapacityType()}
+				oldCount, exists := npCost.offeringCounts[offeringKey]
+				newMap[offeringKey] = OfferingCount{
+					Count: lo.Ternary(exists, oldCount.Count, 0),
+					Price: o.Price,
+				}
+			}
+		}
+		// Add back all of the offering counts that don't exist in the new instance types
+		// This can't occur on container restart, so we may lose cost data from offerings that are no longer returned
+		// from the cloud provider but still have nodeclaims.
+		for key, count := range npCost.offeringCounts {
+			_, exists := newMap[key]
+			if !exists {
+				newMap[key] = count
+			}
+		}
+
+		npCost.offeringCounts = newMap
+		// re-calculate the cost as the instances have changed
+		cost := npCost.updateCost()
+		cc.npCostMap[np.Name].cost = cost
+	}
+}
+
+func (npc *NodePoolCost) updateCost() float64 {
+	cost := 0.0
+	for _, oc := range npc.offeringCounts {
+		// add the new price times the count of that offering
+		cost = cost + (float64(oc.Count) * oc.Price)
+	}
+	return cost
+}
+
+func (cc *ClusterCost) createNewNodePoolCost(npName string, instanceTypes []*cloudprovider.InstanceType) {
+	// create the new npc
+	cc.npCostMap[npName] = &NodePoolCost{
+		offeringCounts: make(map[OfferingKey]OfferingCount),
+		cost:           0.0,
+	}
+	for _, it := range instanceTypes {
+		for _, o := range it.Offerings {
+			cc.npCostMap[npName].offeringCounts[OfferingKey{InstanceName: it.Name, Zone: o.Zone(), CapacityType: o.CapacityType()}] = OfferingCount{
+				Count: 0,
+				Price: o.Price,
+			}
+		}
+	}
+}
+
+// UpdateNodeClaim adds a NodeClaim to cost tracking. The NodeClaim must have
+// all required labels or it will be ignored and logged as an error.
+func (cc *ClusterCost) UpdateNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) error {
+	cc.RLock()
+	_, exists := cc.nodeClaimMap[client.ObjectKeyFromObject(nodeClaim)]
+	cc.RUnlock()
+
+	if exists {
+		return nil
+	}
+
+	failed := false
+	defer func() {
+		if failed {
+			CostTrackingErrorsTotal.Inc(map[string]string{
+				metrics.NodePoolLabel: nodeClaim.Labels[v1.NodePoolLabelKey],
+			})
+		}
+	}()
+
+	// First lets check if the right labels are there
+	if nodeClaimMissingLabels(*nodeClaim) {
+		// not technically a failure mode as we expect to retry once the
+		// labels are propagated
+		return nil
+	}
+
+	nodePoolName := nodeClaim.Labels[v1.NodePoolLabelKey]
+	offeringKey := OfferingKey{CapacityType: nodeClaim.Labels[v1.CapacityTypeLabelKey], Zone: nodeClaim.Labels[corev1.LabelTopologyZone], InstanceName: nodeClaim.Labels[corev1.LabelInstanceTypeStable]}
+
+	cc.Lock()
+	defer cc.Unlock()
+	err := cc.internalAddOffering(ctx, nodePoolName, offeringKey)
+	if err != nil {
+		failed = true
+		return serrors.Wrap(err, "nodeclaim", klog.KObj(nodeClaim), "nodepool", nodePoolName)
+	}
+	cc.nodeClaimMap[client.ObjectKeyFromObject(nodeClaim)] = NodeClaimMetaData{
+		NodePoolName: nodePoolName,
+		NodeClaimKey: offeringKey,
+	}
+	return nil
+}
+
+// DeleteNodeClaim removes a NodeClaim from cost tracking. If the NodeClaim
+// was not being tracked, this operation is a no-op.
+func (cc *ClusterCost) DeleteNodeClaim(ctx context.Context, nn types.NamespacedName) error {
+	cc.RLock()
+	metadata, exists := cc.nodeClaimMap[nn]
+	cc.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	failed := false
+	defer func() {
+		if failed {
+			CostTrackingErrorsTotal.Inc(map[string]string{
+				metrics.NodePoolLabel: metadata.NodePoolName,
+			})
+		}
+	}()
+
+	cc.Lock()
+	defer cc.Unlock()
+
+	err := cc.internalRemoveOffering(metadata.NodePoolName, metadata.NodeClaimKey)
+	if err != nil {
+		failed = true
+		return serrors.Wrap(err, "namespacedName", nn, "nodepool", metadata.NodePoolName)
+	}
+
+	// If it succeeds, we can remove the metadata
+	delete(cc.nodeClaimMap, nn)
+	return nil
+}
+
+func (cc *ClusterCost) DeleteNodePool(ctx context.Context, npName string) {
+	cc.Lock()
+	defer cc.Unlock()
+
+	cc.nodeClaimMap = lo.PickBy(cc.nodeClaimMap, func(_ types.NamespacedName, metadata NodeClaimMetaData) bool {
+		return metadata.NodePoolName != npName
+	})
+	delete(cc.npCostMap, npName)
+}
+
+// internalAddOffering updates the internal clusterCost state to include a new offering for a given nodepool.
+// It is used to increment the overall cost when a node joins the cluster. It is only called by UpdateNodeClaim
+// after that function has determined if a nodeclaim is new.
+func (cc *ClusterCost) internalAddOffering(ctx context.Context, npName string, offeringKey OfferingKey) error {
+	np := &v1.NodePool{}
+	if err := cc.client.Get(ctx, client.ObjectKey{Name: npName}, np, &client.GetOptions{}); err != nil {
+		return err
+	}
+
+	_, exists := cc.npCostMap[npName]
+	if !exists {
+		// create the new npc
+		instanceTypes, err := cc.cloudProvider.GetInstanceTypes(ctx, np)
+		if err != nil {
+			return fmt.Errorf("failed to get instance types for new nodepool %q while adding offering for instance %q, %w", np.Name, offeringKey.InstanceName, err)
+		}
+		cc.createNewNodePoolCost(npName, instanceTypes)
+	}
+
+	oc, exists := cc.npCostMap[npName].offeringCounts[offeringKey]
+	if !exists {
+		// our offerings must be out of date, we should update and retry
+		err := cc.internalNodepoolUpdate(ctx, np)
+		if err != nil {
+			return fmt.Errorf("failed to update nodepool %q during retry while searching for offering for instance %q in zone %q with capacity %q, %w", np.Name, offeringKey.InstanceName, offeringKey.Zone, offeringKey.CapacityType, err)
+		}
+		oc, exists = cc.npCostMap[npName].offeringCounts[offeringKey]
+		if !exists {
+			oc = OfferingCount{Count: 1, Price: 0.0}
+			log.FromContext(ctx).Error(fmt.Errorf("failed to find offering %q during retry while searching for instance %q in zone %q with capacity %q in nodepool %q", offeringKey, offeringKey.InstanceName, offeringKey.Zone, offeringKey.CapacityType, npName), "offering won't be counted towards total cluster cost")
+		}
+	} else {
+		oc.Count += 1
+	}
+	cc.npCostMap[npName].offeringCounts[offeringKey] = oc
+	cc.npCostMap[npName].cost += oc.Price
+	return nil
+}
+
+// internalRemoveOffering updates the internal clusterCost state to remove an existing offering for a given nodepool.
+// It is used to decrement the overall cost when a node leeaves the cluster. It is only called by DeleteNodeClaim
+// after that function has determined if a nodeclaim is already being accounted for.
+func (cc *ClusterCost) internalRemoveOffering(npName string, offeringKey OfferingKey) error {
+	npc, exists := cc.npCostMap[npName]
+	if !exists {
+		return fmt.Errorf("attempted to remove offering from nonexistent nodepool %q (instance, %q, zone, %q, capacity, %q)", npName, offeringKey.InstanceName, offeringKey.Zone, offeringKey.CapacityType)
+	}
+
+	oc, exists := npc.offeringCounts[offeringKey]
+	if !exists {
+		return fmt.Errorf("attempted to remove nonexistent offering from nodepool %q (instance, %q, zone, %q, capacity, %q)", npName, offeringKey.InstanceName, offeringKey.Zone, offeringKey.CapacityType)
+	}
+
+	oc.Count -= 1
+	npc.offeringCounts[offeringKey] = oc
+	npc.cost -= oc.Price
+	if oc.Count == 0 {
+		delete(npc.offeringCounts, offeringKey)
+	}
+	if len(lo.Values(npc.offeringCounts)) == 0 {
+		delete(cc.npCostMap, npName)
+	}
+	return nil
+}
+
+func (cc *ClusterCost) Reset() {
+	cc.Lock()
+	defer cc.Unlock()
+	cc.npCostMap = make(map[string]*NodePoolCost)
+	cc.nodeClaimMap = make(map[types.NamespacedName]NodeClaimMetaData)
+}
+
+// GetClusterCost returns the total cost of all compute resources across
+// all NodePools in the cluster.
+func (cc *ClusterCost) GetClusterCost() float64 {
+	cc.RLock()
+	defer cc.RUnlock()
+	return lo.SumBy(lo.Values(cc.npCostMap), func(npc *NodePoolCost) float64 { return npc.cost })
+}
+
+// GetNodepoolCost returns the total cost of compute resources for a specific
+// NodePool. Returns 0 if the NodePool is not being tracked.
+func (cc *ClusterCost) GetNodepoolCost(np *v1.NodePool) float64 {
+	cc.RLock()
+	defer cc.RUnlock()
+	npc, exists := cc.npCostMap[np.Name]
+	if !exists {
+		return 0
+	}
+	return npc.cost
+}
+
+func nodeClaimMissingLabels(nc v1.NodeClaim) bool {
+	var missingLabels []string
+	for _, key := range NecessaryLabels {
+		_, exists := nc.Labels[key]
+		if !exists {
+			missingLabels = append(missingLabels, key)
+		}
+	}
+	return len(missingLabels) > 0
+}

--- a/pkg/state/cost/suite_test.go
+++ b/pkg/state/cost/suite_test.go
@@ -1,0 +1,630 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cost_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/awslabs/operatorpkg/object"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	clock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/apis/v1alpha1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/nodeoverlay"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	testv1alpha1 "sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var ctx context.Context
+var env *test.Environment
+var fakeClock *clock.FakeClock
+var cluster *state.Cluster
+var nodeOverlayStore *nodeoverlay.InstanceTypeStore
+var nodeOverlayController *nodeoverlay.Controller
+var pricingController *informer.PricingController
+var cloudProvider *fake.CloudProvider
+var clusterCost *cost.ClusterCost
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "State/Cost")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(testv1alpha1.CRDs...), test.WithConfigOptions(func(config *rest.Config) {
+		config.QPS = -1
+	}))
+	ctx = options.ToContext(ctx, test.Options())
+	cloudProvider = fake.NewCloudProvider()
+	fakeClock = clock.NewFakeClock(time.Now())
+	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
+	nodeOverlayStore = nodeoverlay.NewInstanceTypeStore()
+	nodeOverlayController = nodeoverlay.NewController(env.Client, cloudProvider, nodeOverlayStore, cluster)
+	pricingController = informer.NewPricingController(env.Client, cloudProvider, clusterCost)
+	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)
+	cluster.Reset()
+	cloudProvider.Reset()
+})
+
+var _ = Describe("ClusterCost", func() {
+	var testNodePool *v1.NodePool
+	var testNodePool2 *v1.NodePool
+	var testInstanceType *cloudprovider.InstanceType
+	var spotOffering *cloudprovider.Offering
+	var onDemandOffering *cloudprovider.Offering
+	BeforeEach(func() {
+		testNodePool = test.NodePool(v1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-nodepool"},
+		})
+		testNodePool2 = test.NodePool(v1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-nodepool-2"},
+		})
+
+		spotOffering = &cloudprovider.Offering{
+			Requirements: scheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:  v1.CapacityTypeSpot,
+				corev1.LabelTopologyZone: "test-zone-1",
+			}),
+			Price:     1.50,
+			Available: true,
+		}
+
+		onDemandOffering = &cloudprovider.Offering{
+			Requirements: scheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+				corev1.LabelTopologyZone: "test-zone-1",
+			}),
+			Price:     3.00,
+			Available: true,
+		}
+
+		testInstanceType = &cloudprovider.InstanceType{
+			Name: "test-instance",
+			Offerings: []*cloudprovider.Offering{
+				spotOffering,
+				onDemandOffering,
+			},
+		}
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{testInstanceType}
+
+		ExpectApplied(ctx, env.Client, testNodePool, testNodePool2)
+	})
+	Context("UpdateNodeClaim", func() {
+		It("should update costs correctly for single spot offering to empty nodepool", func() {
+			initialClusterCost := clusterCost.GetClusterCost()
+			Expect(initialClusterCost).To(BeNumerically("~", 0.0, 0.001),
+				"Cluster cost should start at 0")
+			RunUpdateNodeClaimTest(
+				clusterCost,
+				testNodePool,
+				testInstanceType.Name,
+				spotOffering.CapacityType(),
+				spotOffering.Zone(),
+				1.50, // expectedNodePoolCost
+				1.50, // expectedClusterCost
+			)
+		})
+		It("should update costs correctly for single on-demand offering to empty nodepool", func() {
+			// Setup: Empty cluster cost (no existing offerings)
+			// No setup needed - starting with clean state
+			RunUpdateNodeClaimTest(
+				clusterCost,
+				testNodePool,
+				testInstanceType.Name,
+				onDemandOffering.CapacityType(),
+				onDemandOffering.Zone(),
+				3.00, // expectedNodePoolCost
+				3.00, // expectedClusterCost
+			)
+		})
+
+		It("should update costs correctly for duplicate spot offering to increment count", func() {
+			// Setup: Add initial spot offering to create baseline
+			nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim)).To(Succeed())
+
+			RunUpdateNodeClaimTest(
+				clusterCost,
+				testNodePool,
+				testInstanceType.Name,
+				spotOffering.CapacityType(),
+				spotOffering.Zone(),
+				3.00, // expectedNodePoolCost (2 * 1.50)
+				3.00, // expectedClusterCost
+			)
+		})
+
+		It("should update costs correctly for different offering types to same nodepool", func() {
+			// Setup: Add spot offering first, then test will add on-demand offering
+			nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim)).To(Succeed())
+
+			RunUpdateNodeClaimTest(
+				clusterCost,
+				testNodePool,
+				testInstanceType.Name,
+				onDemandOffering.CapacityType(),
+				onDemandOffering.Zone(),
+				4.50, // expectedNodePoolCost (1.50 + 3.00)
+				4.50, // expectedClusterCost
+			)
+		})
+
+		It("should update costs correctly for offering to different nodepool", func() {
+			// Setup: Add spot offering to first nodepool, then test will add on-demand to second nodepool
+			nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim)).To(Succeed())
+
+			RunUpdateNodeClaimTest(
+				clusterCost,
+				testNodePool2,
+				testInstanceType.Name,
+				onDemandOffering.CapacityType(),
+				onDemandOffering.Zone(),
+				3.00, // expectedNodePoolCost (second nodepool cost)
+				4.50, // expectedClusterCost (1.50 + 3.00 total)
+			)
+		})
+	})
+
+	Context("DeleteNodeClaim", func() {
+		It("should update costs correctly for single spot offering from nodepool with one offering", func() {
+			// Setup: Add one spot offering to remove
+			nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim)).To(Succeed())
+
+			RunDeleteNodeClaimTest(
+				clusterCost,
+				nodeClaim,
+				testNodePool,
+				0.0, // expectedNodePoolCost
+				0.0, // expectedClusterCost
+			)
+		})
+
+		It("should update costs correctly for one instance of duplicate spot offering", func() {
+			// Setup: Add same spot offering twice so removing one leaves one remaining
+			nodeClaim1 := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			nodeClaim2 := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			nodeClaim2.Name = "test-nodeclaim-2"
+			Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim1)).To(Succeed())
+			Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim2)).To(Succeed())
+
+			RunDeleteNodeClaimTest(
+				clusterCost,
+				nodeClaim1,
+				testNodePool,
+				1.50, // expectedNodePoolCost (one offering remains)
+				1.50, // expectedClusterCost
+			)
+		})
+
+		It("should update costs correctly for spot offering from nodepool with mixed offerings", func() {
+			// Setup: Add both spot and on-demand offerings, test will remove spot
+			spotNodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			onDemandNodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, onDemandOffering.CapacityType(), onDemandOffering.Zone())
+			onDemandNodeClaim.Name = "test-nodeclaim-ondemand"
+			Expect(clusterCost.UpdateNodeClaim(ctx, spotNodeClaim)).To(Succeed())
+			Expect(clusterCost.UpdateNodeClaim(ctx, onDemandNodeClaim)).To(Succeed())
+
+			RunDeleteNodeClaimTest(
+				clusterCost,
+				spotNodeClaim,
+				testNodePool,
+				3.00, // expectedNodePoolCost (only on-demand remains)
+				3.00, // expectedClusterCost
+			)
+		})
+
+		It("should update costs correctly for offering from one of multiple nodepools", func() {
+			// Setup: Add spot offering to first nodepool and on-demand to second nodepool
+			spotNodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			onDemandNodeClaim := createTestNodeClaim(testNodePool2, testInstanceType.Name, onDemandOffering.CapacityType(), onDemandOffering.Zone())
+			onDemandNodeClaim.Name = "test-nodeclaim-ondemand"
+			Expect(clusterCost.UpdateNodeClaim(ctx, spotNodeClaim)).To(Succeed())
+			Expect(clusterCost.UpdateNodeClaim(ctx, onDemandNodeClaim)).To(Succeed())
+
+			RunDeleteNodeClaimTest(
+				clusterCost,
+				spotNodeClaim,
+				testNodePool,
+				0.0, // expectedNodePoolCost (first nodepool now empty)
+				3.0, // expectedClusterCost (only second nodepool remains)
+			)
+		})
+
+		It("should update costs correctly for last offering completely removes nodepool entry", func() {
+			// Setup: Add single spot offering to remove completely
+			nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim)).To(Succeed())
+
+			RunDeleteNodeClaimTest(
+				clusterCost,
+				nodeClaim,
+				testNodePool,
+				0.0, // expectedNodePoolCost
+				0.0, // expectedClusterCost
+			)
+		})
+	})
+
+	Context("UpdateOfferings", func() {
+		It("should recalculate cluster cost appropriately when nodeoverlays change", func() {
+			GinkgoHelper()
+			// Setup: Add initial offering to establish baseline cost
+			nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim)).To(Succeed())
+
+			// Verify initial cost
+			initialCost := clusterCost.GetNodepoolCost(testNodePool)
+			Expect(initialCost).To(BeNumerically("~", 1.50, 0.001))
+			overlay := test.NodeOverlay(v1alpha1.NodeOverlay{
+				Spec: v1alpha1.NodeOverlaySpec{
+					Requirements: []v1alpha1.NodeSelectorRequirement{
+						{
+							Key:      v1.NodePoolLabelKey,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{testNodePool.Name},
+						},
+					},
+					PriceAdjustment: lo.ToPtr("+2.5"),
+					Weight:          lo.ToPtr(int32(10000)),
+				},
+			})
+
+			ExpectApplied(ctx, env.Client, overlay)
+			ExpectReconcileSucceeded(ctx, nodeOverlayController, client.ObjectKeyFromObject(overlay))
+			var err error
+			cloudProvider.InstanceTypes, err = nodeOverlayStore.ApplyAll(testNodePool.Name, cloudProvider.InstanceTypes)
+			Expect(err).To(Succeed())
+			clusterCost.UpdateOfferings(ctx, testNodePool, cloudProvider.InstanceTypes)
+
+			// Verify cost has been updated to reflect new price
+			updatedCost := clusterCost.GetNodepoolCost(testNodePool)
+			Expect(updatedCost).To(BeNumerically("~", 4.0, 0.001),
+				"NodePool cost should be updated to reflect new offering price from nodeoverlay")
+
+			// Verify cluster cost is also updated
+			clusterCost := clusterCost.GetClusterCost()
+			Expect(clusterCost).To(BeNumerically("~", 4.0, 0.001),
+				"Cluster cost should be updated to reflect new offering price")
+		})
+
+		It("should recalculate cluster cost appropriately when cloud provider updates the price of offerings", func() {
+			GinkgoHelper()
+			// Setup: Add multiple nodeclaims across different nodepools to test comprehensive recalculation
+			spotNodeClaim1 := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			onDemandNodeClaim1 := createTestNodeClaim(testNodePool, testInstanceType.Name, onDemandOffering.CapacityType(), onDemandOffering.Zone())
+			onDemandNodeClaim1.Name = "test-nodeclaim-ondemand1"
+			spotNodeClaim2 := createTestNodeClaim(testNodePool2, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+			spotNodeClaim2.Name = "test-nodeclaim-spot2"
+
+			Expect(clusterCost.UpdateNodeClaim(ctx, spotNodeClaim1)).To(Succeed())
+			Expect(clusterCost.UpdateNodeClaim(ctx, onDemandNodeClaim1)).To(Succeed())
+			Expect(clusterCost.UpdateNodeClaim(ctx, spotNodeClaim2)).To(Succeed())
+
+			// Verify initial costs
+			initialNodePool1Cost := clusterCost.GetNodepoolCost(testNodePool)
+			initialNodePool2Cost := clusterCost.GetNodepoolCost(testNodePool2)
+			initialClusterCost := clusterCost.GetClusterCost()
+
+			Expect(initialNodePool1Cost).To(BeNumerically("~", 4.50, 0.001)) // 1.50 + 3.00
+			Expect(initialNodePool2Cost).To(BeNumerically("~", 1.50, 0.001)) // 1.50
+			Expect(initialClusterCost).To(BeNumerically("~", 6.00, 0.001))   // 4.50 + 1.50
+
+			// Simulate cloud provider price changes
+			updatedSpotOffering := &cloudprovider.Offering{
+				Requirements: scheduling.NewLabelRequirements(map[string]string{
+					v1.CapacityTypeLabelKey:  v1.CapacityTypeSpot,
+					corev1.LabelTopologyZone: "test-zone-1",
+				}),
+				Price:     2.50, // Changed from 1.50 to 2.50
+				Available: true,
+			}
+
+			updatedInstanceType := &cloudprovider.InstanceType{
+				Name: "test-instance",
+				Offerings: []*cloudprovider.Offering{
+					updatedSpotOffering,
+					onDemandOffering,
+				},
+			}
+
+			// Update cloudProvider with new prices
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{updatedInstanceType}
+
+			// Call UpdateOfferings to trigger cost recalculation
+			clusterCost.UpdateOfferings(ctx, testNodePool, cloudProvider.InstanceTypes)
+			clusterCost.UpdateOfferings(ctx, testNodePool2, cloudProvider.InstanceTypes)
+
+			// Verify costs have been updated across all nodepools
+			finalNodePool1Cost := clusterCost.GetNodepoolCost(testNodePool)
+			finalNodePool2Cost := clusterCost.GetNodepoolCost(testNodePool2)
+			finalClusterCost := clusterCost.GetClusterCost()
+
+			Expect(finalNodePool1Cost).To(BeNumerically("~", 5.50, 0.001), // 2.50 + 3.00
+				"NodePool1 cost should reflect updated prices for both offerings")
+			Expect(finalNodePool2Cost).To(BeNumerically("~", 2.50, 0.001), // 2.50
+				"NodePool2 cost should reflect updated spot offering price")
+			Expect(finalClusterCost).To(BeNumerically("~", 8.00, 0.001), // 5.50 + 2.50
+				"Cluster cost should be sum of all updated nodepool costs")
+		})
+	})
+
+	Context("Concurrency", func() {
+		It("should be thread-safe with concurrent UpdateNodeClaim calls", func() {
+			GinkgoHelper()
+			numGoroutines := 5
+			numOperationsPerGoroutine := 10
+			var nodeClaims []*v1.NodeClaim
+
+			// Pre-create nodeclaims for concurrent operations
+			for i := 0; i < numGoroutines*numOperationsPerGoroutine; i++ {
+				nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+				nodeClaim.Name = fmt.Sprintf("test-nodeclaim-%d", i)
+				nodeClaims = append(nodeClaims, nodeClaim)
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(numGoroutines)
+
+			// Launch multiple goroutines that concurrently add nodeclaims
+			for i := 0; i < numGoroutines; i++ {
+				go func(goroutineIndex int) {
+					defer wg.Done()
+					for j := 0; j < numOperationsPerGoroutine; j++ {
+						nodeClaimIndex := goroutineIndex*numOperationsPerGoroutine + j
+						Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaims[nodeClaimIndex])).To(Succeed())
+					}
+				}(i)
+			}
+
+			wg.Wait()
+
+			// Verify final cost is correct (should be numGoroutines * numOperationsPerGoroutine * spotOffering.Price)
+			expectedCost := float64(numGoroutines*numOperationsPerGoroutine) * spotOffering.Price
+			finalCost := clusterCost.GetNodepoolCost(testNodePool)
+			Expect(finalCost).To(BeNumerically("~", expectedCost, 0.001),
+				"Final cost should be sum of all concurrent operations")
+		})
+
+		It("should be thread-safe with concurrent DeleteNodeClaim calls", func() {
+			GinkgoHelper()
+			numGoroutines := 25
+			numOperationsPerGoroutine := 10
+			totalOperations := numGoroutines * numOperationsPerGoroutine
+			var nodeClaims []*v1.NodeClaim
+
+			// Setup: Pre-populate with nodeclaims to remove
+			for i := 0; i < totalOperations; i++ {
+				nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+				nodeClaim.Name = fmt.Sprintf("test-nodeclaim-%d", i)
+				nodeClaims = append(nodeClaims, nodeClaim)
+				Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim)).To(Succeed())
+			}
+
+			// Verify setup
+			initialCost := clusterCost.GetNodepoolCost(testNodePool)
+			expectedInitialCost := float64(totalOperations) * spotOffering.Price
+			Expect(initialCost).To(BeNumerically("~", expectedInitialCost, 0.001))
+
+			var wg sync.WaitGroup
+			wg.Add(numGoroutines)
+
+			// Launch multiple goroutines that concurrently remove nodeclaims
+			for i := 0; i < numGoroutines; i++ {
+				go func(goroutineIndex int) {
+					defer wg.Done()
+					for j := 0; j < numOperationsPerGoroutine; j++ {
+						nodeClaimIndex := goroutineIndex*numOperationsPerGoroutine + j
+						Expect(clusterCost.DeleteNodeClaim(ctx, client.ObjectKeyFromObject(nodeClaims[nodeClaimIndex]))).To(Succeed())
+					}
+				}(i)
+			}
+
+			wg.Wait()
+
+			// Verify final cost is zero after all removals
+			finalCost := clusterCost.GetNodepoolCost(testNodePool)
+			Expect(finalCost).To(BeNumerically("==", 0.0),
+				"Final cost should be zero after removing all nodeclaims")
+		})
+
+		It("should handle concurrent updates while reading costs", func() {
+			GinkgoHelper()
+			numReaders := 2
+			numWriters := 1
+			operationsPerWriter := 10
+			duration := time.Second * 2
+
+			var wg sync.WaitGroup
+			stopChan := make(chan struct{})
+			var nodeClaims []*v1.NodeClaim
+
+			// Pre-create nodeclaims for concurrent operations
+			for i := 0; i < operationsPerWriter; i++ {
+				nodeClaim := createTestNodeClaim(testNodePool, testInstanceType.Name, spotOffering.CapacityType(), spotOffering.Zone())
+				nodeClaim.Name = fmt.Sprintf("test-nodeclaim-%d", i)
+				nodeClaims = append(nodeClaims, nodeClaim)
+			}
+
+			// Launch reader goroutines that continuously read costs
+			wg.Add(numReaders)
+			for i := 0; i < numReaders; i++ {
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					for {
+						select {
+						case <-stopChan:
+							return
+						default:
+							// Read costs continuously - these should never panic or return invalid values
+							nodepoolCost := clusterCost.GetNodepoolCost(testNodePool)
+							clusterCost := clusterCost.GetClusterCost()
+
+							// Costs should always be non-negative
+							Expect(nodepoolCost).To(BeNumerically(">=", 0.0))
+							Expect(clusterCost).To(BeNumerically(">=", 0.0))
+						}
+					}
+				}()
+			}
+
+			// Launch writer goroutines that add and remove nodeclaims
+			wg.Add(numWriters)
+			for i := 0; i < numWriters; i++ {
+				go func(_ int) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					for j := 0; j < operationsPerWriter; j++ {
+						// Randomly add or remove nodeclaims
+						if j%2 == 0 {
+							Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaims[j])).To(Succeed())
+						} else {
+							// Only remove if we've added some nodeclaims
+							if j > 0 {
+								Expect(clusterCost.DeleteNodeClaim(ctx, client.ObjectKeyFromObject(nodeClaims[j-1]))).To(Succeed())
+							}
+						}
+
+						// Small delay to allow readers to interleave
+						time.Sleep(time.Millisecond * 10)
+					}
+				}(i)
+			}
+
+			// Stop readers after duration
+			go func() {
+				time.Sleep(duration)
+				close(stopChan)
+			}()
+
+			wg.Wait()
+
+			// Verify that operations completed successfully without race conditions
+			// The exact final cost depends on the timing of operations, but it should be valid
+			finalCost := clusterCost.GetNodepoolCost(testNodePool)
+			Expect(finalCost).To(BeNumerically(">=", 0.0),
+				"Final cost should be non-negative after concurrent operations")
+		})
+	})
+})
+
+func createTestNodeClaim(np *v1.NodePool, instanceName, capacityType, zone string) *v1.NodeClaim {
+	return test.NodeClaim(v1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: test.RandomName(),
+			Labels: map[string]string{
+				v1.NodePoolLabelKey:            np.Name,
+				corev1.LabelInstanceTypeStable: instanceName,
+				v1.CapacityTypeLabelKey:        capacityType,
+				corev1.LabelTopologyZone:       zone,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind: object.GVK(np).Kind,
+					UID:  np.UID,
+				},
+			},
+		},
+	})
+}
+
+func RunUpdateNodeClaimTest(clusterCost *cost.ClusterCost, np *v1.NodePool, instanceName, capacityType, zone string, expectedNodePoolCost float64, expectedClusterCost float64) {
+	GinkgoHelper()
+	// Record initial costs before adding nodeclaim
+	initialNodePoolCost := clusterCost.GetNodepoolCost(np)
+	initialClusterCost := clusterCost.GetClusterCost()
+
+	// Create and add the nodeclaim
+	nodeClaim := createTestNodeClaim(np, instanceName, capacityType, zone)
+	Expect(clusterCost.UpdateNodeClaim(ctx, nodeClaim)).To(Succeed())
+
+	// Verify that nodepool cost has been updated correctly
+	finalNodePoolCost := clusterCost.GetNodepoolCost(np)
+	Expect(finalNodePoolCost).To(BeNumerically("~", expectedNodePoolCost, 0.001),
+		"NodePool cost should match expected value after adding nodeclaim")
+
+	// Verify that cluster cost has been updated correctly
+	finalClusterCost := clusterCost.GetClusterCost()
+	Expect(finalClusterCost).To(BeNumerically("~", expectedClusterCost, 0.001),
+		"Cluster cost should match expected value after adding nodeclaim")
+
+	// Verify that costs have increased (or stayed same if starting from expected value)
+	Expect(finalNodePoolCost).To(BeNumerically(">=", initialNodePoolCost),
+		"NodePool cost should not decrease when adding nodeclaims")
+	Expect(finalClusterCost).To(BeNumerically(">=", initialClusterCost),
+		"Cluster cost should not decrease when adding nodeclaims")
+}
+
+func RunDeleteNodeClaimTest(clusterCost *cost.ClusterCost, nodeClaim *v1.NodeClaim, np *v1.NodePool, expectedNodePoolCost float64, expectedClusterCost float64) {
+	GinkgoHelper()
+	// Record initial costs before removing nodeclaim
+	initialNodePoolCost := clusterCost.GetNodepoolCost(np)
+	initialClusterCost := clusterCost.GetClusterCost()
+
+	// Remove the nodeclaim
+	Expect(clusterCost.DeleteNodeClaim(ctx, client.ObjectKeyFromObject(nodeClaim))).To(Succeed())
+
+	// Verify that nodepool cost has been updated correctly
+	finalNodePoolCost := clusterCost.GetNodepoolCost(np)
+	Expect(finalNodePoolCost).To(BeNumerically("~", expectedNodePoolCost, 0.001),
+		"NodePool cost should match expected value after removing nodeclaim")
+
+	// Verify that cluster cost has been updated correctly
+	finalClusterCost := clusterCost.GetClusterCost()
+	Expect(finalClusterCost).To(BeNumerically("~", expectedClusterCost, 0.001),
+		"Cluster cost should match expected value after removing nodeclaim")
+
+	// Verify that costs have decreased (or stayed same if at zero)
+	Expect(finalNodePoolCost).To(BeNumerically("<=", initialNodePoolCost),
+		"NodePool cost should not increase when removing nodeclaims")
+	Expect(finalClusterCost).To(BeNumerically("<=", initialClusterCost),
+		"Cluster cost should not increase when removing nodeclaims")
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Second attempt at: https://github.com/kubernetes-sigs/karpenter/pull/2584

Updates:

* Now instead of storing instance types or offerings, we store just the relevant information. Notably this avoids storing any scheduling.Requirements, which is a significant memory sink. 
* Includes specific logic to clean up the cluster cost data when a nodepool has been deleted.

**How was this change tested?**

Ran some fuzz testing, scaling up deployments and scaling them down again, created nodepools, scaled them up, then deleted nodepools. Confirmed that the controller does not panic nor does the memory leak


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
