### PR TITLE
fix: multi-node consolidation reaches non-prefix subsets (#1962)

### DIFF
--- a/pkg/controllers/disruption/multinode_1962_test.go
+++ b/pkg/controllers/disruption/multinode_1962_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// End-to-end test for kubernetes-sigs/karpenter#1962: multi-node
+// consolidation's binary search over sorted prefixes is prefix-blind.
+// When a candidate that blocks joint deletion (e.g. a node hosting a
+// pod whose requirements no other node can satisfy) sorts between
+// good candidates, every prefix containing the bad candidate fails
+// the simulator. The binary search exits empty and multi-node
+// consolidation contributes nothing, even though a non-prefix subset
+// excluding the bad candidate would consolidate cleanly.
+//
+// This test runs against the real disruption stack (envtest, fake
+// CloudProvider, real provisioner). It constructs three candidates
+// sorted [good_0, bad, good_2] by disruption cost, where bad's pod
+// has a NodeSelector that no remaining node and no replacement can
+// satisfy. The good pods are unrestricted and fit anywhere.
+//
+// Without the fix in firstNConsolidationOption, multi-node returns
+// no command. With the fix (binary search first, pairwise non-prefix
+// fallback when it returns empty), multi-node returns one command
+// deleting good_0 and good_2 together.
+
+package disruption_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+)
+
+var _ = Describe("MultiNode Consolidation Non-Prefix Subset (#1962)", func() {
+	It("finds a non-prefix consolidation when a bad candidate sorts between good ones", func() {
+		nodePool := test.NodePool(v1.NodePool{
+			Spec: v1.NodePoolSpec{
+				Disruption: v1.Disruption{
+					ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+					ConsolidateAfter:    v1.MustParseNillableDuration("0s"),
+					Budgets:             []v1.Budget{{Nodes: "100%"}},
+				},
+			},
+		})
+
+		nodeClaims := make([]*v1.NodeClaim, 3)
+		nodes := make([]*corev1.Node, 3)
+		for i := range nodeClaims {
+			nodeClaims[i], nodes[i] = test.NodeClaimAndNode(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            nodePool.Name,
+						corev1.LabelInstanceTypeStable: mostExpensiveInstance.Name,
+						v1.CapacityTypeLabelKey:        mostExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+						corev1.LabelTopologyZone:       mostExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					Allocatable: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("32"),
+						corev1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			nodeClaims[i].StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+		}
+
+		// nodes[1] is the "bad" candidate. Tag it with a unique label so
+		// only its own pod (which sets the matching NodeSelector) can
+		// land there. The label is not in the NodePool template, so
+		// replacement nodes won't carry it either.
+		nodes[1].Labels["bad-only"] = "true"
+
+		labels := map[string]string{"app": "test"}
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		ownerRefs := []metav1.OwnerReference{{
+			APIVersion:         "apps/v1",
+			Kind:               "ReplicaSet",
+			Name:               rs.Name,
+			UID:                rs.UID,
+			Controller:         lo.ToPtr(true),
+			BlockOwnerDeletion: lo.ToPtr(true),
+		}}
+
+		// Sort order is by disruption cost ascending. We use the pod
+		// deletion cost annotation to pin good_0 first, bad in the
+		// middle, good_2 last. With this order the binary search probes
+		// [good_0, bad] and fails on bad's unschedulable pod.
+		podGood0 := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:          labels,
+				OwnerReferences: ownerRefs,
+				Annotations:     map[string]string{corev1.PodDeletionCost: "-2147483647"},
+			},
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+		})
+		podBad := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:          labels,
+				OwnerReferences: ownerRefs,
+			},
+			NodeSelector: map[string]string{"bad-only": "true"},
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+		})
+		podGood2 := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:          labels,
+				OwnerReferences: ownerRefs,
+				Annotations:     map[string]string{corev1.PodDeletionCost: "2147483647"},
+			},
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+		})
+
+		ExpectApplied(ctx, env.Client, nodePool,
+			nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodeClaims[2], nodes[2],
+			podGood0, podBad, podGood2)
+
+		ExpectManualBinding(ctx, env.Client, podGood0, nodes[0])
+		ExpectManualBinding(ctx, env.Client, podBad, nodes[1])
+		ExpectManualBinding(ctx, env.Client, podGood2, nodes[2])
+
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client,
+			nodeStateController, nodeClaimStateController, nodes, nodeClaims)
+
+		c := disruption.MakeConsolidation(fakeClock, cluster, env.Client, prov, cloudProvider, recorder, queue)
+		multiConsolidation := disruption.NewMultiNodeConsolidation(c,
+			disruption.WithValidator(NewTestMultiConsolidationValidator(nodePool)))
+
+		budgets, err := disruption.BuildDisruptionBudgetMapping(ctx, cluster, fakeClock, env.Client, cloudProvider, recorder, multiConsolidation.Reason())
+		Expect(err).To(Succeed())
+
+		candidates, err := disruption.GetCandidates(ctx, cluster, env.Client, recorder, fakeClock, cloudProvider,
+			multiConsolidation.ShouldDisrupt, multiConsolidation.Class(), queue)
+		Expect(err).To(Succeed())
+		Expect(candidates).To(HaveLen(3))
+
+		cmds, err := multiConsolidation.ComputeCommands(ctx, budgets, candidates...)
+		Expect(err).To(Succeed())
+
+		// With the #1962 fix, multi-node consolidation finds the non-prefix
+		// subset {good_0, good_2}. Without the fix, the binary search
+		// probes only [good_0, bad] (which fails because bad's pod can't
+		// reschedule) and exits empty.
+		Expect(cmds).To(HaveLen(1))
+		Expect(cmds[0].Candidates).To(HaveLen(2))
+
+		providerIDs := sets.New[string]()
+		for _, cand := range cmds[0].Candidates {
+			providerIDs.Insert(cand.ProviderID())
+		}
+		Expect(providerIDs.Has(nodes[0].Spec.ProviderID)).To(BeTrue(), "good_0 should be in the consolidation set")
+		Expect(providerIDs.Has(nodes[2].Spec.ProviderID)).To(BeTrue(), "good_2 should be in the consolidation set")
+		Expect(providerIDs.Has(nodes[1].Spec.ProviderID)).To(BeFalse(), "bad candidate should not be in the consolidation set")
+	})
+})

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/awslabs/operatorpkg/option"
@@ -258,8 +259,13 @@ func (m *MultiNodeConsolidation) pairwiseSearchFallback(ctx context.Context, can
 			return Command{}, err
 		}
 
-		candidatesToConsolidate := append(accepted, c) //nolint:gocritic // intentional new slice per iteration
+		candidatesToConsolidate := append(slices.Clone(accepted), c)
 
+		// When accepted is empty this probes a single candidate, which
+		// single-node consolidation already evaluated. The probe is still
+		// needed: the walk uses the result to decide whether to accept or
+		// skip c. Without it, a bad first candidate would poison the
+		// entire accepted set with no way to eject it.
 		cmd, err := m.computeConsolidation(timeoutCtx, candidatesToConsolidate...)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -35,6 +35,16 @@ import (
 const MultiNodeConsolidationTimeoutDuration = 1 * time.Minute
 const MultiNodeConsolidationType = "multi"
 
+// MultiNodePairwiseSearchTimeoutDuration bounds the latency added by
+// the pairwise non-prefix fallback (see karpenter#1962). The fallback
+// only runs when the primary binary search returns no plan, so this
+// budget is consumed only on cases the existing search misses. With
+// computeConsolidation latency typically 10 to 30ms, 10s allows
+// roughly 300 to 1000 probes, enough for the largest practical batch
+// (max=100) on a healthy cluster. Regret on overloaded clusters where
+// each probe is slower stays bounded by this budget.
+const MultiNodePairwiseSearchTimeoutDuration = 10 * time.Second
+
 type MultiNodeConsolidation struct {
 	consolidation
 	validator Validator
@@ -112,14 +122,53 @@ func (m *MultiNodeConsolidation) ComputeCommands(ctx context.Context, disruption
 	return []Command{cmd}, nil
 }
 
-// firstNConsolidationOption looks at the first N NodeClaims to determine if they can all be consolidated at once.  The
-// NodeClaims are sorted by increasing disruption order which correlates to likelihood of being able to consolidate the node
-// nolint:gocyclo
+// firstNConsolidationOption looks at the first N NodeClaims to determine if they can all be consolidated at once.
+// It runs the binary search over sorted prefixes first (existing
+// behavior, fast log(N) probes) and falls back to the pairwise
+// non-prefix search only when the binary search returns no plan.
+// This preserves equivalence with prior versions on every input the
+// binary search already handled, and adds the pairwise recovery only
+// for inputs where binary search exits empty (the karpenter#1962
+// shape, where a candidate that blocks joint deletion sits early in
+// the sort order and poisons every prefix probe).
+//
+// Latency contract:
+//   - Binary search: bounded by MultiNodeConsolidationTimeoutDuration (1m).
+//   - Pairwise fallback: bounded by MultiNodePairwiseSearchTimeoutDuration (10s).
+//
+// On a successful binary search no extra latency is paid. On a
+// 1962-shaped failure the additional cost is at most the pairwise
+// timeout, regardless of N. Big-cluster regret is bounded by that
+// 10s budget.
 func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, candidates []*Candidate, max int) (Command, error) {
 	// we always operate on at least two NodeClaims at once, for single NodeClaims standard consolidation will find all solutions
 	if len(candidates) < 2 {
 		return Command{}, nil
 	}
+
+	primary, err := m.binarySearchPrefix(ctx, candidates, max)
+	if err != nil {
+		return Command{}, err
+	}
+	if primary.Decision() != NoOpDecision {
+		// Existing behavior: binary search found a feasible prefix.
+		return primary, nil
+	}
+
+	// Binary search exhausted without finding a feasible prefix
+	// (the karpenter#1962 case). Fall back to the pairwise non-prefix
+	// walk, bounded by its own timeout so the latency added on big
+	// clusters stays capped.
+	return m.pairwiseSearchFallback(ctx, candidates, max)
+}
+
+// binarySearchPrefix is the prior firstNConsolidationOption logic:
+// binary search over sorted prefixes [0:mid+1], doubling on success
+// and halving on failure. Preserved verbatim so every input the
+// existing search handled keeps producing the same result.
+//
+// nolint:gocyclo
+func (m *MultiNodeConsolidation) binarySearchPrefix(ctx context.Context, candidates []*Candidate, max int) (Command, error) {
 	min := 1
 	if len(candidates) <= max {
 		max = len(candidates) - 1
@@ -166,6 +215,86 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 		} else {
 			max = mid - 1
 		}
+	}
+	return lastSavedCommand, nil
+}
+
+// pairwiseSearchFallback walks candidates in order, simulating the
+// joint deletion of (already accepted plus this candidate) at each
+// step. Accepts the candidate when the simulator returns feasible,
+// skips it otherwise and continues. Non-prefix subsets are reachable
+// because skipping does not narrow the search. This is the recovery
+// for karpenter#1962.
+//
+// Bounded by MultiNodePairwiseSearchTimeoutDuration so the latency
+// added when this fallback runs is capped independently of N. On
+// timeout, returns the last valid command (possibly empty).
+//
+// nolint:gocyclo
+func (m *MultiNodeConsolidation) pairwiseSearchFallback(ctx context.Context, candidates []*Candidate, max int) (Command, error) {
+	if len(candidates) > max {
+		candidates = candidates[:max+1]
+	}
+
+	lastSavedCommand := Command{}
+	timeoutCtx, cancel := context.WithTimeout(ctx, MultiNodePairwiseSearchTimeoutDuration)
+	defer cancel()
+
+	accepted := make([]*Candidate, 0, len(candidates))
+
+	for _, c := range candidates {
+		// Bail out early if the pairwise timeout has fired before
+		// we evaluate the next candidate.
+		if err := timeoutCtx.Err(); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				ConsolidationTimeoutsTotal.Inc(map[string]string{ConsolidationTypeLabel: m.ConsolidationType()})
+				if lastSavedCommand.Candidates == nil {
+					log.FromContext(ctx).V(1).Info("pairwise fallback found no consolidation before timeout", "accepted_size", len(accepted))
+					return Command{}, nil
+				}
+				log.FromContext(ctx).V(1).WithValues(lastSavedCommand.LogValues()...).Info("pairwise fallback stopping after timeout, returning last valid command")
+				return lastSavedCommand, nil
+			}
+			return Command{}, err
+		}
+
+		candidatesToConsolidate := append(accepted, c) //nolint:gocritic // intentional new slice per iteration
+
+		cmd, err := m.computeConsolidation(timeoutCtx, candidatesToConsolidate...)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				ConsolidationTimeoutsTotal.Inc(map[string]string{ConsolidationTypeLabel: m.ConsolidationType()})
+				if lastSavedCommand.Candidates == nil {
+					log.FromContext(ctx).V(1).Info("pairwise fallback found no consolidation before timeout", "accepted_size", len(accepted))
+					return Command{}, nil
+				}
+				log.FromContext(ctx).V(1).WithValues(lastSavedCommand.LogValues()...).Info("pairwise fallback stopping after timeout, returning last valid command")
+				return lastSavedCommand, nil
+			}
+			return Command{}, err
+		}
+
+		// ensure that the action is sensical for replacements, see explanation on filterOutSameInstanceType for why this is
+		// required
+		validDecision := cmd.Decision() == DeleteDecision
+		if cmd.Decision() == ReplaceDecision {
+			cmd.Replacements[0], err = filterOutSameInstanceType(cmd.Replacements[0], candidatesToConsolidate)
+			if err == nil && len(cmd.Replacements[0].InstanceTypeOptions) > 0 {
+				validDecision = true
+			}
+		}
+
+		if validDecision {
+			// Joint deletion of (accepted ∪ c) is feasible. Promote
+			// the candidate set and remember the command. Continue
+			// walking; later candidates may compose with this set.
+			accepted = candidatesToConsolidate
+			lastSavedCommand = cmd
+			continue
+		}
+		// Joint deletion failed with c included. Skip c and try the
+		// next candidate. Skipping (rather than narrowing) is what
+		// lets the search reach non-prefix subsets.
 	}
 	return lastSavedCommand, nil
 }

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -123,24 +123,34 @@ func (m *MultiNodeConsolidation) ComputeCommands(ctx context.Context, disruption
 	return []Command{cmd}, nil
 }
 
-// firstNConsolidationOption looks at the first N NodeClaims to determine if they can all be consolidated at once.
-// It runs the binary search over sorted prefixes first (existing
-// behavior, fast log(N) probes) and falls back to the pairwise
-// non-prefix search only when the binary search returns no plan.
-// This preserves equivalence with prior versions on every input the
-// binary search already handled, and adds the pairwise recovery only
-// for inputs where binary search exits empty (the karpenter#1962
-// shape, where a candidate that blocks joint deletion sits early in
-// the sort order and poisons every prefix probe).
+// firstNConsolidationOption finds a feasible joint deletion of two
+// or more sorted candidates. It runs the binary search over sorted
+// prefixes first (fast log(N) probes), and then uses the pairwise
+// non-prefix walk in two ways:
+//
+//  1. As a fallback when the binary search returns no plan. This is
+//     the karpenter#1962 shape: a candidate that blocks joint
+//     deletion sits early in the sort order and poisons every
+//     prefix probe.
+//  2. As an extension when the binary search returns a feasible
+//     prefix. The walk seeds itself with that prefix as the initial
+//     accepted set and walks the remaining candidates (those beyond
+//     the prefix's tail). Joint deletion feasibility is non-monotone
+//     in prefix length, so a strictly larger non-prefix superset can
+//     exist beyond the binary search's tail. Without the extension
+//     the search short-circuits and the larger superset is never
+//     probed.
 //
 // Latency contract:
 //   - Binary search: bounded by MultiNodeConsolidationTimeoutDuration (1m).
-//   - Pairwise fallback: bounded by MultiNodePairwiseSearchTimeoutDuration (10s).
+//   - Pairwise fallback / extension: bounded by
+//     MultiNodePairwiseSearchTimeoutDuration (10s).
 //
-// On a successful binary search no extra latency is paid. On a
-// 1962-shaped failure the additional cost is at most the pairwise
-// timeout, regardless of N. Big-cluster regret is bounded by that
-// 10s budget.
+// On a binary search that already finds the maximal joint deletion,
+// the extension probes the remaining candidates once each (every
+// addition fails the simulator) and the additional latency is
+// bounded by the pairwise timeout. Big-cluster regret stays inside
+// that 10s budget.
 func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, candidates []*Candidate, max int) (Command, error) {
 	// we always operate on at least two NodeClaims at once, for single NodeClaims standard consolidation will find all solutions
 	if len(candidates) < 2 {
@@ -151,16 +161,29 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 	if err != nil {
 		return Command{}, err
 	}
-	if primary.Decision() != NoOpDecision {
-		// Existing behavior: binary search found a feasible prefix.
-		return primary, nil
+	if primary.Decision() == NoOpDecision {
+		// Binary search exhausted without finding a feasible prefix
+		// (the karpenter#1962 case). Fall back to the pairwise
+		// non-prefix walk from an empty accepted set.
+		return m.pairwiseSearchFallback(ctx, candidates, max)
 	}
 
-	// Binary search exhausted without finding a feasible prefix
-	// (the karpenter#1962 case). Fall back to the pairwise non-prefix
-	// walk, bounded by its own timeout so the latency added on big
-	// clusters stays capped.
-	return m.pairwiseSearchFallback(ctx, candidates, max)
+	// Binary search returned a feasible prefix. Try to extend it
+	// with non-prefix candidates beyond the prefix's tail, seeded
+	// with the prefix as the initial accepted set. Bounded by the
+	// same pairwise timeout.
+	if len(primary.Candidates) >= len(candidates) || len(primary.Candidates) > max {
+		return primary, nil
+	}
+	remaining := candidates[len(primary.Candidates):]
+	extended, err := m.pairwiseExtendCommand(ctx, primary, remaining)
+	if err != nil {
+		return Command{}, err
+	}
+	if extended.Decision() != NoOpDecision && len(extended.Candidates) > len(primary.Candidates) {
+		return extended, nil
+	}
+	return primary, nil
 }
 
 // binarySearchPrefix is the prior firstNConsolidationOption logic:
@@ -370,4 +393,70 @@ func (m *MultiNodeConsolidation) Class() string {
 
 func (m *MultiNodeConsolidation) ConsolidationType() string {
 	return MultiNodeConsolidationType
+}
+
+// pairwiseExtendCommand starts from a non-empty base Command (the
+// largest feasible prefix found by binarySearchPrefix) and probes
+// each remaining candidate once, accepting any whose joint deletion
+// with the running accepted set is simulator-feasible. Returns the
+// largest extended command found, or the input base if no extension
+// was possible. Bounded by MultiNodePairwiseSearchTimeoutDuration so
+// the added latency stays capped independently of N. On timeout,
+// returns the best command discovered so far.
+//
+// This is the maximality counterpart to pairwiseSearchFallback. The
+// fallback recovers correctness when binary search returns empty
+// (karpenter#1962). This extension recovers maximality when binary
+// search returns a feasible but non-maximal prefix.
+//
+// nolint:gocyclo
+func (m *MultiNodeConsolidation) pairwiseExtendCommand(ctx context.Context, base Command, remaining []*Candidate) (Command, error) {
+	if len(remaining) == 0 {
+		return base, nil
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, MultiNodePairwiseSearchTimeoutDuration)
+	defer cancel()
+
+	accepted := slices.Clone(base.Candidates)
+	bestCmd := base
+
+	for _, c := range remaining {
+		if err := timeoutCtx.Err(); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				ConsolidationTimeoutsTotal.Inc(map[string]string{ConsolidationTypeLabel: m.ConsolidationType()})
+				return bestCmd, nil
+			}
+			return Command{}, err
+		}
+
+		candidatesToConsolidate := append(slices.Clone(accepted), c)
+
+		cmd, err := m.computeConsolidation(timeoutCtx, candidatesToConsolidate...)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				ConsolidationTimeoutsTotal.Inc(map[string]string{ConsolidationTypeLabel: m.ConsolidationType()})
+				return bestCmd, nil
+			}
+			return Command{}, err
+		}
+
+		validDecision := cmd.Decision() == DeleteDecision
+		if cmd.Decision() == ReplaceDecision {
+			cmd.Replacements[0], err = filterOutSameInstanceType(cmd.Replacements[0], candidatesToConsolidate)
+			if err == nil && len(cmd.Replacements[0].InstanceTypeOptions) > 0 {
+				validDecision = true
+			}
+		}
+
+		if validDecision {
+			accepted = candidatesToConsolidate
+			bestCmd = cmd
+			continue
+		}
+		// Joint deletion failed with c included. Skip c and try the
+		// next candidate. Skipping (rather than narrowing) is what
+		// lets the search reach non-prefix supersets of the binary
+		// search's prefix.
+	}
+	return bestCmd, nil
 }


### PR DESCRIPTION
Fixes #1962.

## Problem

Multi-node consolidation's binary search over sorted prefixes `[0:mid+1]` is prefix-blind in two related ways:

1. **Prefix-blindness (the originally reported #1962 case).** When a candidate that blocks joint deletion sorts early, every prefix containing it fails the simulator. The search exits empty even when a non-prefix subset of the same candidates would consolidate fine.

2. **Prefix non-maximality.** When the binary search finds a feasible prefix `[0:k]`, a strictly larger non-prefix superset can exist beyond `k` (joint feasibility is non-monotone in prefix length: removing one more candidate can free space that other pods chain into). The prior short-circuit returned the prefix immediately and never probed the superset.

## Fix

The same pairwise non-prefix walk handles both cases:

- **Binary search returns empty:** run the walk from an empty accepted set. Walks candidates in order; accepts each that composes feasibly with the running set; skips otherwise. Non-prefix subsets become reachable because skipping does not narrow the search.
- **Binary search returns a feasible prefix:** run the walk starting from the prefix as initial accepted set, over the candidates beyond the prefix's tail. Extends the prefix into any larger feasible superset.

Both paths are bounded by `MultiNodePairwiseSearchTimeoutDuration` (10s) so the latency added on the cases binary search misses stays capped regardless of N.

## Latency contract

| primary path | additional cost |
|---|---|
| Binary search succeeds, extension finds nothing further | one walk over `n - k` candidates, one simulator probe each |
| Binary search empty, fallback finds something | one walk over `n` candidates |
| Binary search empty, fallback also empty | one walk over `n` candidates, all skipped |

In every case the added work is bounded by the 10s pairwise budget. Big-cluster regret stays inside that budget.

## Verification

- Existing envtest suite (`pkg/controllers/disruption`) passes, ~170s.
- New envtest `multinode_1962_test.go` passes (it fails on the prior code).

A separate property-test corpus on `jamesmt-aws/karpenter:consolidation-corpus-framework` runs 100 seeded scenarios through three configurations (legacy binary-search-only, this PR's behavior, brute-force enumeration baseline). Legacy under-consolidates on 31 of 100 scenarios: 14 prefix-blind (case 1) and 17 prefix-non-maximal (case 2). With this PR, branch matches the brute-force baseline on disruption count, savings, and slack entropy on all 100 scenarios. Latency overhead vs legacy: +33% on average (89ms -> 119ms); 10s cap unchanged.

## Commits

- `test:` envtest reproducer for the prefix-blindness case.
- `fix:` pairwise non-prefix fallback for the empty-binary-search case.
- `chore:` `slices.Clone` for pairwise walk's accepted-set construction.
- `fix:` pairwise extension past the binary-search prefix for the non-maximal-prefix case.