### PR TITLE
fix: correct locking in state cost

### DIFF
--- a/pkg/state/cost/cost.go
+++ b/pkg/state/cost/cost.go
@@ -199,11 +199,9 @@ func (cc *ClusterCost) createNewNodePoolCost(npName string, instanceTypes []*clo
 // UpdateNodeClaim adds a NodeClaim to cost tracking. The NodeClaim must have
 // all required labels or it will be ignored and logged as an error.
 func (cc *ClusterCost) UpdateNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) error {
-	cc.RLock()
-	_, exists := cc.nodeClaimMap[client.ObjectKeyFromObject(nodeClaim)]
-	cc.RUnlock()
-
-	if exists {
+	cc.Lock()
+	defer cc.Unlock()
+	if _, exists := cc.nodeClaimMap[client.ObjectKeyFromObject(nodeClaim)]; exists {
 		return nil
 	}
 
@@ -226,12 +224,6 @@ func (cc *ClusterCost) UpdateNodeClaim(ctx context.Context, nodeClaim *v1.NodeCl
 	nodePoolName := nodeClaim.Labels[v1.NodePoolLabelKey]
 	offeringKey := OfferingKey{CapacityType: nodeClaim.Labels[v1.CapacityTypeLabelKey], Zone: nodeClaim.Labels[corev1.LabelTopologyZone], InstanceName: nodeClaim.Labels[corev1.LabelInstanceTypeStable]}
 
-	cc.Lock()
-	defer cc.Unlock()
-	if _, exists = cc.nodeClaimMap[client.ObjectKeyFromObject(nodeClaim)]; exists {
-		return nil
-	}
-
 	err := cc.internalAddOffering(ctx, nodePoolName, offeringKey)
 	if err != nil {
 		failed = true
@@ -247,9 +239,9 @@ func (cc *ClusterCost) UpdateNodeClaim(ctx context.Context, nodeClaim *v1.NodeCl
 // DeleteNodeClaim removes a NodeClaim from cost tracking. If the NodeClaim
 // was not being tracked, this operation is a no-op.
 func (cc *ClusterCost) DeleteNodeClaim(ctx context.Context, nn types.NamespacedName) error {
-	cc.RLock()
+	cc.Lock()
+	defer cc.Unlock()
 	metadata, exists := cc.nodeClaimMap[nn]
-	cc.RUnlock()
 
 	if !exists {
 		return nil
@@ -263,12 +255,6 @@ func (cc *ClusterCost) DeleteNodeClaim(ctx context.Context, nn types.NamespacedN
 			})
 		}
 	}()
-
-	cc.Lock()
-	defer cc.Unlock()
-	if _, exists = cc.nodeClaimMap[nn]; exists {
-		return nil
-	}
 
 	err := cc.internalRemoveOffering(metadata.NodePoolName, metadata.NodeClaimKey)
 	if err != nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #2938

**Description**
Originally, the path is 
```
1. Acquire Read Lock
2. Check nodeClaimMap -> if exists then exit
3. Drop Read Lock
4. Acquire Write lock and make modifications
```
* instead of using read locks, we now acquire a write lock from the state
* this fixes a race condition in cost controller where between steps 3 and 4 another thread can modify costs, resulting in incorrect costs


**How was this change tested?**
* make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
