### PR TITLE
fix: [buildDomainGroups] filter out empty string domains

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -121,6 +121,9 @@ func buildDomainGroups(nodePools []*v1.NodePool, instanceTypes map[string][]*clo
 					domainGroups[topologyKey] = NewTopologyDomainGroup()
 				}
 				for _, domain := range requirement.Values() {
+					if domain == "" {
+						continue
+					}
 					domainGroups[topologyKey].Insert(domain, np.Spec.Template.Spec.Taints...)
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/Azure/karpenter-provider-azure/issues/1384

**Description**

Filter out empty string (`""`) domain values when seeding topology domain groups from instance type requirements in `buildDomainGroups()`.

- Cloud providers (e.g. Azure) may represent non-zonal instance types by setting `topology.kubernetes.io/zone` to `In [""]`, [a set containing an empty string](https://github.com/Azure/karpenter-provider-azure/blob/287d5796c94e2e7051e407ad7900c4c2e294be78/pkg/providers/instancetype/instancetypes.go#L194-L208).
- When `buildDomainGroups()` iterates over all NodePools and their instance types, it inserts these values into a shared `domainGroups` map. If **any** NodePool lacks an explicit zone constraint (meaning there's no existing zone requirement to intersect against), the empty string flows through unopposed and becomes a topology domain.
- This causes topology spread constraints with `whenUnsatisfiable: DoNotSchedule` to become permanently unsatisfiable. The scheduler sees a phantom 4th domain that can never be satisfied:

`Failed to schedule pod, unsatisfiable topology constraint for topology spread, key=topology.kubernetes.io/zone (counts = : 0, westus2-1: 1, westus2-2: 1, westus2-3: 1, podDomains = topology.kubernetes.io/zone Exists, nodeDomains = topology.kubernetes.io/zone In [westus2-1 westus2-2 westus2-3];`

**How was this change tested?**

- Added a unit test
- Still need test this out in an AKS cluster via the reproduction yamls in this [comment](https://github.com/Azure/karpenter-provider-azure/issues/1384#issuecomment-3922716496).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
