### PR TITLE
feat: allow setting a min consolidation savings percent

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -39,10 +39,13 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/utils/env"
 )
 
 // consolidationTTL is the TTL between creating a consolidation command and validating that it still works.
 const consolidationTTL = 15 * time.Second
+
+var consolidationMinSavingsPercent = env.WithDefaultInt("CONSOLIDATION_MIN_SAVINGS_PERCENT", 0)
 
 // MinInstanceTypesForSpotToSpotConsolidation is the minimum number of instanceTypes in a NodeClaim needed to trigger spot-to-spot single-node consolidation
 const MinInstanceTypesForSpotToSpotConsolidation = 15
@@ -194,7 +197,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 	// If we use this directly for spot-to-spot consolidation, we are bound to get repeated consolidations because the strategy that chooses to launch the spot instance from the list does
 	// it based on availability and price which could result in selection/launch of non-lowest priced instance in the list. So, we would keep repeating this loop till we get to lowest priced instance
 	// causing churns and landing onto lower available spot instance ultimately resulting in higher interruptions.
-	results.NewNodeClaims[0], err = results.NewNodeClaims[0].RemoveInstanceTypeOptionsByPriceAndMinValues(results.NewNodeClaims[0].Requirements, candidatePrice)
+	results.NewNodeClaims[0], err = results.NewNodeClaims[0].RemoveInstanceTypeOptionsByPriceAndMinValues(results.NewNodeClaims[0].Requirements, minSavingsPrice(candidatePrice))
 	if err != nil {
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, fmt.Sprintf("Filtering by price: %v", err))...)
@@ -250,7 +253,7 @@ func (c *consolidation) computeSpotToSpotConsolidation(ctx context.Context, cand
 
 	// filterByPrice returns the instanceTypes that are lower priced than the current candidate and any error that indicates the input couldn't be filtered.
 	var err error
-	results.NewNodeClaims[0], err = results.NewNodeClaims[0].RemoveInstanceTypeOptionsByPriceAndMinValues(results.NewNodeClaims[0].Requirements, candidatePrice)
+	results.NewNodeClaims[0], err = results.NewNodeClaims[0].RemoveInstanceTypeOptionsByPriceAndMinValues(results.NewNodeClaims[0].Requirements, minSavingsPrice(candidatePrice))
 	if err != nil {
 		if len(candidates) == 1 {
 			c.recorder.Publish(disruptionevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, fmt.Sprintf("Filtering by price: %v", err))...)
@@ -313,6 +316,10 @@ func (c *consolidation) computeSpotToSpotConsolidation(ctx context.Context, cand
 	cmd.EmitCandidateEvents(c.recorder)
 
 	return cmd, nil
+}
+
+func minSavingsPrice(candidatePrice float64) float64 {
+	return candidatePrice * (1 - float64(consolidationMinSavingsPercent)/100)
 }
 
 // getCandidatePrices returns the sum of the prices of the given candidates


### PR DESCRIPTION
**Description**

our node churn is high because karpenter consolidates on any savings
but I want a lever to make the cluster more stable

adding `CONSOLIDATION_MIN_SAVINGS_PERCENT=10` so if we are not saving 10% of the cost then don't consolidate

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
