### PR TITLE
fix: re-sync node labels after registration hooks complete

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -91,8 +91,8 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (
 	// If any hook is not ready, registration is deferred and the unregistered taint remains.
 	hooksResult, hookErrors := r.checkRegistrationHooks(ctx, nodeClaim)
 	if lo.IsEmpty(hooksResult) && hookErrors == nil {
-		// Re-sync labels after hooks complete since hooks may have mutated nodeClaim labels.
-		node.Labels = lo.Assign(node.Labels, nodeClaim.Labels)
+		// Re-sync the node after hooks complete since hooks may have mutated the nodeClaim.
+		r.syncNode(nodeClaim, node)
 		node.Spec.Taints = lo.Reject(node.Spec.Taints, func(t corev1.Taint, _ int) bool {
 			return t.MatchTaint(&v1.UnregisteredNoExecuteTaint)
 		})

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -91,6 +91,9 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (
 	// If any hook is not ready, registration is deferred and the unregistered taint remains.
 	hooksResult, hookErrors := r.checkRegistrationHooks(ctx, nodeClaim)
 	if lo.IsEmpty(hooksResult) && hookErrors == nil {
+		// Re-sync labels after hooks complete since hooks may have mutated nodeClaim labels
+		// (e.g. resolving the placement group partition number from the empty sentinel value).
+		node.Labels = lo.Assign(node.Labels, nodeClaim.Labels)
 		node.Spec.Taints = lo.Reject(node.Spec.Taints, func(t corev1.Taint, _ int) bool {
 			return t.MatchTaint(&v1.UnregisteredNoExecuteTaint)
 		})

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -91,8 +91,7 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (
 	// If any hook is not ready, registration is deferred and the unregistered taint remains.
 	hooksResult, hookErrors := r.checkRegistrationHooks(ctx, nodeClaim)
 	if lo.IsEmpty(hooksResult) && hookErrors == nil {
-		// Re-sync labels after hooks complete since hooks may have mutated nodeClaim labels
-		// (e.g. resolving the placement group partition number from the empty sentinel value).
+		// Re-sync labels after hooks complete since hooks may have mutated nodeClaim labels.
 		node.Labels = lo.Assign(node.Labels, nodeClaim.Labels)
 		node.Spec.Taints = lo.Reject(node.Spec.Taints, func(t corev1.Taint, _ int) bool {
 			return t.MatchTaint(&v1.UnregisteredNoExecuteTaint)

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -954,5 +954,41 @@ var _ = Describe("Registration", func() {
 			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue()).To(BeTrue())
 			Expect(nodeClaim.Status.NodeName).To(Equal(node.Name))
 		})
+		It("should propagate labels added by a registration hook to both the node and the nodeclaim", func() {
+			hookController := nodeclaimlifecycle.NewController(fakeClock, env.Client, cloudProvider,
+				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				[]cloudprovider.NodeLifecycleHook{
+					testHook{
+						name: "label-mutating-hook",
+						fn: func(_ context.Context, nc *v1.NodeClaim) (cloudprovider.NodeLifecycleHookResult, error) {
+							nc.Labels["test.karpenter.sh/hook-label"] = "resolved-value"
+							return cloudprovider.NodeLifecycleHookResult{}, nil
+						},
+					},
+				},
+			)
+			nodeClaim := test.NodeClaim(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            nodePool.Name,
+						"test.karpenter.sh/hook-label": "",
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+			ExpectObjectReconciled(ctx, env.Client, hookController, nodeClaim)
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+
+			node := test.Node(test.NodeOptions{ProviderID: nodeClaim.Status.ProviderID, Taints: []corev1.Taint{v1.UnregisteredNoExecuteTaint}})
+			ExpectApplied(ctx, env.Client, node)
+			ExpectObjectReconciled(ctx, env.Client, hookController, nodeClaim)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeRegistered).IsTrue()).To(BeTrue())
+			Expect(nodeClaim.Labels).To(HaveKeyWithValue("test.karpenter.sh/hook-label", "resolved-value"))
+
+			node = ExpectExists(ctx, env.Client, node)
+			Expect(node.Labels).To(HaveKeyWithValue("test.karpenter.sh/hook-label", "resolved-value"))
+		})
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
In [this integration test run](https://github.com/aws/karpenter-provider-aws/actions/runs/24738491539/job/72371644543 ), the `[It] should launch an instance into a partition placement group with auto-assigned partition` test failed

I gave the logs to Kiro and this is what it came up with:

```
Confirmed. Here's the exact bug:

Line 88: r.syncNode(nodeClaim, node) — copies nodeClaim.Labels (with partition="") to node.Labels
Line 90: r.checkRegistrationHooks(ctx, nodeClaim) — hook updates nodeClaim.Labels[partition] = "3" but node.Labels still has partition=""
Line 91-94: If hooks pass, the unregistered taint is removed and NodeRegisteredLabelKey is set on the node
Line 96-103: Node is patched — but with the stale empty partition label
Line 108: ConditionTypeRegistered is set to True on the nodeClaim
Next reconcile: line 57 short-circuits because ConditionTypeRegistered is no longer Unknown
The node ends up with placement-group-partition: "" forever. The test then reads node.Labels[v1.LabelPlacementGroupPartition] and gets an empty string, failing the Expect(partitionStr).ToNot(BeEmpty()) assertion.

The fix: after hooks complete successfully, re-sync the node labels from the updated nodeClaim. The simplest approach is to call syncNode again after the hooks, or just re-assign the labels after hooks pass.
```

Putting up this PR so @joshuakguo can take a look

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
