### PR TITLE
chore: use structured logging more

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -242,7 +242,7 @@ func (c *Controller) logAbnormalRuns(ctx context.Context) {
 	defer c.mu.Unlock()
 	for name, runTime := range c.lastRun {
 		if timeSince := c.clock.Since(runTime); timeSince > AbnormalTimeLimit {
-			log.FromContext(ctx).V(1).Info(fmt.Sprintf("abnormal time between runs of %s = %s", name, timeSince))
+			log.FromContext(ctx).V(1).Info("abnormal time between runs", "name", name, "time_since", timeSince)
 		}
 	}
 }

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -140,7 +140,7 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 			if errors.Is(err, context.DeadlineExceeded) {
 				ConsolidationTimeoutsTotal.Inc(map[string]string{ConsolidationTypeLabel: m.ConsolidationType()})
 				if lastSavedCommand.Candidates == nil {
-					log.FromContext(ctx).V(1).Info(fmt.Sprintf("failed to find a multi-node consolidation after timeout, last considered batch had %d", (min+max)/2))
+					log.FromContext(ctx).V(1).Info("failed to find a multi-node consolidation after timeout", "last_batch_size", (min+max)/2)
 					return Command{}, nil
 				}
 				log.FromContext(ctx).V(1).WithValues(lastSavedCommand.LogValues()...).Info("stopping multi-node consolidation after timeout, returning last valid command")

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -68,7 +68,7 @@ func (s *SingleNodeConsolidation) ComputeCommands(ctx context.Context, disruptio
 	for i, candidate := range candidates {
 		if s.clock.Now().After(timeout) {
 			ConsolidationTimeoutsTotal.Inc(map[string]string{ConsolidationTypeLabel: s.ConsolidationType()})
-			log.FromContext(ctx).V(1).Info(fmt.Sprintf("abandoning single-node consolidation due to timeout after evaluating %d candidates", i))
+			log.FromContext(ctx).V(1).Info("abandoning single-node consolidation due to timeout", "candidates_evaluated", i)
 
 			s.PreviouslyUnseenNodePools = unseenNodePools
 
@@ -151,7 +151,7 @@ func (s *SingleNodeConsolidation) shuffleCandidates(ctx context.Context, nodePoo
 	var result []*Candidate
 	// Log any timed out nodepools that we're prioritizing
 	if s.PreviouslyUnseenNodePools.Len() != 0 {
-		log.FromContext(ctx).V(1).Info(fmt.Sprintf("prioritizing nodepools that have not yet been considered due to timeouts in previous runs: %s", strings.Join(s.PreviouslyUnseenNodePools.UnsortedList(), ", ")))
+		log.FromContext(ctx).V(1).Info("prioritizing nodepools that have not yet been considered due to timeouts in previous runs", "nodepools", strings.Join(s.PreviouslyUnseenNodePools.UnsortedList(), ", "))
 	}
 	sortedNodePools := s.PreviouslyUnseenNodePools.UnsortedList()
 	sortedNodePools = append(sortedNodePools, lo.Filter(lo.Keys(nodePoolCandidates), func(nodePoolName string, _ int) bool {

--- a/pkg/controllers/nodeclaim/consistency/controller.go
+++ b/pkg/controllers/nodeclaim/consistency/controller.go
@@ -136,7 +136,7 @@ func (c *Controller) checkConsistency(ctx context.Context, nodeClaim *v1.NodeCla
 			return fmt.Errorf("checking node with %T, %w", check, err)
 		}
 		for _, issue := range issues {
-			log.FromContext(ctx).Info(fmt.Sprintf("failed consistency check, %s", string(issue)))
+			log.FromContext(ctx).Info("failed consistency check", "issue", string(issue))
 			c.recorder.Publish(FailedConsistencyCheckEvent(nodeClaim, string(issue)))
 		}
 		hasIssues = hasIssues || (len(issues) > 0)

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -183,7 +183,7 @@ func (p *Provisioner) GetPendingPods(ctx context.Context) ([]*corev1.Pod, error)
 		if err := p.Validate(ctx, po); err != nil {
 			// Mark in memory that this pod is unschedulable
 			p.cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{po: fmt.Errorf("ignoring pod, %w", err)}, nil, nil)
-			log.FromContext(ctx).WithValues("Pod", klog.KObj(po)).V(1).Info(fmt.Sprintf("ignoring pod, %s", err))
+			log.FromContext(ctx).WithValues("Pod", klog.KObj(po)).V(1).Info("ignoring pod", "error", err)
 			// Don't create pod events for pods that are specifically avoiding scheduling to Karpenter-managed capacity
 			if !errors.Is(err, KarpenterManagedLabelDoesNotExistError) {
 				p.recorder.Publish(scheduler.PodFailedToScheduleEvent(po, err))

--- a/pkg/controllers/provisioning/scheduling/preferences.go
+++ b/pkg/controllers/provisioning/scheduling/preferences.go
@@ -49,7 +49,7 @@ func (p *Preferences) Relax(ctx context.Context, pod *v1.Pod) bool {
 
 	for _, relaxFunc := range relaxations {
 		if reason := relaxFunc(pod); reason != nil {
-			log.FromContext(ctx).WithValues("Pod", klog.KObj(pod)).V(1).Info(fmt.Sprintf("relaxing soft constraints for pod since it previously failed to schedule, %s", lo.FromPtr(reason)))
+			log.FromContext(ctx).WithValues("Pod", klog.KObj(pod)).V(1).Info("relaxing soft constraints for pod since it previously failed to schedule", "reason", lo.FromPtr(reason))
 			return true
 		}
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -610,11 +610,9 @@ func (s *Scheduler) addToNewNodeClaim(ctx context.Context, pod *corev1.Pod) erro
 			} else if len(s.nodeClaimTemplates[i].InstanceTypeOptions) != len(its) {
 				log.FromContext(ctx).V(1).WithValues(
 					"NodePool", klog.KRef("", s.nodeClaimTemplates[i].NodePoolName),
-				).Info(fmt.Sprintf(
-					"%d out of %d instance types were excluded because they would breach limits",
-					len(s.nodeClaimTemplates[i].InstanceTypeOptions)-len(its),
-					len(s.nodeClaimTemplates[i].InstanceTypeOptions),
-				))
+				).Info("instance types were excluded because they would breach limits",
+					"excluded", len(s.nodeClaimTemplates[i].InstanceTypeOptions)-len(its),
+					"total", len(s.nodeClaimTemplates[i].InstanceTypeOptions))
 			}
 		}
 		nodeClaim := NewNodeClaim(s.nodeClaimTemplates[i], s.topology, s.daemonOverhead[s.nodeClaimTemplates[i]], s.daemonHostPortUsage[s.nodeClaimTemplates[i]], its, s.reservationManager, s.reservedOfferingMode)

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -145,7 +145,7 @@ func ResolveDriver(ctx context.Context, kubeClient client.Client, pod *v1.Pod, v
 		//  2. The StorageClass never existed and was used to bind the PVC to an existing PV, but that PV was removed
 		// In either of these cases, we should ignore the PVC while computing limits and continue.
 		if errors.IsNotFound(err) {
-			log.FromContext(ctx).WithValues("volume", volumeName, "Pod", klog.KObj(pod), "PersistentVolumeClaim", klog.KObj(pvc), "StorageClass", klog.KRef("", storageClassName)).V(1).Info(fmt.Sprintf("failed tracking CSI volume limits for volume with unbound PVC, %s", err))
+			log.FromContext(ctx).WithValues("volume", volumeName, "Pod", klog.KObj(pod), "PersistentVolumeClaim", klog.KObj(pvc), "StorageClass", klog.KRef("", storageClassName)).V(1).Info("failed tracking CSI volume limits for volume with unbound PVC", "error", err)
 			return "", nil
 		}
 		return "", err

--- a/pkg/utils/disruption/disruption.go
+++ b/pkg/utils/disruption/disruption.go
@@ -18,7 +18,6 @@ package disruption
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 
@@ -52,8 +51,8 @@ func EvictionCost(ctx context.Context, p *corev1.Pod) float64 {
 	if ok {
 		podDeletionCost, err := strconv.ParseFloat(podDeletionCostStr, 64)
 		if err != nil {
-			log.FromContext(ctx).Error(err, fmt.Sprintf("failed parsing %s=%s from pod %s",
-				corev1.PodDeletionCost, podDeletionCostStr, client.ObjectKeyFromObject(p)))
+			log.FromContext(ctx).Error(err, "failed parsing pod deletion cost",
+				"annotation", corev1.PodDeletionCost, "value", podDeletionCostStr, "pod", client.ObjectKeyFromObject(p))
 		} else {
 			// the pod deletion disruptionCost is in [-2147483647, 2147483647]
 			// the min pod disruptionCost makes one pod ~ -15 pods, and the max pod disruptionCost to ~ 17 pods.


### PR DESCRIPTION
**Description**
continuing work from https://github.com/kubernetes-sigs/karpenter/pull/2599, now converting all remaining unstructured logs

[structured logging](https://stackify.com/what-is-structured-logging-and-why-developers-need-it/) helps filter or exclude the same type of error, but it's harder when every error is different

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

cc @DerekFrank 