### PR TITLE
chore: Fix do-not-disrupt grace period integ test race

### DIFF
--- a/test/suites/regression/integration_test.go
+++ b/test/suites/regression/integration_test.go
@@ -426,6 +426,8 @@ var _ = Describe("Integration", func() {
 	Describe("DoNotDisrupt", func() {
 		Context("Grace Period", func() {
 			It("should drain pods according to their grace period durations and block indefinitely for 'true'", func() {
+				const shortGrace = time.Minute
+				const longGrace = 2 * time.Minute
 				// Pod with a 1-minute grace period
 				shortPod := test.Pod(test.PodOptions{
 					ObjectMeta: metav1.ObjectMeta{
@@ -481,18 +483,36 @@ var _ = Describe("Integration", func() {
 				env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(longPod.Labels), 1)
 				env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(indefinitePod.Labels), 1)
 
+				// Re-fetch pods to get their actual StartTime from the API server.
+				// The do-not-disrupt grace period is measured from pod start time, so we
+				// derive all consistency check windows from the real start times.
+				for _, p := range []*corev1.Pod{shortPod, longPod, indefinitePod} {
+					Expect(env.Client.Get(env, client.ObjectKeyFromObject(p), p)).To(Succeed())
+					Expect(p.Status.StartTime).ToNot(BeNil())
+				}
+				shortExpiry := shortPod.Status.StartTime.Add(shortGrace)
+				longExpiry := longPod.Status.StartTime.Add(longGrace)
+
 				// Delete the nodeclaim to trigger draining
 				env.ExpectDeleted(nodeClaim)
 
-				// During the first minute, all three pods should remain active
-				env.ConsistentlyExpectActivePods(45*time.Second, shortPod, longPod, indefinitePod)
+				// All three pods should remain active until the short grace period expires.
+				shortWindow := time.Until(shortExpiry) - 5*time.Second
+				Expect(shortWindow).To(BeNumerically(">", 0), "short grace period already expired before consistency check")
+				env.ConsistentlyExpectActivePods(shortWindow, shortPod, longPod, indefinitePod)
 
-				// After ~1m the short grace period pod should be drained, but the other two remain
+				// After the short grace period elapses, the short pod should be drained
 				env.EventuallyExpectNotFound(shortPod)
-				env.ConsistentlyExpectActivePods(30*time.Second, longPod, indefinitePod)
 
-				// After ~2m the long grace period pod should be drained, but the indefinite pod remains
+				// The long and indefinite pods should remain active until the long grace period expires.
+				longWindow := time.Until(longExpiry) - 5*time.Second
+				Expect(longWindow).To(BeNumerically(">", 0), "long grace period already expired before consistency check")
+				env.ConsistentlyExpectActivePods(longWindow, longPod, indefinitePod)
+
+				// After the long grace period elapses, the long pod should be drained
 				env.EventuallyExpectNotFound(longPod)
+
+				// The indefinite pod should still be alive indefinitely
 				env.ConsistentlyExpectActivePods(30*time.Second, indefinitePod)
 
 				// The indefinite pod should still be alive — remove the annotation to unblock draining


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
In [this integ test run](https://github.com/aws/karpenter-provider-aws/actions/runs/24872115086/job/72820655463), the hardcoded wait times for the pods caused the test to fail. This PR updates the wait times to dynamically calculate based on the test pods status.StartTime, which is how the do-not-disrupt grace period is actually calculated.

**How was this change tested?**
Ran the integ test muultiple times locally against a cluster, saw logs like these demonstrating new dynamically calculated wait times -
```
STEP: expecting 3 pods to be live for 51.195169782s
STEP: expecting 2 pods to be live for 53.9979467s
STEP: expecting 1 pods to be live for 30s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
