### PR TITLE
perf: improve skip condition for `applyPriceOverlays`

### DIFF
--- a/pkg/controllers/nodeoverlay/store.go
+++ b/pkg/controllers/nodeoverlay/store.go
@@ -146,7 +146,7 @@ func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider
 	}
 
 	// Handle offerings - copy-on-write only for offerings that need price overlay
-	if instanceTypeUpdate.Price != nil {
+	if len(instanceTypeUpdate.Price) != 0 {
 		overriddenInstanceType.Offerings = s.applyPriceOverlays(it.Offerings, instanceTypeUpdate.Price)
 	} else {
 		overriddenInstanceType.Offerings = it.Offerings // Shared - not modified

--- a/pkg/controllers/nodeoverlay/store.go
+++ b/pkg/controllers/nodeoverlay/store.go
@@ -73,9 +73,7 @@ func (s *InstanceTypeStore) ApplyAll(nodePoolName string, its []*cloudprovider.I
 	}
 
 	for _, it := range its {
-		if updatedIt, err := internalStore.apply(nodePoolName, it); err == nil {
-			result = append(result, updatedIt)
-		}
+		result = append(result, internalStore.apply(nodePoolName, it))
 	}
 	return result, nil
 }
@@ -87,11 +85,7 @@ func (s *InstanceTypeStore) Apply(nodePoolName string, it *cloudprovider.Instanc
 		return &cloudprovider.InstanceType{}, cloudprovider.NewUnevaluatedNodePoolError(nodePoolName)
 	}
 
-	updatedIt, err := internalStore.apply(nodePoolName, it)
-	if err != nil {
-		return &cloudprovider.InstanceType{}, err
-	}
-	return updatedIt, nil
+	return internalStore.apply(nodePoolName, it), nil
 }
 
 // InstanceTypeStore manages instance type updates for node pools.
@@ -120,14 +114,14 @@ func newInternalInstanceTypeStore() *internalInstanceTypeStore {
 // - Shared: Requirements and Overhead (never modified, safe to share)
 // - Selective copy: Offerings (only copied if price overlay applied)
 // - Selective copy: Capacity (only copied if capacity overlay applied)
-func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider.InstanceType) (*cloudprovider.InstanceType, error) {
+func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider.InstanceType) *cloudprovider.InstanceType {
 	instanceTypeList, ok := s.updates[nodePoolName]
 	if !ok {
-		return it, nil
+		return it
 	}
 	instanceTypeUpdate, ok := instanceTypeList[it.Name]
 	if !ok {
-		return it, nil
+		return it
 	}
 
 	// Create a shallow copy of the instance type, sharing immutable fields
@@ -151,7 +145,7 @@ func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider
 		overriddenInstanceType.Offerings = it.Offerings // Shared - not modified
 	}
 
-	return overriddenInstanceType, nil
+	return overriddenInstanceType
 }
 
 // applyPriceOverlays creates a new offerings slice with selective copying:

--- a/pkg/controllers/nodeoverlay/store.go
+++ b/pkg/controllers/nodeoverlay/store.go
@@ -115,7 +115,7 @@ func newInternalInstanceTypeStore() *internalInstanceTypeStore {
 // with any stored updates applied. It uses a selective copy-on-write strategy to minimize memory usage:
 // - Shared: Requirements and Overhead (never modified, safe to share)
 // - Selective copy: Offerings (only copied if price overlay applied)
-// - Selective copy: Capacity (only deep copied if capacity overlay applied)
+// - Selective copy: Capacity (only copied if capacity overlay applied)
 func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider.InstanceType) (*cloudprovider.InstanceType, error) {
 	if !lo.Contains(s.evaluatedNodePools.UnsortedList(), nodePoolName) {
 		return &cloudprovider.InstanceType{}, cloudprovider.NewUnevaluatedNodePoolError(nodePoolName)
@@ -135,14 +135,13 @@ func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider
 		Name:         it.Name,
 		Requirements: it.Requirements, // Shared - never modified
 		Overhead:     it.Overhead,     // Shared - never modified
+		Capacity:     it.Capacity,
 	}
 
 	// Handle capacity overlay - only deep copy if we're modifying it
-	if len(lo.Keys(instanceTypeUpdate.Capacity.OverlayUpdate)) != 0 {
-		overriddenInstanceType.Capacity = it.Capacity.DeepCopy()
+	if len(instanceTypeUpdate.Capacity.OverlayUpdate) != 0 {
+		// ApplyCapacityOverlay replaces Capacity with a new merged map (original untouched)
 		overriddenInstanceType.ApplyCapacityOverlay(instanceTypeUpdate.Capacity.OverlayUpdate)
-	} else {
-		overriddenInstanceType.Capacity = it.Capacity // Shared - not modified
 	}
 
 	// Handle offerings - copy-on-write only for offerings that need price overlay

--- a/pkg/controllers/nodeoverlay/store.go
+++ b/pkg/controllers/nodeoverlay/store.go
@@ -61,7 +61,7 @@ func (s *InstanceTypeStore) UpdateStore(updatedStore *internalInstanceTypeStore)
 func (s *InstanceTypeStore) ApplyAll(nodePoolName string, its []*cloudprovider.InstanceType) ([]*cloudprovider.InstanceType, error) {
 	internalStore := lo.FromPtr(s.store.Load())
 
-	if !lo.Contains(internalStore.evaluatedNodePools.UnsortedList(), nodePoolName) {
+	if !internalStore.evaluatedNodePools.Has(nodePoolName) {
 		return []*cloudprovider.InstanceType{}, cloudprovider.NewUnevaluatedNodePoolError(nodePoolName)
 	}
 
@@ -82,6 +82,10 @@ func (s *InstanceTypeStore) ApplyAll(nodePoolName string, its []*cloudprovider.I
 
 func (s *InstanceTypeStore) Apply(nodePoolName string, it *cloudprovider.InstanceType) (*cloudprovider.InstanceType, error) {
 	internalStore := lo.FromPtr(s.store.Load())
+
+	if !internalStore.evaluatedNodePools.Has(nodePoolName) {
+		return &cloudprovider.InstanceType{}, cloudprovider.NewUnevaluatedNodePoolError(nodePoolName)
+	}
 
 	updatedIt, err := internalStore.apply(nodePoolName, it)
 	if err != nil {
@@ -117,10 +121,6 @@ func newInternalInstanceTypeStore() *internalInstanceTypeStore {
 // - Selective copy: Offerings (only copied if price overlay applied)
 // - Selective copy: Capacity (only copied if capacity overlay applied)
 func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider.InstanceType) (*cloudprovider.InstanceType, error) {
-	if !lo.Contains(s.evaluatedNodePools.UnsortedList(), nodePoolName) {
-		return &cloudprovider.InstanceType{}, cloudprovider.NewUnevaluatedNodePoolError(nodePoolName)
-	}
-
 	instanceTypeList, ok := s.updates[nodePoolName]
 	if !ok {
 		return it, nil

--- a/pkg/controllers/nodeoverlay/store_bench_test.go
+++ b/pkg/controllers/nodeoverlay/store_bench_test.go
@@ -82,7 +82,7 @@ func BenchmarkStoreApply(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			for _, it := range instanceTypes {
-				_, _ = store.apply("default", it)
+				_ = store.apply("default", it)
 			}
 		}
 	})
@@ -105,7 +105,7 @@ func BenchmarkStoreApplyNoOverlay(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, it := range instanceTypes {
-			_, _ = store.apply("default", it)
+			_ = store.apply("default", it)
 		}
 	}
 }
@@ -141,7 +141,7 @@ func BenchmarkStoreApplyPriceOnly(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, it := range instanceTypes {
-			_, _ = store.apply("default", it)
+			_ = store.apply("default", it)
 		}
 	}
 }
@@ -174,7 +174,7 @@ func BenchmarkStoreApplyCapacityOnly(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, it := range instanceTypes {
-			_, _ = store.apply("default", it)
+			_ = store.apply("default", it)
 		}
 	}
 }
@@ -214,7 +214,7 @@ func BenchmarkStoreApplyBothOverlays(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, it := range instanceTypes {
-			_, _ = store.apply("default", it)
+			_ = store.apply("default", it)
 		}
 	}
 }
@@ -338,7 +338,7 @@ func BenchmarkNodeOverlayControllerScenario(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, np := range nodePools {
 			for _, it := range instanceTypes {
-				_, _ = store.apply(np, it)
+				_ = store.apply(np, it)
 			}
 		}
 	}

--- a/pkg/controllers/nodeoverlay/store_bench_test.go
+++ b/pkg/controllers/nodeoverlay/store_bench_test.go
@@ -161,7 +161,7 @@ func BenchmarkStoreApplyCapacityOnly(b *testing.B) {
 
 	for _, it := range instanceTypes {
 		store.updates["default"][it.Name] = &instanceTypeUpdate{
-			Price: nil,
+			Price: map[string]*priceUpdate{},
 			Capacity: &capacityUpdate{
 				OverlayUpdate: corev1.ResourceList{
 					"hugepages-2Mi": resource.MustParse("100Mi"),

--- a/pkg/controllers/nodeoverlay/store_memory_test.go
+++ b/pkg/controllers/nodeoverlay/store_memory_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Memory Usage Overlay Scenarios", func() {
 			for i := 0; i < 100; i++ {
 				for _, np := range nodePools {
 					for _, it := range instanceTypes {
-						_, _ = store.apply(np, it)
+						_ = store.apply(np, it)
 					}
 				}
 			}
@@ -178,7 +178,7 @@ var _ = Describe("Memory Usage Overlay Scenarios", func() {
 
 			for i := 0; i < 100; i++ {
 				for _, it := range instanceTypes {
-					_, _ = store.apply("default", it)
+					_ = store.apply("default", it)
 				}
 			}
 
@@ -215,7 +215,7 @@ var _ = Describe("Memory Usage Overlay Scenarios", func() {
 
 			for i := 0; i < 100; i++ {
 				for _, it := range instanceTypes {
-					_, _ = store.apply("default", it)
+					_ = store.apply("default", it)
 				}
 			}
 
@@ -237,7 +237,7 @@ var _ = Describe("Memory Usage Overlay Scenarios", func() {
 			for i := 0; i < 100; i++ {
 				for _, np := range nodePools {
 					for _, it := range instanceTypes {
-						_, _ = store.apply(np, it)
+						_ = store.apply(np, it)
 					}
 				}
 			}
@@ -273,7 +273,7 @@ var _ = Describe("Memory Usage Scale With NodePools", func() {
 			for i := 0; i < 100; i++ {
 				for _, np := range nodePools {
 					for _, it := range instanceTypes {
-						_, _ = store.apply(np, it)
+						_ = store.apply(np, it)
 					}
 				}
 			}
@@ -312,7 +312,7 @@ var _ = Describe("Memory Usage Scale With InstanceTypes", func() {
 			for i := 0; i < 100; i++ {
 				for _, np := range nodePools {
 					for _, it := range instanceTypes {
-						_, _ = store.apply(np, it)
+						_ = store.apply(np, it)
 					}
 				}
 			}

--- a/pkg/controllers/nodeoverlay/store_test.go
+++ b/pkg/controllers/nodeoverlay/store_test.go
@@ -41,8 +41,7 @@ var _ = Describe("Store Apply Selective Copy", func() {
 				},
 			}
 
-			result, err := store.apply("default", instanceType)
-			Expect(err).ToNot(HaveOccurred(), "unexpected error applying overlay")
+			result := store.apply("default", instanceType)
 
 			// Verify Requirements sharing - map comparison by checking first key address
 			if expectSharedReqs {
@@ -218,8 +217,7 @@ var _ = Describe("Store Apply Correctness", func() {
 				},
 			}
 
-			result, err := store.apply("default", instanceType)
-			Expect(err).ToNot(HaveOccurred())
+			result := store.apply("default", instanceType)
 
 			// Verify first offering was modified
 			Expect(result.Offerings[0].Price).To(BeNumerically("==", 0.106), "expected first offering price to be 0.106") // 0.096 + 0.01
@@ -260,8 +258,7 @@ var _ = Describe("Store Apply Correctness", func() {
 				},
 			}
 
-			result, err := store.apply("default", instanceType)
-			Expect(err).ToNot(HaveOccurred())
+			result := store.apply("default", instanceType)
 
 			// Verify hugepages was added
 			hugepages, ok := result.Capacity["hugepages-2Mi"]
@@ -319,12 +316,10 @@ var _ = Describe("Store Apply Isolation Between NodePools", func() {
 		}
 
 		// Apply to NodePool A
-		resultA, err := store.apply("nodepool-a", instanceType)
-		Expect(err).ToNot(HaveOccurred(), "unexpected error for nodepool-a")
+		resultA := store.apply("nodepool-a", instanceType)
 
 		// Apply to NodePool B
-		resultB, err := store.apply("nodepool-b", instanceType)
-		Expect(err).ToNot(HaveOccurred(), "unexpected error for nodepool-b")
+		resultB := store.apply("nodepool-b", instanceType)
 
 		// Verify NodePool A has +10% (0.096 * 1.10 = 0.1056)
 		expectedPriceA := 0.1056
@@ -348,10 +343,14 @@ var _ = Describe("Store Apply Unevaluated NodePool", func() {
 			Name: "m5.large",
 		})
 
+		publicStore := NewInstanceTypeStore()
 		store := newInternalInstanceTypeStore()
+
 		// Don't add "unevaluated" to evaluatedNodePools
 
-		_, err := store.apply("unevaluated", instanceType)
+		publicStore.UpdateStore(store)
+
+		_, err := publicStore.Apply("unevaluated", instanceType)
 		Expect(err).To(HaveOccurred(), "expected error for unevaluated node pool")
 		Expect(cloudprovider.IsUnevaluatedNodePoolError(err)).To(BeTrue(), "expected UnevaluatedNodePoolError")
 	})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

**Description**

Replaces a `m != nil` check with a `len(m) != 0` check to avoid running `applyPriceOverlays` with an empty `priceUpdates` map. This reduced disruption controller CPU usage by ~50% for an idle cluster with NodeOverlays that only affect capacity.

The actual root causes of poor `applyPriceOverlays` performance are not addressed.

**How was this change tested?**

Profiling and metrics. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
