### PR TITLE
fix: accumulate podCount correctly in LogValues reducer

### DIFF
--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -276,7 +276,7 @@ func (c Command) EmitRejectedEvents(recorder events.Recorder, reason string) {
 }
 
 func (c Command) LogValues() []any {
-	podCount := lo.Reduce(c.Candidates, func(_ int, cd *Candidate, _ int) int { return len(cd.reschedulablePods) }, 0)
+	podCount := lo.Reduce(c.Candidates, func(acc int, cd *Candidate, _ int) int { return acc + len(cd.reschedulablePods) }, 0)
 
 	candidateNodes := lo.Map(c.Candidates, func(candidate *Candidate, _ int) interface{} {
 		return map[string]interface{}{


### PR DESCRIPTION
Fixes #2888.

### Description
In `pkg/controllers/disruption/types.go`, `LogValues()` computes the `podCount` for disrupted candidates using a `lo.Reduce` closure. Previously, the accumulator `_ int` was ignored and overwritten on each iteration, causing multi-node consolidations to only report the pod count for the final disrupted candidate in structured logging.

This patch simply tracks the `acc` integer and properly returns `acc + len(cd.reschedulablePods)` to calculate the sum across all candidates accurately. 

Unit tests passing cleanly via `make test` locally.