### PR TITLE
feat: consolidateAfter now applies to destination nodes during consolidation

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -136,7 +136,7 @@ func (c *consolidation) sortCandidates(candidates []*Candidate) []*Candidate {
 func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	var err error
 	// Run scheduling simulation to compute consolidation option
-	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, c.clock, c.recorder, candidates...)
+	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, c.clock, c.recorder, []pscheduling.Options{pscheduling.IsConsolidationSimulation}, candidates...)
 	if err != nil {
 		// if a candidate node is now deleting, just retry
 		if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -3033,6 +3033,201 @@ var _ = Describe("Consolidation", func() {
 			})
 			Expect(ok).To(BeTrue())
 		})
+		It("should not consolidate pods onto a destination node that is under its consolidateAfter window", func() {
+			// Override consolidateAfter to a nonzero duration.
+			// Both nodes are leastExpensiveInstance (from BeforeEach), so no cheaper replacement
+			// exists — the only consolidation path is to delete nodes[1] and move its pod
+			// to nodes[0]. With consolidateAfter still active on nodes[0], this should be blocked.
+			nodePool.Spec.Disruption.ConsolidateAfter = v1.MustParseNillableDuration("1m")
+
+			// create our RS so we can link a pod to it
+			rs := test.ReplicaSet()
+			ExpectApplied(ctx, env.Client, rs)
+			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
+
+			pods := test.Pods(3, test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "ReplicaSet",
+							Name:               rs.Name,
+							UID:                rs.UID,
+							Controller:         lo.ToPtr(true),
+							BlockOwnerDeletion: lo.ToPtr(true),
+						},
+					}}})
+			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodeClaims[0], nodes[0], nodeClaims[1], nodes[1], nodePool)
+
+			// bind pods to node — 2 on nodes[0], 1 on nodes[1]
+			ExpectManualBinding(ctx, env.Client, pods[0], nodes[0])
+			ExpectManualBinding(ctx, env.Client, pods[1], nodes[0])
+			ExpectManualBinding(ctx, env.Client, pods[2], nodes[1])
+
+			// Initialize both nodes — this sets the Initialized condition timestamp to ~env.Clock.Now()
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[0], nodes[1]}, []*v1.NodeClaim{nodeClaims[0], nodeClaims[1]})
+
+			// Do NOT advance clock — both nodes are within the 1m consolidateAfter window.
+			// The scheduler should refuse to place non-pending pods onto nodes[0] because it's under consolidateAfter,
+			// blocking the delete of nodes[1] (which would need to reschedule pods[2] onto nodes[0]).
+			ExpectSingletonReconciled(ctx, disruptionController)
+
+			// No consolidation should happen — destination node is under consolidateAfter
+			cmds := queue.GetCommands()
+			Expect(cmds).To(HaveLen(0))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
+
+			// Advance clock past the 1m consolidateAfter window
+			env.Clock.Step(2 * time.Minute)
+
+			// Re-sync cluster state and re-mark nodeClaims as consolidatable after state update
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{nodes[0], nodes[1]}, []*v1.NodeClaim{nodeClaims[0], nodeClaims[1]})
+			for _, nc := range nodeClaims {
+				nc = ExpectExists(ctx, env.Client, nc)
+				nc.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+				ExpectApplied(ctx, env.Client, nc)
+				ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nc))
+			}
+			// Reset the disruption controller so consolidation methods are not cached as consolidated
+			*queue = lo.FromPtr(disruption.NewQueue(env.Client, recorder, cluster, env.Clock, prov))
+			disruptionController = disruption.NewController(env.Clock, env.Client, prov, cloudProvider, recorder, cluster, queue,
+				disruption.WithMethods(NewMethodsWithNopValidator()...))
+			ExpectSingletonReconciled(ctx, disruptionController)
+
+			// Now consolidation should proceed — consolidateAfter window has expired
+			cmds = queue.GetCommands()
+			Expect(cmds).To(HaveLen(1))
+			ExpectObjectReconciled(ctx, env.Client, queue, cmds[0].Candidates[0].NodeClaim)
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaims[1])
+
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+			ExpectNotFound(ctx, env.Client, nodeClaims[1], nodes[1])
+		})
+		It("should consolidate pods onto a destination node with consolidateAfter set to Never", func() {
+			// consolidateAfter: Never means the node never becomes a consolidation *candidate* (source),
+			// but it should still be a valid *destination* for pods during consolidation.
+			// Set up two NodePools: source allows consolidation (0s), destination has Never.
+			destinationNodePool := test.NodePool(v1.NodePool{
+				Spec: v1.NodePoolSpec{
+					Disruption: v1.Disruption{
+						ConsolidationPolicy: v1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+						Budgets:             []v1.Budget{{Nodes: "100%"}},
+						ConsolidateAfter:    v1.MustParseNillableDuration("Never"),
+					},
+				},
+			})
+
+			// create our RS so we can link a pod to it
+			rs := test.ReplicaSet()
+			ExpectApplied(ctx, env.Client, rs)
+			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
+
+			pod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "ReplicaSet",
+							Name:               rs.Name,
+							UID:                rs.UID,
+							Controller:         lo.ToPtr(true),
+							BlockOwnerDeletion: lo.ToPtr(true),
+						},
+					}}})
+
+			// destination node belongs to the "Never" NodePool
+			destinationNodeClaim, destinationNode := test.NodeClaimAndNode(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            destinationNodePool.Name,
+						corev1.LabelInstanceTypeStable: leastExpensiveInstance.Name,
+						v1.CapacityTypeLabelKey:        leastExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+						corev1.LabelTopologyZone:       leastExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					Allocatable: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("32"),
+						corev1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+
+			ExpectApplied(ctx, env.Client, rs, pod, nodeClaims[0], nodes[0], destinationNodeClaim, destinationNode, nodePool, destinationNodePool)
+			ExpectManualBinding(ctx, env.Client, pod, nodes[0])
+
+			// Initialize both nodes
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController,
+				[]*corev1.Node{nodes[0], destinationNode}, []*v1.NodeClaim{nodeClaims[0], destinationNodeClaim})
+
+			// Do NOT advance clock — destination node should still be valid because
+			// consolidateAfter: Never means the node is never "under consolidateAfter"
+			ExpectSingletonReconciled(ctx, disruptionController)
+
+			// Consolidation should succeed — destination node accepts pods regardless of time
+			cmds := queue.GetCommands()
+			Expect(cmds).To(HaveLen(1))
+			ExpectObjectReconciled(ctx, env.Client, queue, cmds[0].Candidates[0].NodeClaim)
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaims[0])
+
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+			ExpectNotFound(ctx, env.Client, nodeClaims[0], nodes[0])
+		})
+		It("should replace a node with a cheaper one even when consolidateAfter has not expired", func() {
+			// The replace path launches a new NodeClaim rather than scheduling onto an existing node.
+			// consolidateAfter on the destination should not block replacements since there is no
+			// existing destination node to gate — we're creating a brand new one.
+			nodePool.Spec.Disruption.ConsolidateAfter = v1.MustParseNillableDuration("1m")
+
+			// create our RS so we can link a pod to it
+			rs := test.ReplicaSet()
+			ExpectApplied(ctx, env.Client, rs)
+			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
+
+			pod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "ReplicaSet",
+							Name:               rs.Name,
+							UID:                rs.UID,
+							Controller:         lo.ToPtr(true),
+							BlockOwnerDeletion: lo.ToPtr(true),
+						},
+					}}})
+			// Use the most expensive node as the source — consolidation should replace it with a cheaper one
+			ExpectApplied(ctx, env.Client, rs, pod, node, nodeClaim, nodePool)
+
+			// bind pod to the expensive node
+			ExpectManualBinding(ctx, env.Client, pod, node)
+
+			// Initialize node and advance clock past consolidateAfter so the SOURCE is eligible
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
+			env.Clock.Step(2 * time.Minute)
+
+			// Re-sync state after clock advance
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
+
+			ExpectSingletonReconciled(ctx, disruptionController)
+
+			// Should create a replacement — the replace path is not blocked by consolidateAfter
+			cmds := queue.GetCommands()
+			Expect(cmds).To(HaveLen(1))
+			ExpectMakeNewNodeClaimsReady(ctx, env.Client, env.Clock, cluster, cloudProvider, cmds[0])
+			ExpectObjectReconciled(ctx, env.Client, queue, nodeClaim)
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
+
+			// Should have replaced with a cheaper node
+			remainingNodeClaims := ExpectNodeClaims(ctx, env.Client)
+			remainingNodes := ExpectNodes(ctx, env.Client)
+			Expect(remainingNodeClaims).To(HaveLen(1))
+			Expect(remainingNodes).To(HaveLen(1))
+			Expect(remainingNodeClaims[0].Name).ToNot(Equal(nodeClaim.Name))
+			ExpectNotFound(ctx, env.Client, nodeClaim, node)
+		})
 		It("should consider initialized nodes before uninitialized nodes", func() {
 			defaultInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name: "default-instance-type",

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -81,7 +81,7 @@ func (d *Drift) ComputeCommands(ctx context.Context, disruptionBudgetMapping map
 			continue
 		}
 		// Check if we need to create any NodeClaims.
-		results, err := SimulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, d.clock, d.recorder, candidate)
+		results, err := SimulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, d.clock, d.recorder, nil, candidate)
 		if err != nil {
 			// if a candidate is now deleting, just retry
 			if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -49,7 +49,7 @@ var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 
 //nolint:gocyclo
 func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *state.Cluster, provisioner *provisioning.Provisioner, clk clock.Clock, recorder events.Recorder,
-	candidates ...*Candidate,
+	schedulerOpts []scheduling.Options, candidates ...*Candidate,
 ) (scheduling.Results, error) {
 	candidateNames := sets.NewString(lo.Map(candidates, func(t *Candidate, i int) string { return t.Name() })...)
 	nodes := cluster.DeepCopyNodes()
@@ -99,6 +99,7 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 		opts = append(opts, scheduling.IgnorePreferences)
 	}
 	opts = append(opts, scheduling.MinValuesPolicy(options.FromContext(ctx).MinValuesPolicy))
+	opts = append(opts, schedulerOpts...)
 	scheduler, err := provisioner.NewScheduler(
 		log.IntoContext(ctx, operatorlogging.NopLogger),
 		pods,

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -241,7 +241,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, stateNode, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(Succeed())
 
-		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, candidate)
+		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, nil, candidate)
 		Expect(err).To(Succeed())
 		Expect(results.PodErrors[pod]).To(BeNil())
 	})

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -29,6 +29,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
+	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 )
@@ -298,7 +299,7 @@ func (v *validation) validateCommand(ctx context.Context, cmd Command, candidate
 	if len(candidates) == 0 {
 		return NewValidationError(fmt.Errorf("no candidates"))
 	}
-	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, v.clock, v.recorder, candidates...)
+	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, v.clock, v.recorder, []scheduling.Options{scheduling.IsConsolidationSimulation}, candidates...)
 	if err != nil {
 		return fmt.Errorf("simluating scheduling, %w", err)
 	}

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Eviction/Queue", func() {
 			// Set the termination time 1 hour in the past: remaining = -3600s.
 			// Without the clamp the grace period would be <=0, sending gracePeriodSeconds=0
 			// to the API (force-delete). The clamp must produce >= 1.
-			pastTerminationTime := fakeClock.Now().Add(-1 * time.Hour)
+			pastTerminationTime := env.Clock.Now().Add(-1 * time.Hour)
 			Expect(terminatorInstance.DeleteExpiringPods(ctx, []*corev1.Pod{pod}, &pastTerminationTime)).To(Succeed())
 
 			// Verify the delete was graceful (not a force-delete): the Disrupted event must have

--- a/pkg/controllers/nodeclaim/disruption/consolidation.go
+++ b/pkg/controllers/nodeclaim/disruption/consolidation.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/utils/disruption"
 )
 
 // Consolidation is a nodeclaim sub-controller that adds or removes status conditions on empty nodeclaims based on consolidateAfter
@@ -61,8 +62,7 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	// If the lastPodEvent is zero, use the time that the nodeclaim was initialized, as that's when Karpenter recognizes that pods could have started scheduling
 	timeToCheck := lo.Ternary(!nodeClaim.Status.LastPodEventTime.IsZero(), nodeClaim.Status.LastPodEventTime.Time, initialized.LastTransitionTime.Time)
 
-	// Consider a node consolidatable by looking at the lastPodEvent status field on the nodeclaim.
-	if c.clock.Since(timeToCheck) < lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration) {
+	if disruption.IsUnderConsolidateAfter(nodePool, nodeClaim, c.clock) {
 		if hasConsolidatableCondition {
 			_ = nodeClaim.StatusConditions(clockOpt).Clear(v1.ConditionTypeConsolidatable)
 			log.FromContext(ctx).V(1).Info("removing consolidatable status condition",

--- a/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization_test.go
@@ -674,7 +674,7 @@ var _ = Describe("Initialization", func() {
 		node.Spec.ProviderID = nodeClaim.Status.ProviderID
 		ExpectApplied(ctx, env.Client, node)
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
-		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
+		ExpectMakeNodesReady(ctx, env.Client, env.Clock, node) // Remove the not-ready taint
 
 		// Shouldn't consider the node initialized while the NRC taint is present
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)

--- a/pkg/controllers/nodeoverlay/suite_test.go
+++ b/pkg/controllers/nodeoverlay/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/imdario/mergo"

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -47,6 +47,8 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	karpopts "sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+
+	"sigs.k8s.io/karpenter/pkg/utils/disruption"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 	"sigs.k8s.io/karpenter/pkg/utils/resources"
 )
@@ -90,6 +92,7 @@ type options struct {
 	preferencePolicy        PreferencePolicy
 	minValuesPolicy         karpopts.MinValuesPolicy
 	numConcurrentReconciles int
+	enforceConsolidateAfter bool
 }
 
 type Options = option.Function[options]
@@ -112,6 +115,10 @@ var MinValuesPolicy = func(policy karpopts.MinValuesPolicy) func(*options) {
 	return func(opts *options) {
 		opts.minValuesPolicy = policy
 	}
+}
+
+var IsConsolidationSimulation = func(opts *options) {
+	opts.enforceConsolidateAfter = true
 }
 
 func NewScheduler(
@@ -180,7 +187,24 @@ func NewScheduler(
 		minValuesPolicy:         minValuesPolicy,
 		numConcurrentReconciles: lo.Ternary(option.Resolve(opts...).numConcurrentReconciles > 0, option.Resolve(opts...).numConcurrentReconciles, 1),
 	}
-	s.calculateExistingNodeClaims(ctx, stateNodes, daemonSetPods)
+
+	npByName := lo.SliceToMap(nodePools, func(np *v1.NodePool) (string, *v1.NodePool) {
+		return np.Name, np
+	})
+
+	nodeToNodePool := lo.SliceToMap(stateNodes, func(n *state.StateNode) (string, *v1.NodePool) {
+		return n.Name(), npByName[n.Labels()[v1.NodePoolLabelKey]]
+	})
+	// Build a set of node names that are marked for deletion so we can exempt their pods
+	// from the consolidateAfter destination check
+	deletingNodeNames := sets.New[string]()
+	for n := range cluster.Nodes() {
+		if n.MarkedForDeletion() {
+			deletingNodeNames.Insert(n.Name())
+		}
+	}
+	s.deletingNodeNames = deletingNodeNames
+	s.calculateExistingNodeClaims(ctx, stateNodes, daemonSetPods, nodeToNodePool, option.Resolve(opts...).enforceConsolidateAfter)
 	return s
 }
 
@@ -213,6 +237,7 @@ type Scheduler struct {
 	preferencePolicy        PreferencePolicy
 	minValuesPolicy         karpopts.MinValuesPolicy
 	numConcurrentReconciles int
+	deletingNodeNames       sets.Set[string]
 }
 
 // DRAError indicates a pod will not be attempted to be scheduled because it has Dynamic Resource Allocation requirements
@@ -533,7 +558,7 @@ func (s *Scheduler) add(ctx context.Context, pod *corev1.Pod) error {
 	return err
 }
 
-func (s *Scheduler) addToExistingNode(ctx context.Context, pod *corev1.Pod) error {
+func (s *Scheduler) addToExistingNode(ctx context.Context, p *corev1.Pod) error {
 	idx := math.MaxInt
 	var mu sync.Mutex
 
@@ -541,12 +566,17 @@ func (s *Scheduler) addToExistingNode(ctx context.Context, pod *corev1.Pod) erro
 	var requirements scheduling.Requirements
 
 	// determine the volumes that will be mounted if the pod schedules
-	volumes, err := scheduling.GetVolumes(ctx, s.kubeClient, pod)
+	volumes, err := scheduling.GetVolumes(ctx, s.kubeClient, p)
 	if err != nil {
 		return err
 	}
 	parallelizeUntil(s.numConcurrentReconciles, len(s.existingNodes), func(i int) bool {
-		r, err := s.existingNodes[i].CanAdd(pod, s.cachedPodData[pod.UID], volumes)
+		if s.existingNodes[i].isUnderConsolidateAfter && (!pod.IsPending(p) && !s.deletingNodeNames.Has(p.Spec.NodeName)) {
+			// We shouldn't try to schedule candidate pods onto nodes that are under consolidate after.
+			// Pending pods and pods from deleting nodes are exempt.
+			return true
+		}
+		r, err := s.existingNodes[i].CanAdd(p, s.cachedPodData[p.UID], volumes)
 		if err == nil {
 			mu.Lock()
 			defer mu.Unlock()
@@ -564,7 +594,7 @@ func (s *Scheduler) addToExistingNode(ctx context.Context, pod *corev1.Pod) erro
 	})
 	// If we set the existingNode to something valid, this means that we successfully scheduled to one of these nodes
 	if existingNode != nil {
-		existingNode.Add(pod, s.cachedPodData[pod.UID], requirements, volumes)
+		existingNode.Add(p, s.cachedPodData[p.UID], requirements, volumes)
 		return nil
 	}
 	return fmt.Errorf("failed scheduling pod to existing nodes")
@@ -699,12 +729,13 @@ func (s *Scheduler) addToNewNodeClaim(ctx context.Context, pod *corev1.Pod) erro
 	return multierr.Combine(errs...)
 }
 
-func (s *Scheduler) calculateExistingNodeClaims(ctx context.Context, stateNodes []*state.StateNode, daemonSetPods []*corev1.Pod) {
+func (s *Scheduler) calculateExistingNodeClaims(ctx context.Context, stateNodes []*state.StateNode, daemonSetPods []*corev1.Pod, nodePoolMap map[string]*v1.NodePool, enforceConsolidateAfter bool) {
 	// create our existing nodes
 	for _, node := range stateNodes {
 		taints := node.Taints()
 		daemons := s.getCompatibleDaemonPods(ctx, node, taints, daemonSetPods)
-		s.existingNodes = append(s.existingNodes, NewExistingNode(node, s.topology, taints, resources.RequestsForPods(daemons...)))
+		isUnderConsolidateAfter := enforceConsolidateAfter && disruption.IsUnderConsolidateAfter(nodePoolMap[node.Name()], node.NodeClaim, s.clock)
+		s.existingNodes = append(s.existingNodes, NewExistingNode(node, s.topology, taints, resources.RequestsForPods(daemons...), isUnderConsolidateAfter))
 		s.updateRemainingResources(node)
 	}
 	s.sortExistingNodes()

--- a/pkg/utils/disruption/disruption.go
+++ b/pkg/utils/disruption/disruption.go
@@ -75,3 +75,19 @@ func ReschedulingCost(ctx context.Context, pods []*corev1.Pod) float64 {
 	}
 	return cost
 }
+
+func IsUnderConsolidateAfter(nodePool *v1.NodePool, nodeClaim *v1.NodeClaim, c clock.Clock) bool {
+	if nodePool == nil || nodeClaim == nil || nodePool.Spec.Disruption.ConsolidateAfter.Duration == nil || lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration) == 0 {
+		return false
+	}
+	if !nodeClaim.StatusConditions().IsTrue(v1.ConditionTypeInitialized) {
+		return false
+	}
+	initialized := nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized)
+
+	// If the lastPodEvent is zero, use the time that the nodeclaim was initialized, as that's when Karpenter recognizes that pods could have started scheduling
+	timeToCheck := lo.Ternary(!nodeClaim.Status.LastPodEventTime.IsZero(), nodeClaim.Status.LastPodEventTime.Time, initialized.LastTransitionTime.Time)
+
+	// Consider a node under the effect of consolidateAfter by looking at the lastPodEvent status field on the nodeclaim.
+	return c.Since(timeToCheck) < lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration)
+}

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -139,6 +139,10 @@ func IsPreempting(pod *corev1.Pod) bool {
 	return pod.Status.NominatedNodeName != ""
 }
 
+func IsPending(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodPending
+}
+
 func IsTerminal(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded
 }


### PR DESCRIPTION
Fixes #2705, https://github.com/aws/karpenter-provider-aws/issues/7146


**Description**

`consolidateAfter` now applies to destination nodes during consolidation scheduling. Previously it only controlled when a node became eligible as a disruption *source*. Now the scheduler also refuses to place non-pending pods onto nodes still within their `consolidateAfter` window, preventing consolidation churn where recently-created or recently-modified nodes immediately become targets for the next consolidation round.

**How was this change tested?**

New unit test in `consolidation_test.go` verifying that consolidation is blocked when the destination node is under its `consolidateAfter` window, and proceeds after the window expires.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.