### PR TITLE
fix: multi node consolidation: do not block all consolidation because some incompatible nodes are deleting or some incompatible pods are pending

### DIFF
--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -3333,6 +3333,172 @@ var _ = Describe("Consolidation", func() {
 			// and delete the old one
 			ExpectNotFound(ctx, env.Client, nodeClaims[1], nodes[1])
 		})
+		It("can delete nodes when a pending pod from another NodePool with incompatible taints exists", func() {
+			// NodePool A has taint nodepool=a:NoSchedule, NodePool B has taint nodepool=b:NoSchedule.
+			// A pending pod tolerates only nodepool=a — it should not block consolidation of NodePool B's node.
+			nodepoolA := test.NodePool(v1.NodePool{
+				Spec: v1.NodePoolSpec{
+					Template: v1.NodeClaimTemplate{
+						Spec: v1.NodeClaimTemplateSpec{
+							Taints: []corev1.Taint{{Key: "nodepool", Value: "a", Effect: corev1.TaintEffectNoSchedule}},
+						},
+					},
+					Disruption: v1.Disruption{
+						ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+						Budgets:             []v1.Budget{{Nodes: "100%"}},
+						ConsolidateAfter:    v1.MustParseNillableDuration("0s"),
+					},
+				},
+			})
+			nodepoolB := test.NodePool(v1.NodePool{
+				Spec: v1.NodePoolSpec{
+					Template: v1.NodeClaimTemplate{
+						Spec: v1.NodeClaimTemplateSpec{
+							Taints: []corev1.Taint{{Key: "nodepool", Value: "b", Effect: corev1.TaintEffectNoSchedule}},
+						},
+					},
+					Disruption: v1.Disruption{
+						ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+						Budgets:             []v1.Budget{{Nodes: "100%"}},
+						ConsolidateAfter:    v1.MustParseNillableDuration("0s"),
+					},
+				},
+			})
+			nodeclaimB, nodeB := test.NodeClaimAndNode(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            nodepoolB.Name,
+						corev1.LabelInstanceTypeStable: leastExpensiveInstance.Name,
+						v1.CapacityTypeLabelKey:        leastExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+						corev1.LabelTopologyZone:       leastExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					Allocatable: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("32"),
+						corev1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			nodeB.Spec.Taints = append(nodeB.Spec.Taints, corev1.Taint{Key: "nodepool", Value: "b", Effect: corev1.TaintEffectNoSchedule})
+			nodeclaimB.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+
+			// pending pod that only tolerates NodePool A's taint — incompatible with NodePool B
+			pendingPod := test.UnschedulablePod(test.PodOptions{
+				Tolerations: []corev1.Toleration{{Key: "nodepool", Value: "a", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual}},
+			})
+
+			ExpectApplied(ctx, env.Client, nodepoolA, nodepoolB, nodeclaimB, nodeB, pendingPod)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodeB}, []*v1.NodeClaim{nodeclaimB})
+			ExpectSingletonReconciled(ctx, disruptionController)
+
+			// pending pod from NodePool A must not block deletion of NodePool B's empty node
+			cmds := queue.GetCommands()
+			Expect(cmds).To(HaveLen(1))
+			ExpectObjectReconciled(ctx, env.Client, queue, cmds[0].Candidates[0].NodeClaim)
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeclaimB)
+
+			ExpectNotFound(ctx, env.Client, nodeclaimB, nodeB)
+
+			// pending pod is still pending
+			pendingPod = ExpectPodExists(ctx, env.Client, pendingPod.Name, pendingPod.Namespace)
+			Expect(pendingPod.Spec.NodeName).To(BeEmpty())
+		})
+		It("can delete nodes when a pod from a draining node in another NodePool with incompatible taints exists", func() {
+			// Same cross-NodePool setup, but the incompatible pod is on a deleting (draining) node from NodePool A.
+			nodepoolA := test.NodePool(v1.NodePool{
+				Spec: v1.NodePoolSpec{
+					Template: v1.NodeClaimTemplate{
+						Spec: v1.NodeClaimTemplateSpec{
+							Taints: []corev1.Taint{{Key: "nodepool", Value: "a", Effect: corev1.TaintEffectNoSchedule}},
+						},
+					},
+					Disruption: v1.Disruption{
+						ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+						Budgets:             []v1.Budget{{Nodes: "100%"}},
+						ConsolidateAfter:    v1.MustParseNillableDuration("0s"),
+					},
+				},
+			})
+			nodepoolB := test.NodePool(v1.NodePool{
+				Spec: v1.NodePoolSpec{
+					Template: v1.NodeClaimTemplate{
+						Spec: v1.NodeClaimTemplateSpec{
+							Taints: []corev1.Taint{{Key: "nodepool", Value: "b", Effect: corev1.TaintEffectNoSchedule}},
+						},
+					},
+					Disruption: v1.Disruption{
+						ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+						Budgets:             []v1.Budget{{Nodes: "100%"}},
+						ConsolidateAfter:    v1.MustParseNillableDuration("0s"),
+					},
+				},
+			})
+
+			// NodePool A's node is being deleted (draining)
+			nodeclaimA, nodeA := test.NodeClaimAndNode(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            nodepoolA.Name,
+						corev1.LabelInstanceTypeStable: leastExpensiveInstance.Name,
+						v1.CapacityTypeLabelKey:        leastExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+						corev1.LabelTopologyZone:       leastExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					Allocatable: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("32"),
+						corev1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			nodeA.Spec.Taints = append(nodeA.Spec.Taints, corev1.Taint{Key: "nodepool", Value: "a", Effect: corev1.TaintEffectNoSchedule})
+
+			// NodePool B's node is idle and consolidatable
+			nodeclaimB, nodeB := test.NodeClaimAndNode(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            nodepoolB.Name,
+						corev1.LabelInstanceTypeStable: leastExpensiveInstance.Name,
+						v1.CapacityTypeLabelKey:        leastExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+						corev1.LabelTopologyZone:       leastExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					Allocatable: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("32"),
+						corev1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			nodeB.Spec.Taints = append(nodeB.Spec.Taints, corev1.Taint{Key: "nodepool", Value: "b", Effect: corev1.TaintEffectNoSchedule})
+			nodeclaimB.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+
+			// pod on the draining NodePool A node — tolerates only nodepool=a, not nodepool=b
+			drainingPod := test.Pod(test.PodOptions{
+				Tolerations: []corev1.Toleration{{Key: "nodepool", Value: "a", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual}},
+			})
+
+			ExpectApplied(ctx, env.Client, nodepoolA, nodepoolB, nodeclaimA, nodeA, nodeclaimB, nodeB, drainingPod)
+			ExpectManualBinding(ctx, env.Client, drainingPod, nodeA)
+
+			// Initialize nodeA before marking it for deletion so the cluster state reflects it as deleting
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodeA, nodeB}, []*v1.NodeClaim{nodeclaimA, nodeclaimB})
+
+			// Mark NodePool A's nodeclaim as deleting
+			Expect(env.Client.Delete(ctx, nodeclaimA)).To(Succeed())
+			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(nodeA))
+			ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nodeclaimA))
+			ExpectSingletonReconciled(ctx, disruptionController)
+
+			// the pod on the draining NodePool A node must not block deletion of NodePool B's empty node
+			cmds := queue.GetCommands()
+			Expect(cmds).To(HaveLen(1))
+			ExpectObjectReconciled(ctx, env.Client, queue, cmds[0].Candidates[0].NodeClaim)
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeclaimB)
+
+			ExpectNotFound(ctx, env.Client, nodeclaimB, nodeB)
+		})
 	})
 	Context("TTL", func() {
 		var nodeClaims []*v1.NodeClaim

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -3389,7 +3389,7 @@ var _ = Describe("Consolidation", func() {
 			})
 
 			ExpectApplied(ctx, env.Client, nodepoolA, nodepoolB, nodeclaimB, nodeB, pendingPod)
-			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodeB}, []*v1.NodeClaim{nodeclaimB})
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{nodeB}, []*v1.NodeClaim{nodeclaimB})
 			ExpectSingletonReconciled(ctx, disruptionController)
 
 			// pending pod from NodePool A must not block deletion of NodePool B's empty node
@@ -3483,7 +3483,7 @@ var _ = Describe("Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, drainingPod, nodeA)
 
 			// Initialize nodeA before marking it for deletion so the cluster state reflects it as deleting
-			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*corev1.Node{nodeA, nodeB}, []*v1.NodeClaim{nodeclaimA, nodeclaimB})
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{nodeA, nodeB}, []*v1.NodeClaim{nodeclaimA, nodeclaimB})
 
 			// Mark NodePool A's nodeclaim as deleting
 			Expect(env.Client.Delete(ctx, nodeclaimA)).To(Succeed())

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -67,11 +67,12 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 		return scheduling.Results{}, errCandidateDeleting
 	}
 
-	// start by getting all pending pods
-	pods, err := provisioner.GetPendingPods(ctx)
+	// start by getting pending pods that could schedule onto any of the candidates
+	pendingPods, err := provisioner.GetPendingPods(ctx)
 	if err != nil {
 		return scheduling.Results{}, fmt.Errorf("determining pending pods, %w", err)
 	}
+	pods := filterPodsByCompatibleCandidates(pendingPods, candidates)
 
 	// Don't provision capacity for pods which will not get evicted due to fully blocking PDBs.
 	// Since Karpenter doesn't know when these pods will be successfully evicted, spinning up capacity until
@@ -92,7 +93,7 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	if err != nil {
 		return scheduling.Results{}, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
 	}
-	pods = append(pods, deletingNodePods...)
+	pods = append(pods, filterPodsByCompatibleCandidates(deletingNodePods, candidates)...)
 
 	var opts []scheduling.Options
 	if options.FromContext(ctx).PreferencePolicy == options.PreferencePolicyIgnore {
@@ -278,6 +279,15 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 		}
 	}
 	return disruptionBudgetMapping, nil
+}
+
+// filterPodsByCompatibleCandidates returns pods whose nodeSelector and tolerations match at least one candidate
+func filterPodsByCompatibleCandidates(pods []*corev1.Pod, candidates []*Candidate) []*corev1.Pod {
+	return lo.Filter(pods, func(p *corev1.Pod, _ int) bool {
+		return lo.SomeBy(candidates, func(c *Candidate) bool {
+			return scheduling.PodCompatibleWithNode(p, c.Node.Spec.Taints, c.Node.Labels)
+		})
+	})
 }
 
 // mapCandidates maps the list of proposed candidates with the current state

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -281,7 +281,11 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 	return disruptionBudgetMapping, nil
 }
 
-// filterPodsByCompatibleCandidates returns pods whose nodeSelector and tolerations match at least one candidate
+// filterPodsByCompatibleCandidates returns pods whose nodeSelector and tolerations match at least one candidate.
+// This is a necessary but not sufficient guard: the downstream scheduler simulation may still fail if the
+// replacement chosen for a candidate is itself incompatible with the pod (e.g. a replacement from a different
+// NodePool whose taints the pod doesn't tolerate). In that case consolidation is correctly blocked by the
+// simulator, not this filter.
 func filterPodsByCompatibleCandidates(pods []*corev1.Pod, candidates []*Candidate) []*corev1.Pod {
 	return lo.Filter(pods, func(p *corev1.Pod, _ int) bool {
 		return lo.SomeBy(candidates, func(c *Candidate) bool {

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -717,7 +717,7 @@ func (s *Scheduler) getCompatibleDaemonPods(ctx context.Context, node *state.Sta
 		if s.shouldSkipDaemonPod(ctx, p) {
 			continue
 		}
-		if s.isDaemonPodCompatibleWithNode(p, taints, node.Labels()) {
+		if isDaemonPodCompatibleWithNode(p, taints, node.Labels()) {
 			daemons = append(daemons, p)
 		}
 	}
@@ -729,8 +729,16 @@ func (s *Scheduler) shouldSkipDaemonPod(ctx context.Context, p *corev1.Pod) bool
 	return pod.HasDRARequirements(p) && karpopts.FromContext(ctx).IgnoreDRARequests
 }
 
-// isDaemonPodCompatibleWithNode checks if a daemon pod is compatible with the node
-func (s *Scheduler) isDaemonPodCompatibleWithNode(p *corev1.Pod, taints []corev1.Taint, nodeLabels map[string]string) bool {
+// isDaemonPodCompatibleWithNode is a named wrapper for the daemon-set scheduling call site.
+func isDaemonPodCompatibleWithNode(p *corev1.Pod, taints []corev1.Taint, nodeLabels map[string]string) bool {
+	return PodCompatibleWithNode(p, taints, nodeLabels)
+}
+
+// PodCompatibleWithNode reports whether a pod's taint tolerations and nodeSelector/affinity
+// requirements are satisfied by the given node. It is intentionally a prefilter: it does not
+// check resource fit, volume topology, or PDB constraints — those are enforced by the scheduler
+// downstream. Callers that need a full admission check must go through the scheduler instead.
+func PodCompatibleWithNode(p *corev1.Pod, taints []corev1.Taint, nodeLabels map[string]string) bool {
 	if err := scheduling.Taints(taints).ToleratesPod(p); err != nil {
 		return false
 	}


### PR DESCRIPTION
**Description**
given 2 nodepools with incompatible taints
- when a pod for 1 pool is pending consolidation for the other is blocked since the pod can never fit on any replacement nodes
- when a pod for 1 pool is deleting consolidation for the other is blocked since the pod can never fit on any replacement nodes

**How was this change tested?**
before this I can see that replacement candidate evaluation always fail in addToInflightNode because the picked type (A) does not match the pending pod (B) and then karpenter proposes to add a new replacement node, which leads to 2->2 replacement which is invalid

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
