### PR TITLE
chore: ignore pods that reference a pv that is marked for deletion

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -3385,6 +3385,48 @@ var _ = Context("Scheduling", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
+		It("should not launch nodes for pod with bound persistentVolume that is marked for deletion", func() {
+			volumeName := "tmp-ephemeral"
+			pod := test.UnschedulablePod()
+			// Pod has an ephemeral volume claim that has NO storage class, so it should use the default one
+			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					Ephemeral: &corev1.EphemeralVolumeSource{
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+								Resources: corev1.VolumeResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+			pv := test.PersistentVolume(test.PersistentVolumeOptions{
+				Driver: "other-provider",
+			})
+			pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: pod.Namespace,
+					Name:      fmt.Sprintf("%s-%s", pod.Name, volumeName),
+				},
+				VolumeName: pv.Name,
+			})
+			ExpectApplied(ctx, env.Client, nodePool, pvc, pv, pod)
+			ExpectDeletionTimestampSet(ctx, env.Client, pv)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+
+			var nodeList corev1.NodeList
+			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
+			// no nodes should be created as the persistent volume has a deletion timestamp set
+			Expect(nodeList.Items).To(HaveLen(0))
+		})
 		It("should not launch nodes for pod with Lost persistentVolumeClaim", func() {
 			sc := test.StorageClass(test.StorageClassOptions{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/provisioning/scheduling/volumetopology.go
+++ b/pkg/controllers/provisioning/scheduling/volumetopology.go
@@ -206,6 +206,9 @@ func (v *VolumeTopology) validateVolume(ctx context.Context, volumeName string) 
 		if err := v.kubeClient.Get(ctx, types.NamespacedName{Name: volumeName}, pv); err != nil {
 			return err
 		}
+		if !pv.DeletionTimestamp.IsZero() {
+			return fmt.Errorf("persistentvolume is being deleted")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Added validation to reject pods with PersistentVolumes marked for deletion. We are doing this because even if we create a node to which the pod can schedule, it will remain stuck because the volumeattachment will never succeed because the PV is marked for deletion.

- Updated validateVolume() function to check if a PersistentVolume has a DeletionTimestamp set
- Returns an error when attempting to schedule pods that reference PVs being deleted
- Aligns with existing validation pattern that rejects PVCs with deletion timestamps

**How was this change tested?**
- Added test case: "should not launch nodes for pod with bound persistentVolume that is marked for deletion"
- Validates that no nodes are created when PV has deletion timestamp set

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
