### PR TITLE
test: remove flaky single-run thresholds from e2e performance tests

### DIFF
--- a/test/suites/performance/basic_test.go
+++ b/test/suites/performance/basic_test.go
@@ -49,14 +49,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Performance assertions
 			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 2*time.Minute),
 				"Total scale-out time should be less than 2 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.53),
-				"Average CPU utilization should be greater than 53%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.65),
-				"Average memory utilization should be greater than 65%")
-			Expect(scaleOutReport.KarpenterMemoryMB).To(BeNumerically("<", 120+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 120 MB during scale-out")
-			Expect(scaleOutReport.KarpenterCPUNanos).To(BeNumerically("<", 15*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 15s (75%) during scale-out")
 
 			// ========== PHASE 2: CONSOLIDATION TEST ==========
 			By("Executing consolidation performance test (scaling down to 700 pods)")
@@ -75,10 +67,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(consolidationReport.PodsNetChange).To(Equal(-300), "Should have net reduction of 300 pods")
 			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 20*time.Minute),
 				"Consolidation should complete within 20 minutes")
-			Expect(consolidationReport.KarpenterMemoryMB).To(BeNumerically("<", 120+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 120 MB during consolidation")
-			Expect(consolidationReport.KarpenterCPUNanos).To(BeNumerically("<", 8*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 8s (40%) during consolidation")
 
 		})
 	})

--- a/test/suites/performance/basic_test.go
+++ b/test/suites/performance/basic_test.go
@@ -47,16 +47,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(scaleOutReport.TotalPods).To(Equal(1000), "Should have 1000 total pods")
 
 			// Performance assertions
-			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("basic/scaleOut", 2*time.Minute)),
+			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 2*time.Minute),
 				"Total scale-out time should be less than 2 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("basic/scaleOut", 0.53)),
-				"Average CPU utilization should be greater than 53%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("basic/scaleOut", 0.65)),
-				"Average memory utilization should be greater than 65%")
-			Expect(scaleOutReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("basic/scaleOut", 260)),
-				"Karpenter controller P95 memory should be less than 260 MB during scale-out")
-			Expect(scaleOutReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("basic/scaleOut", 0.50)),
-				"Karpenter controller avg CPU should be less than 0.50 cores during scale-out")
 
 			// ========== PHASE 2: CONSOLIDATION TEST ==========
 			By("Executing consolidation performance test (scaling down to 700 pods)")
@@ -73,12 +65,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(consolidationReport.TestType).To(Equal("consolidation"), "Should be detected as consolidation test")
 			Expect(consolidationReport.TotalPods).To(Equal(700), "Should have 700 total pods after scale-in")
 			Expect(consolidationReport.PodsNetChange).To(Equal(-300), "Should have net reduction of 300 pods")
-			Expect(consolidationReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("basic/consolidation", 20*time.Minute)),
+			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 20*time.Minute),
 				"Consolidation should complete within 20 minutes")
-			Expect(consolidationReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("basic/consolidation", 260)),
-				"Karpenter controller P95 memory should be less than 260 MB during consolidation")
-			Expect(consolidationReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("basic/consolidation", 0.25)),
-				"Karpenter controller avg CPU should be less than 0.25 cores during consolidation")
 
 		})
 	})

--- a/test/suites/performance/do_no_disrupt_test.go
+++ b/test/suites/performance/do_no_disrupt_test.go
@@ -62,14 +62,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Performance assertions
 			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 4*time.Minute),
 				"Total scale-out time should be less than 4 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should be greater than 38%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should be greater than 40%")
-			Expect(scaleOutReport.KarpenterMemoryMB).To(BeNumerically("<", 350+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 350 MB during scale-out")
-			Expect(scaleOutReport.KarpenterCPUNanos).To(BeNumerically("<", 20*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 20s (100%) during scale-out")
 
 			// ========== PHASE 2: DISRUPTION PROTECTION TEST ==========
 			By("Testing disruption protection behavior")
@@ -106,14 +98,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 
 			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 35*time.Minute),
 				"Consolidation should complete within 35 minutes")
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should be greater than 38%")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should be greater than 40%")
-			Expect(consolidationReport.KarpenterMemoryMB).To(BeNumerically("<", 320+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 320 MB during consolidation")
-			Expect(consolidationReport.KarpenterCPUNanos).To(BeNumerically("<", 20*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 20s (100%) during consolidation")
 
 			// Check if nodes with do-not-disrupt pods are still present
 			currentNodes := env.Monitor.CreatedNodes()

--- a/test/suites/performance/do_no_disrupt_test.go
+++ b/test/suites/performance/do_no_disrupt_test.go
@@ -60,16 +60,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(scaleOutReport.TotalPods).To(Equal(1100), "Should have 1100 total pods")
 
 			// Performance assertions
-			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("doNotDisrupt/scaleOut", 4*time.Minute)),
+			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 4*time.Minute),
 				"Total scale-out time should be less than 4 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("doNotDisrupt/scaleOut", 0.38)),
-				"Average CPU utilization should be greater than 38%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("doNotDisrupt/scaleOut", 0.40)),
-				"Average memory utilization should be greater than 40%")
-			Expect(scaleOutReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("doNotDisrupt/scaleOut", 645)),
-				"Karpenter controller P95 memory should be less than 645 MB during scale-out")
-			Expect(scaleOutReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("doNotDisrupt/scaleOut", 1.10)),
-				"Karpenter controller avg CPU should be less than 1.10 cores during scale-out")
 
 			// ========== PHASE 2: DISRUPTION PROTECTION TEST ==========
 			By("Testing disruption protection behavior")
@@ -104,16 +96,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(consolidationReport.TotalPods).To(BeNumerically(">=", 600), "Should have at least 600 total pods after scale-in (250+250+100)")
 			Expect(consolidationReport.PodsNetChange).To(BeNumerically(">=", -500), "Should have net reduction of 500 pods")
 
-			Expect(consolidationReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("doNotDisrupt/consolidation", 35*time.Minute)),
+			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 35*time.Minute),
 				"Consolidation should complete within 35 minutes")
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("doNotDisrupt/consolidation", 0.38)),
-				"Average CPU utilization should be greater than 38%")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("doNotDisrupt/consolidation", 0.40)),
-				"Average memory utilization should be greater than 40%")
-			Expect(consolidationReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("doNotDisrupt/consolidation", 585)),
-				"Karpenter controller P95 memory should be less than 585 MB during consolidation")
-			Expect(consolidationReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("doNotDisrupt/consolidation", 0.80)),
-				"Karpenter controller avg CPU should be less than 0.80 cores during consolidation")
 
 			// Check if nodes with do-not-disrupt pods are still present
 			currentNodes := env.Monitor.CreatedNodes()

--- a/test/suites/performance/drift_performance_test.go
+++ b/test/suites/performance/drift_performance_test.go
@@ -60,10 +60,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Performance assertions for initial deployment
 			Expect(initialReport.TotalTime).To(BeNumerically("<", 5*time.Minute),
 				"Initial deployment should complete within 5 minutes")
-			Expect(initialReport.KarpenterMemoryMB).To(BeNumerically("<", 200+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 200 MB during scale-out")
-			Expect(initialReport.KarpenterCPUNanos).To(BeNumerically("<", 18*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 18s (90%) during scale-out")
 
 			// Allow system to stabilize before triggering drift
 			By("Allowing system to stabilize before triggering drift")
@@ -91,10 +87,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Drift performance assertions
 			Expect(driftReport.TotalTime).To(BeNumerically("<", 50*time.Minute),
 				"Drift should complete within 50 minutes")
-			Expect(driftReport.KarpenterMemoryMB).To(BeNumerically("<", 250+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 250 MB during drift")
-			Expect(driftReport.KarpenterCPUNanos).To(BeNumerically("<", 24*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 24s (120%) during drift")
 
 			// ========== PHASE 3: POST-DRIFT VALIDATION ==========
 			By("Validating post-drift cluster state")

--- a/test/suites/performance/drift_performance_test.go
+++ b/test/suites/performance/drift_performance_test.go
@@ -58,12 +58,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(initialReport.TotalPods).To(Equal(600), "Should have 600 total pods")
 
 			// Performance assertions for initial deployment
-			Expect(initialReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("drift/initial", 5*time.Minute)),
+			Expect(initialReport.TotalTime).To(BeNumerically("<", 5*time.Minute),
 				"Initial deployment should complete within 5 minutes")
-			Expect(initialReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("drift/initial", 425)),
-				"Karpenter controller P95 memory should be less than 425 MB during scale-out")
-			Expect(initialReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("drift/initial", 0.70)),
-				"Karpenter controller avg CPU should be less than 0.70 cores during scale-out")
 
 			// Allow system to stabilize before triggering drift
 			By("Allowing system to stabilize before triggering drift")
@@ -89,12 +85,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(driftReport.PodsNetChange).To(Equal(0), "Pods should not change during drift")
 
 			// Drift performance assertions
-			Expect(driftReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("drift/drift", 50*time.Minute)),
+			Expect(driftReport.TotalTime).To(BeNumerically("<", 50*time.Minute),
 				"Drift should complete within 50 minutes")
-			Expect(driftReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("drift/drift", 470)),
-				"Karpenter controller P95 memory should be less than 470 MB during drift")
-			Expect(driftReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("drift/drift", 1.05)),
-				"Karpenter controller avg CPU should be less than 1.05 cores during drift")
 
 			// ========== PHASE 3: POST-DRIFT VALIDATION ==========
 			By("Validating post-drift cluster state")

--- a/test/suites/performance/host_name_spreading_test.go
+++ b/test/suites/performance/host_name_spreading_test.go
@@ -58,14 +58,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Performance assertions - hostname spreading may require more nodes
 			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 5*time.Minute),
 				"Total scale-out time should be less than 5 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should be greater than 38%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should be greater than 55%")
-			Expect(scaleOutReport.KarpenterMemoryMB).To(BeNumerically("<", 300+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 300 MB during scale-out")
-			Expect(scaleOutReport.KarpenterCPUNanos).To(BeNumerically("<", 20*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 20s (100%) during scale-out")
 
 			// ========== PHASE 2: CONSOLIDATION TEST ==========
 			By("Scaling down deployments to trigger consolidation")
@@ -86,14 +78,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(consolidationReport.PodsNetChange).To(Equal(-300), "Should have net reduction of 300 pods")
 
 			// Consolidation assertions
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should be greater than 38%")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should be greater than 40%")
-			Expect(consolidationReport.KarpenterMemoryMB).To(BeNumerically("<", 300+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 300 MB during consolidation")
-			Expect(consolidationReport.KarpenterCPUNanos).To(BeNumerically("<", 24*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 24s (120%) during consolidation")
 
 		})
 	})

--- a/test/suites/performance/host_name_spreading_test.go
+++ b/test/suites/performance/host_name_spreading_test.go
@@ -56,16 +56,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(scaleOutReport.TotalPods).To(Equal(1000), "Should have 1000 total pods")
 
 			// Performance assertions - hostname spreading may require more nodes
-			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("hostNameSpreading/scaleOut", 5*time.Minute)),
+			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 5*time.Minute),
 				"Total scale-out time should be less than 5 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("hostNameSpreading/scaleOut", 0.38)),
-				"Average CPU utilization should be greater than 38%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("hostNameSpreading/scaleOut", 0.40)),
-				"Average memory utilization should be greater than 55%")
-			Expect(scaleOutReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("hostNameSpreading/scaleOut", 680)),
-				"Karpenter controller P95 memory should be less than 680 MB during scale-out")
-			Expect(scaleOutReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("hostNameSpreading/scaleOut", 1.15)),
-				"Karpenter controller avg CPU should be less than 1.15 cores during scale-out")
 
 			// ========== PHASE 2: CONSOLIDATION TEST ==========
 			By("Scaling down deployments to trigger consolidation")
@@ -86,14 +78,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(consolidationReport.PodsNetChange).To(Equal(-300), "Should have net reduction of 300 pods")
 
 			// Consolidation assertions
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("hostNameSpreading/consolidation", 0.38)),
-				"Average CPU utilization should be greater than 38%")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("hostNameSpreading/consolidation", 0.40)),
-				"Average memory utilization should be greater than 40%")
-			Expect(consolidationReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("hostNameSpreading/consolidation", 575)),
-				"Karpenter controller P95 memory should be less than 575 MB during consolidation")
-			Expect(consolidationReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("hostNameSpreading/consolidation", 1.00)),
-				"Karpenter controller avg CPU should be less than 1.00 cores during consolidation")
 
 		})
 	})

--- a/test/suites/performance/host_name_spreading_xl_test.go
+++ b/test/suites/performance/host_name_spreading_xl_test.go
@@ -58,14 +58,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// XL Performance assertions - hostname spreading at scale may require many more nodes
 			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 35*time.Minute),
 				"Total XL scale-out time should be less than 35 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should be greater than 38%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should be greater than 40%")
-			Expect(scaleOutReport.KarpenterMemoryMB).To(BeNumerically("<", 700+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 700 MB during scale-out")
-			Expect(scaleOutReport.KarpenterCPUNanos).To(BeNumerically("<", 20*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 20s (100%) during scale-out")
 
 			// ========== PHASE 2: XL CONSOLIDATION TEST ==========
 			By("Scaling down XL deployments to trigger consolidation")
@@ -88,14 +80,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// XL Consolidation assertions
 			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 35*time.Minute),
 				"XL consolidation should complete within 35 minutes")
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should be greater than 38%")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should be greater than 40%")
-			Expect(consolidationReport.KarpenterMemoryMB).To(BeNumerically("<", 650+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 650 MB during consolidation")
-			Expect(consolidationReport.KarpenterCPUNanos).To(BeNumerically("<", 24*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 24s (120%) during consolidation")
 
 		})
 	})

--- a/test/suites/performance/host_name_spreading_xl_test.go
+++ b/test/suites/performance/host_name_spreading_xl_test.go
@@ -56,16 +56,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(scaleOutReport.TotalPods).To(BeNumerically(">=", 1999), "Should have 2000 total pods")
 
 			// XL Performance assertions - hostname spreading at scale may require many more nodes
-			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("hostNameSpreadingXL/scaleOut", 35*time.Minute)),
+			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 35*time.Minute),
 				"Total XL scale-out time should be less than 35 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("hostNameSpreadingXL/scaleOut", 0.38)),
-				"Average CPU utilization should be greater than 38%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("hostNameSpreadingXL/scaleOut", 0.40)),
-				"Average memory utilization should be greater than 40%")
-			Expect(scaleOutReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("hostNameSpreadingXL/scaleOut", 1330)),
-				"Karpenter controller P95 memory should be less than 1330 MB during scale-out")
-			Expect(scaleOutReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("hostNameSpreadingXL/scaleOut", 1.40)),
-				"Karpenter controller avg CPU should be less than 1.40 cores during scale-out")
 
 			// ========== PHASE 2: XL CONSOLIDATION TEST ==========
 			By("Scaling down XL deployments to trigger consolidation")
@@ -86,16 +78,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(consolidationReport.PodsNetChange).To(Equal(-600), "Should have net reduction of 600 pods")
 
 			// XL Consolidation assertions
-			Expect(consolidationReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("hostNameSpreadingXL/consolidation", 35*time.Minute)),
+			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 35*time.Minute),
 				"XL consolidation should complete within 35 minutes")
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("hostNameSpreadingXL/consolidation", 0.38)),
-				"Average CPU utilization should be greater than 38%")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("hostNameSpreadingXL/consolidation", 0.40)),
-				"Average memory utilization should be greater than 40%")
-			Expect(consolidationReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("hostNameSpreadingXL/consolidation", 1200)),
-				"Karpenter controller P95 memory should be less than 1200 MB during consolidation")
-			Expect(consolidationReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("hostNameSpreadingXL/consolidation", 1.70)),
-				"Karpenter controller avg CPU should be less than 1.70 cores during consolidation")
 
 		})
 	})

--- a/test/suites/performance/interference_test.go
+++ b/test/suites/performance/interference_test.go
@@ -57,14 +57,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Performance assertions - self anti-affinity requires one pod per node
 			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 5*time.Minute),
 				"Total scale-out time should be less than 5 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should be greater than 38%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should be greater than 40%")
-			Expect(scaleOutReport.KarpenterMemoryMB).To(BeNumerically("<", 300+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 300 MB during scale-out")
-			Expect(scaleOutReport.KarpenterCPUNanos).To(BeNumerically("<", 22*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 22s (110%) during scale-out")
 
 			// ========== PHASE 2: Interference Scale Out TEST ==========
 			By("Net scaling out interference test")
@@ -86,14 +78,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Consolidation assertions
 			Expect(interferenceReport.TotalTime).To(BeNumerically("<", 10*time.Minute),
 				"Scaling should complete within 10 minutes")
-			Expect(interferenceReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should be greater than 38%")
-			Expect(interferenceReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should be greater than 40%")
-			Expect(interferenceReport.KarpenterMemoryMB).To(BeNumerically("<", 550+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 550 MB during scale-out")
-			Expect(interferenceReport.KarpenterCPUNanos).To(BeNumerically("<", 20*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 20s (100%) during scale-out")
 
 			// ========== PHASE 3: Interference Scale In TEST ==========
 			By("Executing interference consolidation test (small_deployment scales out to 400, large_deployment scales in to 200)")
@@ -120,14 +104,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Consolidation performance assertions
 			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 25*time.Minute),
 				"Mixed scaling and consolidation should complete within 25 minutes")
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.38),
-				"Average CPU utilization should remain greater than 38% after consolidation")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.40),
-				"Average memory utilization should remain greater than 40% after consolidation")
-			Expect(consolidationReport.KarpenterMemoryMB).To(BeNumerically("<", 450+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 450 MB during consolidation")
-			Expect(consolidationReport.KarpenterCPUNanos).To(BeNumerically("<", 16*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 16s (80%) during consolidation")
 
 		})
 	})

--- a/test/suites/performance/interference_test.go
+++ b/test/suites/performance/interference_test.go
@@ -55,16 +55,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(scaleOutReport.TotalPods).To(Equal(500), "Should have 500 total pods")
 
 			// Performance assertions - self anti-affinity requires one pod per node
-			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("interference/scaleOut", 5*time.Minute)),
+			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 5*time.Minute),
 				"Total scale-out time should be less than 5 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("interference/scaleOut", 0.38)),
-				"Average CPU utilization should be greater than 38%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("interference/scaleOut", 0.40)),
-				"Average memory utilization should be greater than 40%")
-			Expect(scaleOutReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("interference/scaleOut", 620)),
-				"Karpenter controller P95 memory should be less than 620 MB during scale-out")
-			Expect(scaleOutReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("interference/scaleOut", 0.90)),
-				"Karpenter controller avg CPU should be less than 0.90 cores during scale-out")
 
 			// ========== PHASE 2: Interference Scale Out TEST ==========
 			By("Net scaling out interference test")
@@ -84,16 +76,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(interferenceReport.TotalPods).To(Equal(750), "Should have 750 total pods after scale-in")
 
 			// Consolidation assertions
-			Expect(interferenceReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("interference/interference", 10*time.Minute)),
+			Expect(interferenceReport.TotalTime).To(BeNumerically("<", 10*time.Minute),
 				"Scaling should complete within 10 minutes")
-			Expect(interferenceReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("interference/interference", 0.38)),
-				"Average CPU utilization should be greater than 38%")
-			Expect(interferenceReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("interference/interference", 0.40)),
-				"Average memory utilization should be greater than 40%")
-			Expect(interferenceReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("interference/interference", 1205)),
-				"Karpenter controller P95 memory should be less than 1205 MB during interference")
-			Expect(interferenceReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("interference/interference", 1.30)),
-				"Karpenter controller avg CPU should be less than 1.30 cores during interference")
 
 			// ========== PHASE 3: Interference Scale In TEST ==========
 			By("Executing interference consolidation test (small_deployment scales out to 400, large_deployment scales in to 200)")
@@ -118,16 +102,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(consolidationReport.PodsNetChange).To(Equal(-150), "Should have net reduction of 150 pods")
 
 			// Consolidation performance assertions
-			Expect(consolidationReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("interference/consolidation", 25*time.Minute)),
+			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 25*time.Minute),
 				"Mixed scaling and consolidation should complete within 25 minutes")
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("interference/consolidation", 0.38)),
-				"Average CPU utilization should remain greater than 38% after consolidation")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("interference/consolidation", 0.40)),
-				"Average memory utilization should remain greater than 40% after consolidation")
-			Expect(consolidationReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("interference/consolidation", 820)),
-				"Karpenter controller P95 memory should be less than 820 MB during consolidation")
-			Expect(consolidationReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("interference/consolidation", 0.80)),
-				"Karpenter controller avg CPU should be less than 0.80 cores during consolidation")
 
 		})
 	})

--- a/test/suites/performance/overhead.go
+++ b/test/suites/performance/overhead.go
@@ -19,22 +19,36 @@ package performance
 import (
 	"os"
 	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
 )
 
-// MemoryOverheadMB returns the additional memory overhead (in MB) to add to
-// Karpenter controller memory thresholds. This is read from the
-// KARPENTER_MEMORY_OVERHEAD_MB environment variable and defaults to 0.
-// This is useful for internal providers where daemonsets and other overhead
-// cause the karpenter pod to consistently use more memory.
+// MemoryOverheadMB returns the additional memory overhead (in MB) configured via
+// the KARPENTER_MEMORY_OVERHEAD_MB environment variable (defaults to 0).
+// This value represents expected baseline memory overhead from daemonsets and
+// other environment-specific components. It is reported in test output for
+// observability but is NOT used to gate test pass/fail.
 func MemoryOverheadMB() float64 {
 	return envFloat64("KARPENTER_MEMORY_OVERHEAD_MB", 0)
 }
 
-// CPUOverheadNanos returns the additional CPU overhead (in nanoseconds) to add
-// to Karpenter controller CPU thresholds. This is read from the
-// KARPENTER_CPU_OVERHEAD_NANOS environment variable and defaults to 0.
+// CPUOverheadNanos returns the additional CPU overhead (in nanoseconds) configured
+// via the KARPENTER_CPU_OVERHEAD_NANOS environment variable (defaults to 0).
+// This value represents expected baseline CPU overhead from environment-specific
+// components. It is reported in test output for observability but is NOT used to
+// gate test pass/fail.
 func CPUOverheadNanos() float64 {
 	return envFloat64("KARPENTER_CPU_OVERHEAD_NANOS", 0)
+}
+
+// ReportOverhead logs the configured overhead values to the test output.
+// Call this at the beginning of performance test suites to record the
+// environment-specific overhead configuration for later analysis.
+func ReportOverhead() {
+	memOverhead := MemoryOverheadMB()
+	cpuOverhead := CPUOverheadNanos()
+	GinkgoWriter.Printf("Configured memory overhead: %.2f MB\n", memOverhead)
+	GinkgoWriter.Printf("Configured CPU overhead: %.0f ns\n", cpuOverhead)
 }
 
 func envFloat64(key string, defaultVal float64) float64 {

--- a/test/suites/performance/overhead.go
+++ b/test/suites/performance/overhead.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package performance
+
+import (
+	"os"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// MemoryOverheadMB returns the additional memory overhead (in MB) configured via
+// the KARPENTER_MEMORY_OVERHEAD_MB environment variable (defaults to 0).
+// This value represents expected baseline memory overhead from daemonsets and
+// other environment-specific components. It is reported in test output for
+// observability but is NOT used to gate test pass/fail.
+func MemoryOverheadMB() float64 {
+	return envFloat64("KARPENTER_MEMORY_OVERHEAD_MB", 0)
+}
+
+// CPUOverheadNanos returns the additional CPU overhead (in nanoseconds) configured
+// via the KARPENTER_CPU_OVERHEAD_NANOS environment variable (defaults to 0).
+// This value represents expected baseline CPU overhead from environment-specific
+// components. It is reported in test output for observability but is NOT used to
+// gate test pass/fail.
+func CPUOverheadNanos() float64 {
+	return envFloat64("KARPENTER_CPU_OVERHEAD_NANOS", 0)
+}
+
+// ReportOverhead logs the configured overhead values to the test output.
+// Call this at the beginning of performance test suites to record the
+// environment-specific overhead configuration for later analysis.
+func ReportOverhead() {
+	memOverhead := MemoryOverheadMB()
+	cpuOverhead := CPUOverheadNanos()
+	GinkgoWriter.Printf("Configured memory overhead: %.2f MB\n", memOverhead)
+	GinkgoWriter.Printf("Configured CPU overhead: %.0f ns\n", cpuOverhead)
+}
+
+func envFloat64(key string, defaultVal float64) float64 {
+	if v, ok := os.LookupEnv(key); ok {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return defaultVal
+}

--- a/test/suites/performance/suite_test.go
+++ b/test/suites/performance/suite_test.go
@@ -39,6 +39,7 @@ func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	BeforeSuite(func() {
 		env = common.NewEnvironment(t)
+		ReportOverhead()
 	})
 	AfterSuite(func() {
 		env.Stop()

--- a/test/suites/performance/wide_deployments_test.go
+++ b/test/suites/performance/wide_deployments_test.go
@@ -176,14 +176,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Performance assertions for wide deployments
 			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 5*time.Minute),
 				"Total scale-out time should be less than 10 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.2),
-				"Average CPU utilization should be greater than 20%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.20),
-				"Average memory utilization should be greater than 20%")
-			Expect(scaleOutReport.KarpenterMemoryMB).To(BeNumerically("<", 150+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 150 MB during scale-out")
-			Expect(scaleOutReport.KarpenterCPUNanos).To(BeNumerically("<", 14*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 14s (70%) during scale-out")
 
 			// ========== PHASE 2: WIDE CONSOLIDATION TEST ==========
 			By("Scaling down all 30 deployments to trigger consolidation")
@@ -208,14 +200,6 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			// Wide consolidation assertions
 			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 40*time.Minute),
 				"Wide consolidation should complete within 40 minutes")
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", 0.20),
-				"Average CPU utilization should be greater than 20%")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", 0.20),
-				"Average memory utilization should be greater than 20%")
-			Expect(consolidationReport.KarpenterMemoryMB).To(BeNumerically("<", 175+MemoryOverheadMB()),
-				"Karpenter controller memory should be less than 175 MB during consolidation")
-			Expect(consolidationReport.KarpenterCPUNanos).To(BeNumerically("<", 12*1e9+CPUOverheadNanos()),
-				"Karpenter controller CPU should be less than 12s (60%) during consolidation")
 
 		})
 	})

--- a/test/suites/performance/wide_deployments_test.go
+++ b/test/suites/performance/wide_deployments_test.go
@@ -174,16 +174,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(scaleOutReport.TotalPods).To(Equal(1000), "Should have 1000 total pods")
 
 			// Performance assertions for wide deployments
-			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("wideDeployments/scaleOut", 5*time.Minute)),
+			Expect(scaleOutReport.TotalTime).To(BeNumerically("<", 5*time.Minute),
 				"Total scale-out time should be less than 10 minutes")
-			Expect(scaleOutReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("wideDeployments/scaleOut", 0.2)),
-				"Average CPU utilization should be greater than 20%")
-			Expect(scaleOutReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("wideDeployments/scaleOut", 0.20)),
-				"Average memory utilization should be greater than 20%")
-			Expect(scaleOutReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("wideDeployments/scaleOut", 370)),
-				"Karpenter controller P95 memory should be less than 370 MB during scale-out")
-			Expect(scaleOutReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("wideDeployments/scaleOut", 0.70)),
-				"Karpenter controller avg CPU should be less than 0.70 cores during scale-out")
 
 			// ========== PHASE 2: WIDE CONSOLIDATION TEST ==========
 			By("Scaling down all 30 deployments to trigger consolidation")
@@ -206,16 +198,8 @@ var _ = Describe("Performance", Label(debug.NoWatch), func() {
 			Expect(consolidationReport.PodsNetChange).To(Equal(-300), "Should have net reduction of 300 pods")
 
 			// Wide consolidation assertions
-			Expect(consolidationReport.TotalTime).To(BeNumerically("<", TotalTimeThreshold("wideDeployments/consolidation", 40*time.Minute)),
+			Expect(consolidationReport.TotalTime).To(BeNumerically("<", 40*time.Minute),
 				"Wide consolidation should complete within 40 minutes")
-			Expect(consolidationReport.TotalReservedCPUUtil).To(BeNumerically(">", CPUUtilThreshold("wideDeployments/consolidation", 0.20)),
-				"Average CPU utilization should be greater than 20%")
-			Expect(consolidationReport.TotalReservedMemoryUtil).To(BeNumerically(">", MemoryUtilThreshold("wideDeployments/consolidation", 0.20)),
-				"Average memory utilization should be greater than 20%")
-			Expect(consolidationReport.KarpenterP95MemoryMB).To(BeNumerically("<", MemoryThreshold("wideDeployments/consolidation", 340)),
-				"Karpenter controller P95 memory should be less than 340 MB during consolidation")
-			Expect(consolidationReport.KarpenterAvgCPUCores).To(BeNumerically("<", CPUThreshold("wideDeployments/consolidation", 0.30)),
-				"Karpenter controller avg CPU should be less than 0.30 cores during consolidation")
 
 		})
 	})


### PR DESCRIPTION
### Summary

Remove hard-coded per-test performance threshold assertions from the E2E performance test suite. These absolute limits cause false failures when resource usage varies across different test environments.

### Motivation

The thresholds cause false failures across cluster configurations:
- Memory: 200MB limit vs 622MB actual in environments with additional daemonsets
- CPU: 22s/110% limit vs 71s/355% actual with sidecar overhead
- Utilization: 38-65% lower bounds too low to catch real regressions, better evaluated across multiple runs

These were calibrated for one configuration and don't account for overhead variance across environments.

### What changed

**Removed** (from all performance test files):
- `Expect(report.KarpenterMemoryMB).To(BeNumerically("<", ...))` assertions
- `Expect(report.KarpenterCPUNanos).To(BeNumerically("<", ...))` assertions
- `Expect(report.TotalReservedCPUUtil).To(BeNumerically(">", ...))` assertions
- `Expect(report.TotalReservedMemoryUtil).To(BeNumerically(">", ...))` assertions

**Modified**:
- `test/suites/performance/overhead.go` -- `MemoryOverheadMB()` and `CPUOverheadNanos()` repurposed from threshold adjusters to reporting-only helpers. Added `ReportOverhead()` function that logs configured overhead values at suite start for observability.

**Retained**:
- All metrics collection and reporting (memory/CPU/utilization values still captured and written to output)
- `TotalTime` upper bounds (test-completion timeout guards, not performance thresholds)
- All behavioral/correctness assertions (pod counts, node counts, net changes, test types)

### Replacement mechanism

PR #2994 introduces multi-trial statistical comparison for regression detection — compares distributions across runs rather than asserting absolute limits on any single run.

### Testing

- `go build ./test/suites/performance/...` passes cleanly
- Performance tests still collect all metrics and report memory/CPU/utilization data
- Overhead values logged at suite startup for environment analysis

/kind cleanup
/area testing