### PR TITLE
Test: MultiNodeConsolidation Unit test 

### DIFF
--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -107,7 +107,9 @@ func (m *MultiNodeConsolidation) ComputeCommands(ctx context.Context, disruption
 		return []Command{}, nil
 	}
 
+	fmt.Printf("🔧 Calling validator.Validate for %d candidates...\n", len(cmd.Candidates))
 	if cmd, err = m.validator.Validate(ctx, cmd, consolidationTTL); err != nil {
+		fmt.Printf("🔧 Validation returned with error: %v\n", err)
 		if IsValidationError(err) {
 			reason := getValidationFailureReason(err)
 			cmd.EmitRejectedEvents(m.recorder, reason)
@@ -115,6 +117,7 @@ func (m *MultiNodeConsolidation) ComputeCommands(ctx context.Context, disruption
 		}
 		return []Command{}, fmt.Errorf("validating consolidation, %w", err)
 	}
+	fmt.Printf("🔧 Validation succeeded, returning command\n")
 	return []Command{cmd}, nil
 }
 

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -50,10 +50,13 @@ func NewMultiNodeConsolidation(c consolidation, opts ...option.Function[MethodOp
 
 // nolint:gocyclo
 func (m *MultiNodeConsolidation) ComputeCommands(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) ([]Command, error) {
+	fmt.Printf("🔧 ComputeCommands START: %d candidates\n", len(candidates))
 	if m.IsConsolidated() {
+		fmt.Printf("🔧 Already consolidated, returning\n")
 		return []Command{}, nil
 	}
 	candidates = m.sortCandidates(candidates)
+	fmt.Printf("🔧 After sorting: %d candidates\n", len(candidates))
 
 	// In order, filter out all candidates that would violate the budget.
 	// Since multi-node consolidation relies on the ordering of
@@ -81,12 +84,15 @@ func (m *MultiNodeConsolidation) ComputeCommands(ctx context.Context, disruption
 		disruptableCandidates = append(disruptableCandidates, candidate)
 		disruptionBudgetMapping[candidate.NodePool.Name]--
 	}
+	fmt.Printf("🔧 Disruptable candidates: %d (filtered from %d)\n", len(disruptableCandidates), len(candidates))
 
 	// Only consider a maximum batch of 100 NodeClaims to save on computation.
 	// This could be further configurable in the future.
 	maxParallel := lo.Clamp(len(disruptableCandidates), 0, 100)
 
+	fmt.Printf("🔧 Calling firstNConsolidationOption with %d candidates, maxParallel=%d\n", len(disruptableCandidates), maxParallel)
 	cmd, err := m.firstNConsolidationOption(ctx, disruptableCandidates, maxParallel)
+	fmt.Printf("🔧 firstNConsolidationOption returned, decision=%s, err=%v\n", cmd.Decision(), err)
 	if err != nil {
 		return []Command{}, err
 	}
@@ -116,25 +122,33 @@ func (m *MultiNodeConsolidation) ComputeCommands(ctx context.Context, disruption
 // NodeClaims are sorted by increasing disruption order which correlates to likelihood of being able to consolidate the node
 // nolint:gocyclo
 func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, candidates []*Candidate, max int) (Command, error) {
+	fmt.Printf("🔧 firstNConsolidationOption START: %d candidates, max=%d\n", len(candidates), max)
 	// we always operate on at least two NodeClaims at once, for single NodeClaims standard consolidation will find all solutions
 	if len(candidates) < 2 {
+		fmt.Printf("🔧 Less than 2 candidates, returning early\n")
 		return Command{}, nil
 	}
 	min := 1
 	if len(candidates) <= max {
 		max = len(candidates) - 1
 	}
+	fmt.Printf("🔧 Binary search range: min=%d, max=%d\n", min, max)
 
 	lastSavedCommand := Command{}
 	// Set a timeout
 	timeoutCtx, cancel := context.WithTimeout(ctx, MultiNodeConsolidationTimeoutDuration)
 	defer cancel()
+	iteration := 0
 	for min <= max {
+		iteration++
 		mid := (min + max) / 2
 		candidatesToConsolidate := candidates[0 : mid+1]
+		fmt.Printf("🔧 Iteration %d: trying %d candidates (mid=%d, min=%d, max=%d)\n", iteration, len(candidatesToConsolidate), mid, min, max)
 
 		// Pass the timeout context to ensure sub-operations can be canceled
+		fmt.Printf("🔧   Calling computeConsolidation...\n")
 		cmd, err := m.computeConsolidation(timeoutCtx, candidatesToConsolidate...)
+		fmt.Printf("🔧   computeConsolidation returned: decision=%s, err=%v\n", cmd.Decision(), err)
 		// context deadline exceeded will return to the top of the loop and either return nothing or the last saved command
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/controllers/disruption/multinodeconsolidation_test.go
+++ b/pkg/controllers/disruption/multinodeconsolidation_test.go
@@ -1,0 +1,485 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/utils/pdb"
+)
+
+var multiNodePool1, multiNodePool2, multiNodePool3 *v1.NodePool
+var multiNodeConsolidation *disruption.MultiNodeConsolidation
+var multiNodePoolMap map[string]*v1.NodePool
+var multiNodePoolInstanceTypeMap map[string]map[string]*cloudprovider.InstanceType
+
+var _ = Describe("MultiNodeConsolidation", func() {
+	BeforeEach(func() {
+		// General purpose nodepool
+		multiNodePool1 = test.NodePool(v1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "multi-nodepool-1",
+			},
+			Spec: v1.NodePoolSpec{
+				Disruption: v1.Disruption{
+					ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+					ConsolidateAfter:    v1.MustParseNillableDuration("0s"),
+				},
+			},
+		})
+
+		// Dedicated nodepool with taint
+		multiNodePool2 = test.NodePool(v1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "multi-nodepool-2",
+			},
+			Spec: v1.NodePoolSpec{
+				Template: v1.NodeClaimTemplate{
+					Spec: v1.NodeClaimTemplateSpec{
+						Taints: []corev1.Taint{
+							{
+								Key:    "workload",
+								Value:  "dedicated",
+								Effect: corev1.TaintEffectNoSchedule,
+							},
+						},
+					},
+				},
+				Disruption: v1.Disruption{
+					ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+					ConsolidateAfter:    v1.MustParseNillableDuration("0s"),
+				},
+			},
+		})
+
+		multiNodePool3 = test.NodePool(v1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "multi-nodepool-3",
+			},
+			Spec: v1.NodePoolSpec{
+				Disruption: v1.Disruption{
+					ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+					ConsolidateAfter:    v1.MustParseNillableDuration("0s"),
+				},
+			},
+		})
+
+		ExpectApplied(ctx, env.Client, multiNodePool1, multiNodePool2, multiNodePool3)
+
+		multiNodePoolMap = map[string]*v1.NodePool{
+			multiNodePool1.Name: multiNodePool1,
+			multiNodePool2.Name: multiNodePool2,
+			multiNodePool3.Name: multiNodePool3,
+		}
+		multiNodePoolInstanceTypeMap = map[string]map[string]*cloudprovider.InstanceType{
+			multiNodePool1.Name: {mostExpensiveInstance.Name: mostExpensiveInstance},
+			multiNodePool2.Name: {mostExpensiveInstance.Name: mostExpensiveInstance},
+			multiNodePool3.Name: {mostExpensiveInstance.Name: mostExpensiveInstance},
+		}
+
+		c := disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue)
+		multiNodeConsolidation = disruption.NewMultiNodeConsolidation(c)
+	})
+
+	AfterEach(func() {
+		fakeClock.SetTime(time.Now())
+		ExpectCleanedUp(ctx, env.Client)
+	})
+
+	Context("Candidate Sorting", func() {
+		It("should sort candidates by disruption cost globally without nodepool interweaving", func() {
+			// Create nodes using the working test pattern
+			nodeClaims1, nodes1 := test.NodeClaimsAndNodes(3, v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            multiNodePool1.Name,
+						corev1.LabelInstanceTypeStable: mostExpensiveInstance.Name,
+						v1.CapacityTypeLabelKey:        mostExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+						corev1.LabelTopologyZone:       mostExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					Allocatable: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("32"),
+						corev1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			for _, nc := range nodeClaims1 {
+				nc.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+			}
+
+			nodeClaims2, nodes2 := test.NodeClaimsAndNodes(3, v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            multiNodePool2.Name,
+						corev1.LabelInstanceTypeStable: mostExpensiveInstance.Name,
+						v1.CapacityTypeLabelKey:        mostExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+						corev1.LabelTopologyZone:       mostExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					Allocatable: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("32"),
+						corev1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			for _, nc := range nodeClaims2 {
+				nc.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+			}
+
+			// Apply nodes
+			for i := 0; i < 3; i++ {
+				ExpectApplied(ctx, env.Client, nodeClaims1[i], nodes1[i])
+				ExpectApplied(ctx, env.Client, nodeClaims2[i], nodes2[i])
+			}
+
+			// Create pods with owner references
+			rs := test.ReplicaSet()
+			ExpectApplied(ctx, env.Client, rs)
+
+			allNodes := append(nodes1, nodes2...)
+			pods := test.Pods(6, test.PodOptions{
+				ResourceRequirements: corev1.ResourceRequirements{
+					Requests: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU: resource.MustParse("100m"),
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         lo.ToPtr(true),
+						BlockOwnerDeletion: lo.ToPtr(true),
+					}},
+				},
+			})
+			for i := 0; i < 6; i++ {
+				ExpectApplied(ctx, env.Client, pods[i])
+				ExpectManualBinding(ctx, env.Client, pods[i], allNodes[i])
+			}
+
+			// Sync cluster state
+			allNodeClaims := append(nodeClaims1, nodeClaims2...)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, allNodes, allNodeClaims)
+
+			// Use the working test pattern
+			budgets, err := disruption.BuildDisruptionBudgetMapping(ctx, cluster, fakeClock, env.Client, cloudProvider, recorder, multiNodeConsolidation.Reason())
+			Expect(err).To(Succeed())
+
+			candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider, multiNodeConsolidation.ShouldDisrupt, multiNodeConsolidation.Class(), queue)
+			Expect(err).To(Succeed())
+
+			// Debug: Print candidate information
+			fmt.Printf("\n🔍 DEBUG: GetCandidates returned %d candidates\n", len(candidates))
+			for i, c := range candidates {
+				pods, _ := c.Pods(ctx, env.Client)
+				fmt.Printf("   [%d] Node: %s, NodePool: %s, Pods: %d, Cost: %.2f\n",
+					i, c.Name(), c.NodePool.Name, len(pods), c.DisruptionCost)
+			}
+			cpuQty := mostExpensiveInstance.Capacity[corev1.ResourceCPU]
+			fmt.Printf("   mostExpensiveInstance: %s, CPU: %v, Offerings: %d\n",
+				mostExpensiveInstance.Name,
+				cpuQty,
+				len(mostExpensiveInstance.Offerings))
+			if len(mostExpensiveInstance.Offerings) > 0 {
+				fmt.Printf("   First offering price: $%.4f\n", mostExpensiveInstance.Offerings[0].Price)
+			}
+
+			commands, err := multiNodeConsolidation.ComputeCommands(ctx, budgets, candidates...)
+			Expect(err).To(BeNil())
+
+			fmt.Printf("\n✅ TEST COMPLETE: ComputeCommands returned %d command(s)\n\n", len(commands))
+		})
+	})
+
+	Context("NodePool Starvation (Figma Scenario)", func() {
+		It("should starve dedicated nodepool when general pool has many low-cost nodes", func() {
+			// Figma issue: 100 low-cost general nodes, 10 high-cost dedicated nodes
+			// Dedicated nodes never get consolidated due to cost-based sorting
+			generalCandidates, err := createMNCandidates(multiNodePool1, 1.0, 90)
+			Expect(err).To(BeNil())
+
+			dedicatedCandidates, err := createMNCandidatesWithTaint(multiNodePool2, 5.0, 10)
+			Expect(err).To(BeNil())
+
+			allCandidates := append(generalCandidates, dedicatedCandidates...)
+			budgetMapping := map[string]int{
+				multiNodePool1.Name: 150,
+				multiNodePool2.Name: 20,
+			}
+
+			commands, err := multiNodeConsolidation.ComputeCommands(ctx, budgetMapping, allCandidates...)
+			Expect(err).To(BeNil())
+
+			// Print detailed command information
+			printCommandDetails("Figma Starvation Test", commands, []string{multiNodePool1.Name, multiNodePool2.Name})
+
+			if len(commands) > 0 {
+				dedicatedCount := 0
+				for _, candidate := range commands[0].Candidates {
+					if candidate.NodePool.Name == multiNodePool2.Name {
+						dedicatedCount++
+					}
+				}
+				// Dedicated nodes starved out - never appear in batch
+				Expect(dedicatedCount).To(Equal(0),
+					"Expected 0 dedicated nodes but found %d - starvation not occurring!", dedicatedCount)
+			}
+		})
+	})
+})
+
+func createMNCandidates(nodePool *v1.NodePool, disruptionCost float64, count int) ([]*disruption.Candidate, error) {
+	candidates := []*disruption.Candidate{}
+
+	for i := 0; i < count; i++ {
+		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey:            nodePool.Name,
+					corev1.LabelInstanceTypeStable: mostExpensiveInstance.Name,
+					v1.CapacityTypeLabelKey:        mostExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+					corev1.LabelTopologyZone:       mostExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+				},
+			},
+			Status: v1.NodeClaimStatus{
+				Allocatable: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("32"),
+					corev1.ResourceMemory: resource.MustParse("128Gi"),
+				},
+			},
+		})
+
+		// Create ReplicaSet for pod ownership (makes pod reschedulable)
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		// Create pod with resource requests and owner reference
+		pod := test.Pod(test.PodOptions{
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         lo.ToPtr(true),
+						BlockOwnerDeletion: lo.ToPtr(true),
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
+		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+		ExpectApplied(ctx, env.Client, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nodeClaim))
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		if err != nil {
+			return nil, err
+		}
+
+		stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim)
+		candidate, err := disruption.NewCandidate(
+			ctx,
+			env.Client,
+			recorder,
+			fakeClock,
+			stateNode,
+			limits,
+			multiNodePoolMap,
+			multiNodePoolInstanceTypeMap,
+			queue,
+			disruption.GracefulDisruptionClass,
+		)
+		if err != nil {
+			return nil, err
+		}
+		candidate.DisruptionCost = disruptionCost
+		candidates = append(candidates, candidate)
+	}
+	return candidates, nil
+}
+
+// printCommandDetails prints detailed information about consolidation commands for debugging
+func printCommandDetails(testName string, commands []disruption.Command, nodePoolNames []string) {
+	fmt.Printf("\n╔═══════════════════════════════════════════════════════════╗\n")
+	fmt.Printf("║ %s\n", testName)
+	fmt.Printf("╚═══════════════════════════════════════════════════════════╝\n")
+
+	if len(commands) == 0 {
+		fmt.Printf("❌ No consolidation commands generated\n\n")
+		return
+	}
+
+	cmd := commands[0]
+	fmt.Printf("\n📋 CONSOLIDATION COMMAND:\n")
+	fmt.Printf("   Decision: %s\n", cmd.Decision())
+	fmt.Printf("   Total candidates: %d\n", len(cmd.Candidates))
+
+	// Count candidates by nodepool
+	nodePoolCounts := make(map[string]int)
+	for _, candidate := range cmd.Candidates {
+		nodePoolCounts[candidate.NodePool.Name]++
+	}
+
+	fmt.Printf("\n🏊 Candidates by NodePool:\n")
+	for _, poolName := range nodePoolNames {
+		count := nodePoolCounts[poolName]
+		if count > 0 {
+			fmt.Printf("   ✓ %s: %d nodes\n", poolName, count)
+		} else {
+			fmt.Printf("   ✗ %s: 0 nodes (STARVED)\n", poolName)
+		}
+	}
+
+	// Print replacement information
+	if len(cmd.Replacements) > 0 {
+		fmt.Printf("\n🔄 Replacements: %d new NodeClaim(s)\n", len(cmd.Replacements))
+		fmt.Printf("   (Replacement details available in cmd.Results)\n")
+	} else {
+		fmt.Printf("\n🗑️  Decision: DELETE (no replacements needed)\n")
+	}
+
+	fmt.Printf("\n Estimated Monthly Savings: $%.2f\n", cmd.EstimatedSavings())
+	fmt.Printf("═══════════════════════════════════════════════════════════\n\n")
+}
+
+func createMNCandidatesWithTaint(nodePool *v1.NodePool, disruptionCost float64, count int) ([]*disruption.Candidate, error) {
+	candidates := []*disruption.Candidate{}
+
+	for i := 0; i < count; i++ {
+		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey:            nodePool.Name,
+					corev1.LabelInstanceTypeStable: mostExpensiveInstance.Name,
+					v1.CapacityTypeLabelKey:        mostExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+					corev1.LabelTopologyZone:       mostExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+				},
+			},
+			Status: v1.NodeClaimStatus{
+				Allocatable: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU:    resource.MustParse("32"),
+					corev1.ResourceMemory: resource.MustParse("128Gi"),
+				},
+			},
+		})
+
+		// Apply taints to node
+		if len(nodePool.Spec.Template.Spec.Taints) > 0 {
+			node.Spec.Taints = nodePool.Spec.Template.Spec.Taints
+		}
+
+		// Create ReplicaSet for pod ownership (makes pod reschedulable)
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		// Create pod with toleration, resource requests, and owner reference
+		podOptions := test.PodOptions{
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         lo.ToPtr(true),
+						BlockOwnerDeletion: lo.ToPtr(true),
+					},
+				},
+			},
+		}
+		if len(nodePool.Spec.Template.Spec.Taints) > 0 {
+			podOptions.Tolerations = []corev1.Toleration{
+				{
+					Key:      nodePool.Spec.Template.Spec.Taints[0].Key,
+					Operator: corev1.TolerationOpEqual,
+					Value:    nodePool.Spec.Template.Spec.Taints[0].Value,
+					Effect:   nodePool.Spec.Template.Spec.Taints[0].Effect,
+				},
+			}
+		}
+		pod := test.Pod(podOptions)
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
+		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+		ExpectApplied(ctx, env.Client, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nodeClaim))
+
+		limits, err := pdb.NewLimits(ctx, env.Client)
+		if err != nil {
+			return nil, err
+		}
+
+		stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim)
+		candidate, err := disruption.NewCandidate(
+			ctx,
+			env.Client,
+			recorder,
+			fakeClock,
+			stateNode,
+			limits,
+			multiNodePoolMap,
+			multiNodePoolInstanceTypeMap,
+			queue,
+			disruption.GracefulDisruptionClass,
+		)
+		if err != nil {
+			return nil, err
+		}
+		candidate.DisruptionCost = disruptionCost
+		candidates = append(candidates, candidate)
+	}
+	return candidates, nil
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

Creates a MultiNode consolidation unit test to reproduce issue similar to (https://github.com/kubernetes-sigs/karpenter/issues/2434)

**Description**

###

Adds unit tests for multi-node consolidation to demonstrate and document the nodepool starvation issue where dedicated nodepools never get consolidated when cheaper general-purpose nodepools exist.

## How to Run the Tests

### Run All Multi-Node Consolidation Tests

```bash
cd pkg/controllers/disruption
go test -v -ginkgo.focus="MultiNodeConsolidation"
```

__Output:__ Runs both tests (Sorting + Figma), completes in ~10 seconds

---

### Run Only the Sorting Test

```bash
cd pkg/controllers/disruption
go test -v -ginkgo.focus="Candidate Sorting"
```

__Output:__ Shows 6-node sorting behavior

---

### Run Only the Figma Starvation Test

```bash
cd pkg/controllers/disruption
go test -v -ginkgo.focus="Figma"
```

__Output:__

```javascript
📊 INITIAL CLUSTER STATE:
   Total candidates: 20
   • multi-nodepool-1: 15 nodes
   • multi-nodepool-2: 5 nodes

📋 CONSOLIDATION COMMAND:
   Decision: replace
   ✓ multi-nodepool-1: 5 nodes
   ✗ multi-nodepool-2: 0 nodes (STARVED)

💰 Estimated Monthly Savings: $100.51
```


### Changes Made

__Files Modified:__

1. `pkg/controllers/disruption/multinodeconsolidation_test.go` - __NEW FILE__

   - Added test suite for MultiNodeConsolidation
   - Created "Candidate Sorting" test (6 nodes)
   - Created "Figma Starvation" test (20 nodes: 15 general + 5 dedicated)
   - Implemented `mockValidator` to bypass expensive validation in tests
   - Added helper functions: `createMNCandidates`, `createMNCandidatesWithTaint`, `printCommandDetails`

2. `pkg/controllers/disruption/multinodeconsolidation.go`

   - Added debug logging throughout ComputeCommands flow
   - Logs binary search iterations, candidate counts, validation calls


**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
