### PR TITLE
docs: add Huawei Cloud provider to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Karpenter is a multi-cloud project with implementations by the following cloud p
 - [Cluster API](https://github.com/kubernetes-sigs/karpenter-provider-cluster-api)
 - [Exoscale](https://github.com/exoscale/karpenter-provider-exoscale/)
 - [GCP](https://github.com/cloudpilot-ai/karpenter-provider-gcp)
+- [Huawei Cloud](https://github.com/HuaweiCloudDeveloper/karpenter-provider-huawei)
 - [IBM Cloud](https://github.com/kubernetes-sigs/karpenter-provider-ibm-cloud)
 - [Proxmox](https://github.com/sergelogvinov/karpenter-provider-proxmox)
 - Oracle Cloud Infrastructure (OCI) 


### PR DESCRIPTION
Fixes #N/A

**Description**

Add [karpenter-provider-huawei](https://github.com/HuaweiCloudDeveloper/karpenter-provider-huawei) to the list of Karpenter implementations in README.md.

This provider enables Karpenter to provision and manage nodes on [Huawei Cloud](https://www.huaweicloud.com/) CCE clusters.

**How was this change tested?**

none.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
