### PR TITLE
fix: lo.Reduce in Command.LogValues discards accumulator

### DIFF
--- a/pkg/controllers/disruption/consolidation_logging_test.go
+++ b/pkg/controllers/disruption/consolidation_logging_test.go
@@ -291,6 +291,44 @@ func mockCandidate(name string) *Candidate {
 	}
 }
 
+func TestLogValues_PodCount(t *testing.T) {
+	// Create candidates with different numbers of reschedulable pods
+	c1 := mockCandidate("node-1")
+	c1.NodeClaim = &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Name: "nc-1"}}
+	c1.reschedulablePods = []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}},
+	}
+
+	c2 := mockCandidate("node-2")
+	c2.NodeClaim = &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Name: "nc-2"}}
+	c2.reschedulablePods = []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-4"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-5"}},
+	}
+
+	cmd := Command{
+		Candidates:   []*Candidate{c1, c2},
+		Replacements: []*Replacement{},
+	}
+
+	logValues := cmd.LogValues()
+	// LogValues returns key-value pairs: find the "pod-count" key and check its value
+	var podCount int
+	for i := 0; i < len(logValues)-1; i += 2 {
+		if logValues[i] == "pod-count" {
+			podCount = logValues[i+1].(int)
+			break
+		}
+	}
+
+	// pod-count should be 3 + 2 = 5, not just 2 (the last candidate's count)
+	if podCount != 5 {
+		t.Errorf("LogValues() pod-count = %d, want 5 (sum of all candidates' pods)", podCount)
+	}
+}
+
 func TestConsolidationCandidateEvent(t *testing.T) {
 	recorder := test.NewEventRecorder()
 

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -276,7 +276,7 @@ func (c Command) EmitRejectedEvents(recorder events.Recorder, reason string) {
 }
 
 func (c Command) LogValues() []any {
-	podCount := lo.Reduce(c.Candidates, func(_ int, cd *Candidate, _ int) int { return len(cd.reschedulablePods) }, 0)
+	podCount := lo.Reduce(c.Candidates, func(acc int, cd *Candidate, _ int) int { return acc + len(cd.reschedulablePods) }, 0)
 
 	candidateNodes := lo.Map(c.Candidates, func(candidate *Candidate, _ int) interface{} {
 		return map[string]interface{}{


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/karpenter/issues/2888

**Description**

The `lo.Reduce` call in `LogValues()` was ignoring the accumulator parameter, so it returned only the last candidate's reschedulable pod count instead of the sum across all candidates. This caused the `"pod-count"` field in structured disruption logs to under-report during multi-node consolidation.

**How was this change tested?**

Added `TestLogValues_PodCount` that creates a `Command` with two candidates (3 and 2 reschedulable pods) and verifies the pod count is the sum (5), not the last candidate's count (2). Full disruption test suite passes (232/232).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.