### PR TITLE
feat: dra device allocation tracking

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"unique"
 	"sort"
 	"strconv"
 	"strings"
@@ -622,4 +623,16 @@ func IsUnevaluatedNodePoolError(err error) bool {
 	}
 	var onatnpErr *UnevaluatedNodePoolError
 	return errors.As(err, &onatnpErr)
+}
+
+// DeviceID is a hashable, unique ID for a device. This ID is absolute - depending on the driver, pool, and device
+// names - as opposed to relative - depending on in-memory indexes.
+type DeviceID struct {
+	Driver unique.Handle[string]
+	Pool   unique.Handle[string]
+	Device unique.Handle[string]
+}
+
+func (id DeviceID) String() string {
+	return fmt.Sprintf("%s/%s/%s", id.Driver.Value(), id.Pool.Value(), id.Device.Value())
 }

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -21,12 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"unique"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unique"
 
 	"github.com/awslabs/operatorpkg/serrors"
 	"github.com/awslabs/operatorpkg/status"

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -98,8 +98,6 @@ func NewControllers(
 	disruptionQueue := disruption.NewQueue(kubeClient, recorder, cluster, clock, p)
 	npState := nodepoolhealth.NewState()
 	clusterCost := cost.NewClusterCost(ctx, cloudProvider, kubeClient)
-	deviceAllocationController := deviceallocation.NewController(kubeClient)
-
 	controllers := []controller.Controller{
 		p, evictionQueue, disruptionQueue,
 		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue),
@@ -125,7 +123,10 @@ func NewControllers(
 		nodeclaimdisruption.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimhydration.NewController(kubeClient, cloudProvider),
 		nodehydration.NewController(kubeClient, cloudProvider),
-		deviceAllocationController,
+	}
+
+	if !options.FromContext(ctx).IgnoreDRARequests {
+		controllers = append(controllers, deviceallocation.NewController(kubeClient))
 	}
 
 	if !options.FromContext(ctx).DisableClusterStateObservability {

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -34,6 +34,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	metricsnode "sigs.k8s.io/karpenter/pkg/controllers/metrics/node"
 	metricsnodepool "sigs.k8s.io/karpenter/pkg/controllers/metrics/nodepool"
 	metricspod "sigs.k8s.io/karpenter/pkg/controllers/metrics/pod"
@@ -97,6 +98,7 @@ func NewControllers(
 	disruptionQueue := disruption.NewQueue(kubeClient, recorder, cluster, clock, p)
 	npState := nodepoolhealth.NewState()
 	clusterCost := cost.NewClusterCost(ctx, cloudProvider, kubeClient)
+	deviceAllocationController := deviceallocation.NewController(kubeClient)
 
 	controllers := []controller.Controller{
 		p, evictionQueue, disruptionQueue,
@@ -123,6 +125,7 @@ func NewControllers(
 		nodeclaimdisruption.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimhydration.NewController(kubeClient, cloudProvider),
 		nodehydration.NewController(kubeClient, cloudProvider),
+		deviceAllocationController,
 	}
 
 	if !options.FromContext(ctx).DisableClusterStateObservability {

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -1,0 +1,240 @@
+package deviceallocation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"sync"
+	"time"
+	"unique"
+
+	"github.com/awslabs/operatorpkg/serrors"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
+)
+
+const (
+	minReconciles = 10
+	maxReconciles = 3000
+)
+
+type Controller struct {
+	kubeClient client.Client
+
+	mu               sync.RWMutex
+	allocatedDevices map[cloudprovider.DeviceID]Metadata
+	claimsPerDevice  map[cloudprovider.DeviceID]sets.Set[types.NamespacedName]
+	devicesPerClaim  map[types.NamespacedName]sets.Set[cloudprovider.DeviceID]
+	metadataPerClaim map[types.NamespacedName]Metadata
+
+	hydrationCh   chan struct{}
+	hydrationOnce sync.Once
+}
+
+// Metadata contains supplementary information about an allocated device, derived from the ReservedFor status of all
+// ResourceClaims that reference it.
+type Metadata struct {
+	// Releasable is true when every ResourceClaim referencing the device has a non-empty ReservedFor list composed
+	// entirely of pod consumers. A device that is not reserved, or that is reserved by any non-pod consumer, is not
+	// releasable.
+	Releasable bool
+	// PodUIDs is the aggregate set of pod UIDs from the ReservedFor entries of all ResourceClaims that reference the
+	// device. Non-pod consumer UIDs are excluded.
+	PodUIDs []types.UID
+}
+
+func NewController(kubeClient client.Client) *Controller {
+	return &Controller{
+		kubeClient:       kubeClient,
+		allocatedDevices: make(map[cloudprovider.DeviceID]Metadata),
+		claimsPerDevice:  make(map[cloudprovider.DeviceID]sets.Set[types.NamespacedName]),
+		devicesPerClaim:  make(map[types.NamespacedName]sets.Set[cloudprovider.DeviceID]),
+		metadataPerClaim: make(map[types.NamespacedName]Metadata),
+		hydrationCh:      make(chan struct{}),
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	c.hydrationOnce.Do(func() {
+		c.Hydrate(ctx)
+	})
+
+	claim := &resourcev1.ResourceClaim{}
+	if err := c.kubeClient.Get(ctx, req.NamespacedName, claim, client.UnsafeDisableDeepCopy); err != nil {
+		if apierrors.IsNotFound(err) {
+			c.finalizeClaim(ctx, req.NamespacedName)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, serrors.Wrap(fmt.Errorf("getting resourceclaim, %w", err), "resourceclaim", klog.KRef(req.Namespace, req.Name))
+	}
+	c.reconcileClaim(ctx, req.NamespacedName, claim)
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) Hydrate(ctx context.Context) {
+	// SAFETY: This list hits the informer cache, and should not error since it's already guaranteed to be synced.
+	claimList := &resourcev1.ResourceClaimList{}
+	lo.Must0(c.kubeClient.List(ctx, claimList, client.UnsafeDisableDeepCopy))
+	for i := range claimList.Items {
+		claim := &claimList.Items[i]
+		c.reconcileClaim(ctx, client.ObjectKeyFromObject(claim), claim)
+	}
+	close(c.hydrationCh)
+}
+
+func (c *Controller) reconcileClaim(ctx context.Context, nn types.NamespacedName, claim *resourcev1.ResourceClaim) {
+	if claim.Status.Allocation == nil || len(claim.Status.Allocation.Devices.Results) == 0 {
+		c.finalizeClaim(ctx, nn)
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	allocatedDevices := make(sets.Set[cloudprovider.DeviceID], len(claim.Status.Allocation.Devices.Results))
+	for i := range claim.Status.Allocation.Devices.Results {
+		result := &claim.Status.Allocation.Devices.Results[i]
+		allocatedDevices.Insert(cloudprovider.DeviceID{
+			Driver: unique.Make(result.Driver),
+			Pool:   unique.Make(result.Pool),
+			Device: unique.Make(result.Device),
+		})
+	}
+
+	devicesToRemove := c.devicesPerClaim[nn].Difference(allocatedDevices)
+	var devicesToAdd sets.Set[cloudprovider.DeviceID]
+	if log.FromContext(ctx).V(1).Enabled() {
+		devicesToAdd = allocatedDevices.Difference(c.devicesPerClaim[nn])
+	}
+
+	c.devicesPerClaim[nn] = allocatedDevices
+	c.metadataPerClaim[nn] = claimMetadata(claim)
+	for device := range devicesToRemove {
+		c.claimsPerDevice[device].Delete(nn)
+		if len(c.claimsPerDevice[device]) == 0 {
+			delete(c.claimsPerDevice, device)
+			delete(c.allocatedDevices, device)
+		} else {
+			c.allocatedDevices[device] = c.computeDeviceMetadata(device)
+		}
+	}
+	for device := range allocatedDevices {
+		claims, ok := c.claimsPerDevice[device]
+		if !ok {
+			claims = sets.New[types.NamespacedName]()
+			c.claimsPerDevice[device] = claims
+		}
+		claims.Insert(nn)
+		c.allocatedDevices[device] = c.computeDeviceMetadata(device)
+	}
+
+	if log.FromContext(ctx).V(1).Enabled() {
+		log.FromContext(ctx).V(1).Info(
+			"updated tracked devices for claim",
+			"ResourceClaim", klog.KRef(nn.Namespace, nn.Name),
+			"added", lo.Map(lo.Keys(devicesToAdd), deviceIDToString),
+			"removed", lo.Map(lo.Keys(devicesToRemove), deviceIDToString),
+			"tracked", lo.Map(lo.Keys(allocatedDevices), deviceIDToString),
+		)
+	}
+}
+
+func (c *Controller) finalizeClaim(ctx context.Context, nn types.NamespacedName) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	devices := c.devicesPerClaim[nn]
+	delete(c.metadataPerClaim, nn)
+	for device := range devices {
+		claims := c.claimsPerDevice[device]
+		claims.Delete(nn)
+		if len(claims) == 0 {
+			delete(c.allocatedDevices, device)
+			delete(c.claimsPerDevice, device)
+		} else {
+			c.allocatedDevices[device] = c.computeDeviceMetadata(device)
+		}
+	}
+	delete(c.devicesPerClaim, nn)
+	log.FromContext(ctx).V(1).Info(
+		"updated tracked devices for claim",
+		"ResourceClaim", klog.KRef(nn.Namespace, nn.Name),
+		"added", []string{},
+		"removed", lo.Map(lo.Keys(devices), deviceIDToString),
+		"tracked", []string{},
+	)
+}
+
+// AllocatedDevices returns an iterator over all allocated devices and their metadata. The read lock is held for the
+// duration of iteration and released when the iterator completes or the caller breaks out of the loop.
+func (c *Controller) AllocatedDevices(ctx context.Context) (iter.Seq2[cloudprovider.DeviceID, Metadata], error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, 10*time.Second, errors.New("timed out awaiting allocated device hydration"))
+	defer cancel()
+	select {
+	case <-c.hydrationCh:
+		return func(yield func(cloudprovider.DeviceID, Metadata) bool) {
+			c.mu.RLock()
+			defer c.mu.RUnlock()
+			for id, meta := range c.allocatedDevices {
+				if !yield(id, meta) {
+					return
+				}
+			}
+		}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// claimMetadata computes Metadata for a single claim from its ReservedFor entries.
+func claimMetadata(claim *resourcev1.ResourceClaim) Metadata {
+	meta := Metadata{Releasable: len(claim.Status.ReservedFor) > 0}
+	for i := range claim.Status.ReservedFor {
+		ref := &claim.Status.ReservedFor[i]
+		if ref.Resource == string(corev1.ResourcePods) && ref.APIGroup == "" {
+			meta.PodUIDs = append(meta.PodUIDs, ref.UID)
+		} else {
+			meta.Releasable = false
+		}
+	}
+	return meta
+}
+
+// computeDeviceMetadata aggregates metadata across all claims that reference a device.
+// Must be called while holding c.mu.
+func (c *Controller) computeDeviceMetadata(device cloudprovider.DeviceID) Metadata {
+	meta := Metadata{Releasable: true}
+	for nn := range c.claimsPerDevice[device] {
+		claimMeta := c.metadataPerClaim[nn]
+		if !claimMeta.Releasable {
+			meta.Releasable = false
+		}
+		meta.PodUIDs = append(meta.PodUIDs, claimMeta.PodUIDs...)
+	}
+	return meta
+}
+
+func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("dynamicresources.deviceallocation").
+		For(&resourcev1.ResourceClaim{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: utilscontroller.LinearScaleReconciles(utilscontroller.CPUCount(ctx), minReconciles, maxReconciles)}).
+		Complete(c)
+}
+
+func deviceIDToString(d cloudprovider.DeviceID, _ int) string {
+	return d.String()
+}

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -1,12 +1,26 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deviceallocation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"iter"
 	"sync"
-	"time"
 	"unique"
 
 	"github.com/awslabs/operatorpkg/serrors"
@@ -23,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
 )
@@ -90,8 +105,7 @@ func (c *Controller) Hydrate(ctx context.Context) {
 	claimList := &resourcev1.ResourceClaimList{}
 	lo.Must0(c.kubeClient.List(ctx, claimList, client.UnsafeDisableDeepCopy))
 	for i := range claimList.Items {
-		claim := &claimList.Items[i]
-		c.reconcileClaim(ctx, client.ObjectKeyFromObject(claim), claim)
+		c.reconcileClaim(ctx, client.ObjectKeyFromObject(&claimList.Items[i]), &claimList.Items[i])
 	}
 	close(c.hydrationCh)
 }
@@ -169,20 +183,20 @@ func (c *Controller) finalizeClaim(ctx context.Context, nn types.NamespacedName)
 		}
 	}
 	delete(c.devicesPerClaim, nn)
-	log.FromContext(ctx).V(1).Info(
-		"updated tracked devices for claim",
-		"ResourceClaim", klog.KRef(nn.Namespace, nn.Name),
-		"added", []string{},
-		"removed", lo.Map(lo.Keys(devices), deviceIDToString),
-		"tracked", []string{},
-	)
+	if log.FromContext(ctx).V(1).Enabled() {
+		log.FromContext(ctx).V(1).Info(
+			"updated tracked devices for claim",
+			"ResourceClaim", klog.KRef(nn.Namespace, nn.Name),
+			"added", []string{},
+			"removed", lo.Map(lo.Keys(devices), deviceIDToString),
+			"tracked", []string{},
+		)
+	}
 }
 
 // AllocatedDevices returns an iterator over all allocated devices and their metadata. The read lock is held for the
 // duration of iteration and released when the iterator completes or the caller breaks out of the loop.
 func (c *Controller) AllocatedDevices(ctx context.Context) (iter.Seq2[cloudprovider.DeviceID, Metadata], error) {
-	ctx, cancel := context.WithTimeoutCause(ctx, 10*time.Second, errors.New("timed out awaiting allocated device hydration"))
-	defer cancel()
 	select {
 	case <-c.hydrationCh:
 		return func(yield func(cloudprovider.DeviceID, Metadata) bool) {

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -68,7 +68,8 @@ type Metadata struct {
 	// releasable.
 	Releasable bool
 	// PodUIDs is the aggregate set of pod UIDs from the ReservedFor entries of all ResourceClaims that reference the
-	// device. Non-pod consumer UIDs are excluded.
+	// device. Non-pod consumer UIDs are excluded. Duplicates are possible and consumers should not assume uniqueness.
+	// This is intentionally a slice rather than a set for performance reasons, as membership is expected to be small.
 	PodUIDs []types.UID
 }
 

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -1,0 +1,596 @@
+package deviceallocation_test
+
+import (
+	"context"
+	"iter"
+	"testing"
+	"time"
+	"unique"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	deviceallocation "sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var (
+	ctx        context.Context
+	env        *test.Environment
+	controller *deviceallocation.Controller
+)
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DeviceAllocation")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
+	ctx = options.ToContext(ctx, test.Options())
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed())
+})
+
+var _ = BeforeEach(func() {
+	controller = deviceallocation.NewController(env.Client)
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+// resourceClaim constructs a ResourceClaim in the default namespace. If any results are provided
+// they are set as the claim's allocation status. A matching spec request named "request" is
+// included so that the allocation result passes API server validation.
+func resourceClaim(name string, results ...resourcev1.DeviceRequestAllocationResult) *resourcev1.ResourceClaim {
+	claim := &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{
+				Requests: []resourcev1.DeviceRequest{
+					{
+						Name:    "request",
+						Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: "test-class"},
+					},
+				},
+			},
+		},
+	}
+	if len(results) > 0 {
+		claim.Status.Allocation = &resourcev1.AllocationResult{
+			Devices: resourcev1.DeviceAllocationResult{
+				Results: results,
+			},
+		}
+	}
+	return claim
+}
+
+// withReservedFor sets the ReservedFor status on a ResourceClaim and returns it for chaining.
+func withReservedFor(claim *resourcev1.ResourceClaim, refs ...resourcev1.ResourceClaimConsumerReference) *resourcev1.ResourceClaim {
+	claim.Status.ReservedFor = refs
+	return claim
+}
+
+// podRef creates a ResourceClaimConsumerReference for a pod.
+func podRef(name string, uid types.UID) resourcev1.ResourceClaimConsumerReference {
+	return resourcev1.ResourceClaimConsumerReference{
+		Resource: "pods",
+		Name:     name,
+		UID:      uid,
+	}
+}
+
+// nonPodRef creates a ResourceClaimConsumerReference for a non-pod consumer.
+func nonPodRef(resource, name string, uid types.UID) resourcev1.ResourceClaimConsumerReference {
+	return resourcev1.ResourceClaimConsumerReference{
+		APIGroup: "example.com",
+		Resource: resource,
+		Name:     name,
+		UID:      uid,
+	}
+}
+
+// deviceResult constructs a DeviceRequestAllocationResult for use in ResourceClaim status.
+func deviceResult(driver, pool, device string) resourcev1.DeviceRequestAllocationResult {
+	return resourcev1.DeviceRequestAllocationResult{
+		Request: "request",
+		Driver:  driver,
+		Pool:    pool,
+		Device:  device,
+	}
+}
+
+// deviceID constructs a cloudprovider.DeviceID using interned handles, matching the controller's representation.
+func deviceID(driver, pool, device string) cloudprovider.DeviceID {
+	return cloudprovider.DeviceID{
+		Driver: unique.Make(driver),
+		Pool:   unique.Make(pool),
+		Device: unique.Make(device),
+	}
+}
+
+// collectDevices drains an iterator into a map for test assertions.
+func collectDevices(seq iter.Seq2[cloudprovider.DeviceID, deviceallocation.Metadata]) map[cloudprovider.DeviceID]deviceallocation.Metadata {
+	m := make(map[cloudprovider.DeviceID]deviceallocation.Metadata)
+	for id, meta := range seq {
+		m[id] = meta
+	}
+	return m
+}
+
+// expectedDevices builds the expected map with zero-value metadata for each device.
+func expectedDevices(ids ...cloudprovider.DeviceID) map[cloudprovider.DeviceID]deviceallocation.Metadata {
+	m := make(map[cloudprovider.DeviceID]deviceallocation.Metadata, len(ids))
+	for _, id := range ids {
+		m[id] = deviceallocation.Metadata{}
+	}
+	return m
+}
+
+// triggerHydration reconciles a no-allocation claim to fire the controller's hydrationOnce, making
+// subsequent AllocatedDevices calls non-blocking. Call this at the start of any test that is not
+// explicitly testing the hydration blocking behavior.
+func triggerHydration() {
+	dummy := resourceClaim("hydration-trigger")
+	ExpectApplied(ctx, env.Client, dummy)
+	ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(dummy))
+}
+
+var _ = Describe("DeviceAllocation Controller", func() {
+	Describe("Hydration", func() {
+		It("blocks until the first reconcile completes", func() {
+			results := make(chan map[cloudprovider.DeviceID]deviceallocation.Metadata, 1)
+			go func() {
+				defer GinkgoRecover()
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				results <- collectDevices(seq)
+			}()
+
+			Consistently(results).WithTimeout(100 * time.Millisecond).WithPolling(10 * time.Millisecond).ShouldNot(Receive())
+
+			triggerHydration()
+
+			Eventually(results).Should(Receive(BeEmpty()))
+		})
+		It("hydration includes devices from ResourceClaims that existed before the first reconcile", func() {
+			// Apply claims before any reconcile has run — these must be picked up by Hydrate()
+			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			ExpectApplied(ctx, env.Client, claimA, claimB)
+
+			triggerHydration()
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(Equal(expectedDevices(
+				deviceID("driver.example.com", "pool-a", "device-0"),
+				deviceID("driver.example.com", "pool-a", "device-1"),
+			)))
+		})
+		It("returns a copy that is not affected by subsequent reconciliations", func() {
+			triggerHydration()
+
+			claim := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			snapshot := collectDevices(seq)
+
+			// Reconcile a new claim to mutate the controller's internal state after the snapshot was taken
+			claim = resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			Expect(snapshot).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-0"))))
+		})
+		It("does not block on subsequent calls after hydration", func() {
+			triggerHydration()
+
+			// Calling AllocatedDevices synchronously would deadlock if it still blocked.
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(BeEmpty())
+		})
+		It("returns a context error when the context is canceled before hydration completes", func() {
+			cancelCtx, cancel := context.WithCancel(ctx)
+			cancel()
+
+			_, err := controller.AllocatedDevices(cancelCtx)
+			Expect(err).To(Equal(context.Canceled))
+		})
+	})
+
+	Describe("Basic allocation", func() {
+		BeforeEach(func() {
+			triggerHydration()
+		})
+		It("returns an empty set when a claim has no allocation", func() {
+			claim := resourceClaim("no-alloc-claim")
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(BeEmpty())
+		})
+		It("returns a single device from a ResourceClaim with one allocation", func() {
+			claim := resourceClaim("single-claim", deviceResult("driver.example.com", "pool-a", "device-0"))
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-0"))))
+		})
+		It("returns all devices from a ResourceClaim with multiple allocations", func() {
+			claim := resourceClaim("multi-device-claim",
+				deviceResult("driver.example.com", "pool-a", "device-0"),
+				deviceResult("driver.example.com", "pool-a", "device-1"),
+			)
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(Equal(expectedDevices(
+				deviceID("driver.example.com", "pool-a", "device-0"),
+				deviceID("driver.example.com", "pool-a", "device-1"),
+			)))
+		})
+		It("returns the union of distinct devices across multiple ResourceClaims", func() {
+			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			ExpectApplied(ctx, env.Client, claimA, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(Equal(expectedDevices(
+				deviceID("driver.example.com", "pool-a", "device-0"),
+				deviceID("driver.example.com", "pool-a", "device-1"),
+			)))
+		})
+		It("returns a shared device only once when multiple ResourceClaims allocate it", func() {
+			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0"))
+			ExpectApplied(ctx, env.Client, claimA, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-0"))))
+		})
+	})
+
+	Describe("Mutation", func() {
+		BeforeEach(func() {
+			triggerHydration()
+		})
+		It("removes a device when its only ResourceClaim is deleted", func() {
+			claim := resourceClaim("single-claim", deviceResult("driver.example.com", "pool-a", "device-0"))
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			ExpectDeleted(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(BeEmpty())
+		})
+		It("removes only the deleted claim's devices when a subset of claims is deleted", func() {
+			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			ExpectApplied(ctx, env.Client, claimA, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			ExpectDeleted(ctx, env.Client, claimA)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-1"))))
+		})
+		It("does not remove a shared device when one of multiple claims that allocate it is deleted", func() {
+			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0"))
+			ExpectApplied(ctx, env.Client, claimA, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			ExpectDeleted(ctx, env.Client, claimA)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-0"))))
+		})
+		It("removes devices when a claim is deleted and recreated without an allocation", func() {
+			// claim-b holds device-1 throughout the test; it is the shared device
+			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			ExpectApplied(ctx, env.Client, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			// my-claim initially allocates device-0 (distinct) and device-1 (shared with claim-b)
+			claim := resourceClaim("my-claim",
+				deviceResult("driver.example.com", "pool-a", "device-0"),
+				deviceResult("driver.example.com", "pool-a", "device-1"),
+			)
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			// Don't re-reconcile after deleting. devicesPerClaim["my-claim"] still holds device-0
+			// and device-1 when the recreated claim is reconciled.
+			ExpectDeleted(ctx, env.Client, claim)
+
+			// Recreate with no allocation — reconcile hits the nil allocation path (controller.go:86)
+			// and calls finalizeClaim, which drains devicesPerClaim["my-claim"]
+			claim = resourceClaim("my-claim")
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			// device-0 removed (was distinct to my-claim, last reference gone)
+			// device-1 persists (still held by claim-b)
+			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-1"))))
+		})
+		It("replaces devices when a claim is deleted and recreated with a different allocation", func() {
+			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			ExpectApplied(ctx, env.Client, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			// my-claim initially allocates device-0 (distinct to my-claim) and device-1 (shared with claim-b)
+			claim := resourceClaim("my-claim",
+				deviceResult("driver.example.com", "pool-a", "device-0"),
+				deviceResult("driver.example.com", "pool-a", "device-1"),
+			)
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			// Don't re-reconcile after deleting. This exercises the mutation path where
+			// devicesPerClaim["my-claim"] still holds device-0 and device-1 when the
+			// recreated claim is reconciled.
+			ExpectDeleted(ctx, env.Client, claim)
+
+			// Recreate with the same name: drops device-0 (distinct, should be removed),
+			// keeps device-1 (shared with claim-b, must persist), adds device-2 (new distinct)
+			claim = resourceClaim("my-claim",
+				deviceResult("driver.example.com", "pool-a", "device-1"),
+				deviceResult("driver.example.com", "pool-a", "device-2"),
+			)
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			Expect(devices).To(Equal(expectedDevices(
+				deviceID("driver.example.com", "pool-a", "device-1"),
+				deviceID("driver.example.com", "pool-a", "device-2"),
+			)))
+		})
+	})
+
+	Describe("Metadata", func() {
+		BeforeEach(func() {
+			triggerHydration()
+		})
+
+		Describe("Releasable", func() {
+			It("is true when a claim is reserved for a single pod", func() {
+				claim := withReservedFor(
+					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					podRef("pod-a", "uid-a"),
+				)
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				Expect(devices).To(HaveKeyWithValue(
+					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
+				))
+			})
+			It("is true when a claim is reserved for multiple pods", func() {
+				claim := withReservedFor(
+					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					podRef("pod-a", "uid-a"),
+					podRef("pod-b", "uid-b"),
+				)
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				Expect(devices).To(HaveKeyWithValue(
+					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a", "uid-b"}},
+				))
+			})
+			It("is true when two claims sharing a device are both reserved only for pods", func() {
+				claimA := withReservedFor(
+					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					podRef("pod-a", "uid-a"),
+				)
+				claimB := withReservedFor(
+					resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0")),
+					podRef("pod-b", "uid-b"),
+				)
+				ExpectApplied(ctx, env.Client, claimA, claimB)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				meta := devices[deviceID("driver.example.com", "pool-a", "device-0")]
+				Expect(meta.Releasable).To(BeTrue())
+				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a"), types.UID("uid-b")))
+			})
+			It("is false when a claim has an empty ReservedFor", func() {
+				claim := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				Expect(devices).To(HaveKeyWithValue(
+					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceallocation.Metadata{Releasable: false},
+				))
+			})
+			It("is false when a claim is reserved for a non-pod consumer", func() {
+				claim := withReservedFor(
+					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					nonPodRef("services", "svc-a", "uid-svc"),
+				)
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				meta := devices[deviceID("driver.example.com", "pool-a", "device-0")]
+				Expect(meta.Releasable).To(BeFalse())
+				Expect(meta.PodUIDs).To(BeNil())
+			})
+			It("is false when a claim is reserved for a mix of pod and non-pod consumers", func() {
+				claim := withReservedFor(
+					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					podRef("pod-a", "uid-a"),
+					nonPodRef("services", "svc-a", "uid-svc"),
+				)
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				meta := devices[deviceID("driver.example.com", "pool-a", "device-0")]
+				Expect(meta.Releasable).To(BeFalse())
+				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a")))
+			})
+			It("is false when two claims share a device and one has a non-pod consumer", func() {
+				claimA := withReservedFor(
+					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					podRef("pod-a", "uid-a"),
+				)
+				claimB := withReservedFor(
+					resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0")),
+					nonPodRef("services", "svc-a", "uid-svc"),
+				)
+				ExpectApplied(ctx, env.Client, claimA, claimB)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				meta := devices[deviceID("driver.example.com", "pool-a", "device-0")]
+				Expect(meta.Releasable).To(BeFalse())
+				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a")))
+			})
+		})
+
+		Describe("Mutation", func() {
+			It("becomes releasable when a claim is updated from non-pod to pod-only reservation", func() {
+				claim := withReservedFor(
+					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					nonPodRef("services", "svc-a", "uid-svc"),
+				)
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				Expect(devices[deviceID("driver.example.com", "pool-a", "device-0")].Releasable).To(BeFalse())
+
+				// Update to pod-only reservation
+				claim.Status.ReservedFor = []resourcev1.ResourceClaimConsumerReference{
+					{Resource: "pods", Name: "pod-a", UID: "uid-a"},
+				}
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err = controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices = collectDevices(seq)
+				Expect(devices).To(HaveKeyWithValue(
+					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
+				))
+			})
+			It("becomes releasable when the only non-pod claim sharing a device is deleted", func() {
+				claimA := withReservedFor(
+					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					podRef("pod-a", "uid-a"),
+				)
+				claimB := withReservedFor(
+					resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0")),
+					nonPodRef("services", "svc-a", "uid-svc"),
+				)
+				ExpectApplied(ctx, env.Client, claimA, claimB)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				Expect(devices[deviceID("driver.example.com", "pool-a", "device-0")].Releasable).To(BeFalse())
+
+				// Delete the non-pod claim
+				ExpectDeleted(ctx, env.Client, claimB)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+				seq, err = controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices = collectDevices(seq)
+				Expect(devices).To(HaveKeyWithValue(
+					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
+				))
+			})
+		})
+	})
+})

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deviceallocation_test
 
 import (
@@ -99,30 +115,30 @@ func podRef(name string, uid types.UID) resourcev1.ResourceClaimConsumerReferenc
 }
 
 // nonPodRef creates a ResourceClaimConsumerReference for a non-pod consumer.
-func nonPodRef(resource, name string, uid types.UID) resourcev1.ResourceClaimConsumerReference {
+func nonPodRef() resourcev1.ResourceClaimConsumerReference {
 	return resourcev1.ResourceClaimConsumerReference{
 		APIGroup: "example.com",
-		Resource: resource,
-		Name:     name,
-		UID:      uid,
+		Resource: "services",
+		Name:     "svc-a",
+		UID:      "uid-svc",
 	}
 }
 
 // deviceResult constructs a DeviceRequestAllocationResult for use in ResourceClaim status.
-func deviceResult(driver, pool, device string) resourcev1.DeviceRequestAllocationResult {
+func deviceResult(device string) resourcev1.DeviceRequestAllocationResult {
 	return resourcev1.DeviceRequestAllocationResult{
 		Request: "request",
-		Driver:  driver,
-		Pool:    pool,
+		Driver:  "driver.example.com",
+		Pool:    "pool-a",
 		Device:  device,
 	}
 }
 
 // deviceID constructs a cloudprovider.DeviceID using interned handles, matching the controller's representation.
-func deviceID(driver, pool, device string) cloudprovider.DeviceID {
+func deviceID(device string) cloudprovider.DeviceID {
 	return cloudprovider.DeviceID{
-		Driver: unique.Make(driver),
-		Pool:   unique.Make(pool),
+		Driver: unique.Make("driver.example.com"),
+		Pool:   unique.Make("pool-a"),
 		Device: unique.Make(device),
 	}
 }
@@ -173,8 +189,8 @@ var _ = Describe("DeviceAllocation Controller", func() {
 		})
 		It("hydration includes devices from ResourceClaims that existed before the first reconcile", func() {
 			// Apply claims before any reconcile has run — these must be picked up by Hydrate()
-			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
-			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			claimA := resourceClaim("claim-a", deviceResult("device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("device-1"))
 			ExpectApplied(ctx, env.Client, claimA, claimB)
 
 			triggerHydration()
@@ -183,14 +199,14 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			devices := collectDevices(seq)
 			Expect(devices).To(Equal(expectedDevices(
-				deviceID("driver.example.com", "pool-a", "device-0"),
-				deviceID("driver.example.com", "pool-a", "device-1"),
+				deviceID("device-0"),
+				deviceID("device-1"),
 			)))
 		})
 		It("returns a copy that is not affected by subsequent reconciliations", func() {
 			triggerHydration()
 
-			claim := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claim := resourceClaim("claim-a", deviceResult("device-0"))
 			ExpectApplied(ctx, env.Client, claim)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
 
@@ -199,11 +215,11 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			snapshot := collectDevices(seq)
 
 			// Reconcile a new claim to mutate the controller's internal state after the snapshot was taken
-			claim = resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			claim = resourceClaim("claim-b", deviceResult("device-1"))
 			ExpectApplied(ctx, env.Client, claim)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
 
-			Expect(snapshot).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-0"))))
+			Expect(snapshot).To(Equal(expectedDevices(deviceID("device-0"))))
 		})
 		It("does not block on subsequent calls after hydration", func() {
 			triggerHydration()
@@ -238,19 +254,19 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			Expect(devices).To(BeEmpty())
 		})
 		It("returns a single device from a ResourceClaim with one allocation", func() {
-			claim := resourceClaim("single-claim", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claim := resourceClaim("single-claim", deviceResult("device-0"))
 			ExpectApplied(ctx, env.Client, claim)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
 
 			seq, err := controller.AllocatedDevices(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			devices := collectDevices(seq)
-			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-0"))))
+			Expect(devices).To(Equal(expectedDevices(deviceID("device-0"))))
 		})
 		It("returns all devices from a ResourceClaim with multiple allocations", func() {
 			claim := resourceClaim("multi-device-claim",
-				deviceResult("driver.example.com", "pool-a", "device-0"),
-				deviceResult("driver.example.com", "pool-a", "device-1"),
+				deviceResult("device-0"),
+				deviceResult("device-1"),
 			)
 			ExpectApplied(ctx, env.Client, claim)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
@@ -259,13 +275,13 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			devices := collectDevices(seq)
 			Expect(devices).To(Equal(expectedDevices(
-				deviceID("driver.example.com", "pool-a", "device-0"),
-				deviceID("driver.example.com", "pool-a", "device-1"),
+				deviceID("device-0"),
+				deviceID("device-1"),
 			)))
 		})
 		It("returns the union of distinct devices across multiple ResourceClaims", func() {
-			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
-			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			claimA := resourceClaim("claim-a", deviceResult("device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("device-1"))
 			ExpectApplied(ctx, env.Client, claimA, claimB)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
@@ -274,13 +290,13 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			devices := collectDevices(seq)
 			Expect(devices).To(Equal(expectedDevices(
-				deviceID("driver.example.com", "pool-a", "device-0"),
-				deviceID("driver.example.com", "pool-a", "device-1"),
+				deviceID("device-0"),
+				deviceID("device-1"),
 			)))
 		})
 		It("returns a shared device only once when multiple ResourceClaims allocate it", func() {
-			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
-			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claimA := resourceClaim("claim-a", deviceResult("device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("device-0"))
 			ExpectApplied(ctx, env.Client, claimA, claimB)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
@@ -288,7 +304,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			seq, err := controller.AllocatedDevices(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			devices := collectDevices(seq)
-			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-0"))))
+			Expect(devices).To(Equal(expectedDevices(deviceID("device-0"))))
 		})
 	})
 
@@ -297,7 +313,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			triggerHydration()
 		})
 		It("removes a device when its only ResourceClaim is deleted", func() {
-			claim := resourceClaim("single-claim", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claim := resourceClaim("single-claim", deviceResult("device-0"))
 			ExpectApplied(ctx, env.Client, claim)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
 
@@ -310,8 +326,8 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			Expect(devices).To(BeEmpty())
 		})
 		It("removes only the deleted claim's devices when a subset of claims is deleted", func() {
-			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
-			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			claimA := resourceClaim("claim-a", deviceResult("device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("device-1"))
 			ExpectApplied(ctx, env.Client, claimA, claimB)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
@@ -322,11 +338,11 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			seq, err := controller.AllocatedDevices(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			devices := collectDevices(seq)
-			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-1"))))
+			Expect(devices).To(Equal(expectedDevices(deviceID("device-1"))))
 		})
 		It("does not remove a shared device when one of multiple claims that allocate it is deleted", func() {
-			claimA := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
-			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0"))
+			claimA := resourceClaim("claim-a", deviceResult("device-0"))
+			claimB := resourceClaim("claim-b", deviceResult("device-0"))
 			ExpectApplied(ctx, env.Client, claimA, claimB)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
@@ -337,18 +353,18 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			seq, err := controller.AllocatedDevices(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			devices := collectDevices(seq)
-			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-0"))))
+			Expect(devices).To(Equal(expectedDevices(deviceID("device-0"))))
 		})
 		It("removes devices when a claim is deleted and recreated without an allocation", func() {
 			// claim-b holds device-1 throughout the test; it is the shared device
-			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			claimB := resourceClaim("claim-b", deviceResult("device-1"))
 			ExpectApplied(ctx, env.Client, claimB)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
 
 			// my-claim initially allocates device-0 (distinct) and device-1 (shared with claim-b)
 			claim := resourceClaim("my-claim",
-				deviceResult("driver.example.com", "pool-a", "device-0"),
-				deviceResult("driver.example.com", "pool-a", "device-1"),
+				deviceResult("device-0"),
+				deviceResult("device-1"),
 			)
 			ExpectApplied(ctx, env.Client, claim)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
@@ -368,17 +384,17 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			devices := collectDevices(seq)
 			// device-0 removed (was distinct to my-claim, last reference gone)
 			// device-1 persists (still held by claim-b)
-			Expect(devices).To(Equal(expectedDevices(deviceID("driver.example.com", "pool-a", "device-1"))))
+			Expect(devices).To(Equal(expectedDevices(deviceID("device-1"))))
 		})
 		It("replaces devices when a claim is deleted and recreated with a different allocation", func() {
-			claimB := resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-1"))
+			claimB := resourceClaim("claim-b", deviceResult("device-1"))
 			ExpectApplied(ctx, env.Client, claimB)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
 
 			// my-claim initially allocates device-0 (distinct to my-claim) and device-1 (shared with claim-b)
 			claim := resourceClaim("my-claim",
-				deviceResult("driver.example.com", "pool-a", "device-0"),
-				deviceResult("driver.example.com", "pool-a", "device-1"),
+				deviceResult("device-0"),
+				deviceResult("device-1"),
 			)
 			ExpectApplied(ctx, env.Client, claim)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
@@ -391,8 +407,8 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			// Recreate with the same name: drops device-0 (distinct, should be removed),
 			// keeps device-1 (shared with claim-b, must persist), adds device-2 (new distinct)
 			claim = resourceClaim("my-claim",
-				deviceResult("driver.example.com", "pool-a", "device-1"),
-				deviceResult("driver.example.com", "pool-a", "device-2"),
+				deviceResult("device-1"),
+				deviceResult("device-2"),
 			)
 			ExpectApplied(ctx, env.Client, claim)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
@@ -401,8 +417,8 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			devices := collectDevices(seq)
 			Expect(devices).To(Equal(expectedDevices(
-				deviceID("driver.example.com", "pool-a", "device-1"),
-				deviceID("driver.example.com", "pool-a", "device-2"),
+				deviceID("device-1"),
+				deviceID("device-2"),
 			)))
 		})
 	})
@@ -415,7 +431,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 		Describe("Releasable", func() {
 			It("is true when a claim is reserved for a single pod", func() {
 				claim := withReservedFor(
-					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					resourceClaim("claim-a", deviceResult("device-0")),
 					podRef("pod-a", "uid-a"),
 				)
 				ExpectApplied(ctx, env.Client, claim)
@@ -425,13 +441,13 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
-					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceID("device-0"),
 					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
 				))
 			})
 			It("is true when a claim is reserved for multiple pods", func() {
 				claim := withReservedFor(
-					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					resourceClaim("claim-a", deviceResult("device-0")),
 					podRef("pod-a", "uid-a"),
 					podRef("pod-b", "uid-b"),
 				)
@@ -442,17 +458,17 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
-					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceID("device-0"),
 					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a", "uid-b"}},
 				))
 			})
 			It("is true when two claims sharing a device are both reserved only for pods", func() {
 				claimA := withReservedFor(
-					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					resourceClaim("claim-a", deviceResult("device-0")),
 					podRef("pod-a", "uid-a"),
 				)
 				claimB := withReservedFor(
-					resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0")),
+					resourceClaim("claim-b", deviceResult("device-0")),
 					podRef("pod-b", "uid-b"),
 				)
 				ExpectApplied(ctx, env.Client, claimA, claimB)
@@ -462,12 +478,14 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				seq, err := controller.AllocatedDevices(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
-				meta := devices[deviceID("driver.example.com", "pool-a", "device-0")]
+				meta := devices[deviceID("device-0")]
 				Expect(meta.Releasable).To(BeTrue())
 				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a"), types.UID("uid-b")))
 			})
+			// This shouldn't occur since KCM should atomically remove the allocation when it removes the last reservation. If
+			// this does occur, we should be conservative and consider the device allocated.
 			It("is false when a claim has an empty ReservedFor", func() {
-				claim := resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0"))
+				claim := resourceClaim("claim-a", deviceResult("device-0"))
 				ExpectApplied(ctx, env.Client, claim)
 				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
 
@@ -475,14 +493,14 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
-					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceID("device-0"),
 					deviceallocation.Metadata{Releasable: false},
 				))
 			})
 			It("is false when a claim is reserved for a non-pod consumer", func() {
 				claim := withReservedFor(
-					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
-					nonPodRef("services", "svc-a", "uid-svc"),
+					resourceClaim("claim-a", deviceResult("device-0")),
+					nonPodRef(),
 				)
 				ExpectApplied(ctx, env.Client, claim)
 				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
@@ -490,15 +508,15 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				seq, err := controller.AllocatedDevices(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
-				meta := devices[deviceID("driver.example.com", "pool-a", "device-0")]
+				meta := devices[deviceID("device-0")]
 				Expect(meta.Releasable).To(BeFalse())
 				Expect(meta.PodUIDs).To(BeNil())
 			})
 			It("is false when a claim is reserved for a mix of pod and non-pod consumers", func() {
 				claim := withReservedFor(
-					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					resourceClaim("claim-a", deviceResult("device-0")),
 					podRef("pod-a", "uid-a"),
-					nonPodRef("services", "svc-a", "uid-svc"),
+					nonPodRef(),
 				)
 				ExpectApplied(ctx, env.Client, claim)
 				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
@@ -506,18 +524,18 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				seq, err := controller.AllocatedDevices(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
-				meta := devices[deviceID("driver.example.com", "pool-a", "device-0")]
+				meta := devices[deviceID("device-0")]
 				Expect(meta.Releasable).To(BeFalse())
 				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a")))
 			})
 			It("is false when two claims share a device and one has a non-pod consumer", func() {
 				claimA := withReservedFor(
-					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					resourceClaim("claim-a", deviceResult("device-0")),
 					podRef("pod-a", "uid-a"),
 				)
 				claimB := withReservedFor(
-					resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0")),
-					nonPodRef("services", "svc-a", "uid-svc"),
+					resourceClaim("claim-b", deviceResult("device-0")),
+					nonPodRef(),
 				)
 				ExpectApplied(ctx, env.Client, claimA, claimB)
 				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
@@ -526,7 +544,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				seq, err := controller.AllocatedDevices(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
-				meta := devices[deviceID("driver.example.com", "pool-a", "device-0")]
+				meta := devices[deviceID("device-0")]
 				Expect(meta.Releasable).To(BeFalse())
 				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a")))
 			})
@@ -535,8 +553,8 @@ var _ = Describe("DeviceAllocation Controller", func() {
 		Describe("Mutation", func() {
 			It("becomes releasable when a claim is updated from non-pod to pod-only reservation", func() {
 				claim := withReservedFor(
-					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
-					nonPodRef("services", "svc-a", "uid-svc"),
+					resourceClaim("claim-a", deviceResult("device-0")),
+					nonPodRef(),
 				)
 				ExpectApplied(ctx, env.Client, claim)
 				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
@@ -544,7 +562,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				seq, err := controller.AllocatedDevices(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
-				Expect(devices[deviceID("driver.example.com", "pool-a", "device-0")].Releasable).To(BeFalse())
+				Expect(devices[deviceID("device-0")].Releasable).To(BeFalse())
 
 				// Update to pod-only reservation
 				claim.Status.ReservedFor = []resourcev1.ResourceClaimConsumerReference{
@@ -557,18 +575,18 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				devices = collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
-					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceID("device-0"),
 					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
 				))
 			})
 			It("becomes releasable when the only non-pod claim sharing a device is deleted", func() {
 				claimA := withReservedFor(
-					resourceClaim("claim-a", deviceResult("driver.example.com", "pool-a", "device-0")),
+					resourceClaim("claim-a", deviceResult("device-0")),
 					podRef("pod-a", "uid-a"),
 				)
 				claimB := withReservedFor(
-					resourceClaim("claim-b", deviceResult("driver.example.com", "pool-a", "device-0")),
-					nonPodRef("services", "svc-a", "uid-svc"),
+					resourceClaim("claim-b", deviceResult("device-0")),
+					nonPodRef(),
 				)
 				ExpectApplied(ctx, env.Client, claimA, claimB)
 				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
@@ -577,7 +595,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				seq, err := controller.AllocatedDevices(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				devices := collectDevices(seq)
-				Expect(devices[deviceID("driver.example.com", "pool-a", "device-0")].Releasable).To(BeFalse())
+				Expect(devices[deviceID("device-0")].Releasable).To(BeFalse())
 
 				// Delete the non-pod claim
 				ExpectDeleted(ctx, env.Client, claimB)
@@ -587,7 +605,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				devices = collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
-					deviceID("driver.example.com", "pool-a", "device-0"),
+					deviceID("device-0"),
 					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
 				))
 			})

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -54,6 +54,9 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
+	if env.Version.Minor() < 34 {
+		Skip("ResourceClaims are only available starting in K8s version >= 1.34.x")
+	}
 	ctx = options.ToContext(ctx, test.Options())
 })
 

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -612,6 +612,31 @@ var _ = Describe("DeviceAllocation Controller", func() {
 					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
 				))
 			})
+			It("becomes non-releasable when a claim's reservations are cleared", func() {
+				claim := withReservedFor(
+					resourceClaim("claim-a", deviceResult("device-0")),
+					podRef("pod-a", "uid-a"),
+				)
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err := controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices := collectDevices(seq)
+				Expect(devices[deviceID("device-0")].Releasable).To(BeTrue())
+
+				claim.Status.ReservedFor = nil
+				ExpectApplied(ctx, env.Client, claim)
+				ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+				seq, err = controller.AllocatedDevices(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				devices = collectDevices(seq)
+				Expect(devices).To(HaveKeyWithValue(
+					deviceID("device-0"),
+					deviceallocation.Metadata{Releasable: false},
+				))
+			})
 		})
 	})
 })

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -266,8 +266,12 @@ func ExpectCleanedUp(ctx context.Context, c client.Client) {
 				GinkgoHelper()
 				defer wg.Done()
 				defer GinkgoRecover()
-				Expect(c.DeleteAllOf(ctx, object, client.InNamespace(namespace),
-					&client.DeleteAllOfOptions{DeleteOptions: client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}})).ToNot(HaveOccurred())
+				err := c.DeleteAllOf(ctx, object, client.InNamespace(namespace),
+					&client.DeleteAllOfOptions{DeleteOptions: client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}})
+				// Fail open for CRDs that don't exist on this k8s version (e.g. ResourceClaim on < 1.34)
+				if err != nil && !meta.IsNoMatchError(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
 			}(object, namespace.Name)
 		}
 	}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -39,6 +39,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -257,6 +258,7 @@ func ExpectCleanedUp(ctx context.Context, c client.Client) {
 		&testv1alpha1.TestNodeClass{},
 		&v1.NodeClaim{},
 		&v1alpha1.NodeOverlay{},
+		&resourcev1.ResourceClaim{},
 	} {
 		for _, namespace := range namespaces.Items {
 			wg.Add(1)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The first in a sequence of PRs to support DRA in Karpenter. This PR adds a controller (`dynamicresources.deviceallocation`) responsible for tracking allocated devices based on `ResourceClaim` statuses. The controller provides an iterator interface which will be consumed by the provisioner and disruption controllers when creating the DRA allocator (PR to follow). 

Some design considerations:
- Multiple pods can consume the same ResourceClaim. To avoid overprovisioning, we need to release a device when all pods with reservations for that device are in a deleting state. A subset of pods deleting is not sufficient since it won't result in the device being released.
- This controller ensures that initial data is hydrated before returning any results. While this isn't strictly necessary since under counting allocated devices would just result in under provisioning on startup, making this deterministic isn't particularly complicated and eases reproducibility while testing.
- While ConsumableCapacity is out of scope of the initial DRA release, this implementation should be forward compatible. It supports tracking multiple claims allocated to the same device and taking the union of pods.

Additionally, I have staged changes to add a debug endpoint for querying internal device allocation state. I'm debating if this should live in the upstream project, but we've had several discussions about exposing similar endpoints for cluster state as the main mechanism for exposing high-cardinality data for issue diagnosis. I think this would be a good first-step in that direction: https://github.com/jmdeal/karpenter/pull/4

**How was this change tested?**

`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
