### PR TITLE
POC: speedup single node consolidation by grouping nodes and pools to a single node-type

### DIFF
--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -94,13 +94,16 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	}
 	pods = append(pods, deletingNodePods...)
 
+	var candidateNodeTypes []string
+	stateNodes, candidateNodeTypes = filterStateNodesByCandidateNodeTypes(stateNodes, candidates)
+
 	var opts []scheduling.Options
 	if options.FromContext(ctx).PreferencePolicy == options.PreferencePolicyIgnore {
 		opts = append(opts, scheduling.IgnorePreferences)
 	}
 	opts = append(opts, scheduling.MinValuesPolicy(options.FromContext(ctx).MinValuesPolicy))
 	scheduler, err := provisioner.NewScheduler(
-		log.IntoContext(ctx, operatorlogging.NopLogger),
+		context.WithValue(log.IntoContext(ctx, operatorlogging.NopLogger), "filterNodePoolsByStateNodeNodeTypes", candidateNodeTypes),
 		pods,
 		stateNodes,
 		opts...,
@@ -167,6 +170,25 @@ func instanceTypesAreSubset(lhs []*cloudprovider.InstanceType, rhs []*cloudprovi
 	rhsNames := sets.NewString(lo.Map(rhs, func(t *cloudprovider.InstanceType, i int) string { return t.Name })...)
 	lhsNames := sets.NewString(lo.Map(lhs, func(t *cloudprovider.InstanceType, i int) string { return t.Name })...)
 	return len(rhsNames.Intersection(lhsNames)) == len(lhsNames)
+}
+
+// speed up computation by only considering nodes that have the same "node-type" label as the candidates
+func filterStateNodesByCandidateNodeTypes(stateNodes []*state.StateNode, candidates []*Candidate) ([]*state.StateNode, []string) {
+	candidateNodeTypes := lo.Uniq(lo.Map(candidates, func(c *Candidate, _ int) string {
+		if c.Node != nil {
+			return c.Node.Labels["node-type"]
+		}
+		return ""
+	}))
+
+	if lo.Contains(candidateNodeTypes, "") { // something was weird, do not filter, even if some had node-type
+		return stateNodes, candidateNodeTypes
+	}
+
+	stateNodes = lo.Filter(stateNodes, func(n *state.StateNode, _ int) bool {
+		return lo.Contains(candidateNodeTypes, n.Labels()["node-type"])
+	})
+	return stateNodes, candidateNodeTypes
 }
 
 // GetCandidates returns nodes that appear to be currently deprovisionable based off of their nodePool

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -255,6 +255,9 @@ func (p *Provisioner) NewScheduler(
 		}
 		return np.DeletionTimestamp.IsZero()
 	})
+	if nodeTypes, ok := ctx.Value("filterNodePoolsByStateNodeNodeTypes").([]string); ok {
+		nodePools = filterNodePoolsByStateNodeNodeTypes(nodePools, nodeTypes)
+	}
 	if len(nodePools) == 0 {
 		return nil, ErrNodePoolsNotFound
 	}
@@ -304,6 +307,17 @@ func (p *Provisioner) NewScheduler(
 	}
 	// Pass volumeReqs to scheduler - added to nodeRequirements for NodeClaim zone selection
 	return scheduler.NewScheduler(ctx, p.kubeClient, nodePools, p.cluster, stateNodes, topology, instanceTypes, daemonSetPods, p.recorder, p.clock, volumeReqs, opts...), nil
+}
+
+// speed up computation by only considering pools that have the same "node-type" label as the nodes
+func filterNodePoolsByStateNodeNodeTypes(nodePools []*v1.NodePool, candidateNodeTypes []string) []*v1.NodePool {
+	if lo.Contains(candidateNodeTypes, "") { // something was weird, do not filter
+		return nodePools
+	}
+
+	return lo.Filter(nodePools, func(np *v1.NodePool, _ int) bool {
+		return lo.Contains(candidateNodeTypes, np.Spec.Template.Labels["node-type"])
+	})
 }
 
 func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {


### PR DESCRIPTION
**Description**
this took us from ~5m -> 30s because we have lots of nodes and node-pools
the label for grouping should be made user-configurable, see https://github.com/kubernetes-sigs/karpenter/pull/2871 and https://github.com/kubernetes-sigs/karpenter/issues/2814

we sadly had to also add a delay after each consolidation since otherwise our node-churn almost doubled
that would be another useful feature to have as a config option
see https://github.com/kubernetes-sigs/karpenter/pull/2961


**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
