### PR TITLE
ci: drop Kubernetes 1.29 from presubmit matrix

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8sVersion: ["1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x"]
+        k8sVersion: ["1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x"]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/install-deps


### PR DESCRIPTION
Kubernetes 1.29 reached end-of-life in February 2025. The 1.29.x presubmit is failing on unrelated tests and adding noise to PR checks.

One-line change: remove `"1.29.x"` from the k8sVersion matrix in `.github/workflows/presubmit.yaml`.