### PR TITLE
chore: complete operator enum validation for NodeSelectorRequirement

### DIFF
--- a/hack/validation/requirements.sh
+++ b/hack/validation/requirements.sh
@@ -7,8 +7,6 @@ yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.req
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations += [
     {"message": "label domain \"karpenter.sh\" is restricted", "rule": "self in [\"karpenter.sh/capacity-type\", \"karpenter.sh/nodepool\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.sh\")"},
     {"message": "label \"kubernetes.io/hostname\" is restricted", "rule": "self != \"kubernetes.io/hostname\""}]' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
-## operator enum values
-yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.operator.enum += ["In","NotIn","Exists","DoesNotExist","Gt","Lt"]' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
 ## Valid requirement value check
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.values.maxLength = 63' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.values.pattern = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -22,8 +20,6 @@ yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.tem
     {"message": "label domain \"karpenter.sh\" is restricted", "rule": "self in [\"karpenter.sh/capacity-type\", \"karpenter.sh/nodepool\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.sh\")"},
     {"message": "label \"karpenter.sh/nodepool\" is restricted", "rule": "self != \"karpenter.sh/nodepool\""},
     {"message": "label \"kubernetes.io/hostname\" is restricted", "rule": "self != \"kubernetes.io/hostname\""}]' -i pkg/apis/crds/karpenter.sh_nodepools.yaml
-## operator enum values
-yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.operator.enum  += ["In","NotIn","Exists","DoesNotExist","Gt","Lt"]' -i pkg/apis/crds/karpenter.sh_nodepools.yaml
 ## Valid requirement value check
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.values.maxLength = 63' -i pkg/apis/crds/karpenter.sh_nodepools.yaml
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.values.pattern  = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"' -i pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -36,8 +32,6 @@ yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.req
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations += [
     {"message": "label domain \"karpenter.sh\" is restricted", "rule": "self in [\"karpenter.sh/capacity-type\", \"karpenter.sh/nodepool\"] || !self.find(\"^([^/]+)\").endsWith(\"karpenter.sh\")"},
     {"message": "label \"kubernetes.io/hostname\" is restricted", "rule": "self != \"kubernetes.io/hostname\""}]' -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
-## operator enum values
-yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.operator.enum  += ["In","NotIn","Exists","DoesNotExist","Gt","Lt"]' -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
 ## Valid requirement value check
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.values.maxLength = 63' -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.values.pattern  = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"' -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml

--- a/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeclaims.yaml
@@ -147,14 +147,14 @@ spec:
                           Represents a key's relationship to a set of values.
                           Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
                         enum:
-                          - Gte
-                          - Lte
                           - In
                           - NotIn
                           - Exists
                           - DoesNotExist
                           - Gt
                           - Lt
+                          - Gte
+                          - Lte
                         type: string
                       values:
                         description: |-

--- a/kwok/charts/crds/karpenter.sh_nodeoverlays.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeoverlays.yaml
@@ -104,14 +104,14 @@ spec:
                           Represents a key's relationship to a set of values.
                           Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
                         enum:
-                          - Gte
-                          - Lte
                           - In
                           - NotIn
                           - Exists
                           - DoesNotExist
                           - Gt
                           - Lt
+                          - Gte
+                          - Lte
                         type: string
                       values:
                         description: |-

--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -302,14 +302,14 @@ spec:
                                   Represents a key's relationship to a set of values.
                                   Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
                                 enum:
-                                  - Gte
-                                  - Lte
                                   - In
                                   - NotIn
                                   - Exists
                                   - DoesNotExist
                                   - Gt
                                   - Lt
+                                  - Gte
+                                  - Lte
                                 type: string
                               values:
                                 description: |-

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -145,14 +145,14 @@ spec:
                           Represents a key's relationship to a set of values.
                           Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
                         enum:
-                          - Gte
-                          - Lte
                           - In
                           - NotIn
                           - Exists
                           - DoesNotExist
                           - Gt
                           - Lt
+                          - Gte
+                          - Lte
                         type: string
                       values:
                         description: |-

--- a/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
@@ -104,14 +104,14 @@ spec:
                           Represents a key's relationship to a set of values.
                           Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
                         enum:
-                          - Gte
-                          - Lte
                           - In
                           - NotIn
                           - Exists
                           - DoesNotExist
                           - Gt
                           - Lt
+                          - Gte
+                          - Lte
                         type: string
                       values:
                         description: |-

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -300,14 +300,14 @@ spec:
                                   Represents a key's relationship to a set of values.
                                   Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
                                 enum:
-                                  - Gte
-                                  - Lte
                                   - In
                                   - NotIn
                                   - Exists
                                   - DoesNotExist
                                   - Gt
                                   - Lt
+                                  - Gte
+                                  - Lte
                                 type: string
                               values:
                                 description: |-

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -101,7 +101,7 @@ type NodeSelectorRequirementWithMinValues struct {
 	//nolint:kubeapilinter
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
-	// +kubebuilder:validation:Enum:=Gte;Lte
+	// +kubebuilder:validation:Enum:=In;NotIn;Exists;DoesNotExist;Gt;Lt;Gte;Lte
 	// +required
 	Operator v1.NodeSelectorOperator `json:"operator,omitempty"`
 	//nolint:kubeapilinter

--- a/pkg/apis/v1/nodeclaim.go
+++ b/pkg/apis/v1/nodeclaim.go
@@ -95,9 +95,6 @@ type NodeSelectorRequirementWithMinValues struct {
 	// +required
 	Key string `json:"key"`
 
-	// NOTE below: The code generator works strangely, and will union these
-	// enum values into the ones already defined on v1.NodeSelectorOperator
-
 	//nolint:kubeapilinter
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.

--- a/pkg/apis/v1alpha1/nodeoverlay.go
+++ b/pkg/apis/v1alpha1/nodeoverlay.go
@@ -38,7 +38,7 @@ type NodeSelectorRequirement struct {
 	//nolint:kubeapilinter
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
-	// +kubebuilder:validation:Enum:=Gte;Lte
+	// +kubebuilder:validation:Enum:=In;NotIn;Exists;DoesNotExist;Gt;Lt;Gte;Lte
 	// +required
 	Operator corev1.NodeSelectorOperator `json:"operator,omitempty"`
 	//nolint:kubeapilinter

--- a/pkg/apis/v1alpha1/nodeoverlay.go
+++ b/pkg/apis/v1alpha1/nodeoverlay.go
@@ -32,9 +32,6 @@ type NodeSelectorRequirement struct {
 	// +required
 	Key string `json:"key"`
 
-	// NOTE below: The code generator works strangely, and will union these
-	// enum values into the ones already defined on v1.NodeSelectorOperator
-
 	//nolint:kubeapilinter
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2876

**Description**

The kubebuilder validation enum for the Operator field in both NodeSelectorRequirementWithMinValues (v1/nodeclaim.go) and NodeSelectorRequirement (v1alpha1/nodeoverlay.go) was incomplete, only allowing Gte and Lte while omitting In, NotIn, Exists, DoesNotExist, Gt, and Lt. This caused valid operators to be incorrectly rejected during API validation.

**How was this change tested?**

make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
