### PR TITLE
docs: add feature lifecycle, scope guidelines, RFC template, and updated contributing docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -2,9 +2,17 @@ name: Feature
 description: Suggest an idea for a new feature
 labels: ['kind/feature']
 body:
+- type: markdown
+  attributes:
+    value: |
+      > [!IMPORTANT]
+      > Before filing, please review the [Feature Lifecycle](https://github.com/kubernetes-sigs/karpenter/blob/main/FEATURE_LIFECYCLE.md) to understand how feature requests are evaluated and the [Scope Guidelines](https://github.com/kubernetes-sigs/karpenter/blob/main/SCOPE.md) to check if your idea is in scope.
+      >
+      > Provider-specific features belong in the provider repo (e.g. [karpenter-provider-aws](https://github.com/aws/karpenter-provider-aws/issues/new/choose)).
 - type: textarea
   attributes:
     label: Description
+    description: Describe the problem you're trying to solve, not just the solution you have in mind.
     value: |
       **What problem are you trying to solve?**
 
@@ -12,4 +20,5 @@ body:
 
       * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
       * Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
-      * If you are interested in working on this issue or have submitted a pull request, please leave a comment
+      * Comments asking for updates generate extra noise for issue followers and do not help maintainers prioritize issues. If you think the issue is higher priority than it is [labelled](https://github.com/kubernetes-sigs/karpenter/blob/main/FEATURE_LIFECYCLE.md#3-check-the-priority), please instead add your user story.
+      * If you are interested in working on this issue or have submitted a pull request, please assign yourself

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,47 @@
-# Contributing Guidelines
+# Contributing to Karpenter
 
-Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://git.k8s.io/community)! The Kubernetes community abides by the CNCF [code of conduct](code-of-conduct.md). Here is an excerpt:
-
-_As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
+Welcome to Karpenter! We are excited about the prospect of you joining our [community](https://git.k8s.io/community). The Kubernetes community abides by the CNCF [code of conduct](code-of-conduct.md).
 
 ## Getting Started
 
-We have full documentation on how to get started contributing here:
-
-- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) - Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
-- [Kubernetes Contributor Guide](https://k8s.dev/guide) - Main contributor documentation, or you can just jump directly to the [contributing page](https://k8s.dev/docs/guide/contributing/)
+- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) - You must sign a CLA before we can accept your pull requests
+- [Kubernetes Contributor Guide](https://k8s.dev/guide) - Main contributor documentation
 - [Contributor Cheat Sheet](https://k8s.dev/cheatsheet) - Common resources for existing developers
+- [Mentoring Initiatives](https://k8s.dev/community/mentoring) - Programs available for new contributors
 
-## Mentorship
+The best way to get involved is to attend our [working group meetings](README.md#working-group-meetings). These are open to everyone and are where design decisions, feature discussions, and release planning happen.
 
-- [Mentoring Initiatives](https://k8s.dev/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!
+## Finding Work
+
+Issues labelled [`help-wanted`](https://github.com/kubernetes-sigs/karpenter/labels/help%20wanted) are good starting points for contributions. If you want to work on an issue, assign yourself to indicate that you're working on it. Assigning is not authoritative — it's a heads up to everyone else.
+
+### Features
+
+Features follow a structured lifecycle from proposal to implementation. Before starting work on a feature, read the [Feature Lifecycle](FEATURE_LIFECYCLE.md) and [Scope Guidelines](SCOPE.md).
+
+### Bug Fixes, Refactors, Tests, and Documentation
+
+For non-feature contributions, open a pull request referencing the relevant issue. If no issue exists, create one first for bug fixes so the problem can be discussed. For test improvements or documentation changes, a PR without a prior issue is fine.
+
+## Pull Request Guidelines
+
+- Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for your PR title (`feat:`, `fix:`, `chore:`, `perf:`, `docs:`, `test:`, `ci:`)
+- Reference the issue your PR addresses
+- Ensure tests cover any behavior changes
+- Update documentation for user-facing changes
+- Large changes should be split into smaller PRs when possible
+
+## Key Documents
+
+| Document | Purpose |
+|----------|---------|
+| [Feature Lifecycle](FEATURE_LIFECYCLE.md) | How features are proposed, evaluated, and tracked |
+| [Scope Guidelines](SCOPE.md) | What Karpenter will and won't do |
+| [RFC Template](designs/rfc-template.md) | Template for design proposals |
+| [Contributor Ladder](contributing-guidelines.md) | Path from contributor to reviewer to approver |
+| [Release Process](RELEASE.md) | How releases are versioned and published |
+| [Development Guide](https://karpenter.sh/docs/contributing/development-guide/) | Setting up your local environment |
 
 ## Contact Information
 
-- [Slack channel](https://kubernetes.slack.com/messages/sig-k8s-infra) 
+For questions about using or deploying Karpenter, reach out in [#karpenter](https://kubernetes.slack.com/archives/C02SFFZSA2K) on Kubernetes Slack. For contribution and development discussions, use [#karpenter-dev](https://kubernetes.slack.com/archives/C04JW2J5J5P). See the [README](README.md#community-discussion-contribution-and-support) for meeting schedules and additional resources.

--- a/FEATURE_LIFECYCLE.md
+++ b/FEATURE_LIFECYCLE.md
@@ -1,0 +1,74 @@
+## Feature Lifecycle
+
+This document describes how a feature request moves from idea to merged code in Karpenter. Understanding this process helps you invest your time effectively.
+
+### 1. Open an Issue
+
+All features start as a GitHub issue. Use the feature request template and describe the problem you're trying to solve, not just the solution you have in mind.
+
+Search existing issues first — your idea may already be tracked. If it is, add your use case as a comment and upvote the issue with a thumbs-up reaction.
+
+You are encouraged to bring your feature request to the [bi-weekly working group meeting](https://karpenter.sh/docs/contributing/community-meetings/) for discussion. This helps maintainers understand your use case and gives you early signal on whether the idea fits the project before you invest further effort.
+
+### 2. Triage
+
+Maintainers evaluate feature requests during [issue triage meetings](https://github.com/kubernetes-sigs/karpenter#issue-triage-meetings). After triage, an issue will be in one of these states:
+
+| State | Labels | What it means |
+|-------|--------|---------------|
+| Accepted | `triage/accepted` | The feature is in scope |
+| Needs information | `triage/needs-information` | We can't evaluate this yet — the reporter needs to clarify |
+| Out of scope | Issue closed | The feature doesn't fit the project's scope (see [Scope Guidelines](SCOPE.md)) |
+
+If you would like to participate in the triaging process, attending [issue triage](https://github.com/kubernetes-sigs/karpenter#issue-triage-meetings) will let your voice be heard during the process.
+
+### 3. Check the Priority
+
+Once a feature is accepted, check whether it is labelled `backlog`:
+
+- **No `backlog` label** — You can submit an RFC/PR for this issue.
+- **`backlog`** — We want to do this, but aren't accepting contributions for it right now. An RFC/PR will likely not get reviewed if submitted.
+
+If a feature has an **assignee**, that means someone is actively working on it.
+
+If a feature is labelled `maintainer-owned`, a maintainer is driving the feature and we won't accept a contribution for it. Issues labelled `help-wanted` are especially good for community contributions.
+
+If a feature is in `backlog` and you want it moved up, add your use case to the issue and bring it to the [working group meeting](https://karpenter.sh/docs/contributing/community-meetings/) or [issue triage](https://github.com/kubernetes-sigs/karpenter#issue-triage-meetings). More voices and concrete user stories help maintainers reprioritize.
+
+### 4. Request for Comments (`needs-design`)
+
+Maintainers determine whether a feature requires an RFC. Issues that require an RFC will be labelled `needs-design`. The following guidelines indicate when an RFC is likely required:
+
+1. **API changes** — Adding, removing, or modifying fields on any Karpenter CRD (NodePool, NodeClaim, etc.), introducing new custom resources, or changing cloud provider interface signatures.
+
+2. **User-visible behavior changes** — Altering how Karpenter schedules, provisions, disrupts, or repairs nodes in ways users will observe. If a user would need to change how they operate Karpenter, or would notice different behavior after upgrading, an RFC is likely needed.
+
+3. **Significant architectural changes** — Introducing new controllers, replacing core algorithms (e.g. scheduling, bin-packing), unifying or splitting existing controllers, or redesigning internal data models.
+
+#### Submitting an RFC
+
+1. Write your proposal following the [RFC template](designs/rfc-template.md). The other designs in the [designs/](designs/) folder are good prior art to understand how RFCs are written.
+2. Open a PR to the `designs/` folder
+3. Gather broad feedback — surface your RFC at the [working group meeting](https://karpenter.sh/docs/contributing/community-meetings/), in the [#karpenter Slack channel](https://kubernetes.slack.com/archives/C02SFFZSA2K), and with any Kubernetes SIGs whose scope your design touches. The bigger the change, the more likely it has broader implications than intended.
+4. Iterate on feedback until maintainers approve the RFC PR
+
+Once the RFC PR is merged, the issue will be labelled `needs-implementation` and `needs-design` will be removed. The feature is now ready for code.
+
+### 5. Implementation (`needs-implementation`)
+
+Once an RFC is merged (or if no RFC is required):
+
+1. Open a PR referencing the feature issue
+2. Follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title
+3. Ensure tests cover the new behavior
+4. Update documentation if the change is user-facing
+
+Large features may be split across multiple PRs. This is encouraged — smaller PRs are easier to review and less risky to merge.
+
+We welcome reviews from all contributors and users, not just maintainers. If you see a PR and have feedback, please share it.
+
+### 6. Merge
+
+A maintainer approves and merges the PR. The feature issue is closed when the implementation is complete.
+
+See [RELEASE.md](RELEASE.md) for information on release cadence and how merged features are published.

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,0 +1,29 @@
+## Scope Guidelines
+
+Karpenter is a node autoscaler. It provisions compute capacity so pods can run, and removes capacity that is no longer needed. The project maintains a strong bias toward:
+
+- **Saying "no"** to changes that don't clearly demonstrate broad benefit
+- **Minimizing API surface** — no API is the best API
+- **Simple solutions to complex problems** — features should "just work" without user knobs
+
+### Out-of-Scope Categories
+
+#### 1. Notification and Alerting Delivery
+
+Karpenter emits Kubernetes events, status conditions, and Prometheus metrics. Delivering notifications (webhooks, Slack, email, PagerDuty) is the responsibility of external tooling that consumes these signals.
+
+#### 2. Pod-Level Scheduling Decisions
+
+Karpenter provisions nodes, not pods. Decisions about which pod runs on which node belong to the kube-scheduler. Features that attempt to influence pod placement, emit pod-level events for scheduling decisions, or duplicate scheduler functionality are out of scope.
+
+#### 3. Exposing Internal Implementation Details
+
+Karpenter exposes configuration that lets users express desired behavior — for example, consolidation policy or disruption budgets. What Karpenter does not accept is configuration that exposes internal implementation mechanics, like thread concurrency. Users should express *what* they want Karpenter to do, not *how* it does it internally.
+
+#### 4. Provider-Specific Features
+
+kubernetes-sigs/karpenter is the provider-neutral core. Features that are specific to a single cloud provider belong in that provider's repository (e.g. [karpenter-provider-aws](https://github.com/aws/karpenter-provider-aws), [karpenter-provider-azure](https://github.com/Azure/karpenter-provider-azure)). See the [full list of providers](README.md#karpenter-implementations). Only features that apply across all provider implementations belong here.
+
+#### 5. Workload Management
+
+Karpenter is not a workload manager. It is not responsible for scaling workloads or pods. Features that manage pod replicas, autoscale deployments, or otherwise control workload lifecycle belong in other systems (e.g. HPA, KEDA, VPA).

--- a/designs/rfc-template.md
+++ b/designs/rfc-template.md
@@ -1,0 +1,82 @@
+# Title
+
+<!-- One-line summary of what this RFC proposes. Name it after the feature, not the solution. -->
+
+## Motivation
+
+<!-- Tell the story: what's the current state, why is it a problem, and who is affected?
+     Link to relevant GitHub issues to ground the problem in real user requests.
+     Keep it brief — if the reader doesn't understand the problem, the solution won't land. -->
+
+### Use Cases
+
+<!-- 2-4 concrete scenarios showing how users hit this problem today.
+     Each should be specific enough to validate proposed solutions against. -->
+
+### Non-Goals
+
+<!-- What does this RFC explicitly NOT address? Defining boundaries prevents scope creep
+     during review and sets expectations for what is left for future work. -->
+
+## Proposal
+
+<!-- Describe the recommended solution. Lead with the user-facing API or behavior change,
+     then explain how it works internally. Include YAML specs, Go structs, or diagrams
+     as appropriate. This section should be self-contained — a reader should be able to
+     understand what ships without reading Alternatives. -->
+
+### Proposed Spec
+
+<!-- Show the API surface: CRD YAML, Go type definitions, annotation formats, CLI examples.
+     Omit if the change has no user-facing API. -->
+
+### How It Works
+
+<!-- Explain the implementation at design level. Cover the controller loop, scheduling
+     interactions, or algorithm changes. Not a code walkthrough — just enough that
+     another contributor could implement it from this description. -->
+
+### Interaction with Existing Features
+
+<!-- How does this compose with consolidation, drift, disruption budgets, PDBs, etc.?
+     Call out anything that changes existing behavior. -->
+
+### Observability
+
+<!-- What metrics, events, status conditions, or log lines help users understand
+     the feature is working? Omit if not applicable. -->
+
+### Edge Cases
+
+<!-- Known corner cases and how the design handles them. A few worked examples
+     are more valuable than exhaustive enumeration. -->
+
+## Alternatives Considered
+
+<!-- For each alternative: state what it is, how it works (briefly), and why it was
+     rejected. The goal is to show the reader that obvious alternatives were evaluated,
+     not to re-derive the solution. -->
+
+### Alternative 1: ...
+
+### Alternative 2: ...
+
+## Backward Compatibility
+
+<!-- What happens to existing users? Are there migration steps? Does existing YAML
+     continue to work unchanged? -->
+
+## Graduation Criteria
+
+<!-- Not all features need a feature gate. If the change is low-risk and backwards
+     compatible, it may ship enabled by default.
+
+     If gated, describe what's needed at each stage:
+     - Alpha: What makes this too risky to enable by default?
+     - Beta: What feedback or stability proof is needed before enabling by default?
+     - GA: What's needed before removing the gate entirely? -->
+
+## Open Questions
+
+<!-- Unresolved decisions that need feedback or data before implementation.
+     Number them so reviewers can reference them easily. -->


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The Karpenter project has had some issue and PR churn, the maintainers have had some signals that the path to accepting community contributions could be clearer.

We are also clearly bottlenecked on review cycles, and we need a way to communicate to the community what issues we (the maintainers) have bandwidth to review right now, and which are backlogged. I have proposed removing all of the `priority/` buckets besides two, which indicate if we have review cycles for it right now.

**How was this change tested?**

docs only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
