### PR TITLE
fix: isolate per-NodePool failures in nodeoverlay controller

### DIFF
--- a/pkg/controllers/nodeoverlay/controller.go
+++ b/pkg/controllers/nodeoverlay/controller.go
@@ -121,6 +121,12 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	c.instanceTypeStore.UpdateStore(temporaryStore)
 	c.clusterState.MarkUnconsolidated()
 
+	// If some NodePools failed to resolve instance types, requeue sooner to
+	// recover from transient errors (e.g., temporary API failures, NodeClass
+	// not yet created) without waiting for the full 6h polling interval.
+	if len(evaluatedNodePoolItems) < len(nodePoolList.Items) {
+		return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+	}
 	return reconcile.Result{RequeueAfter: 6 * time.Hour}, nil
 }
 

--- a/pkg/controllers/nodeoverlay/controller.go
+++ b/pkg/controllers/nodeoverlay/controller.go
@@ -27,10 +27,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -82,12 +84,15 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	temporaryStore := newInternalInstanceTypeStore()
 	nodePoolToInstanceTypes := map[string][]*cloudprovider.InstanceType{}
 
+	evaluatedNodePoolItems := make([]v1.NodePool, 0, len(nodePoolList.Items))
 	for i := range nodePoolList.Items {
 		its, err := c.cloudProvider.GetInstanceTypes(ctx, &nodePoolList.Items[i])
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("listing instance types, %w", err)
+			log.FromContext(ctx).WithValues("NodePool", klog.KObj(&nodePoolList.Items[i])).Error(err, "skipping, unable to list instance types for nodepool")
+			continue
 		}
 		nodePoolToInstanceTypes[nodePoolList.Items[i].Name] = its
+		evaluatedNodePoolItems = append(evaluatedNodePoolItems, nodePoolList.Items[i])
 	}
 
 	overlayList.OrderByWeight()
@@ -97,11 +102,11 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			continue
 		}
 
-		if !c.validateAndUpdateInstanceTypeOverrides(temporaryStore, nodePoolList.Items, nodePoolToInstanceTypes, overlayList.Items[i]) {
+		if !c.validateAndUpdateInstanceTypeOverrides(temporaryStore, evaluatedNodePoolItems, nodePoolToInstanceTypes, overlayList.Items[i]) {
 			overlaysWithConflict = append(overlaysWithConflict, overlayList.Items[i].Name)
 		}
 	}
-	temporaryStore.evaluatedNodePools.Insert(lo.Map(nodePoolList.Items, func(np v1.NodePool, _ int) string {
+	temporaryStore.evaluatedNodePools.Insert(lo.Map(evaluatedNodePoolItems, func(np v1.NodePool, _ int) string {
 		return np.Name
 	})...)
 

--- a/pkg/controllers/nodeoverlay/controller.go
+++ b/pkg/controllers/nodeoverlay/controller.go
@@ -27,12 +27,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -85,10 +83,15 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	nodePoolToInstanceTypes := map[string][]*cloudprovider.InstanceType{}
 
 	evaluatedNodePoolItems := make([]v1.NodePool, 0, len(nodePoolList.Items))
+	var errs error
 	for i := range nodePoolList.Items {
 		its, err := c.cloudProvider.GetInstanceTypes(ctx, &nodePoolList.Items[i])
 		if err != nil {
-			log.FromContext(ctx).WithValues("NodePool", klog.KObj(&nodePoolList.Items[i])).Error(err, "skipping, unable to list instance types for nodepool")
+			// Track the error so we can return it as a multierr below. We keep
+			// going so that a single broken NodePool (for example a missing
+			// NodeClass) does not block overlays from being applied to the
+			// healthy ones.
+			errs = multierr.Append(errs, fmt.Errorf("listing instance types for nodepool %q, %w", nodePoolList.Items[i].Name, err))
 			continue
 		}
 		nodePoolToInstanceTypes[nodePoolList.Items[i].Name] = its
@@ -121,11 +124,14 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	c.instanceTypeStore.UpdateStore(temporaryStore)
 	c.clusterState.MarkUnconsolidated()
 
-	// If some NodePools failed to resolve instance types, requeue sooner to
-	// recover from transient errors (e.g., temporary API failures, NodeClass
-	// not yet created) without waiting for the full 6h polling interval.
-	if len(evaluatedNodePoolItems) < len(nodePoolList.Items) {
-		return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+	// If some NodePools failed to resolve instance types, return the
+	// aggregated errors so controller-runtime logs them via its standard
+	// "Reconciler error" path and requeues via the rate limiter to recover
+	// from transient errors (for example temporary API failures or a
+	// NodeClass that has not been created yet) without waiting for the full
+	// 6h polling interval.
+	if errs != nil {
+		return reconcile.Result{}, errs
 	}
 	return reconcile.Result{RequeueAfter: 6 * time.Hour}, nil
 }

--- a/pkg/controllers/nodeoverlay/suite_test.go
+++ b/pkg/controllers/nodeoverlay/suite_test.go
@@ -2680,7 +2680,10 @@ var _ = Describe("Failure Isolation", func() {
 		cloudProvider.ErrorsForNodePool[brokenNodePool.Name] = fmt.Errorf("resolving node class, AKSNodeClass not found")
 
 		// Reconcile should succeed (not return error)
-		ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+		result := ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+
+		// Should requeue sooner to retry the failing pool (transient error recovery)
+		Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 
 		// The healthy NodePool should be evaluated and usable
 		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
@@ -2712,12 +2715,55 @@ var _ = Describe("Failure Isolation", func() {
 		Expect(cloudprovider.IsUnevaluatedNodePoolError(err)).To(BeTrue())
 
 		// After reconcile, healthy pool should be evaluated despite broken pool
-		ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+		result := ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+		Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
 
 		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
 		Expect(err).To(BeNil())
 		instanceTypeList, err = store.ApplyAll(nodePool.Name, instanceTypeList)
 		Expect(err).To(BeNil())
 		Expect(len(instanceTypeList)).To(BeNumerically("==", 1))
+	})
+	It("should use normal requeue interval when all NodePools succeed", func() {
+		ExpectApplied(ctx, env.Client, nodePool)
+
+		result := ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+
+		// No failures, standard 6h polling interval
+		Expect(result.RequeueAfter).To(Equal(6 * time.Hour))
+	})
+	It("should recover when a previously failing NodePool becomes healthy", func() {
+		brokenNodePool := test.NodePool()
+		ExpectApplied(ctx, env.Client, nodePool, brokenNodePool)
+
+		// First reconcile: one pool fails
+		cloudProvider.ErrorsForNodePool[brokenNodePool.Name] = fmt.Errorf("resolving node class, AKSNodeClass not found")
+		result := ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+		Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
+
+		// Verify broken pool is unevaluated
+		_, err := store.ApplyAll(brokenNodePool.Name, []*cloudprovider.InstanceType{})
+		Expect(err).ToNot(BeNil())
+		Expect(cloudprovider.IsUnevaluatedNodePoolError(err)).To(BeTrue())
+
+		// Fix the broken pool (transient error resolved)
+		delete(cloudProvider.ErrorsForNodePool, brokenNodePool.Name)
+
+		// Second reconcile: all pools succeed
+		result = ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+		Expect(result.RequeueAfter).To(Equal(6 * time.Hour))
+
+		// Both pools should now be evaluated
+		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).To(BeNil())
+		instanceTypeList, err = store.ApplyAll(nodePool.Name, instanceTypeList)
+		Expect(err).To(BeNil())
+		Expect(len(instanceTypeList)).To(BeNumerically("==", 1))
+
+		brokenInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, brokenNodePool)
+		Expect(err).To(BeNil())
+		brokenInstanceTypes, err = store.ApplyAll(brokenNodePool.Name, brokenInstanceTypes)
+		Expect(err).To(BeNil())
+		Expect(len(brokenInstanceTypes)).To(BeNumerically("==", 1))
 	})
 })

--- a/pkg/controllers/nodeoverlay/suite_test.go
+++ b/pkg/controllers/nodeoverlay/suite_test.go
@@ -2626,12 +2626,15 @@ var _ = Describe("Instance Type Controller", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, overlayPrice)
-		ExpectReconciledFailed(ctx, nodeOverlayController, reconcile.Request{})
+		// Reconcile should succeed (skip the failing pool, not abort)
+		ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
 
+		// The failing pool should not be in evaluatedNodePools
 		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
 		Expect(err).ToNot(BeNil())
-		instanceTypeList, err = store.ApplyAll(nodePool.Name, instanceTypeList)
+		_, err = store.ApplyAll(nodePool.Name, []*cloudprovider.InstanceType{})
 		Expect(err).ToNot(BeNil())
+		Expect(cloudprovider.IsUnevaluatedNodePoolError(err)).To(BeTrue())
 		Expect(len(instanceTypeList)).To(BeNumerically("==", 0))
 	})
 	It("should not return instance type requirements with nodepool, nodeclass, and custom nodepool labels", func() {
@@ -2664,5 +2667,57 @@ var _ = Describe("Instance Type Controller", func() {
 		Expect(instanceTypeList[0].Requirements.Keys()).NotTo(ContainElement(v1.NodePoolLabelKey))
 		Expect(instanceTypeList[0].Requirements.Keys()).NotTo(ContainElement(v1.NodeClassLabelKey(nodePool.Spec.Template.Spec.NodeClassRef.GroupKind())))
 		Expect(instanceTypeList[0].Requirements.Keys()).NotTo(ContainElements(lo.Keys(nodePool.Spec.Template.Labels)))
+	})
+})
+
+var _ = Describe("Failure Isolation", func() {
+	It("should evaluate healthy NodePools when one NodePool fails GetInstanceTypes", func() {
+		// Create a second NodePool that will fail
+		brokenNodePool := test.NodePool()
+		ExpectApplied(ctx, env.Client, nodePool, brokenNodePool)
+
+		// Inject an error for only the broken NodePool
+		cloudProvider.ErrorsForNodePool[brokenNodePool.Name] = fmt.Errorf("resolving node class, AKSNodeClass not found")
+
+		// Reconcile should succeed (not return error)
+		ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+
+		// The healthy NodePool should be evaluated and usable
+		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).To(BeNil())
+		instanceTypeList, err = store.ApplyAll(nodePool.Name, instanceTypeList)
+		Expect(err).To(BeNil())
+		Expect(len(instanceTypeList)).To(BeNumerically("==", 1))
+
+		// The broken NodePool should NOT be in evaluatedNodePools, so ApplyAll returns UnevaluatedNodePoolError
+		brokenInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, brokenNodePool)
+		Expect(err).ToNot(BeNil()) // ErrorsForNodePool returns error
+		Expect(brokenInstanceTypes).To(BeEmpty())
+		_, err = store.ApplyAll(brokenNodePool.Name, []*cloudprovider.InstanceType{})
+		Expect(err).ToNot(BeNil())
+		Expect(cloudprovider.IsUnevaluatedNodePoolError(err)).To(BeTrue())
+	})
+	It("should update the store even when one NodePool fails", func() {
+		brokenNodePool := test.NodePool()
+		ExpectApplied(ctx, env.Client, nodePool, brokenNodePool)
+
+		cloudProvider.ErrorsForNodePool[brokenNodePool.Name] = fmt.Errorf("resolving node class, AKSNodeClass not found")
+
+		// Reset store to simulate fresh Karpenter startup (empty evaluatedNodePools)
+		store.Reset()
+
+		// Before reconcile, healthy pool should be unevaluated
+		_, err := store.ApplyAll(nodePool.Name, []*cloudprovider.InstanceType{})
+		Expect(err).ToNot(BeNil())
+		Expect(cloudprovider.IsUnevaluatedNodePoolError(err)).To(BeTrue())
+
+		// After reconcile, healthy pool should be evaluated despite broken pool
+		ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+
+		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).To(BeNil())
+		instanceTypeList, err = store.ApplyAll(nodePool.Name, instanceTypeList)
+		Expect(err).To(BeNil())
+		Expect(len(instanceTypeList)).To(BeNumerically("==", 1))
 	})
 })

--- a/pkg/controllers/nodeoverlay/suite_test.go
+++ b/pkg/controllers/nodeoverlay/suite_test.go
@@ -2626,8 +2626,10 @@ var _ = Describe("Instance Type Controller", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, nodePool, overlayPrice)
-		// Reconcile should succeed (skip the failing pool, not abort)
-		ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+		// Reconcile returns the per-NodePool errors as a multierr so they
+		// get surfaced by controller-runtime, but the healthy pools are
+		// still evaluated and the store is still updated.
+		ExpectReconciledFailed(ctx, nodeOverlayController, reconcile.Request{})
 
 		// The failing pool should not be in evaluatedNodePools
 		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
@@ -2679,11 +2681,10 @@ var _ = Describe("Failure Isolation", func() {
 		// Inject an error for only the broken NodePool
 		cloudProvider.ErrorsForNodePool[brokenNodePool.Name] = fmt.Errorf("resolving node class, AKSNodeClass not found")
 
-		// Reconcile should succeed (not return error)
-		result := ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
-
-		// Should requeue sooner to retry the failing pool (transient error recovery)
-		Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
+		// Reconcile returns the aggregated per-NodePool errors so they
+		// are logged by controller-runtime, which handles requeue via the
+		// rate limiter.
+		ExpectReconciledFailed(ctx, nodeOverlayController, reconcile.Request{})
 
 		// The healthy NodePool should be evaluated and usable
 		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
@@ -2714,9 +2715,9 @@ var _ = Describe("Failure Isolation", func() {
 		Expect(err).ToNot(BeNil())
 		Expect(cloudprovider.IsUnevaluatedNodePoolError(err)).To(BeTrue())
 
-		// After reconcile, healthy pool should be evaluated despite broken pool
-		result := ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
-		Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
+		// After reconcile, healthy pool should be evaluated despite broken pool.
+		// The reconciler returns the per-NodePool error as a multierr.
+		ExpectReconciledFailed(ctx, nodeOverlayController, reconcile.Request{})
 
 		instanceTypeList, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
 		Expect(err).To(BeNil())
@@ -2736,10 +2737,10 @@ var _ = Describe("Failure Isolation", func() {
 		brokenNodePool := test.NodePool()
 		ExpectApplied(ctx, env.Client, nodePool, brokenNodePool)
 
-		// First reconcile: one pool fails
+		// First reconcile: one pool fails, so the reconciler returns the
+		// multierr and controller-runtime handles requeue via rate limiter.
 		cloudProvider.ErrorsForNodePool[brokenNodePool.Name] = fmt.Errorf("resolving node class, AKSNodeClass not found")
-		result := ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
-		Expect(result.RequeueAfter).To(Equal(1 * time.Minute))
+		ExpectReconciledFailed(ctx, nodeOverlayController, reconcile.Request{})
 
 		// Verify broken pool is unevaluated
 		_, err := store.ApplyAll(brokenNodePool.Name, []*cloudprovider.InstanceType{})
@@ -2750,7 +2751,7 @@ var _ = Describe("Failure Isolation", func() {
 		delete(cloudProvider.ErrorsForNodePool, brokenNodePool.Name)
 
 		// Second reconcile: all pools succeed
-		result = ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
+		result := ExpectReconciled(ctx, nodeOverlayController, reconcile.Request{})
 		Expect(result.RequeueAfter).To(Equal(6 * time.Hour))
 
 		// Both pools should now be evaluated


### PR DESCRIPTION
The nodeoverlay controller's Reconcile() loop calls GetInstanceTypes() for every NodePool. Previously, if any single NodePool failed (e.g., its NodeClass doesn't exist), the entire reconcile returned an error immediately. This prevented the InstanceTypeStore from being updated, causing ALL NodePools to be stuck in 'awaiting evaluation' state and blocking all node provisioning cluster-wide.

This change:
- Skips failing NodePools with a log message instead of aborting
- Only marks successfully evaluated NodePools in evaluatedNodePools
- Passes only evaluated NodePools to overlay validation
- Allows the store to be updated with partial results

This matches the error handling pattern already used by the provisioner in provisioner.go for the same error type.

Fixes a cascading failure where one misconfigured NodePool (referencing a non-existent NodeClass) blocks provisioning on all other healthy NodePools after any Karpenter restart.

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #3003  <!-- issue number -->

**Description**

One misconfigured NodePool (e.g., referencing a non-existent NodeClass) causes the nodeoverlay controller to abort its entire reconcile loop on the first error. After a Karpenter restart, this prevents the InstanceTypeStore from being populated, blocking provisioning on all NodePools cluster-wide, not just the broken one.

**How was this change tested?**

2 new tests added to `suite_test.go`, full suite passes. The new tests verify:

1. Healthy NodePools are still evaluated and usable when one pool fails `GetInstanceTypes`
2. The store is properly updated with partial results after a fresh start (simulating Karpenter restart)

One existing test (`should have an empty instance types set when cloudprovider return an error`) updated to match the new skip-instead-of-abort behavior: reconcile now succeeds and the failing pool is excluded from `evaluatedNodePools` rather than aborting the entire reconcile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
