### PR TITLE
chore: rename shadowed store in BenchmarkStoreApplyAllScenario

### DIFF
--- a/pkg/controllers/nodeoverlay/store_bench_test.go
+++ b/pkg/controllers/nodeoverlay/store_bench_test.go
@@ -236,7 +236,7 @@ func BenchmarkStoreApplyAllScenario(b *testing.B) {
 		}
 	}
 
-	store := NewInstanceTypeStore()
+	publicStore := NewInstanceTypeStore()
 	internalStore := newInternalInstanceTypeStore()
 
 	// Setup overlays for 5 node pools
@@ -264,13 +264,13 @@ func BenchmarkStoreApplyAllScenario(b *testing.B) {
 		}
 	}
 
-	store.UpdateStore(internalStore)
+	publicStore.UpdateStore(internalStore)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, np := range nodePools {
-			_, _ = store.ApplyAll(np, instanceTypes)
+			_, _ = publicStore.ApplyAll(np, instanceTypes)
 		}
 	}
 }


### PR DESCRIPTION
Fixes N/A

**Description**

`pkg/controllers/nodeoverlay/store_bench_test.go:239` declares `store := NewInstanceTypeStore()` inside `BenchmarkStoreApplyAllScenario`, which govet's shadow analyzer flags as shadowing the same-named local in `BenchmarkStoreApply`. This is the lint failure currently blocking `make verify` for PRs that touch the nodeoverlay package (observed on #3033, where it kept the presubmit jobs red across all K8s versions even though the actual code changes are unrelated).

Rename `store` to `publicStore` only inside `BenchmarkStoreApplyAllScenario`. The new name also disambiguates from the same-function `internalStore` (line 240), making the public-vs-internal store relationship explicit at the call site. No functional change.

**How was this change tested?**

- `go build ./pkg/controllers/nodeoverlay/...` — passes
- `go vet ./pkg/controllers/nodeoverlay/...` — passes (silences the govet shadow warning)
- Benchmarks still compile under `go test -bench=. -run=^$ ./pkg/controllers/nodeoverlay/...`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
