### PR TITLE
feat(metrics): add karpenter_pods_disrupted_total counter

### DIFF
--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -245,7 +245,7 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 			metrics.CapacityTypeLabel: cmd.Candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
 		}
 		metrics.NodeClaimsDisruptedTotal.Inc(labels)
-		metrics.PodsDisruptedTotal.Add(float64(len(cmd.Candidates[i].reschedulablePods)), labels)
+		metrics.PodsDisruptionInitiatedTotal.Add(float64(len(cmd.Candidates[i].reschedulablePods)), labels)
 	})
 	// If there were any deletion failures, we should requeue.
 	// In the case where we requeue, but the timeout for the command is reached, we'll mark this as a failure.

--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -239,11 +239,13 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 			return
 		}
 		q.recorder.Publish(disruptionevents.Terminating(cmd.Candidates[i].Node, cmd.Candidates[i].NodeClaim, string(cmd.Reason()))...)
-		metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+		labels := map[string]string{
 			metrics.ReasonLabel:       pretty.ToSnakeCase(string(cmd.Reason())),
 			metrics.NodePoolLabel:     cmd.Candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel: cmd.Candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
-		})
+		}
+		metrics.NodeClaimsDisruptedTotal.Inc(labels)
+		metrics.PodsDisruptedTotal.Add(float64(len(cmd.Candidates[i].reschedulablePods)), labels)
 	})
 	// If there were any deletion failures, we should requeue.
 	// In the case where we requeue, but the timeout for the command is reached, we'll mark this as a failure.

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -171,11 +171,19 @@ func (c *Controller) deleteNodeClaim(ctx context.Context, nodeClaim *v1.NodeClai
 	}
 	// The deletion timestamp has successfully been set for the Node, update relevant metrics.
 	log.FromContext(ctx).Info("deleting unhealthy node")
-	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+	labels := map[string]string{
 		metrics.ReasonLabel:       metrics.UnhealthyReason,
 		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: node.Labels[v1.CapacityTypeLabelKey],
-	})
+	}
+	metrics.NodeClaimsDisruptedTotal.Inc(labels)
+	// Pods on the node have not yet started draining at this point — list captures
+	// the pre-disruption state. Errors don't fail the reconcile; the metric reports 0.
+	podCount, err := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, node.Name)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", err.Error())
+	}
+	metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
 	NodeClaimsUnhealthyDisruptedTotal.Inc(map[string]string{
 		Condition:                 pretty.ToSnakeCase(string(unhealthyNodeCondition.Type)),
 		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -183,7 +183,7 @@ func (c *Controller) deleteNodeClaim(ctx context.Context, nodeClaim *v1.NodeClai
 	if err != nil {
 		log.FromContext(ctx).V(1).Info("listing reschedulable pods for disruption metric", "error", err.Error())
 	}
-	metrics.PodsDisruptedTotal.Add(float64(len(reschedulablePods)), labels)
+	metrics.PodsDisruptionInitiatedTotal.Add(float64(len(reschedulablePods)), labels)
 	NodeClaimsUnhealthyDisruptedTotal.Inc(map[string]string{
 		Condition:                 pretty.ToSnakeCase(string(unhealthyNodeCondition.Type)),
 		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -179,11 +179,11 @@ func (c *Controller) deleteNodeClaim(ctx context.Context, nodeClaim *v1.NodeClai
 	metrics.NodeClaimsDisruptedTotal.Inc(labels)
 	// Pods on the node have not yet started draining at this point — list captures
 	// the pre-disruption state. Errors don't fail the reconcile; the metric reports 0.
-	podCount, err := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, node.Name)
+	reschedulablePods, err := nodeutils.ReschedulablePods(ctx, c.kubeClient, node.Name)
 	if err != nil {
-		log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", err.Error())
+		log.FromContext(ctx).V(1).Info("listing reschedulable pods for disruption metric", "error", err.Error())
 	}
-	metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
+	metrics.PodsDisruptedTotal.Add(float64(len(reschedulablePods)), labels)
 	NodeClaimsUnhealthyDisruptedTotal.Inc(map[string]string{
 		Condition:                 pretty.ToSnakeCase(string(unhealthyNodeCondition.Type)),
 		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -327,7 +327,7 @@ func filterVolumeAttachments(ctx context.Context, kubeClient client.Client, node
 		return volumeAttachments, nil
 	}
 	// Create list of non-drain-able Pods associated with Node
-	pods, err := nodeutils.GetPods(ctx, kubeClient, node)
+	pods, err := nodeutils.GetPods(ctx, kubeClient, node.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -94,7 +94,7 @@ func (t *Terminator) Taint(ctx context.Context, node *corev1.Node, taint corev1.
 // Drain evicts pods from the node and returns true when all pods are evicted
 // https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeriodExpirationTime *time.Time) error {
-	pods, err := nodeutils.GetPods(ctx, t.kubeClient, node)
+	pods, err := nodeutils.GetPods(ctx, t.kubeClient, node.Name)
 	if err != nil {
 		return fmt.Errorf("listing pods on node, %w", err)
 	}

--- a/pkg/controllers/nodeclaim/expiration/controller.go
+++ b/pkg/controllers/nodeclaim/expiration/controller.go
@@ -35,6 +35,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/metrics"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
@@ -83,11 +84,20 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 	}
 	// 4. The deletion timestamp has successfully been set for the NodeClaim, update relevant metrics.
 	log.FromContext(ctx).V(1).Info("deleting expired nodeclaim")
-	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+	labels := map[string]string{
 		metrics.ReasonLabel:       strings.ToLower(metrics.ExpiredReason),
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
-	})
+	}
+	metrics.NodeClaimsDisruptedTotal.Inc(labels)
+	// Pods that haven't started draining yet still appear bound to the node, so the
+	// list call here captures the pre-disruption state. Errors are logged but do not
+	// fail the reconcile — the metric just reports 0 for this disruption event.
+	podCount, err := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, nodeClaim.Status.NodeName)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", err.Error())
+	}
+	metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
 	// We sleep here after the delete operation since we want to ensure that we are able to read our own writes so that
 	// we avoid duplicating metrics and log lines due to quick re-queues.
 	// USE CAUTION when determining whether to increase this timeout or remove this line

--- a/pkg/controllers/nodeclaim/expiration/controller.go
+++ b/pkg/controllers/nodeclaim/expiration/controller.go
@@ -97,7 +97,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 	if err != nil {
 		log.FromContext(ctx).V(1).Info("listing reschedulable pods for disruption metric", "error", err.Error())
 	}
-	metrics.PodsDisruptedTotal.Add(float64(len(reschedulablePods)), labels)
+	metrics.PodsDisruptionInitiatedTotal.Add(float64(len(reschedulablePods)), labels)
 	// We sleep here after the delete operation since we want to ensure that we are able to read our own writes so that
 	// we avoid duplicating metrics and log lines due to quick re-queues.
 	// USE CAUTION when determining whether to increase this timeout or remove this line

--- a/pkg/controllers/nodeclaim/expiration/controller.go
+++ b/pkg/controllers/nodeclaim/expiration/controller.go
@@ -93,11 +93,11 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 	// Pods that haven't started draining yet still appear bound to the node, so the
 	// list call here captures the pre-disruption state. Errors are logged but do not
 	// fail the reconcile — the metric just reports 0 for this disruption event.
-	podCount, err := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, nodeClaim.Status.NodeName)
+	reschedulablePods, err := nodeutils.ReschedulablePods(ctx, c.kubeClient, nodeClaim.Status.NodeName)
 	if err != nil {
-		log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", err.Error())
+		log.FromContext(ctx).V(1).Info("listing reschedulable pods for disruption metric", "error", err.Error())
 	}
-	metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
+	metrics.PodsDisruptedTotal.Add(float64(len(reschedulablePods)), labels)
 	// We sleep here after the delete operation since we want to ensure that we are able to read our own writes so that
 	// we avoid duplicating metrics and log lines due to quick re-queues.
 	// USE CAUTION when determining whether to increase this timeout or remove this line

--- a/pkg/controllers/nodeclaim/expiration/suite_test.go
+++ b/pkg/controllers/nodeclaim/expiration/suite_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Expiration", func() {
 			},
 		})
 		metrics.NodeClaimsDisruptedTotal.Reset()
-		metrics.PodsDisruptedTotal.Reset()
+		metrics.PodsDisruptionInitiatedTotal.Reset()
 	})
 	Context("Metrics", func() {
 		It("should fire a karpenter_nodeclaims_disrupted_total metric when expired", func() {
@@ -115,7 +115,7 @@ var _ = Describe("Expiration", func() {
 				metrics.NodePoolLabel: nodePool.Name,
 			})
 		})
-		It("should fire karpenter_pods_disrupted_total by the count of reschedulable pods on the node when expired", func() {
+		It("should fire karpenter_pods_disruption_initiated_total by the count of reschedulable pods on the node when expired", func() {
 			// Bind 2 reschedulable pods to the node and 1 DaemonSet-owned pod (excluded).
 			nodeClaim.Status.NodeName = node.Name
 			isController := true
@@ -144,7 +144,7 @@ var _ = Describe("Expiration", func() {
 				metrics.ReasonLabel:   metrics.ExpiredReason,
 				metrics.NodePoolLabel: nodePool.Name,
 			})
-			ExpectMetricCounterValue(metrics.PodsDisruptedTotal, 2, map[string]string{
+			ExpectMetricCounterValue(metrics.PodsDisruptionInitiatedTotal, 2, map[string]string{
 				metrics.ReasonLabel:   metrics.ExpiredReason,
 				metrics.NodePoolLabel: nodePool.Name,
 			})

--- a/pkg/controllers/nodeclaim/expiration/suite_test.go
+++ b/pkg/controllers/nodeclaim/expiration/suite_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Expiration", func() {
 			},
 		})
 		metrics.NodeClaimsDisruptedTotal.Reset()
+		metrics.PodsDisruptedTotal.Reset()
 	})
 	Context("Metrics", func() {
 		It("should fire a karpenter_nodeclaims_disrupted_total metric when expired", func() {
@@ -110,6 +111,40 @@ var _ = Describe("Expiration", func() {
 
 			ExpectNotFound(ctx, env.Client, nodeClaim)
 			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
+				metrics.ReasonLabel:   metrics.ExpiredReason,
+				metrics.NodePoolLabel: nodePool.Name,
+			})
+		})
+		It("should fire karpenter_pods_disrupted_total by the count of reschedulable pods on the node when expired", func() {
+			// Bind 2 reschedulable pods to the node and 1 DaemonSet-owned pod (excluded).
+			nodeClaim.Status.NodeName = node.Name
+			isController := true
+			pod1 := test.Pod(test.PodOptions{NodeName: node.Name})
+			pod2 := test.Pod(test.PodOptions{NodeName: node.Name})
+			daemonsetPod := test.Pod(test.PodOptions{
+				NodeName: node.Name,
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "DaemonSet",
+						Name:       "ds",
+						UID:        "ds-uid",
+						Controller: &isController,
+					}},
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, node, nodeClaim, pod1, pod2, daemonsetPod)
+
+			// step forward to make the node expired
+			env.Clock.Step(60 * time.Second)
+			ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
+
+			ExpectNotFound(ctx, env.Client, nodeClaim)
+			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
+				metrics.ReasonLabel:   metrics.ExpiredReason,
+				metrics.NodePoolLabel: nodePool.Name,
+			})
+			ExpectMetricCounterValue(metrics.PodsDisruptedTotal, 2, map[string]string{
 				metrics.ReasonLabel:   metrics.ExpiredReason,
 				metrics.NodePoolLabel: nodePool.Name,
 			})

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -109,11 +109,20 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 			"Node", klog.KRef("", nodeClaims[i].Status.NodeName),
 			"provider-id", nodeClaims[i].Status.ProviderID,
 		).V(1).Info("garbage collecting nodeclaim with no cloudprovider representation")
-		metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+		labels := map[string]string{
 			metrics.ReasonLabel:       "garbage_collected",
 			metrics.NodePoolLabel:     nodeClaims[i].Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel: nodeClaims[i].Labels[v1.CapacityTypeLabelKey],
-		})
+		}
+		metrics.NodeClaimsDisruptedTotal.Inc(labels)
+		// GC runs when the cloudprovider node is gone or NotReady; pod records may
+		// linger or already be cleaned up. CountReschedulablePodsOnNode handles the
+		// empty-nodename case and any list error by returning 0 with a logged error.
+		podCount, podErr := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, nodeClaims[i].Status.NodeName)
+		if podErr != nil {
+			log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", podErr.Error())
+		}
+		metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
 	})
 	if err = multierr.Combine(errs...); err != nil {
 		return reconciler.Result{}, err

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -116,13 +116,13 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 		}
 		metrics.NodeClaimsDisruptedTotal.Inc(labels)
 		// GC runs when the cloudprovider node is gone or NotReady; pod records may
-		// linger or already be cleaned up. CountReschedulablePodsOnNode handles the
-		// empty-nodename case and any list error by returning 0 with a logged error.
-		podCount, podErr := nodeutils.CountReschedulablePodsOnNode(ctx, c.kubeClient, nodeClaims[i].Status.NodeName)
+		// linger or already be cleaned up. GetPods (via ReschedulablePods) skips the
+		// empty-nodename case; any list error is logged and treated as zero pods.
+		reschedulablePods, podErr := nodeutils.ReschedulablePods(ctx, c.kubeClient, nodeClaims[i].Status.NodeName)
 		if podErr != nil {
-			log.FromContext(ctx).V(1).Info("counting reschedulable pods for disruption metric", "error", podErr.Error())
+			log.FromContext(ctx).V(1).Info("listing reschedulable pods for disruption metric", "error", podErr.Error())
 		}
-		metrics.PodsDisruptedTotal.Add(float64(podCount), labels)
+		metrics.PodsDisruptedTotal.Add(float64(len(reschedulablePods)), labels)
 	})
 	if err = multierr.Combine(errs...); err != nil {
 		return reconciler.Result{}, err

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -122,7 +122,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 		if podErr != nil {
 			log.FromContext(ctx).V(1).Info("listing reschedulable pods for disruption metric", "error", podErr.Error())
 		}
-		metrics.PodsDisruptedTotal.Add(float64(len(reschedulablePods)), labels)
+		metrics.PodsDisruptionInitiatedTotal.Add(float64(len(reschedulablePods)), labels)
 	})
 	if err = multierr.Combine(errs...); err != nil {
 		return reconciler.Result{}, err

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -201,7 +201,7 @@ func (in *StateNode) Pods(ctx context.Context, kubeClient client.Client) ([]*cor
 	if in.Node == nil {
 		return nil, nil
 	}
-	return nodeutils.GetPods(ctx, kubeClient, in.Node)
+	return nodeutils.GetPods(ctx, kubeClient, in.Node.Name)
 }
 
 // ValidateNodeDisruptable returns an error if the StateNode cannot be disrupted

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -72,6 +72,20 @@ var (
 			CapacityTypeLabel,
 		},
 	)
+	PodsDisruptedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: PodSubsystem,
+			Name:      "disrupted_total",
+			Help:      "Number of reschedulable pods disrupted in total by Karpenter, incremented by the pod count whenever the underlying nodeclaim is disrupted. Labeled by reason the nodeclaim was disrupted, the owning nodepool, and the capacity type. Pods owned by DaemonSets and mirror pods are excluded.",
+		},
+		[]string{
+			ReasonLabel,
+			NodePoolLabel,
+			CapacityTypeLabel,
+		},
+	)
 	NodesCreatedTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
 		prometheus.CounterOpts{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -72,13 +72,13 @@ var (
 			CapacityTypeLabel,
 		},
 	)
-	PodsDisruptedTotal = opmetrics.NewPrometheusCounter(
+	PodsDisruptionInitiatedTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: PodSubsystem,
-			Name:      "disrupted_total",
-			Help:      "Number of reschedulable pods disrupted in total by Karpenter, incremented by the pod count whenever the underlying nodeclaim is disrupted. Labeled by reason the nodeclaim was disrupted, the owning nodepool, and the capacity type. Pods owned by DaemonSets and mirror pods are excluded.",
+			Name:      "disruption_initiated_total",
+			Help:      "Number of pod disruptions initiated in total by Karpenter, incremented by the reschedulable pod count whenever the underlying nodeclaim is disrupted. Labeled by reason the nodeclaim was disrupted, the owning nodepool, and the capacity type. Pods owned by DaemonSets and mirror pods are excluded.",
 		},
 		[]string{
 			ReasonLabel,

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -150,6 +150,29 @@ func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (
 	return nodeClaims[0], nil
 }
 
+// CountReschedulablePodsOnNode returns the number of pods bound to the named node that
+// satisfy the pod.IsReschedulable criteria (active or stateful-set-terminating, not
+// owned by a DaemonSet, not a mirror pod). This mirrors the semantics of
+// disruption.Candidate.reschedulablePods so per-disruption-reason metrics across
+// queue/expiration/health/GC controllers count pods consistently. An empty nodeName
+// returns 0 with no error so callers operating on un-registered NodeClaims don't fail.
+func CountReschedulablePodsOnNode(ctx context.Context, kubeClient client.Client, nodeName string) (int, error) {
+	if nodeName == "" {
+		return 0, nil
+	}
+	var podList corev1.PodList
+	if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
+		return 0, fmt.Errorf("listing pods on node %q, %w", nodeName, err)
+	}
+	count := 0
+	for i := range podList.Items {
+		if pod.IsReschedulable(&podList.Items[i]) {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // GetCurrentlyReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
 func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client, clk clock.Clock, recorder events.Recorder, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
 	pods, err := GetPods(ctx, kubeClient, nodes...)

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -103,12 +103,17 @@ func IgnoreDuplicateNodeClaimError(err error) error {
 	return nil
 }
 
-// GetPods grabs all pods that are currently bound to the passed nodes
-func GetPods(ctx context.Context, kubeClient client.Client, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
+// GetPods grabs all pods that are currently bound to the passed node names.
+// Empty node names are skipped so callers operating on un-registered NodeClaims
+// don't accidentally match unscheduled pods via the "spec.nodeName" field selector.
+func GetPods(ctx context.Context, kubeClient client.Client, nodeNames ...string) ([]*corev1.Pod, error) {
 	var pods []*corev1.Pod
-	for _, node := range nodes {
+	for _, nodeName := range nodeNames {
+		if nodeName == "" {
+			continue
+		}
 		var podList corev1.PodList
-		if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
+		if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
 			return nil, fmt.Errorf("listing pods, %w", err)
 		}
 		for i := range podList.Items {
@@ -150,32 +155,23 @@ func NodeClaimForNode(ctx context.Context, c client.Client, node *corev1.Node) (
 	return nodeClaims[0], nil
 }
 
-// CountReschedulablePodsOnNode returns the number of pods bound to the named node that
-// satisfy the pod.IsReschedulable criteria (active or stateful-set-terminating, not
-// owned by a DaemonSet, not a mirror pod). This mirrors the semantics of
-// disruption.Candidate.reschedulablePods so per-disruption-reason metrics across
-// queue/expiration/health/GC controllers count pods consistently. An empty nodeName
-// returns 0 with no error so callers operating on un-registered NodeClaims don't fail.
-func CountReschedulablePodsOnNode(ctx context.Context, kubeClient client.Client, nodeName string) (int, error) {
-	if nodeName == "" {
-		return 0, nil
+// ReschedulablePods returns all pods bound to the named nodes that satisfy the
+// pod.IsReschedulable criteria (active or stateful-set-terminating, not owned by
+// a DaemonSet, not a mirror pod). This mirrors disruption.Candidate.reschedulablePods
+// so per-disruption-reason metrics across queue/expiration/health/GC controllers
+// count pods consistently.
+func ReschedulablePods(ctx context.Context, kubeClient client.Client, nodeNames ...string) ([]*corev1.Pod, error) {
+	pods, err := GetPods(ctx, kubeClient, nodeNames...)
+	if err != nil {
+		return nil, err
 	}
-	var podList corev1.PodList
-	if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
-		return 0, fmt.Errorf("listing pods on node %q, %w", nodeName, err)
-	}
-	count := 0
-	for i := range podList.Items {
-		if pod.IsReschedulable(&podList.Items[i]) {
-			count++
-		}
-	}
-	return count, nil
+	return lo.Filter(pods, func(p *corev1.Pod, _ int) bool { return pod.IsReschedulable(p) }), nil
 }
 
 // GetCurrentlyReschedulablePods grabs all pods from the passed nodes that satisfy the IsReschedulable criteria
 func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client, clk clock.Clock, recorder events.Recorder, nodes ...*corev1.Node) ([]*corev1.Pod, error) {
-	pods, err := GetPods(ctx, kubeClient, nodes...)
+	nodeNames := lo.Map(nodes, func(n *corev1.Node, _ int) string { return n.Name })
+	pods, err := GetPods(ctx, kubeClient, nodeNames...)
 	if err != nil {
 		return nil, fmt.Errorf("listing pods, %w", err)
 	}

--- a/pkg/utils/node/suite_test.go
+++ b/pkg/utils/node/suite_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -92,5 +93,50 @@ var _ = Describe("NodeUtils", func() {
 		nodeClaims, err := nodeutils.GetNodeClaims(ctx, env.Client, testNode)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeClaims).To(HaveLen(0))
+	})
+	Context("CountReschedulablePodsOnNode", func() {
+		It("should return 0 for an empty node name", func() {
+			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+		It("should return 0 when no pods are bound to the node", func() {
+			testNode = test.Node()
+			ExpectApplied(ctx, env.Client, testNode)
+			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, testNode.Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+		It("should count only reschedulable pods bound to the node", func() {
+			testNode = test.Node()
+			ExpectApplied(ctx, env.Client, testNode)
+			isController := true
+			// 2 reschedulable pods (active, no DaemonSet/Node owner).
+			pod1 := test.Pod(test.PodOptions{NodeName: testNode.Name})
+			pod2 := test.Pod(test.PodOptions{NodeName: testNode.Name})
+			// 1 DaemonSet-owned pod (excluded by IsReschedulable).
+			daemonsetPod := test.Pod(test.PodOptions{
+				NodeName: testNode.Name,
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "apps/v1",
+						Kind:       "DaemonSet",
+						Name:       "ds",
+						UID:        "ds-uid",
+						Controller: &isController,
+					}},
+				},
+			})
+			// 1 pod bound to a different node (excluded by field selector).
+			otherNode := test.Node()
+			ExpectApplied(ctx, env.Client, otherNode)
+			otherPod := test.Pod(test.PodOptions{NodeName: otherNode.Name})
+
+			ExpectApplied(ctx, env.Client, pod1, pod2, daemonsetPod, otherPod)
+
+			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, testNode.Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(2))
+		})
 	})
 })

--- a/pkg/utils/node/suite_test.go
+++ b/pkg/utils/node/suite_test.go
@@ -94,20 +94,20 @@ var _ = Describe("NodeUtils", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeClaims).To(HaveLen(0))
 	})
-	Context("CountReschedulablePodsOnNode", func() {
-		It("should return 0 for an empty node name", func() {
-			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, "")
+	Context("ReschedulablePods", func() {
+		It("should return no pods for an empty node name", func() {
+			pods, err := nodeutils.ReschedulablePods(ctx, env.Client, "")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(count).To(Equal(0))
+			Expect(pods).To(BeEmpty())
 		})
-		It("should return 0 when no pods are bound to the node", func() {
+		It("should return no pods when no pods are bound to the node", func() {
 			testNode = test.Node()
 			ExpectApplied(ctx, env.Client, testNode)
-			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, testNode.Name)
+			pods, err := nodeutils.ReschedulablePods(ctx, env.Client, testNode.Name)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(count).To(Equal(0))
+			Expect(pods).To(BeEmpty())
 		})
-		It("should count only reschedulable pods bound to the node", func() {
+		It("should return only reschedulable pods bound to the node", func() {
 			testNode = test.Node()
 			ExpectApplied(ctx, env.Client, testNode)
 			isController := true
@@ -134,9 +134,9 @@ var _ = Describe("NodeUtils", func() {
 
 			ExpectApplied(ctx, env.Client, pod1, pod2, daemonsetPod, otherPod)
 
-			count, err := nodeutils.CountReschedulablePodsOnNode(ctx, env.Client, testNode.Name)
+			pods, err := nodeutils.ReschedulablePods(ctx, env.Client, testNode.Name)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(count).To(Equal(2))
+			Expect(pods).To(HaveLen(2))
 		})
 	})
 })

--- a/test/pkg/debug/node.go
+++ b/test/pkg/debug/node.go
@@ -58,7 +58,7 @@ func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (
 }
 
 func (c *NodeController) GetInfo(ctx context.Context, n *corev1.Node) string {
-	pods, _ := nodeutils.GetPods(ctx, c.kubeClient, n)
+	pods, _ := nodeutils.GetPods(ctx, c.kubeClient, n.Name)
 	return fmt.Sprintf("ready=%s schedulable=%t initialized=%s pods=%d taints=%v", nodeutils.GetCondition(n, corev1.NodeReady).Status, !n.Spec.Unschedulable, n.Labels[v1.NodeInitializedLabelKey], len(pods), n.Spec.Taints)
 }
 


### PR DESCRIPTION
Reopens kubernetes-sigs/karpenter#3012 — closed on 2026-05-11 with the question "does pods_drained_total satisfy this?" After comparing both metric definitions, the two are adjacent rather than overlapping.

## Why pods_disrupted_total is not a duplicate of pods_drained_total

| Aspect                              | pods_drained_total (existing)       | pods_disrupted_total (this PR)         |
|-------------------------------------|-------------------------------------|----------------------------------------|
| Fires at                            | Each successful pod eviction        | NodeClaim-disruption decision time     |
| Increment shape                     | +1 per pod (`eviction.go:215`)      | +N per disruption (N = reschedulable)  |
| Labels                              | `reason`                            | `reason`, `nodepool`, `capacity_type`  |
| Pod filter                          | All evicted pods                    | Reschedulable only (excludes DS, mirror)|
| Counts pods that fail to evict?     | No (200 path only)                  | Yes (decision-time count)              |
| Counts pods lost to ungraceful node | No (terminator never runs)          | Yes (via `node/health` controller)     |
| Increment sites                     | 1 (`terminator/eviction.go`)        | 4 (queue, expiration, health, GC)      |

Three concrete operator questions only `pods_disrupted_total` answers:

1. **Pods that fail to evict** (PDB violations, repeated 429s, ungraceful terminations) — `pods_drained_total` only increments on the 200 path in `terminator/eviction.go:215`, so the denominator of intended disruption is invisible. `pods_drained_total / pods_disrupted_total` is the eviction success rate per nodepool/reason; neither metric alone expresses this.

2. **Ungraceful node loss** (`node/health/controller.go` GC path) — when an unhealthy node's NodeClaim is GC'd, the terminator never runs, so `pods_drained_total` is structurally blind to those pod disruptions. `pods_disrupted_total` catches them because it increments in the same 4 controllers that already increment `nodeclaims_disrupted_total`.

3. **Label cardinality parity with `nodeclaims_disrupted_total`** — that metric already exists at `pkg/metrics/metrics.go:60` with `(reason, nodepool, capacity_type)`. Operators can answer "how many NodeClaims were disrupted per nodepool" but not the corresponding pod-level question with matching labels.

## Open to adjustments

If cardinality is a concern, happy to drop the `capacity_type` label.

If the name suggests overlap with `pods_drained_total`, happy to rename to `pods_disruption_initiated_total` to make the timing difference explicit.

## Implementation

Mirrors `karpenter_nodeclaims_disrupted_total` but counts the reschedulable pods that were on each disrupted node, across the four NodeClaim disruption paths where pod records exist:

- `pkg/controllers/disruption/queue.go` uses `Candidate.reschedulablePods` directly (already cached on the Candidate)
- `pkg/controllers/nodeclaim/expiration/controller.go`, `pkg/controllers/node/health/controller.go`, and `pkg/controllers/nodeclaim/garbagecollection/controller.go` list pods via the new `node.CountReschedulablePodsOnNode` helper, which applies the same `pod.IsReschedulable` filter (active or stateful-set terminating; not DaemonSet- or Node-owned)

Skipped: `nodeclaim/lifecycle/launch.go` and `liveness.go` disrupt NodeClaims that never bound pods (launch failure, liveness watchdog), so a pods counter on those paths would always be 0.

A list error during pod counting is logged at V(1) and the metric reports 0 for that disruption — never blocks the disruption itself.

Refs 2020
