### PR TITLE
fix: use accumulator in lo.Reduce for disruption pod count

### DIFF
--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -276,7 +276,7 @@ func (c Command) EmitRejectedEvents(recorder events.Recorder, reason string) {
 }
 
 func (c Command) LogValues() []any {
-	podCount := lo.Reduce(c.Candidates, func(_ int, cd *Candidate, _ int) int { return len(cd.reschedulablePods) }, 0)
+	podCount := lo.Reduce(c.Candidates, func(acc int, cd *Candidate, _ int) int { return acc + len(cd.reschedulablePods) }, 0)
 
 	candidateNodes := lo.Map(c.Candidates, func(candidate *Candidate, _ int) interface{} {
 		return map[string]interface{}{


### PR DESCRIPTION
## Summary

The `lo.Reduce` callback in `Command.LogValues()` discards the accumulator (`_ int`), so the `pod-count` field in disruption logs only reports the last candidate's pod count instead of the sum across all candidates.

**Before:** `func(_ int, cd *Candidate, _ int) int { return len(cd.reschedulablePods) }`
**After:** `func(acc int, cd *Candidate, _ int) int { return acc + len(cd.reschedulablePods) }`

Single-candidate disruptions were unaffected (last == only), but multi-node consolidation under-reported.

Fixes #2888

## Test plan

- [x] `go build ./pkg/controllers/disruption/...` — builds clean
- [ ] Existing disruption tests (CI)