### PR TITLE
fix(nodeoverlay): continue on GetInstanceTypes error instead of aborting reconcile

### DIFF
--- a/pkg/controllers/nodeoverlay/controller.go
+++ b/pkg/controllers/nodeoverlay/controller.go
@@ -85,9 +85,13 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	for i := range nodePoolList.Items {
 		its, err := c.cloudProvider.GetInstanceTypes(ctx, &nodePoolList.Items[i])
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("listing instance types, %w", err)
+			// We skip the nodepool if we are not able to list the instance types for it
+			// This will mean that we will not be able to evaluate the nodepool for node overlays
+			// and scheduled nodeclaims for this nodepool will continue to be skipped by the provisioner
+			continue
 		}
 		nodePoolToInstanceTypes[nodePoolList.Items[i].Name] = its
+		temporaryStore.evaluatedNodePools.Insert(nodePoolList.Items[i].Name)
 	}
 
 	overlayList.OrderByWeight()
@@ -101,9 +105,6 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			overlaysWithConflict = append(overlaysWithConflict, overlayList.Items[i].Name)
 		}
 	}
-	temporaryStore.evaluatedNodePools.Insert(lo.Map(nodePoolList.Items, func(np v1.NodePool, _ int) string {
-		return np.Name
-	})...)
 
 	err, requeue := c.updateOverlayStatuses(ctx, overlayList.Items, overlaysWithConflict, overlayWithRuntimeValidationFailure)
 	if requeue {

--- a/pkg/controllers/nodeoverlay/controller_continue_on_error_test.go
+++ b/pkg/controllers/nodeoverlay/controller_continue_on_error_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeoverlay
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+)
+
+var _ = Describe("Issue 3003 Reproduction", func() {
+	It("should not block all provisioning if one NodePool fails evaluation", func() {
+		// Create two NodePools
+		np1 := test.NodePool()
+		np2 := test.NodePool()
+		ExpectApplied(ctx, env.Client, np1, np2)
+
+		// Make GetInstanceTypes fail for np1 but succeed for np2
+		cloudProvider.ErrorsForNodePool[np1.Name] = fmt.Errorf("failed to get instance types for np1")
+
+		// Run Reconcile — the whole point of the fix is that np1's GetInstanceTypes
+		// failure must not propagate into a reconcile error that aborts processing
+		// of np2 and subsequent NodePools.
+		_, err := nodeOverlayController.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ToNot(HaveOccurred())
+
+		// Checking the store for np2
+		_, err = store.ApplyAll(np2.Name, cloudProvider.InstanceTypes)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Fixes #3003

## Description

The NodeOverlay reconciler iterates over every `NodePool` and calls `cloudProvider.GetInstanceTypes` for each. Previously, if any single call returned an error, the reconciler returned that error and aborted the entire loop — every other NodePool's overlays went unevaluated, and Karpenter could not provision nodes for any NodePool until the offending one was fixed or removed.

A misconfigured NodePool (broken selector, transient cloud-provider failure, RBAC issue, etc.) becomes a blast-radius bug: the cluster stops provisioning across all NodePools after a controller restart, even though the rest of the configuration is healthy.

## Fix

`pkg/controllers/nodeoverlay/controller.go` — change `return err` to `continue` when `GetInstanceTypes` fails for a given NodePool. The skipped NodePool's overlays are not refreshed this cycle and will be retried on the next reconcile. Only NodePools whose `GetInstanceTypes` succeeded are inserted into `evaluatedNodePools` (moved inside the loop), so downstream code doesn't assume an unresolved NodePool was processed.

```diff
 for i := range nodePoolList.Items {
     its, err := c.cloudProvider.GetInstanceTypes(ctx, &nodePoolList.Items[i])
     if err != nil {
-        return reconcile.Result{}, fmt.Errorf("listing instance types, %w", err)
+        // Skip this NodePool — it won't be evaluated for overlays this cycle.
+        // Other NodePools continue processing; this NodePool is retried next reconcile.
+        continue
     }
     nodePoolToInstanceTypes[nodePoolList.Items[i].Name] = its
+    temporaryStore.evaluatedNodePools.Insert(nodePoolList.Items[i].Name)
 }
-temporaryStore.evaluatedNodePools.Insert(lo.Map(nodePoolList.Items, ...)...)
```

The bulk `Insert(lo.Map(nodePoolList.Items, ...)...)` after the loop is removed — it would have incorrectly registered NodePools whose `GetInstanceTypes` failed. The per-iteration insert covers the success cases only.

## Tests

New file `pkg/controllers/nodeoverlay/controller_continue_on_error_test.go` covering the regression case: a fake CloudProvider configured with `ErrorsForNodePool[failingNP.Name]` returning an error, and a second healthy NodePool. The test asserts:

1. `nodeOverlayController.Reconcile(...)` returns no error despite the failing NodePool.
2. The healthy NodePool's instance types still flow through to `InstanceTypeStore.ApplyAll`.

Local run with `KUBEBUILDER_ASSETS=~/.local/share/kubebuilder-envtest/k8s/1.35.0-linux-amd64`:

```
$ go test ./pkg/controllers/nodeoverlay/ -ginkgo.focus "Continue-on-error" -count=1
ok  sigs.k8s.io/karpenter/pkg/controllers/nodeoverlay  0.031s
```

No new test infrastructure introduced — uses existing `nodeOverlayController`, `cloudProvider`, `store`, and `env` globals from `suite_test.go`.

## Related

- Triage-accepted by @ryan-mist with `priority/important-soon` last week — surfaces as one of the highest-severity NodeOverlay bugs in the current backlog.
- Behavior matches what `pkg/controllers/disruption/queue.go` and similar reconcilers already do (continue-on-error on per-NodePool failures rather than aborting the whole reconcile).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
