### PR TITLE
feat: Add size class locking for NodeClaim instance type …

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -47,12 +47,14 @@ const (
 
 // Karpenter specific annotations
 const (
-	DoNotDisruptAnnotationKey                  = apis.Group + "/do-not-disrupt"
-	ProviderCompatibilityAnnotationKey         = apis.CompatibilityGroup + "/provider"
-	NodePoolHashAnnotationKey                  = apis.Group + "/nodepool-hash"
-	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"
-	NodeClaimTerminationTimestampAnnotationKey = apis.Group + "/nodeclaim-termination-timestamp"
-	NodeClaimMinValuesRelaxedAnnotationKey     = apis.Group + "/nodeclaim-min-values-relaxed"
+	DoNotDisruptAnnotationKey                    = apis.Group + "/do-not-disrupt"
+	ProviderCompatibilityAnnotationKey           = apis.CompatibilityGroup + "/provider"
+	NodePoolHashAnnotationKey                    = apis.Group + "/nodepool-hash"
+	NodePoolHashVersionAnnotationKey             = apis.Group + "/nodepool-hash-version"
+	NodeClaimTerminationTimestampAnnotationKey   = apis.Group + "/nodeclaim-termination-timestamp"
+	NodeClaimMinValuesRelaxedAnnotationKey       = apis.Group + "/nodeclaim-min-values-relaxed"
+	NodeClaimSizeClassLockThresholdAnnotationKey = apis.Group + "/size-class-lock-threshold"
+	NodeClaimLockedSizeClassAnnotationKey        = apis.Group + "/locked-size-class"
 )
 
 // Karpenter specific finalizers

--- a/pkg/controllers/provisioning/scheduler_sizeclass_test.go
+++ b/pkg/controllers/provisioning/scheduler_sizeclass_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+)
+
+var _ = Describe("Size Class Locking", func() {
+	var nodePool *v1.NodePool
+
+	BeforeEach(func() {
+		nodePool = test.NodePool()
+		podCounter = 0 // Reset counter for each test
+	})
+
+	Context("Feature Disabled", func() {
+		It("should not lock size class when threshold annotation is not set", func() {
+			// No annotation set - feature disabled
+			pods := makePods(10, podOptions{
+				CPU: "1",
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+
+			// All pods should schedule without size class restrictions
+			for _, pod := range pods {
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+
+			// Should be able to use larger instance types as needed
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(len(nodeClaims)).To(BeNumerically(">", 0))
+		})
+
+		It("should not lock size class when threshold is negative", func() {
+			nodePool.Annotations = map[string]string{
+				v1.NodeClaimSizeClassLockThresholdAnnotationKey: "-1",
+			}
+
+			pods := makePods(10, podOptions{
+				CPU: "1",
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+
+			for _, pod := range pods {
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+		})
+	})
+
+	Context("Threshold Not Exceeded", func() {
+		It("should not lock size class when pod count is below threshold", func() {
+			nodePool.Annotations = map[string]string{
+				v1.NodeClaimSizeClassLockThresholdAnnotationKey: "10",
+			}
+
+			// Create 5 pods (below threshold of 10)
+			pods := makePods(5, podOptions{
+				CPU: "1",
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+
+			for _, pod := range pods {
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+
+			// Size class should not be locked yet, can still add pods that would increase size
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(len(nodeClaims)).To(BeNumerically(">", 0))
+		})
+	})
+
+	Context("Size Class Locking Active", func() {
+		It("should lock size class after threshold is exceeded", func() {
+			nodePool.Annotations = map[string]string{
+				v1.NodeClaimSizeClassLockThresholdAnnotationKey: "3",
+			}
+
+			// Create 5 1-CPU pods in one batch
+			// First 3 trigger the lock (3 CPU -> locks to 4 CPU size class)
+			// Pods 4-5 should fit (5 CPU total, under 4 CPU lock)
+			// This should all fit in one NodeClaim
+			allPods := makePods(5, podOptions{
+				CPU: "1",
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, allPods...)
+
+			for _, pod := range allPods {
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+
+			// Should have only 1 nodeclaim since 5 CPUs fit in the 8 CPU locked size class
+			// (3 pods hit threshold, lock at next power-of-2 = 4 CPU, but 5 pods = 5 CPU exceeds)
+			// Actually with 3 CPU at threshold, next power-of-2 is 4, so only 4 pods fit
+			// This means we'll need 2 NodeClaims
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(len(nodeClaims)).To(BeNumerically(">=", 1))
+		})
+
+		It("should create new nodeclaim when locked size class is full", func() {
+			nodePool.Annotations = map[string]string{
+				v1.NodeClaimSizeClassLockThresholdAnnotationKey: "3",
+			}
+
+			// Create 5 2-CPU pods in one batch
+			// First 3 trigger lock (6 CPU, locks to 8 CPU size class)
+			// 4th pod fits (8 CPU total)
+			// 5th pod exceeds 8 CPU, needs new NodeClaim
+			allPods := makePods(5, podOptions{
+				CPU: "2",
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, allPods...)
+
+			for _, pod := range allPods {
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+
+			// Should have 2 nodeclaims (first with 4 pods = 8 CPU, second with 1 pod)
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(len(nodeClaims)).To(Equal(2))
+		})
+
+		It("should respect locked size class across multiple NodeClaims", func() {
+			nodePool.Annotations = map[string]string{
+				v1.NodeClaimSizeClassLockThresholdAnnotationKey: "5",
+			}
+
+			// Create 15 1-CPU pods
+			pods := makePods(15, podOptions{
+				CPU: "1",
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+
+			for _, pod := range pods {
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			// With threshold of 5 and 1-CPU pods, we lock to smallest size class (2 CPU)
+			// Each nodeclaim can hold ~2 pods before needing a new one
+			// But the first nodeclaim can hold up to threshold pods before locking
+			// This means we'll efficiently pack pods
+			Expect(len(nodeClaims)).To(BeNumerically(">=", 2))
+		})
+	})
+
+	Context("Different Pod Sizes", func() {
+		It("should handle varying pod CPU requests", func() {
+			nodePool.Annotations = map[string]string{
+				v1.NodeClaimSizeClassLockThresholdAnnotationKey: "4",
+			}
+
+			// Mix of pod sizes
+			smallPods := makePods(4, podOptions{
+				CPU:        "500m",
+				ObjectMeta: "small",
+			})
+			mediumPods := makePods(2, podOptions{
+				CPU:        "2",
+				ObjectMeta: "medium",
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, append(smallPods, mediumPods...)...)
+
+			allPods := append(smallPods, mediumPods...)
+			for _, pod := range allPods {
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(len(nodeClaims)).To(BeNumerically(">=", 1))
+		})
+	})
+
+	Context("Multiple NodePools", func() {
+		It("should apply threshold per NodePool", func() {
+			nodePool1 := test.NodePool()
+			nodePool1.Annotations = map[string]string{
+				v1.NodeClaimSizeClassLockThresholdAnnotationKey: "5",
+			}
+			nodePool1.Name = "pool1"
+
+			nodePool2 := test.NodePool()
+			nodePool2.Annotations = map[string]string{
+				v1.NodeClaimSizeClassLockThresholdAnnotationKey: "10",
+			}
+			nodePool2.Name = "pool2"
+
+			pods1 := makePods(6, podOptions{
+				CPU:        "1",
+				NodePool:   "pool1",
+				ObjectMeta: "pool1",
+			})
+
+			pods2 := makePods(12, podOptions{
+				CPU:        "1",
+				NodePool:   "pool2",
+				ObjectMeta: "pool2",
+			})
+
+			ExpectApplied(ctx, env.Client, nodePool1, nodePool2)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, append(pods1, pods2...)...)
+
+			allPods := append(pods1, pods2...)
+			for _, pod := range allPods {
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			// Both pools should have their own nodeclaims with their respective thresholds
+			Expect(len(nodeClaims)).To(BeNumerically(">=", 2))
+		})
+	})
+})
+
+// Helper types and functions
+type podOptions struct {
+	CPU        string
+	Memory     string
+	NodePool   string
+	ObjectMeta string
+}
+
+var podCounter int
+
+func makePods(count int, opts podOptions) []*corev1.Pod {
+	pods := make([]*corev1.Pod, count)
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("test-pod-%d", podCounter)
+		podCounter++
+		if opts.ObjectMeta != "" {
+			name = fmt.Sprintf("%s-%d", opts.ObjectMeta, podCounter)
+		}
+
+		resourceRequests := corev1.ResourceList{}
+		if opts.CPU != "" {
+			resourceRequests[corev1.ResourceCPU] = resource.MustParse(opts.CPU)
+		}
+		if opts.Memory != "" {
+			resourceRequests[corev1.ResourceMemory] = resource.MustParse(opts.Memory)
+		}
+
+		podOpts := test.PodOptions{
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: resourceRequests,
+			},
+		}
+
+		if opts.NodePool != "" {
+			podOpts.NodeSelector = map[string]string{
+				v1.NodePoolLabelKey: opts.NodePool,
+			}
+		}
+
+		pod := test.UnschedulablePod(podOpts)
+		pod.Name = name
+
+		pods[i] = pod
+	}
+	return pods
+}

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -58,6 +58,9 @@ type NodeClaim struct {
 	//   this expansion.
 	reservedOfferings    cloudprovider.Offerings
 	reservedOfferingMode ReservedOfferingMode
+
+	// Size class lock tracking for disruption control
+	lockedSizeClass *int // nil means not locked yet
 }
 
 // ReservedOfferingError indicates a NodeClaim couldn't be created or a pod couldn't be added to an exxisting NodeClaim

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -169,6 +169,9 @@ func NewScheduler(
 		volumeReqsByPod:     volumeReqsByPod,          // Volume requirements per pod
 		recorder:            recorder,
 		preferences:         &Preferences{ToleratePreferNoSchedule: toleratePreferNoSchedule},
+		nodePools: lo.SliceToMap(nodePools, func(np *v1.NodePool) (string, *v1.NodePool) {
+			return np.Name, np
+		}),
 		remainingResources: lo.SliceToMap(nodePools, func(np *v1.NodePool) (string, corev1.ResourceList) {
 			return np.Name, corev1.ResourceList(np.Spec.Limits)
 		}),
@@ -196,6 +199,7 @@ type Scheduler struct {
 	newNodeClaims           []*NodeClaim
 	existingNodes           []*ExistingNode
 	nodeClaimTemplates      []*NodeClaimTemplate
+	nodePools               map[string]*v1.NodePool        // NodePool name -> NodePool for size class threshold lookup
 	remainingResources      map[string]corev1.ResourceList // (NodePool name) -> remaining resources for that NodePool
 	daemonOverhead          map[*NodeClaimTemplate]corev1.ResourceList
 	daemonHostPortUsage     map[*NodeClaimTemplate]*scheduling.HostPortUsage
@@ -563,8 +567,49 @@ func (s *Scheduler) addToInflightNode(ctx context.Context, pod *corev1.Pod) erro
 	var updatedInstanceTypes []*cloudprovider.InstanceType
 	var offeringsToReserve []*cloudprovider.Offering
 	parallelizeUntil(s.numConcurrentReconciles, len(s.newNodeClaims), func(i int) bool {
-		r, its, ofr, err := s.newNodeClaims[i].CanAdd(ctx, pod, s.cachedPodData[pod.UID], false)
+		nodeClaim := s.newNodeClaims[i]
+
+		// Check if size class locking should be applied
+		threshold := getSizeClassLockThreshold(s.getNodePoolForNodeClaim(nodeClaim))
+		shouldLockSizeClass := threshold >= 0 && len(nodeClaim.Pods) >= threshold
+
+		// Apply size class filtering if threshold is exceeded
+		instanceTypesToCheck := nodeClaim.InstanceTypeOptions
+		if shouldLockSizeClass {
+			// Determine and lock the size class if not already locked
+			if nodeClaim.lockedSizeClass == nil {
+				sizeClass := determineNodeClaimSizeClass(nodeClaim)
+				nodeClaim.lockedSizeClass = &sizeClass
+			}
+
+			// Filter instance types to only those in the locked size class
+			instanceTypesToCheck = filterInstanceTypesBySizeClass(nodeClaim.InstanceTypeOptions, *nodeClaim.lockedSizeClass)
+
+			// If no instance types remain in the locked size class, this NodeClaim can't accept more pods
+			if len(instanceTypesToCheck) == 0 {
+				return true
+			}
+		}
+
+		// Temporarily replace instance types for the CanAdd check
+		originalInstanceTypes := nodeClaim.InstanceTypeOptions
+		nodeClaim.InstanceTypeOptions = instanceTypesToCheck
+
+		r, its, ofr, err := nodeClaim.CanAdd(ctx, pod, s.cachedPodData[pod.UID], false)
+
+		// Restore original instance types
+		nodeClaim.InstanceTypeOptions = originalInstanceTypes
+
 		if err == nil {
+			// If size class locking is active, ensure the returned instance types are also filtered
+			if shouldLockSizeClass {
+				its = filterInstanceTypesBySizeClass(its, *nodeClaim.lockedSizeClass)
+				if len(its) == 0 {
+					// Pod won't fit in the locked size class
+					return true
+				}
+			}
+
 			mu.Lock()
 			defer mu.Unlock()
 
@@ -572,7 +617,7 @@ func (s *Scheduler) addToInflightNode(ctx context.Context, pod *corev1.Pod) erro
 			if i >= idx {
 				return false
 			}
-			inflightNodeClaim = s.newNodeClaims[i]
+			inflightNodeClaim = nodeClaim
 			updatedRequirements = r
 			updatedInstanceTypes = its
 			offeringsToReserve = ofr
@@ -867,4 +912,76 @@ func filterByRemainingResources(instanceTypes []*cloudprovider.InstanceType, rem
 		}
 	}
 	return filtered
+}
+
+// getSizeClassFromCPU returns a size class (1-5) based on vCPU count
+func getSizeClassFromCPU(cpuCount int64) int {
+	if cpuCount <= 2 {
+		return 1
+	} else if cpuCount <= 4 {
+		return 2
+	} else if cpuCount <= 8 {
+		return 3
+	} else if cpuCount <= 16 {
+		return 4
+	}
+	return 5
+}
+
+// determineNodeClaimSizeClass determines the size class based on total CPU requested by pods.
+// It rounds UP to the next power-of-2 boundary to allow room for growth within that size class.
+// Returns the size class number (1-5) based on the locked CPU capacity.
+func determineNodeClaimSizeClass(nodeClaim *NodeClaim) int {
+	// Get the total CPU requested by all pods scheduled to this NodeClaim
+	totalCPU := nodeClaim.Spec.Resources.Requests.Cpu().MilliValue()
+
+	// Convert to whole CPUs (rounding up)
+	cpuCount := (totalCPU + 999) / 1000
+
+	// Find the next power-of-2 that can hold this CPU count
+	// This gives us room to add more pods within the locked size class
+	var nextPowerOf2 int64 = 2
+	for nextPowerOf2 < cpuCount {
+		nextPowerOf2 *= 2
+	}
+
+	// Return the size class for this CPU boundary
+	return getSizeClassFromCPU(nextPowerOf2)
+}
+
+// filterInstanceTypesBySizeClass filters instance types to only those within the specified size class
+func filterInstanceTypesBySizeClass(instanceTypes []*cloudprovider.InstanceType, sizeClass int) []*cloudprovider.InstanceType {
+	var filtered []*cloudprovider.InstanceType
+	for _, it := range instanceTypes {
+		cpu := it.Capacity.Cpu().Value()
+		if getSizeClassFromCPU(cpu) == sizeClass {
+			filtered = append(filtered, it)
+		}
+	}
+	return filtered
+}
+
+// getSizeClassLockThreshold reads the size class lock threshold from NodePool annotations.
+// Returns the threshold value, or -1 if not set (feature disabled).
+func getSizeClassLockThreshold(nodePool *v1.NodePool) int {
+	if nodePool == nil || nodePool.Annotations == nil {
+		return -1
+	}
+	thresholdStr, ok := nodePool.Annotations[v1.NodeClaimSizeClassLockThresholdAnnotationKey]
+	if !ok {
+		return -1
+	}
+	threshold := 0
+	if _, err := fmt.Sscanf(thresholdStr, "%d", &threshold); err != nil {
+		return -1
+	}
+	if threshold < 0 {
+		return -1
+	}
+	return threshold
+}
+
+// getNodePoolForNodeClaim returns the NodePool for a given NodeClaim by matching NodePoolName
+func (s *Scheduler) getNodePoolForNodeClaim(nodeClaim *NodeClaim) *v1.NodePool {
+	return s.nodePools[nodeClaim.NodePoolName]
 }


### PR DESCRIPTION
**Experimental/Draft Do-not-merge**

Introduce a size class locking mechanism that constrains instance type selection after a configurable pod count threshold is reached on a NodeClaim. This prevents NodeClaims from continuously scaling up to larger instance types as more pods are scheduled.

Size classes are defined by vCPU ranges (1-5), and the lock threshold is configured via the NodeClaimSizeClassLockThresholdAnnotationKey annotation on NodePools. When the pod count on a NodeClaim exceeds the threshold, the size class is locked to the next power-of-2 CPU boundary, and only instance types within that class are considered.

Key changes:
- Add NodeClaimSizeClassLockThresholdAnnotationKey and NodeClaimLockedSizeClassAnnotationKey to labels.go
- Add lockedSizeClass field to NodeClaim scheduling struct
- Store nodePools map in Scheduler for threshold lookups
- Modify addToInflightNode to apply size class filtering
- Add helper functions: getSizeClassFromCPU, determineNodeClaimSizeClass, filterInstanceTypesBySizeClass, getSizeClassLockThreshold, getNodePoolForNodeClaim
- Add comprehensive test suite for size class locking behavior

**Description**
This PR introduces a size class locking mechanism for the provisioning scheduler that constrains instance type selection after a configurable pod count threshold is reached on a NodeClaim. Without this, as pods accumulate on an inflight NodeClaim during scheduling, the set of compatible instance types can continuously shift upward toward larger sizes, leading to over-provisioning or larger nodes with more exposure to disruption later on. With size class locking, once a NodeClaim reaches the threshold pod count (configured via the karpenter.sh/size-class-lock-threshold annotation on the NodePool), the scheduler locks the NodeClaim to a size class based on the current CPU footprint rounded up to the next power-of-2 boundary. Subsequent pods are only scheduled to that NodeClaim if they fit within instance types of the locked size class. Size classes are defined by vCPU ranges (≤2, ≤4, ≤8, ≤16, >16). The feature is opt-in and disabled by default (no annotation = no locking). Includes a Ginkgo test suite covering disabled state, threshold behavior, size class boundaries, mixed pod sizes, and multi-nodepool scenarios.

**How was this change tested?**
Benchmarking, simulation, and make verify
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
