### PR TITLE
feat: make disruption polling interval configurable

### DIFF
--- a/kwok/charts/README.md
+++ b/kwok/charts/README.md
@@ -51,9 +51,10 @@ For full Karpenter documentation please checkout [https://karpenter.sh](https://
 | serviceMonitor.additionalLabels | object | `{}` | Additional labels for the ServiceMonitor. |
 | serviceMonitor.enabled | bool | `false` | Specifies whether a ServiceMonitor should be created. |
 | serviceMonitor.endpointConfig | object | `{}` | Endpoint configuration for the ServiceMonitor. |
-| settings | object | `{"batchIdleDuration":"1s","batchMaxDuration":"10s","featureGates":{"nodeRepair":false,"spotToSpotConsolidation":false},"minValuesPolicy":"Strict","preferencePolicy":"Respect"}` | Global Settings to configure Karpenter |
+| settings | object | `{"batchIdleDuration":"1s","batchMaxDuration":"10s","disruptionPollingPeriod":"10s","featureGates":{"nodeRepair":false,"spotToSpotConsolidation":false},"minValuesPolicy":"Strict","preferencePolicy":"Respect"}` | Global Settings to configure Karpenter |
 | settings.batchIdleDuration | string | `"1s"` | The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately. |
 | settings.batchMaxDuration | string | `"10s"` | The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes. |
+| settings.disruptionPollingPeriod | string | `"10s"` | The interval between polling rounds for disruption calculations.  |
 | settings.featureGates | object | `{"nodeRepair":false,"spotToSpotConsolidation":false}` | Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features |
 | settings.featureGates.nodeRepair | bool | `false` | nodeRepair is ALPHA and is disabled by default. Setting this to true will enable node repair. |
 | settings.featureGates.spotToSpotConsolidation | bool | `false` | spotToSpotConsolidation is ALPHA and is disabled by default. Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation. |

--- a/kwok/charts/templates/deployment.yaml
+++ b/kwok/charts/templates/deployment.yaml
@@ -110,6 +110,10 @@ spec:
             - name: BATCH_IDLE_DURATION
               value: "{{ . }}"
           {{- end }}
+          {{- with .Values.settings.disruptionPollingPeriod }}
+            - name: DISRUPTION_POLLING_PERIOD
+              value: "{{ . }}"
+          {{- end }}
           {{- with .Values.settings.preferencePolicy }}
             - name: PREFERENCE_POLICY
               value: "{{ . }}"

--- a/kwok/charts/values.yaml
+++ b/kwok/charts/values.yaml
@@ -134,7 +134,7 @@ settings:
   # will be batched separately.
   batchIdleDuration: 1s
   # -- The interval between polling rounds for disruption calculations. 
-  disruptionPollingInterval: 10s
+  disruptionPollingPeriod: 10s
   # -- How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution
   # node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'
   preferencePolicy: Respect

--- a/kwok/charts/values.yaml
+++ b/kwok/charts/values.yaml
@@ -133,6 +133,8 @@ settings:
   # faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods
   # will be batched separately.
   batchIdleDuration: 1s
+  # -- The interval between polling rounds for disruption calculations. 
+  disruptionPollingInterval: 10s
   # -- How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution
   # node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'
   preferencePolicy: Respect

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -81,7 +81,7 @@ func NewControllers(
 
 	controllers := []controller.Controller{
 		p, evictionQueue, disruptionQueue,
-		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue),
+		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue, disruption.WithPollingPeriod(options.FromContext(ctx).DisruptionPollingPeriod)),
 		provisioning.NewPodController(kubeClient, p, cluster),
 		provisioning.NewNodeController(kubeClient, p),
 		nodepoolhash.NewController(kubeClient, cloudProvider),

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeEach(func() {
 	recorder.Reset() // Reset the events that we captured during the run
 
 	// Ensure that we reset the disruption controller's methods after each test run
-	disruptionController = disruption.NewController(fakeClock, env.Client, prov, cloudProvider, recorder, cluster, queue, disruption.WithMethods(NewMethodsWithNopValidator()...))
+	disruptionController = disruption.NewController(fakeClock, env.Client, prov, cloudProvider, recorder, cluster, queue, disruption.WithMethods(NewMethodsWithNopValidator()...), disruption.WithPollingPeriod(options.FromContext(ctx).DisruptionPollingPeriod))
 	fakeClock.SetTime(time.Now())
 	cluster.Reset()
 	*queue = lo.FromPtr(disruption.NewQueue(env.Client, recorder, cluster, fakeClock, prov))

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -83,6 +83,7 @@ type Options struct {
 	LogErrorOutputPaths              string
 	BatchMaxDuration                 time.Duration
 	BatchIdleDuration                time.Duration
+	DisruptionPollingPeriod          time.Duration
 	preferencePolicyRaw              string
 	PreferencePolicy                 PreferencePolicy
 	minValuesPolicyRaw               string
@@ -127,6 +128,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.LogErrorOutputPaths, "log-error-output-paths", env.WithDefaultString("LOG_ERROR_OUTPUT_PATHS", "stderr"), "Optional comma separated paths for logging error output")
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")
 	fs.DurationVar(&o.BatchIdleDuration, "batch-idle-duration", env.WithDefaultDuration("BATCH_IDLE_DURATION", time.Second), "The maximum amount of time with no new pending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately.")
+	fs.DurationVar(&o.DisruptionPollingPeriod, "disruption-polling-period", env.WithDefaultDuration("DISRUPTION_POLLING_PERIOD", 10*time.Second), "The interval between polling rounds for disruption calculations.")
 	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Options", func() {
 		"LOG_ERROR_OUTPUT_PATHS",
 		"BATCH_MAX_DURATION",
 		"BATCH_IDLE_DURATION",
+		"DISRUPTION_POLLING_PERIOD",
 		"PREFERENCE_POLICY",
 		"MIN_VALUES_POLICY",
 		"FEATURE_GATES",
@@ -118,6 +119,7 @@ var _ = Describe("Options", func() {
 				LogErrorOutputPaths:              lo.ToPtr("stderr"),
 				BatchMaxDuration:                 lo.ToPtr(10 * time.Second),
 				BatchIdleDuration:                lo.ToPtr(time.Second),
+				DisruptionPollingPeriod:          lo.ToPtr(10 * time.Second),
 				PreferencePolicy:                 lo.ToPtr(options.PreferencePolicyRespect),
 				MinValuesPolicy:                  lo.ToPtr(options.MinValuesPolicyStrict),
 				FeatureGates: test.FeatureGates{
@@ -153,6 +155,7 @@ var _ = Describe("Options", func() {
 				"--log-error-output-paths", "/etc/k8s/testerror",
 				"--batch-max-duration", "5s",
 				"--batch-idle-duration", "5s",
+				"--disruption-polling-period", "5s",
 				"--preference-policy", "Ignore",
 				"--min-values-policy", "BestEffort",
 				"--feature-gates", "ReservedCapacity=false,SpotToSpotConsolidation=true,NodeRepair=true,NodeOverlay=true,StaticCapacity=true",
@@ -176,6 +179,7 @@ var _ = Describe("Options", func() {
 				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
 				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
 				BatchIdleDuration:                lo.ToPtr(5 * time.Second),
+				DisruptionPollingPeriod:          lo.ToPtr(5 * time.Second),
 				PreferencePolicy:                 lo.ToPtr(options.PreferencePolicyIgnore),
 				MinValuesPolicy:                  lo.ToPtr(options.MinValuesPolicyBestEffort),
 				FeatureGates: test.FeatureGates{
@@ -207,6 +211,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("LOG_ERROR_OUTPUT_PATHS", "/etc/k8s/testerror")
 			os.Setenv("BATCH_MAX_DURATION", "5s")
 			os.Setenv("BATCH_IDLE_DURATION", "5s")
+			os.Setenv("DISRUPTION_POLLING_PERIOD", "5s")
 			os.Setenv("PREFERENCE_POLICY", "Ignore")
 			os.Setenv("MIN_VALUES_POLICY", "BestEffort")
 			os.Setenv("FEATURE_GATES", "ReservedCapacity=false,SpotToSpotConsolidation=true,NodeRepair=true,NodeOverlay=true,StaticCapacity=true")
@@ -234,6 +239,7 @@ var _ = Describe("Options", func() {
 				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
 				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
 				BatchIdleDuration:                lo.ToPtr(5 * time.Second),
+				DisruptionPollingPeriod:          lo.ToPtr(5 * time.Second),
 				PreferencePolicy:                 lo.ToPtr(options.PreferencePolicyIgnore),
 				MinValuesPolicy:                  lo.ToPtr(options.MinValuesPolicyBestEffort),
 				FeatureGates: test.FeatureGates{
@@ -260,6 +266,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("LOG_LEVEL", "debug")
 			os.Setenv("BATCH_MAX_DURATION", "5s")
 			os.Setenv("BATCH_IDLE_DURATION", "5s")
+			os.Setenv("DISRUPTION_POLLING_PERIOD", "5s")
 			os.Setenv("PREFERENCE_POLICY", "Ignore")
 			os.Setenv("MIN_VALUES_POLICY", "BestEffort")
 			os.Setenv("FEATURE_GATES", "ReservedCapacity=false,SpotToSpotConsolidation=true,NodeRepair=true,NodeOverlay=true,StaticCapacity=true")
@@ -294,6 +301,7 @@ var _ = Describe("Options", func() {
 				LogErrorOutputPaths:              lo.ToPtr("/etc/k8s/testerror"),
 				BatchMaxDuration:                 lo.ToPtr(5 * time.Second),
 				BatchIdleDuration:                lo.ToPtr(5 * time.Second),
+				DisruptionPollingPeriod:          lo.ToPtr(5 * time.Second),
 				PreferencePolicy:                 lo.ToPtr(options.PreferencePolicyRespect),
 				MinValuesPolicy:                  lo.ToPtr(options.MinValuesPolicyStrict),
 				FeatureGates: test.FeatureGates{
@@ -398,6 +406,7 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.LogErrorOutputPaths).To(Equal(optsB.LogErrorOutputPaths))
 	Expect(optsA.BatchMaxDuration).To(Equal(optsB.BatchMaxDuration))
 	Expect(optsA.BatchIdleDuration).To(Equal(optsB.BatchIdleDuration))
+	Expect(optsA.DisruptionPollingPeriod).To(Equal(optsB.DisruptionPollingPeriod))
 	Expect(optsA.PreferencePolicy).To(Equal(optsB.PreferencePolicy))
 	Expect(optsA.MinValuesPolicy).To(Equal(optsB.MinValuesPolicy))
 	Expect(optsA.FeatureGates.ReservedCapacity).To(Equal(optsB.FeatureGates.ReservedCapacity))

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -47,6 +47,7 @@ type OptionsFields struct {
 	PreferencePolicy                 *options.PreferencePolicy
 	MinValuesPolicy                  *options.MinValuesPolicy
 	BatchMaxDuration                 *time.Duration
+	DisruptionPollingPeriod          *time.Duration
 	BatchIdleDuration                *time.Duration
 	IgnoreDRARequests                *bool
 	FeatureGates                     FeatureGates
@@ -85,6 +86,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 		LogErrorOutputPaths:              lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),
 		BatchMaxDuration:                 lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
 		BatchIdleDuration:                lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
+		DisruptionPollingPeriod:          lo.FromPtrOr(opts.DisruptionPollingPeriod, 10*time.Second),
 		PreferencePolicy:                 lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
 		MinValuesPolicy:                  lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
 		IgnoreDRARequests:                lo.FromPtrOr(opts.IgnoreDRARequests, true),


### PR DESCRIPTION
**Description**

This PR aims to make the pollingInterval be configurable by operator options. Currently the pollingInterval is const and set to 10 seconds and IMO that's overkill for calculating the disruptions.

```go
func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
...
    success, err := c.disrupt(ctx, m)
    // If c.disrupt returns false, nil it fallbacks to return statement below
...
	// All methods did nothing, so return nothing to do
	return reconciler.Result{RequeueAfter: pollingPeriod}, nil
``` 

In a case Karpenter can't delete or replace the node (i.e: can't replace with cheaper node) it tries to do the calculation 10 seconds later. 

**How was this change tested?**

```shell
go test ./pkg/operator/options/... 

make apply-with-kind 
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
