### PR TITLE
feat(metrics): add karpenter_pods_disrupted_total counter

### DIFF
--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -238,11 +238,13 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 			return
 		}
 		q.recorder.Publish(disruptionevents.Terminating(cmd.Candidates[i].Node, cmd.Candidates[i].NodeClaim, string(cmd.Reason()))...)
-		metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+		labels := map[string]string{
 			metrics.ReasonLabel:       pretty.ToSnakeCase(string(cmd.Reason())),
 			metrics.NodePoolLabel:     cmd.Candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel: cmd.Candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
-		})
+		}
+		metrics.NodeClaimsDisruptedTotal.Inc(labels)
+		metrics.PodsDisruptedTotal.Add(float64(len(cmd.Candidates[i].reschedulablePods)), labels)
 	})
 	// If there were any deletion failures, we should requeue.
 	// In the case where we requeue, but the timeout for the command is reached, we'll mark this as a failure.

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -171,11 +171,19 @@ func (c *Controller) deleteNodeClaim(ctx context.Context, nodeClaim *v1.NodeClai
 	}
 	// The deletion timestamp has successfully been set for the Node, update relevant metrics.
 	log.FromContext(ctx).Info("deleting unhealthy node")
-	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+	labels := map[string]string{
 		metrics.ReasonLabel:       metrics.UnhealthyReason,
 		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: node.Labels[v1.CapacityTypeLabelKey],
-	})
+	}
+	metrics.NodeClaimsDisruptedTotal.Inc(labels)
+	// Pods on the node have not yet started draining at this point — list captures
+	// the pre-disruption state. Errors don't fail the reconcile; the metric reports 0.
+	podCount, err := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, node.Name)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", err.Error())
+	}
+	metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
 	NodeClaimsUnhealthyDisruptedTotal.Inc(map[string]string{
 		Condition:                 pretty.ToSnakeCase(string(unhealthyNodeCondition.Type)),
 		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],

--- a/pkg/controllers/nodeclaim/expiration/controller.go
+++ b/pkg/controllers/nodeclaim/expiration/controller.go
@@ -35,6 +35,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/metrics"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
@@ -83,11 +84,20 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 	}
 	// 4. The deletion timestamp has successfully been set for the NodeClaim, update relevant metrics.
 	log.FromContext(ctx).V(1).Info("deleting expired nodeclaim")
-	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+	labels := map[string]string{
 		metrics.ReasonLabel:       strings.ToLower(metrics.ExpiredReason),
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
-	})
+	}
+	metrics.NodeClaimsDisruptedTotal.Inc(labels)
+	// Pods that haven't started draining yet still appear bound to the node, so the
+	// list call here captures the pre-disruption state. Errors are logged but do not
+	// fail the reconcile — the metric just reports 0 for this disruption event.
+	podCount, err := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, nodeClaim.Status.NodeName)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", err.Error())
+	}
+	metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
 	// We sleep here after the delete operation since we want to ensure that we are able to read our own writes so that
 	// we avoid duplicating metrics and log lines due to quick re-queues.
 	// USE CAUTION when determining whether to increase this timeout or remove this line

--- a/pkg/controllers/nodeclaim/expiration/suite_test.go
+++ b/pkg/controllers/nodeclaim/expiration/suite_test.go
@@ -87,6 +87,7 @@ var _ = Describe("Expiration", func() {
 			},
 		})
 		metrics.NodeClaimsDisruptedTotal.Reset()
+		metrics.PodsDisruptedTotal.Reset()
 	})
 	Context("Metrics", func() {
 		It("should fire a karpenter_nodeclaims_disrupted_total metric when expired", func() {
@@ -113,6 +114,40 @@ var _ = Describe("Expiration", func() {
 
 			ExpectNotFound(ctx, env.Client, nodeClaim)
 			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
+				metrics.ReasonLabel:   metrics.ExpiredReason,
+				metrics.NodePoolLabel: nodePool.Name,
+			})
+		})
+		It("should fire karpenter_pods_disrupted_total by the count of reschedulable pods on the node when expired", func() {
+			// Bind 2 reschedulable pods to the node and 1 DaemonSet-owned pod (excluded).
+			nodeClaim.Status.NodeName = node.Name
+			isController := true
+			pod1 := test.Pod(test.PodOptions{NodeName: node.Name})
+			pod2 := test.Pod(test.PodOptions{NodeName: node.Name})
+			daemonsetPod := test.Pod(test.PodOptions{
+				NodeName: node.Name,
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "DaemonSet",
+						Name:       "ds",
+						UID:        "ds-uid",
+						Controller: &isController,
+					}},
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, node, nodeClaim, pod1, pod2, daemonsetPod)
+
+			// step forward to make the node expired
+			fakeClock.Step(60 * time.Second)
+			ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
+
+			ExpectNotFound(ctx, env.Client, nodeClaim)
+			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
+				metrics.ReasonLabel:   metrics.ExpiredReason,
+				metrics.NodePoolLabel: nodePool.Name,
+			})
+			ExpectMetricCounterValue(metrics.PodsDisruptedTotal, 2, map[string]string{
 				metrics.ReasonLabel:   metrics.ExpiredReason,
 				metrics.NodePoolLabel: nodePool.Name,
 			})

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -109,11 +109,20 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 			"Node", klog.KRef("", nodeClaims[i].Status.NodeName),
 			"provider-id", nodeClaims[i].Status.ProviderID,
 		).V(1).Info("garbage collecting nodeclaim with no cloudprovider representation")
-		metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+		labels := map[string]string{
 			metrics.ReasonLabel:       "garbage_collected",
 			metrics.NodePoolLabel:     nodeClaims[i].Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel: nodeClaims[i].Labels[v1.CapacityTypeLabelKey],
-		})
+		}
+		metrics.NodeClaimsDisruptedTotal.Inc(labels)
+		// GC runs when the cloudprovider node is gone or NotReady; pod records may
+		// linger or already be cleaned up. CountReschedulablePodsOnNode handles the
+		// empty-nodename case and any list error by returning 0 with a logged error.
+		podCount, podErr := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, nodeClaims[i].Status.NodeName)
+		if podErr != nil {
+			log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", podErr.Error())
+		}
+		metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
 	})
 	if err = multierr.Combine(errs...); err != nil {
 		return reconciler.Result{}, err

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,6 +71,20 @@ var (
 			CapacityTypeLabel,
 		},
 	)
+	PodsDisruptedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: PodSubsystem,
+			Name:      "disrupted_total",
+			Help:      "Number of reschedulable pods disrupted in total by Karpenter, incremented by the pod count whenever the underlying nodeclaim is disrupted. Labeled by reason the nodeclaim was disrupted, the owning nodepool, and the capacity type. Pods owned by DaemonSets and mirror pods are excluded.",
+		},
+		[]string{
+			ReasonLabel,
+			NodePoolLabel,
+			CapacityTypeLabel,
+		},
+	)
 	NodesCreatedTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
 		prometheus.CounterOpts{

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -150,6 +150,29 @@ func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (
 	return nodeClaims[0], nil
 }
 
+// CountReschedulablePodsOnNode returns the number of pods bound to the named node that
+// satisfy the pod.IsReschedulable criteria (active or stateful-set-terminating, not
+// owned by a DaemonSet, not a mirror pod). This mirrors the semantics of
+// disruption.Candidate.reschedulablePods so per-disruption-reason metrics across
+// queue/expiration/health/GC controllers count pods consistently. An empty nodeName
+// returns 0 with no error so callers operating on un-registered NodeClaims don't fail.
+func CountReschedulablePodsOnNode(ctx context.Context, kubeClient client.Client, nodeName string) (int, error) {
+	if nodeName == "" {
+		return 0, nil
+	}
+	var podList corev1.PodList
+	if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
+		return 0, fmt.Errorf("listing pods on node %q, %w", nodeName, err)
+	}
+	count := 0
+	for i := range podList.Items {
+		if pod.IsReschedulable(&podList.Items[i]) {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // GetCurrentlyReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
 func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client, clk clock.Clock, recorder events.Recorder, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
 	pods, err := GetPods(ctx, kubeClient, nodes...)

--- a/pkg/utils/node/suite_test.go
+++ b/pkg/utils/node/suite_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -92,5 +93,50 @@ var _ = Describe("NodeUtils", func() {
 		nodeClaims, err := nodeutils.GetNodeClaims(ctx, env.Client, testNode)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeClaims).To(HaveLen(0))
+	})
+	Context("CountReschedulablePodsOnNode", func() {
+		It("should return 0 for an empty node name", func() {
+			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+		It("should return 0 when no pods are bound to the node", func() {
+			testNode = test.Node()
+			ExpectApplied(ctx, env.Client, testNode)
+			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, testNode.Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+		It("should count only reschedulable pods bound to the node", func() {
+			testNode = test.Node()
+			ExpectApplied(ctx, env.Client, testNode)
+			isController := true
+			// 2 reschedulable pods (active, no DaemonSet/Node owner).
+			pod1 := test.Pod(test.PodOptions{NodeName: testNode.Name})
+			pod2 := test.Pod(test.PodOptions{NodeName: testNode.Name})
+			// 1 DaemonSet-owned pod (excluded by IsReschedulable).
+			daemonsetPod := test.Pod(test.PodOptions{
+				NodeName: testNode.Name,
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "DaemonSet",
+						Name:       "ds",
+						UID:        "ds-uid",
+						Controller: &isController,
+					}},
+				},
+			})
+			// 1 pod bound to a different node (excluded by field selector).
+			otherNode := test.Node()
+			ExpectApplied(ctx, env.Client, otherNode)
+			otherPod := test.Pod(test.PodOptions{NodeName: otherNode.Name})
+
+			ExpectApplied(ctx, env.Client, pod1, pod2, daemonsetPod, otherPod)
+
+			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, testNode.Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(2))
+		})
 	})
 })


### PR DESCRIPTION
Fixes #2020

## Description

Mirrors karpenter_nodeclaims_disrupted_total but counts the reschedulable
pods that were on each disrupted node. Operators can now correlate the
NodeClaim-level disruption volume with the pod-level user impact across
the same (reason, nodepool, capacity_type) labels.

Emit sites match the four NodeClaim disruption paths where pod records
exist on the node:

- pkg/controllers/disruption/queue.go uses Candidate.reschedulablePods
  directly (already cached on the Candidate)
- pkg/controllers/nodeclaim/expiration/controller.go,
  pkg/controllers/node/health/controller.go, and
  pkg/controllers/nodeclaim/garbagecollection/controller.go list pods
  via the new node.CountReschedulablePodsOnNode helper, which applies
  the same pod.IsReschedulable filter (active or stateful-set
  terminating; not DaemonSet- or Node-owned)

Skipped: nodeclaim/lifecycle/launch.go and liveness.go disrupt
NodeClaims that never bound pods (launch failure, liveness watchdog),
so a pods counter on those paths would always be 0.

A list error during pod counting is logged at V(1) and the metric
reports 0 for that disruption — never blocks the disruption itself.

Refs #2020

Signed-off-by: praveen9354 <praveen9354@gmail.com>

## How was this change tested?

Local verification of the changed file's adjacent test suite.
Upstream CI runs the full matrix on push.

