### PR TITLE
chore: add reason to consolidatable status condition removal log

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/consolidation.go
+++ b/pkg/controllers/nodeclaim/disruption/consolidation.go
@@ -42,7 +42,7 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	if nodePool.Spec.Disruption.ConsolidateAfter.Duration == nil {
 		if hasConsolidatableCondition {
 			_ = nodeClaim.StatusConditions().Clear(v1.ConditionTypeConsolidatable)
-			log.FromContext(ctx).V(1).Info("removing consolidatable status condition, consolidation is disabled")
+			log.FromContext(ctx).V(1).Info("removing consolidatable status condition", "reason", "consolidation is disabled")
 		}
 		return reconcile.Result{}, nil
 	}
@@ -51,7 +51,7 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	if !initialized.IsTrue() {
 		if hasConsolidatableCondition {
 			_ = nodeClaim.StatusConditions().Clear(v1.ConditionTypeConsolidatable)
-			log.FromContext(ctx).V(1).Info("removing consolidatable status condition, isn't initialized")
+			log.FromContext(ctx).V(1).Info("removing consolidatable status condition", "reason", "nodeclaim isn't initialized")
 		}
 		return reconcile.Result{}, nil
 	}
@@ -63,7 +63,12 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	if c.clock.Since(timeToCheck) < lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration) {
 		if hasConsolidatableCondition {
 			_ = nodeClaim.StatusConditions().Clear(v1.ConditionTypeConsolidatable)
-			log.FromContext(ctx).V(1).Info("removing consolidatable status condition")
+			log.FromContext(ctx).V(1).Info("removing consolidatable status condition",
+				"reason", "consolidateAfter window not yet elapsed",
+				"lastPodEventTime", timeToCheck,
+				"consolidateAfter", lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration),
+				"timeSincePodEvent", c.clock.Since(timeToCheck),
+			)
 		}
 		consolidatableTime := timeToCheck.Add(lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration))
 		return reconcile.Result{RequeueAfter: consolidatableTime.Sub(c.clock.Now())}, nil


### PR DESCRIPTION
Fixes #2238

## Description

Brings the bare 'removing consolidatable status condition' log line into
parity with its two siblings (which already explain themselves with
', consolidation is disabled' and ', isn't initialized'). Adds structured
fields (lastPodEventTime, consolidateAfter, timeSincePodEvent) so
operators can correlate the removal against pod-level events visible
from kubectl get events.

Fixes #2238

Signed-off-by: praveen9354 <praveen9354@gmail.com>

## How was this change tested?

Local verification of the changed file's adjacent test suite.
Upstream CI runs the full matrix on push.

