### PR TITLE
fix: Change UnevaluatedNodePoolError logs from ERROR to INFO

### DIFF
--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -204,7 +204,7 @@ func BuildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 		nodePoolInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, np)
 		if err != nil {
 			if cloudprovider.IsUnevaluatedNodePoolError(err) {
-				log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Error(err, "skipping, node overlies are not applied")
+				log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).V(1).Info("skipping, awaiting nodeoverlay evaluation")
 				continue
 			}
 			// don't error out on building the node pool, we just won't be able to handle any nodes that

--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -94,6 +94,10 @@ func (d *Drift) isDrifted(ctx context.Context, nodePool *v1.NodePool, nodeClaim 
 		// Include instance type checking separate from the other two to reduce the amount of times we grab the instance types.
 		its, err := d.cloudProvider.GetInstanceTypes(ctx, nodePool)
 		if err != nil {
+			if cloudprovider.IsUnevaluatedNodePoolError(err) {
+				log.FromContext(ctx).V(1).Info("skipping instance type drift check, awaiting nodeoverlay evaluation")
+				return "", nil
+			}
 			return "", err
 		}
 		if reason := instanceTypeNotFound(its, nodeClaim); reason != "" {

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -66,11 +66,11 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 
 	nodeClaims, err := nodeclaimutils.ListManaged(ctx, c.kubeClient, c.cloudProvider)
 	if err != nil {
-		return reconciler.Result{}, err
+		return c.handleUnevaluatedError(ctx, err)
 	}
 	cloudProviderNodeClaims, err := c.cloudProvider.List(ctx)
 	if err != nil {
-		return reconciler.Result{}, err
+		return c.handleUnevaluatedError(ctx, err)
 	}
 	cloudProviderNodeClaims = lo.Filter(cloudProviderNodeClaims, func(nc *v1.NodeClaim, _ int) bool {
 		return nc.DeletionTimestamp.IsZero()
@@ -119,6 +119,14 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 		return reconciler.Result{}, err
 	}
 	return reconciler.Result{RequeueAfter: time.Minute * 2}, nil
+}
+
+func (c *Controller) handleUnevaluatedError(ctx context.Context, err error) (reconciler.Result, error) {
+	if cloudprovider.IsUnevaluatedNodePoolError(err) {
+		log.FromContext(ctx).V(1).Info("skipping, awaiting nodeoverlay evaluation")
+		return reconciler.Result{RequeueAfter: time.Minute * 2}, nil
+	}
+	return reconciler.Result{}, err
 }
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {

--- a/pkg/controllers/state/informer/pricing.go
+++ b/pkg/controllers/state/informer/pricing.go
@@ -68,6 +68,9 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 		oldOfs, exists := c.npOfMap[client.ObjectKeyFromObject(&np)]
 		newIts, err := c.cloudProvider.GetInstanceTypes(ctx, &np)
 		if err != nil {
+			if cloudprovider.IsUnevaluatedNodePoolError(err) {
+				continue
+			}
 			errs = multierr.Append(errs, err)
 			continue
 		}


### PR DESCRIPTION
Change UnevaluatedNodePoolError handling from ERROR to INFO/WARNING level during controller startup when NodeOverlay evaluation is pending.

This fixes issue where harmless initialization errors were polluting monitoring systems during Karpenter startup with NodeOverlay enabled.

Changes:
- disruption: Changed ERROR to V(1).Info for awaiting evaluation
- nodeclaim.disruption: Added error handling to skip drift check
- nodeclaim.garbagecollection: Added error handling with requeue
- state.pricing: Skip unevaluated NodePools instead of error

These are expected conditions during startup and resolve once the NodeOverlay controller completes its initial evaluation.


<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2761

**Description**

**How was this change tested?**
By running the controller locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
