### PR TITLE
feat: feature-gated custom drain strategy based on 'rollout restart' for single replica deploy/sts.

### DIFF
--- a/designs/rollout-restart-drain-strategy.md
+++ b/designs/rollout-restart-drain-strategy.md
@@ -1,0 +1,345 @@
+# Rollout-Restart Drain Strategy
+
+## Summary
+
+This feature adds an opt-in drain strategy that, for singleton (`spec.replicas: 1`) Deployments and StatefulSets, replaces the pod-eviction call during node drain with a `kubectl rollout restart`
+–equivalent patch on the workload's pod template. The behavior is gated behind a new `RolloutRestartDrainStrategy` feature gate (default `false`) and only applies to pods whose owner is an apps/v1
+Deployment or StatefulSet with `spec.replicas == 1`. All other pods continue to drain via the existing eviction path.
+
+## Motivation
+
+### Problem Statement
+
+Karpenter drains nodes by calling the [eviction subresource](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/) on each non-DaemonSet pod. Eviction is the right primitive for the
+multi-replica case — it respects `PodDisruptionBudget` (PDB), so Kubernetes can guarantee a minimum of available replicas during the drain. For singleton workloads, however, eviction has two
+well-known shortcomings:
+
+1. **PDB deadlock on singletons.** A common policy is to set `minAvailable: 1` (or `maxUnavailable: 0`) on every workload's PDB so that disruption tooling can never voluntarily take the workload below
+   one Ready replica. For a Deployment or StatefulSet with `spec.replicas: 1`, that policy is *self-conflicting under eviction*: the eviction API will refuse the request indefinitely (HTTP 429,
+   `Cannot evict pod as it would violate the pod's disruption budget`). Karpenter retries forever, the node never drains, and the only way out is either to forcibly delete the pod (via
+   `terminationGracePeriod` expiry) — losing the PDB guarantee anyway — or for an operator to manually `kubectl rollout restart` the workload.
+
+2. **Avoidable downtime on Deployments.** Even when no PDB blocks eviction, eviction on a singleton Deployment causes a full pod-lifetime of downtime: the old pod is deleted, then the Deployment
+   controller creates a new pod, the scheduler places it, the kubelet pulls the image, and the application boots. For applications with multi-minute startup times (JVM apps such as Spring Boot are a
+   common case, with 2+ minute boots), this is a multi-minute outage *every consolidation cycle*. A `kubectl rollout restart` on the same Deployment, by contrast, uses `maxSurge` to bring the
+   replacement Ready *before* deleting the old pod — zero-downtime by design.
+
+In both cases the operator's manual remediation is the same: trigger a rollout restart of the singleton's owner. Karpenter has the same information the operator has (the pod's owner chain, the owner's
+replica count, the owner's rollout status) and is in a position to do the same thing automatically.
+
+### Why This Feature Belongs in Karpenter
+
+The drain step is owned by Karpenter — it is the component holding the node and deciding which API to call to remove each pod. Eviction is currently the only option in that step, and "drain a
+singleton without downtime / without PDB deadlock" is a recurring failure mode of that single option:
+
+- It is **not solvable at the workload layer** without giving up the PDB guarantee that platform teams want everywhere. The strict-PDB-everywhere policy is desirable; the singleton-deadlock is a
+  side effect.
+- It is **not solvable by PDB tuning** in a way that scales — relaxing PDB on singletons means writing per-workload PDBs, which is precisely what platform teams use admission policies to *prevent*.
+- It is **not solvable by `terminationGracePeriod`** alone — that resolves the deadlock by forcefully terminating the pod after a timeout, which is exactly the outage the user is trying to avoid.
+
+Rollout-restart-as-drain takes a primitive every Kubernetes user already understands (`kubectl rollout restart`) and uses it at the right layer (the node-drain step) for the case where eviction is
+structurally a poor fit. Because the behavior is gated and scoped narrowly (singleton apps/v1 owners only), it does not change Karpenter's drain semantics for any workload that is not already failing
+under the status quo.
+
+### Use Cases
+
+1. **Singleton service with strict PDB.** A Deployment with `replicas: 1` and a PDB `minAvailable: 1` (or any equivalent zero-disruption policy). Today: Karpenter is stuck draining the node forever,
+   or `terminationGracePeriod` eventually force-kills the pod with downtime. With this feature: Karpenter patches the Deployment, `maxSurge` brings the replacement Ready, the old pod is gracefully
+   removed, the node drains.
+
+2. **Singleton with slow boot.** A Deployment with `replicas: 1`, no strict PDB, but a multi-minute application startup (JVM, ML model load, etc.). Today: every consolidation cycle causes a full-boot
+   outage. With this feature: surge keeps the service Ready throughout.
+
+3. **Singleton StatefulSet.** A StatefulSet with `replicas: 1` backing a piece of stateful infrastructure (a leader process, a Postgres primary, a singleton broker) behind a strict PDB. Today:
+   eviction is refused, drain stalls. With this feature: the StatefulSet controller is asked to recreate the pod via its normal rollout path. StatefulSets cannot surge, so this is not zero-downtime —
+   it is, however, the same amount of downtime a successful eviction would have caused, and crucially it *completes*, which eviction does not.
+
+### Non-Goals
+
+- **Multi-replica workloads.** Eviction + PDB is the correct primitive there, and rolling every replica of a multi-replica Deployment just to drain one node would be both wasteful and surprising. The
+  feature deliberately gates on `spec.replicas == 1`.
+- **Workloads with no rollout-capable owner.** Bare Pods, Jobs, custom controllers, etc. fall through to eviction unchanged.
+- **Replacing the existing eviction path.** This is an additional path taken for one narrow case. The default behavior of Karpenter does not change when the feature gate is `false`.
+
+## Proposal
+
+### Feature Gate
+
+A new feature gate is added to the existing `--feature-gates` flag / `FEATURE_GATES` env var:
+
+```
+--feature-gates=...,RolloutRestartDrainStrategy=true
+```
+
+- Default: `false`.
+- When `false`, drain behavior is unchanged.
+- When `true`, the drain queue applies the rollout-restart path described below before falling through to eviction.
+
+### Behavior
+
+When the queue picks up a pod to drain and the feature gate is on, Karpenter performs the following check before the existing eviction call:
+
+1. **Identify a singleton rollout target.** Walk the pod's `ownerReferences`:
+    - If the pod is directly owned by an apps/v1 `StatefulSet` and that StatefulSet has `spec.replicas == 1`, the target is that StatefulSet.
+    - Otherwise, if the pod is owned by an apps/v1 `ReplicaSet` whose owner is an apps/v1 `Deployment` with `spec.replicas == 1`, the target is that Deployment.
+    - Otherwise, there is no rollout target — fall through to eviction.
+
+2. **Gate on the owner's rollout status.** If the target already has a rollout in progress (defined below), Karpenter does *not* patch — patching now would create a third revision and cause the
+   in-flight replacement pod to be killed before it becomes Ready. Karpenter emits a `RolloutRestartInProgress` event on the pod, drops the pod from the in-memory drain queue, and lets the next
+   reconcile pass re-examine the situation. This is the critical fix: a naive "patch every time we see this pod" implementation creates an infinite deploy loop on any workload whose boot time exceeds
+   Karpenter's consolidation cadence.
+
+3. **Trigger the rollout restart.** If no rollout is in progress, Karpenter issues a strategic-merge patch on the target's `spec.template.metadata.annotations` setting
+   `kubectl.kubernetes.io/restartedAt` to the current RFC3339 timestamp — identical to what `kubectl rollout restart deployment/<name>` writes. The Deployment / StatefulSet controller then drives the
+   rollout to completion as it would for any other restart. Karpenter emits a `RolloutRestarted` event on the pod and removes the pod from the drain queue; the pod will be deleted by the workload
+   controller as part of the rollout, at which point the node-drain controller's next pass observes one fewer pod on the node.
+
+4. **Fall through.** If no singleton rollout target exists, or if the target lookup hits a transient API error, the existing eviction code path runs.
+
+### Defining "rollout in progress"
+
+The in-flight gate mirrors `kubectl rollout status`. For each kind:
+
+**Deployment** — a rollout is in progress if any of the following hold:
+
+- `status.observedGeneration < metadata.generation` (the controller hasn't yet reconciled the latest spec)
+- `status.updatedReplicas < spec.replicas` (the new ReplicaSet hasn't reached desired count)
+- `status.replicas > status.updatedReplicas` (the **surge-cleanup window**: the new pod is up, possibly Ready, but the old pod hasn't been deleted yet)
+- `status.availableReplicas < status.updatedReplicas` (new pods exist but aren't Available yet)
+
+The `status.replicas > status.updatedReplicas` check is essential and is the reason a status-based gate was chosen over a timestamp-based one. During surge, `UpdatedReplicas` reaches the desired count
+*before* the old pod is removed; without this clause the gate would report "rollout done" while the old pod still exists on the draining node, and Karpenter would patch again, starting a new rollout
+that kills the not-yet-Ready surge pod. This is the failure mode observed in development against slow-booting workloads and is what the second commit in this series fixes.
+
+**StatefulSet** — a rollout is in progress if any of:
+
+- `status.observedGeneration < metadata.generation`
+- `status.updatedReplicas < spec.replicas`
+- `status.readyReplicas < spec.replicas`
+- `status.currentRevision != status.updateRevision`
+
+StatefulSets do not surge, so there is no surge-cleanup clause. `rollingUpdate.partition` is intentionally **not** special-cased — a partitioned rollout on a singleton is degenerate (any non-zero
+partition means "do nothing"), and adding it as a gate would cause a partial rollout to look "in progress" forever.
+
+### Events
+
+Two new event reasons are added on the pod:
+
+- `RolloutRestarted` — emitted when Karpenter has patched the owner.
+- `RolloutRestartInProgress` — emitted when Karpenter observed an in-flight rollout and intentionally skipped patching. This is the diagnostic signal for "why isn't this node draining yet?" on
+  slow-booting singletons.
+
+Both are `Normal` events and use the pod name for dedupe so the same singleton on the same drain doesn't spam the event stream.
+
+### Implementation Outline
+
+```
+pkg/operator/options/options.go
+  + FeatureGates.RolloutRestartDrainStrategy bool (default false)
+  + parse + default in DefaultFeatureGates / ParseFeatureGates
+
+pkg/utils/pod/scheduling.go
+  + type SingletonRolloutTarget { Object, Kind, RolloutInProgress }
+  + SingletonRolloutTargetForPod(ctx, client, pod) — owner-chain walk + replica gate
+  + deploymentRolloutInProgress / statefulSetRolloutInProgress — Status-based gates
+
+pkg/controllers/node/termination/terminator/eviction.go
+  + Queue.tryRolloutRestart(ctx, pod) — called before eviction.Create when gate is on
+  + Queue.rolloutRestart(ctx, target) — strategic-merge patch of restartedAt
+
+pkg/controllers/node/termination/terminator/events/events.go
+  + RolloutRestartedPod / RolloutRestartInProgress event constructors
+
+pkg/events/reason.go
+  + Reason constants: RolloutRestarted, RolloutRestartInProgress
+```
+
+The change is self-contained inside the eviction queue. No NodeClaim, NodePool, or scheduling code is touched. The existing eviction code path is reached unchanged whenever `tryRolloutRestart` returns
+`(false, nil)`.
+
+## Examples
+
+### Example 1: Singleton Deployment with strict PDB (zero-downtime)
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    spec:
+      containers: [ ... ]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: payments-api
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: payments-api
+```
+
+**Today (eviction):** Drain calls eviction → 429 (`would violate disruption budget`). Karpenter retries forever. The node never drains until `terminationGracePeriod` fires and force-deletes the pod.
+
+**With `RolloutRestartDrainStrategy=true`:** Drain patches the Deployment's `restartedAt` annotation. The Deployment controller surges a new pod onto another node, the new pod becomes Ready, the old
+pod is gracefully deleted by the Deployment controller. The PDB invariant `minAvailable: 1` is preserved throughout. The node drains.
+
+### Example 2: Singleton Deployment with slow boot (no PDB conflict, but avoidable outage)
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-boot-singleton
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  # No PDB on this workload.
+```
+
+**Today:** Eviction succeeds immediately, pod is deleted, ~2 minutes of downtime while the JVM starts on the replacement.
+
+**With the feature on:** Same surge behavior as Example 1 — zero observed downtime.
+
+### Example 3: Singleton StatefulSet behind a strict PDB
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: leader
+spec:
+  replicas: 1
+  # ...
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: leader
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: leader
+```
+
+**Today:** Eviction is refused. Drain stalls until `terminationGracePeriod`.
+
+**With the feature on:** Karpenter patches the StatefulSet's `restartedAt`. The StatefulSet controller deletes the pod and recreates it (StatefulSets do not surge). Downtime = one pod lifetime — the
+same downtime a successful eviction would have caused, but the drain *completes*.
+
+### Example 4: Slow-booting singleton, mid-rollout (in-flight gate)
+
+A second drain pass observes the same pod while the rollout from the first pass is still surging. Karpenter sees `status.replicas (2) > status.updatedReplicas (1)` — the new pod is Ready but the old
+one is still being torn down — and emits `RolloutRestartInProgress` instead of patching. Without this gate, the second patch would create a third revision and kill the not-yet-fully-promoted
+replacement, leading to an infinite restart loop. **This scenario is the reason the original timestamp-based dedup was replaced with a Status-based gate.**
+
+### Example 5: Pod is not a singleton (no behavior change)
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 5
+```
+
+`SingletonRolloutTargetForPod` returns `nil` because `spec.replicas != 1`. The drain falls through to the existing eviction path. The feature gate being on has no effect on this workload.
+
+## Interaction with Other Features
+
+### PodDisruptionBudget
+
+The rollout-restart path **does not call eviction**, so it is not subject to PDB. This is intentional: the entire point of the feature is to drain workloads that the workload owner has declared (via
+strict PDB) "should never go below one Ready replica," and the rollout primitive is the *only* mechanism that can honor that invariant for a singleton.
+
+For Deployments, the surge behavior preserves the spirit of the PDB during the drain — the new pod is Ready before the old one goes away. For StatefulSets, the PDB invariant is briefly violated (one
+pod-lifetime of downtime), exactly as it would be in a normal `kubectl rollout restart`. Operators who consider this unacceptable should leave the feature gate off, and accept that singleton
+StatefulSets behind strict PDBs are not drainable without an admin override.
+
+### `terminationGracePeriod`
+
+This feature is complementary to NodeClaim `spec.terminationGracePeriod`:
+
+| Mechanism                     | When it acts                                  | What it does                                                     |
+|-------------------------------|-----------------------------------------------|------------------------------------------------------------------|
+| `RolloutRestartDrainStrategy` | Drain-time, only for singleton apps/v1 owners | Surge / rollout the workload owner to gracefully replace the pod |
+| `terminationGracePeriod`      | Drain-time, all pods, after timer expires     | Force-delete blocking pods so the node terminates                |
+
+A node with both configured will, in the common case, drain via rollout restart well before the termination grace period fires. The termination grace period remains the safety net for cases the
+rollout-restart path can't handle (workloads whose owners aren't singleton apps/v1, or whose rollouts themselves get stuck).
+
+### `do-not-disrupt` (pod-level)
+
+`do-not-disrupt` is evaluated upstream of the drain queue — a pod with active `do-not-disrupt` protection is not put into the drain queue, so this feature never sees it. No interaction.
+
+### Pod `terminationGracePeriodSeconds`
+
+The pod's `terminationGracePeriodSeconds` continues to govern how the old pod shuts down (the kubelet honors it during the Deployment/StatefulSet controller's deletion of the pod, just as it does for
+`kubectl rollout restart`). This feature only changes *how* the deletion is initiated, not *how* it completes.
+
+### Eviction metrics
+
+`PodsEvictionRequestsTotal` is not incremented on the rollout-restart path because no eviction API call is made. `PodsDrainedTotal` should be updated by a follow-up to count rollout-driven drains
+alongside eviction-driven drains (see Future Enhancements).
+
+## Alternatives Considered
+
+### Alternative 1: Leave it to operators
+
+Document the singleton-strict-PDB failure mode and tell operators to either relax their PDB or pre-emptively `kubectl rollout restart` workloads before draining.
+
+**Rejected**: this is the status quo, and the status quo is what motivated this RFC. Operationally, it requires either (a) relaxing PDBs on singleton workloads - which defeats the strict-PDB policies
+platform teams commonly enforce via admission — or (b) external automation that watches Karpenter's drain activity and issues rollout restarts ahead of it. Option (b) duplicates information Karpenter
+already has at the drain step (the pod, its owner, the owner's replica count, the owner's rollout status) and introduces an out-of-band controller that has to stay in sync with Karpenter's behavior.
+Keeping this opt-in and gated leaves operators free to continue using either workaround if they prefer.
+
+### Alternative 2: Use `kubectl delete pod` (or DELETE pods/<name>) directly
+
+Skip eviction's PDB check by deleting the pod via the pods API instead. The workload controller will recreate the pod elsewhere.
+
+**Rejected**: this is exactly what `terminationGracePeriod` already does after timeout, and it has the same downtime cost as eviction. It would resolve the *deadlock* but not the *outage*. The whole
+reason to use the rollout primitive is that for Deployments it triggers `maxSurge`, which neither eviction nor direct delete can do.
+
+### Alternative 3: Use `apps/v1/deployments/<name>/scale` to scale up, then evict
+
+Scale the Deployment to 2 → wait for the new pod to be Ready → evict the old pod → scale back to 1.
+
+**Rejected**: this fights the Deployment controller (the scale change is observable to anyone watching the workload), it requires Karpenter to remember to scale back down (which is fragile if
+Karpenter dies mid-drain), and it doesn't help StatefulSets. Rollout restart is the primitive the platform already supports.
+
+### Alternative 4: Annotation-timestamp dedup (the original approach)
+
+The first commit in this series used a 2-minute window on the `restartedAt` annotation as the in-flight gate: "if we already patched this owner within 2 minutes, don't patch again."
+
+**Rejected (mid-implementation)**: Karpenter's consolidation cadence matches the 2-minute window almost exactly, so the dedup never fired in practice. Combined with a Spring Boot–style slow boot, this
+caused every consolidation cycle to patch the workload again *before* the previous rollout finished, killing the not-yet-Ready surge pod and starting over — an infinite deploy loop reproduced in
+development. The status-based gate (current proposal) reads the owner's actual rollout progress instead of guessing from a timestamp and is robust to arbitrary boot times.
+
+### Alternative 5: Apply to multi-replica workloads too
+
+Rollout-restart every workload regardless of replica count.
+
+**Rejected**: rolling 50 replicas to drain 1 pod is wasteful, surprising, and breaks the well-understood eviction+PDB contract that multi-replica workloads already rely on. The singleton case is the
+unique one where eviction's contract fails the workload owner; multi-replica works fine as-is.
+
+## Backward Compatibility
+
+Fully backward-compatible:
+
+- The feature gate defaults to `false`. Existing clusters see no behavior change on upgrade.
+- When the gate is `on`, only pods with a singleton apps/v1 owner are routed to the new path. All other pods continue through the existing eviction path with identical semantics.
+- No CRDs, annotations, or API contracts change.

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/karpenter/pkg/operator/logging"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -72,6 +73,7 @@ var _ = BeforeSuite(func() {
 		test.WithFieldIndexers(test.NodeClaimProviderIDFieldIndexer(ctx), test.VolumeAttachmentFieldIndexer(ctx)),
 	)
 
+	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	recorder = test.NewEventRecorder()
 	queue = terminator.NewQueue(env.Client, recorder)

--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -40,6 +40,31 @@ func EvictPod(pod *corev1.Pod, reason string) events.Event {
 	}
 }
 
+// RolloutRestartedPod records that a pod was drained by triggering a rollout restart
+// on its singleton owner (Deployment or StatefulSet), rather than via the eviction API.
+func RolloutRestartedPod(pod *corev1.Pod, ownerKind, ownerName string) events.Event {
+	return events.Event{
+		InvolvedObject: pod,
+		Type:           corev1.EventTypeNormal,
+		Reason:         events.RolloutRestarted,
+		Message:        fmt.Sprintf("Triggered rollout restart of %s %q to drain singleton pod", ownerKind, ownerName),
+		DedupeValues:   []string{pod.Name},
+	}
+}
+
+// RolloutRestartInProgress records that we observed an in-flight rollout on the pod's singleton
+// owner and skipped patching so the previous rollout can finish. Look for this when diagnosing
+// "why isn't this node draining yet?" on slow-booting workloads.
+func RolloutRestartInProgress(pod *corev1.Pod, ownerKind, ownerName string) events.Event {
+	return events.Event{
+		InvolvedObject: pod,
+		Type:           corev1.EventTypeNormal,
+		Reason:         events.RolloutRestartInProgress,
+		Message:        fmt.Sprintf("Waiting on in-flight rollout of %s %q before draining singleton pod", ownerKind, ownerName),
+		DedupeValues:   []string{pod.Name},
+	}
+}
+
 func DisruptPodDelete(pod *corev1.Pod, gracePeriodSeconds *int64, nodeGracePeriodTerminationTime *time.Time) events.Event {
 	return events.Event{
 		InvolvedObject: pod,

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -26,6 +26,7 @@ import (
 	"github.com/awslabs/operatorpkg/serrors"
 	"github.com/samber/lo"
 	"golang.org/x/time/rate"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,6 +49,7 @@ import (
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
@@ -60,6 +62,10 @@ const (
 	maxReconciles          = 5000
 
 	multiplePodDisruptionBudgetsError = "This pod has more than one PodDisruptionBudget, which the eviction subresource does not support."
+
+	// RolloutRestartAnnotation matches the annotation `kubectl rollout restart` writes onto the workload's pod template;
+	// setting it triggers the Deployment controller to surge a fresh pod and delete the old one.
+	RolloutRestartAnnotation = "kubectl.kubernetes.io/restartedAt"
 )
 
 type NodeDrainError struct {
@@ -167,6 +173,13 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 		//controller can reconcile on it
 		return reconcile.Result{}, nil
 	}
+	handled, err := q.tryRolloutRestart(ctx, pod)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if handled {
+		return reconcile.Result{}, nil
+	}
 	// Evict the pod
 	if err := q.kubeClient.SubResource("eviction").Create(ctx,
 		pod,
@@ -218,6 +231,67 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 	defer q.Unlock()
 	q.set.Delete(NewQueueKey(pod))
 	return reconcile.Result{}, nil
+}
+
+// tryRolloutRestart drains a pod via rollout restart of its singleton owner when the feature gate
+// is on. Returns (true, nil) when handled (skip eviction), (false, nil) when not applicable, and a
+// non-nil error to surface as a reconcile failure. See pkg/utils/pod/scheduling.go for the
+// Deployment-vs-StatefulSet trade-offs.
+//
+// If the owner already has a rollout in flight, we don't patch — that would create a third revision
+// and kill the in-flight replacement before it becomes Ready. We still return handled=true so the
+// caller doesn't fall through to eviction (which would force-kill the old pod and defeat the
+// surge), and drop the pod from the local queue so the drain controller's next pass re-Adds it
+// and we re-check Status.
+func (q *Queue) tryRolloutRestart(ctx context.Context, pod *corev1.Pod) (bool, error) {
+	if !options.FromContext(ctx).FeatureGates.RolloutRestartDrainStrategy {
+		fmt.Printf("DEBUG tryRolloutRestart: feature gate OFF for pod %s/%s\n", pod.Namespace, pod.Name)
+		return false, nil
+	}
+	target, err := podutils.SingletonRolloutTargetForPod(ctx, q.kubeClient, pod)
+	if err != nil {
+		fmt.Printf("DEBUG tryRolloutRestart: err for pod %s/%s: %v\n", pod.Namespace, pod.Name, err)
+		return false, err
+	}
+	if target == nil {
+		fmt.Printf("DEBUG tryRolloutRestart: target=nil for pod %s/%s (owners=%+v)\n", pod.Namespace, pod.Name, pod.OwnerReferences)
+		return false, nil
+	}
+	if dep, ok := target.Object.(*appsv1.Deployment); ok {
+		fmt.Printf("DEBUG tryRolloutRestart: Deployment %s Gen=%d ObsGen=%d UpdRepl=%d Repl=%d AvlRepl=%d SpecRepl=%d rolloutInProgress=%v\n",
+			dep.Name, dep.Generation, dep.Status.ObservedGeneration, dep.Status.UpdatedReplicas, dep.Status.Replicas, dep.Status.AvailableReplicas, *dep.Spec.Replicas, target.RolloutInProgress)
+	} else {
+		fmt.Printf("DEBUG tryRolloutRestart: target found kind=%s name=%s rolloutInProgress=%v\n", target.Kind, target.Object.GetName(), target.RolloutInProgress)
+	}
+	if target.RolloutInProgress {
+		q.recorder.Publish(terminatorevents.RolloutRestartInProgress(pod, target.Kind, target.Object.GetName()))
+		q.Lock()
+		defer q.Unlock()
+		q.set.Delete(NewQueueKey(pod))
+		return true, nil
+	}
+	if err := q.rolloutRestart(ctx, target); err != nil {
+		return false, err
+	}
+	q.recorder.Publish(terminatorevents.RolloutRestartedPod(pod, target.Kind, target.Object.GetName()))
+	q.Lock()
+	defer q.Unlock()
+	q.set.Delete(NewQueueKey(pod))
+	return true, nil
+}
+
+// rolloutRestart patches a singleton workload with the standard restartedAt annotation, matching
+// `kubectl rollout restart`. Caller must gate on target.RolloutInProgress to avoid clobbering an
+// in-flight rollout.
+func (q *Queue) rolloutRestart(ctx context.Context, target *podutils.SingletonRolloutTarget) error {
+	patch := []byte(fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`,
+		RolloutRestartAnnotation, time.Now().UTC().Format(time.RFC3339),
+	))
+	if err := q.kubeClient.Patch(ctx, target.Object, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
+		return fmt.Errorf("rollout-restarting %s %s/%s: %w", target.Kind, target.Object.GetNamespace(), target.Object.GetName(), err)
+	}
+	return nil
 }
 
 func evictionReason(ctx context.Context, pod *corev1.Pod, kubeClient client.Client) string {

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -25,9 +25,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
@@ -279,6 +281,219 @@ var _ = Describe("Eviction/Queue", func() {
 			// even with a finalizer in older Kubernetes; a set DeletionTimestamp confirms graceful).
 			pod = ExpectExists(ctx, env.Client, pod)
 			Expect(pod.DeletionTimestamp).ToNot(BeNil())
+		})
+	})
+
+	Context("Rollout Restart Drain Strategy", func() {
+		restartAnnotation := terminator.RolloutRestartAnnotation
+
+		// buildDeploymentPod stitches together a Deployment, its owning ReplicaSet, and a pod referencing the ReplicaSet.
+		// The Deployment is built with a converged Status (ObservedGeneration=1, Updated/ReadyReplicas matching Spec.Replicas)
+		// so the happy-path tests don't trip the rollout-in-progress gate. Tests that want to simulate an in-flight rollout zero out dep.Status before ExpectApplied.
+		buildDeploymentPod := func(name string, replicas int32) (*appsv1.Deployment, *appsv1.ReplicaSet, *corev1.Pod) {
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: lo.ToPtr(replicas),
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Replicas:           replicas,
+					UpdatedReplicas:    replicas,
+					ReadyReplicas:      replicas,
+					AvailableReplicas:  replicas,
+				},
+			}
+			rs := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name + "-rs", Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: name, UID: types.UID(name + "-uid")}},
+				},
+				Spec: appsv1.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+					},
+				},
+			}
+			p := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name + "-pod", Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: rs.Name, UID: types.UID(rs.Name + "-uid")}},
+				},
+				NodeName: node.Name,
+			})
+			return dep, rs, p
+		}
+
+		It("falls through to eviction when the feature gate is off, even for a singleton Deployment", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				FeatureGates: test.FeatureGates{RolloutRestartDrainStrategy: lo.ToPtr(false)},
+			}))
+			dep, rs, p := buildDeploymentPod("singleton", 1)
+			ExpectApplied(ctx, env.Client, dep, rs, p, node)
+			queue.Add(p)
+			ExpectObjectReconciled(ctx, env.Client, queue, p)
+
+			Expect(recorder.Calls(events.Evicted)).To(Equal(1))
+			Expect(recorder.Calls(events.RolloutRestarted)).To(Equal(0))
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Annotations[restartAnnotation]).To(BeEmpty())
+		})
+
+		It("rollout-restarts the Deployment and skips eviction for a singleton Deployment", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				FeatureGates: test.FeatureGates{RolloutRestartDrainStrategy: lo.ToPtr(true)},
+			}))
+			dep, rs, p := buildDeploymentPod("singleton", 1)
+			ExpectApplied(ctx, env.Client, dep, rs, p, node)
+			queue.Add(p)
+			ExpectObjectReconciled(ctx, env.Client, queue, p)
+
+			Expect(recorder.Calls(events.Evicted)).To(Equal(0))
+			Expect(recorder.Calls(events.RolloutRestarted)).To(Equal(1))
+			Expect(recorder.Calls(events.RolloutRestartInProgress)).To(Equal(0))
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Annotations[restartAnnotation]).ToNot(BeEmpty())
+			Expect(queue.Has(p)).To(BeFalse())
+		})
+
+		It("evicts pods owned by a multi-replica Deployment instead of rollout-restarting", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				FeatureGates: test.FeatureGates{RolloutRestartDrainStrategy: lo.ToPtr(true)},
+			}))
+			dep, rs, p := buildDeploymentPod("multi", 3)
+			ExpectApplied(ctx, env.Client, dep, rs, p, node)
+			queue.Add(p)
+			ExpectObjectReconciled(ctx, env.Client, queue, p)
+
+			Expect(recorder.Calls(events.Evicted)).To(Equal(1))
+			Expect(recorder.Calls(events.RolloutRestarted)).To(Equal(0))
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Annotations[restartAnnotation]).To(BeEmpty())
+		})
+
+		buildStatefulSetPod := func(name string, replicas int32) (*appsv1.StatefulSet, *corev1.Pod) {
+			ss := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: lo.ToPtr(replicas),
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+					},
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					Replicas:           replicas,
+					UpdatedReplicas:    replicas,
+					ReadyReplicas:      replicas,
+					AvailableReplicas:  replicas,
+				},
+			}
+			p := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name + "-pod", Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "StatefulSet", Name: name, UID: types.UID(name + "-uid")}},
+				},
+				NodeName: node.Name,
+			})
+			return ss, p
+		}
+
+		It("rollout-restarts a singleton StatefulSet instead of evicting (drain progress under blocking PDBs)", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				FeatureGates: test.FeatureGates{RolloutRestartDrainStrategy: lo.ToPtr(true)},
+			}))
+			ss, p := buildStatefulSetPod("singleton-ss", 1)
+			ExpectApplied(ctx, env.Client, ss, p, node)
+			queue.Add(p)
+			ExpectObjectReconciled(ctx, env.Client, queue, p)
+
+			Expect(recorder.Calls(events.Evicted)).To(Equal(0))
+			Expect(recorder.Calls(events.RolloutRestarted)).To(Equal(1))
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: ss.Name, Namespace: ss.Namespace}, ss)).To(Succeed())
+			Expect(ss.Spec.Template.Annotations[restartAnnotation]).ToNot(BeEmpty())
+			Expect(queue.Has(p)).To(BeFalse())
+		})
+
+		It("evicts pods owned by a multi-replica StatefulSet instead of rollout-restarting", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				FeatureGates: test.FeatureGates{RolloutRestartDrainStrategy: lo.ToPtr(true)},
+			}))
+			ss, p := buildStatefulSetPod("multi-ss", 3)
+			ExpectApplied(ctx, env.Client, ss, p, node)
+			queue.Add(p)
+			ExpectObjectReconciled(ctx, env.Client, queue, p)
+
+			Expect(recorder.Calls(events.Evicted)).To(Equal(1))
+			Expect(recorder.Calls(events.RolloutRestarted)).To(Equal(0))
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: ss.Name, Namespace: ss.Namespace}, ss)).To(Succeed())
+			Expect(ss.Spec.Template.Annotations[restartAnnotation]).To(BeEmpty())
+		})
+
+		// Regression: prevents the deploy-loop where a slow-booting Spring Boot pod
+		// gets killed by a fresh rollout patch every ~2 minutes (one consolidation
+		// cycle) before it can become Ready. The Deployment's Status reports an
+		// in-flight rollout, so we must not re-patch.
+		It("skips the patch and emits RolloutRestartInProgress when a rollout is already in flight (ObservedGeneration behind)", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				FeatureGates: test.FeatureGates{RolloutRestartDrainStrategy: lo.ToPtr(true)},
+			}))
+			dep, rs, p := buildDeploymentPod("observing", 1)
+			// Controller has not yet observed the latest spec — classic in-flight signal.
+			dep.Status.ObservedGeneration = 0
+			ExpectApplied(ctx, env.Client, dep, rs, p, node)
+			queue.Add(p)
+			ExpectObjectReconciled(ctx, env.Client, queue, p)
+
+			Expect(recorder.Calls(events.Evicted)).To(Equal(0))
+			Expect(recorder.Calls(events.RolloutRestarted)).To(Equal(0))
+			Expect(recorder.Calls(events.RolloutRestartInProgress)).To(Equal(1))
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Annotations[restartAnnotation]).To(BeEmpty())
+			Expect(queue.Has(p)).To(BeFalse())
+		})
+
+		It("skips the patch when the Deployment has unready replicas (slow-booting pod still coming up)", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				FeatureGates: test.FeatureGates{RolloutRestartDrainStrategy: lo.ToPtr(true)},
+			}))
+			dep, rs, p := buildDeploymentPod("unready", 1)
+			// Spec.Replicas=1, UpdatedReplicas=1, but new pod hasn't become Ready yet.
+			dep.Status.ReadyReplicas = 0
+			dep.Status.AvailableReplicas = 0
+			ExpectApplied(ctx, env.Client, dep, rs, p, node)
+			queue.Add(p)
+			ExpectObjectReconciled(ctx, env.Client, queue, p)
+
+			Expect(recorder.Calls(events.RolloutRestarted)).To(Equal(0))
+			Expect(recorder.Calls(events.RolloutRestartInProgress)).To(Equal(1))
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Annotations[restartAnnotation]).To(BeEmpty())
+		})
+
+		It("skips the patch when a singleton StatefulSet has an in-flight rollout", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				FeatureGates: test.FeatureGates{RolloutRestartDrainStrategy: lo.ToPtr(true)},
+			}))
+			ss, p := buildStatefulSetPod("ss-inflight", 1)
+			ss.Status.UpdatedReplicas = 0
+			ExpectApplied(ctx, env.Client, ss, p, node)
+			queue.Add(p)
+			ExpectObjectReconciled(ctx, env.Client, queue, p)
+
+			Expect(recorder.Calls(events.RolloutRestarted)).To(Equal(0))
+			Expect(recorder.Calls(events.RolloutRestartInProgress)).To(Equal(1))
+			Expect(env.Client.Get(ctx, types.NamespacedName{Name: ss.Name, Namespace: ss.Namespace}, ss)).To(Succeed())
+			Expect(ss.Spec.Template.Annotations[restartAnnotation]).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/events/reason.go
+++ b/pkg/events/reason.go
@@ -40,6 +40,8 @@ const (
 	Disrupted                      = "Disrupted"
 	Evicted                        = "Evicted"
 	FailedDraining                 = "FailedDraining"
+	RolloutRestarted               = "RolloutRestarted"
+	RolloutRestartInProgress       = "RolloutRestartInProgress"
 	TerminationGracePeriodExpiring = "TerminationGracePeriodExpiring"
 	TerminationFailed              = "FailedTermination"
 

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -56,12 +56,13 @@ type optionsKey struct{}
 type FeatureGates struct {
 	inputStr string
 
-	NodeRepair              bool
-	ReservedCapacity        bool
-	SpotToSpotConsolidation bool
-	NodeOverlay             bool
-	StaticCapacity          bool
-	CapacityBuffer          bool
+	NodeRepair                  bool
+	ReservedCapacity            bool
+	SpotToSpotConsolidation     bool
+	NodeOverlay                 bool
+	StaticCapacity              bool
+	CapacityBuffer              bool
+	RolloutRestartDrainStrategy bool
 }
 
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
@@ -131,7 +132,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")
-	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false,CapacityBuffer=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, StaticCapacity, and CapacityBuffer.")
+	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false,CapacityBuffer=false,RolloutRestartDrainStrategy=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, StaticCapacity, and CapacityBuffer.")
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {
@@ -169,12 +170,13 @@ func (o *Options) ToContext(ctx context.Context) context.Context {
 
 func DefaultFeatureGates() FeatureGates {
 	return FeatureGates{
-		NodeRepair:              false,
-		ReservedCapacity:        true,
-		SpotToSpotConsolidation: false,
-		NodeOverlay:             false,
-		StaticCapacity:          false,
-		CapacityBuffer:          false,
+		NodeRepair:                  false,
+		ReservedCapacity:            true,
+		SpotToSpotConsolidation:     false,
+		NodeOverlay:                 false,
+		StaticCapacity:              false,
+		CapacityBuffer:              false,
+		RolloutRestartDrainStrategy: false,
 	}
 }
 
@@ -204,6 +206,9 @@ func ParseFeatureGates(gateStr string) (FeatureGates, error) {
 	}
 	if val, ok := gateMap["CapacityBuffer"]; ok {
 		gates.CapacityBuffer = val
+	}
+	if val, ok := gateMap["RolloutRestartDrainStrategy"]; ok {
+		gates.RolloutRestartDrainStrategy = val
 	}
 
 	return gates, nil

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -53,12 +53,13 @@ type OptionsFields struct {
 }
 
 type FeatureGates struct {
-	NodeRepair              *bool
-	ReservedCapacity        *bool
-	SpotToSpotConsolidation *bool
-	NodeOverlay             *bool
-	StaticCapacity          *bool
-	CapacityBuffer          *bool
+	NodeRepair                  *bool
+	ReservedCapacity            *bool
+	SpotToSpotConsolidation     *bool
+	NodeOverlay                 *bool
+	StaticCapacity              *bool
+	CapacityBuffer              *bool
+	RolloutRestartDrainStrategy *bool
 }
 
 func Options(overrides ...OptionsFields) *options.Options {
@@ -90,12 +91,13 @@ func Options(overrides ...OptionsFields) *options.Options {
 		MinValuesPolicy:                  lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
 		IgnoreDRARequests:                lo.FromPtrOr(opts.IgnoreDRARequests, true),
 		FeatureGates: options.FeatureGates{
-			NodeRepair:              lo.FromPtrOr(opts.FeatureGates.NodeRepair, false),
-			ReservedCapacity:        lo.FromPtrOr(opts.FeatureGates.ReservedCapacity, true),
-			SpotToSpotConsolidation: lo.FromPtrOr(opts.FeatureGates.SpotToSpotConsolidation, false),
-			NodeOverlay:             lo.FromPtrOr(opts.FeatureGates.NodeOverlay, false),
-			StaticCapacity:          lo.FromPtrOr(opts.FeatureGates.StaticCapacity, false),
-			CapacityBuffer:          lo.FromPtrOr(opts.FeatureGates.CapacityBuffer, false),
+			NodeRepair:                  lo.FromPtrOr(opts.FeatureGates.NodeRepair, false),
+			ReservedCapacity:            lo.FromPtrOr(opts.FeatureGates.ReservedCapacity, true),
+			SpotToSpotConsolidation:     lo.FromPtrOr(opts.FeatureGates.SpotToSpotConsolidation, false),
+			NodeOverlay:                 lo.FromPtrOr(opts.FeatureGates.NodeOverlay, false),
+			StaticCapacity:              lo.FromPtrOr(opts.FeatureGates.StaticCapacity, false),
+			CapacityBuffer:              lo.FromPtrOr(opts.FeatureGates.CapacityBuffer, false),
+			RolloutRestartDrainStrategy: lo.FromPtrOr(opts.FeatureGates.RolloutRestartDrainStrategy, false),
 		},
 	}
 }

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -17,12 +17,18 @@ limitations under the License.
 package pod
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/events"
@@ -187,6 +193,126 @@ func IsOwnedBy(pod *corev1.Pod, gvks []schema.GroupVersionKind) bool {
 		}
 	}
 	return false
+}
+
+// SingletonRolloutTarget identifies a workload owner with spec.replicas == 1 that can be drained by
+// triggering a rollout restart (writing `kubectl.kubernetes.io/restartedAt` into its pod template).
+// Callers must skip patching when RolloutInProgress is true — otherwise a second patch creates a
+// third revision that kills the in-flight replacement before it becomes Ready.
+type SingletonRolloutTarget struct {
+	Object            client.Object
+	Kind              string
+	RolloutInProgress bool
+}
+
+// SingletonRolloutTargetForPod returns the workload owner of the pod iff it's an apps/v1
+// StatefulSet with spec.replicas == 1 (direct owner) or an apps/v1 Deployment with spec.replicas
+// == 1 (transitive owner via the pod's ReplicaSet). Returns (nil, nil) when no qualifying owner
+// exists or the owner chain points at missing objects; transient API errors are surfaced so the
+// caller can retry. The replicas==1 gate keeps blast radius small — multi-replica workloads drain
+// fine through eviction + PDB, and bumping their template would roll every pod across the fleet.
+//
+// StatefulSets are included even though they don't surge: a singleton SS behind a PDB that forbids
+// disruption (e.g. minAvailable=1) can't be drained via eviction at all (429 forever). Rollout
+// restart deletes the pod through the pods API, bypassing PDB, at the cost of one pod-lifetime of
+// downtime — the same downtime a successful eviction would have caused. Zero-downtime is only
+// achievable for Deployments, where maxSurge brings up the replacement before deleting the old pod.
+func SingletonRolloutTargetForPod(ctx context.Context, c client.Client, pod *corev1.Pod) (*SingletonRolloutTarget, error) {
+	if target, err := singletonStatefulSetOwner(ctx, c, pod); target != nil || err != nil {
+		return target, err
+	}
+	return singletonDeploymentOwner(ctx, c, pod)
+}
+
+// appsOwnerName returns the name of the first owner with the given Kind and apps/v1
+// APIVersion, or "" if none is present.
+func appsOwnerName(owners []metav1.OwnerReference, kind string) string {
+	for _, o := range owners {
+		if o.Kind == kind && o.APIVersion == "apps/v1" {
+			return o.Name
+		}
+	}
+	return ""
+}
+
+func singletonStatefulSetOwner(ctx context.Context, c client.Client, pod *corev1.Pod) (*SingletonRolloutTarget, error) {
+	name := appsOwnerName(pod.OwnerReferences, "StatefulSet")
+	if name == "" {
+		return nil, nil
+	}
+	ss := &appsv1.StatefulSet{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: name}, ss); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if ss.Spec.Replicas == nil || *ss.Spec.Replicas != 1 {
+		return nil, nil
+	}
+	return &SingletonRolloutTarget{
+		Object:            ss,
+		Kind:              "StatefulSet",
+		RolloutInProgress: statefulSetRolloutInProgress(ss),
+	}, nil
+}
+
+func singletonDeploymentOwner(ctx context.Context, c client.Client, pod *corev1.Pod) (*SingletonRolloutTarget, error) {
+	rsName := appsOwnerName(pod.OwnerReferences, "ReplicaSet")
+	if rsName == "" {
+		return nil, nil
+	}
+	rs := &appsv1.ReplicaSet{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: rsName}, rs); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	depName := appsOwnerName(rs.OwnerReferences, "Deployment")
+	if depName == "" {
+		return nil, nil
+	}
+	dep := &appsv1.Deployment{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: depName}, dep); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 1 {
+		return nil, nil
+	}
+	return &SingletonRolloutTarget{
+		Object:            dep,
+		Kind:              "Deployment",
+		RolloutInProgress: deploymentRolloutInProgress(dep),
+	}, nil
+}
+
+// deploymentRolloutInProgress / statefulSetRolloutInProgress mirror `kubectl rollout status`. Both
+// flag latest-spec-not-observed, updated-pods-not-yet-created, and new-pods-not-yet-ready; they
+// diverge on the surge phase. Deployments surge by default — after the new pod is Ready the old
+// one lingers while the controller tears it down, and UpdatedReplicas already equals Spec.Replicas
+// in that window. Status.Replicas > Status.UpdatedReplicas covers it; missing this check is what
+// caused the deploy-loop on slow-booting Spring Boot workloads. StatefulSets replace in place, so
+// we just need ReadyReplicas to catch up and the revision pair to converge. We don't special-case
+// rollingUpdate.partition (would make a partial rollout look in-progress forever) — partition use
+// on a singleton is vanishingly rare.
+func deploymentRolloutInProgress(dep *appsv1.Deployment) bool {
+	desired := *dep.Spec.Replicas
+	return dep.Generation > dep.Status.ObservedGeneration ||
+		dep.Status.UpdatedReplicas < desired ||
+		dep.Status.Replicas > dep.Status.UpdatedReplicas ||
+		dep.Status.AvailableReplicas < dep.Status.UpdatedReplicas
+}
+
+func statefulSetRolloutInProgress(ss *appsv1.StatefulSet) bool {
+	desired := *ss.Spec.Replicas
+	return ss.Generation > ss.Status.ObservedGeneration ||
+		ss.Status.UpdatedReplicas < desired ||
+		ss.Status.ReadyReplicas < desired ||
+		ss.Status.CurrentRevision != ss.Status.UpdateRevision
 }
 
 // parseDoNotDisrupt parses the do-not-disrupt annotation value as a duration.


### PR DESCRIPTION
Fixes #740. Codependent with https://github.com/aws/karpenter-provider-aws/pull/9158

## Rollout Restart Drain Strategy

An opt-in drain mode for single-replica workloads (deploys and statefulsets). Instead of evicting the only pod and taking downtime, Karpenter asks the owner to roll itself - a fresh pod comes up first, then the old one goes away.

- **Singleton deploys**: zero downtime - maxSurge brings the new pod up before the old one is deleted.
- **Singleton statefulsets**: brief downtime (no surge), but the drain bypasses blocking PDBs that would otherwise stall it.
- **Multi-replica workloads**: unchanged - still drain via eviction.

Turn it on with the `RolloutRestartDrainStrategy` feature gate (off by default).

### How it decides when to patch

We only trigger a rollout when the owner's `Status` says the previous one is done - same predicate `kubectl rollout status` uses. If a rollout is still in flight, we skip and emit a `RolloutRestartInProgress` event so you can see why the drain is waiting.

For deploys the predicate is:

```go
dep.Generation > dep.Status.ObservedGeneration ||
    dep.Status.UpdatedReplicas < *dep.Spec.Replicas ||
    dep.Status.Replicas > dep.Status.UpdatedReplicas ||       // surge cleanup still in flight
    dep.Status.AvailableReplicas < dep.Status.UpdatedReplicas
```

The `Replicas > UpdatedReplicas` term is the load-bearing one for singletons: once the new surge pod becomes Ready, `UpdatedReplicas == Spec.Replicas == 1` already, but the old pod hasn't been deleted yet - without this term we'd re-patch and clobber the rollout.

The first cut used a 2-minute timestamp dedup, which matched Karpenter's consolidation cadence and basically never fired. Slow-booting pods (~2+ min) got killed every cycle and never reached Ready. The status-based gate fixes that loop.

### Testing

- 8 unit tests in `pkg/controllers/node/termination/terminator/suite_test.go` - feature gate off/on, singleton vs multi-replica, deploys and statefulsets, plus three in-flight-rollout regression cases. `make presubmit` passes.
- Live cluster test with `egordeev/karpenter-controller-aws:1.12.1-rollout-restart2`:
  - Singleton deploy with blocking PDB (`minAvailable: 1`) → drained with zero downtime, PDB bypassed.
  - Singleton statefulset → drained with brief downtime, as expected.
  - Multi-replica deploy and statefulset → still evicted, unchanged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.