### PR TITLE
chore: Consolidate pod force-deletion into the eviction queue

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -97,7 +97,7 @@ func NewControllers(
 	o := option.Resolve(opts...)
 	deviceAllocationController := deviceallocation.NewController(kubeClient)
 	p := provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster, clock, deviceAllocationController)
-	evictionQueue := terminator.NewQueue(kubeClient, recorder)
+	evictionQueue := terminator.NewQueue(clock, kubeClient, recorder)
 	disruptionQueue := disruption.NewQueue(kubeClient, recorder, cluster, clock, p)
 	npState := nodepoolhealth.NewState()
 	clusterCost := cost.NewClusterCost(ctx, cloudProvider, kubeClient)

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -112,7 +112,7 @@ func NewControllers(
 	deviceAllocationController := deviceallocation.NewController(kubeClient)
 	virtualPodCache := virtualpods.NewVirtualPodCache(kubeClient)
 	p := provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster, clock, deviceAllocationController, virtualPodCache)
-	evictionQueue := terminator.NewQueue(kubeClient, recorder)
+	evictionQueue := terminator.NewQueue(clock, kubeClient, recorder)
 	disruptionQueue := disruption.NewQueue(kubeClient, recorder, cluster, clock, p)
 	npState := nodepoolhealth.NewState()
 	clusterCost := cost.NewClusterCost(ctx, cloudProvider, kubeClient)

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 	cloudProvider = fake.NewCloudProvider()
 	cloudProvider = fake.NewCloudProvider()
 	recorder = test.NewEventRecorder()
-	queue = terminator.NewQueue(env.Client, recorder)
+	queue = terminator.NewQueue(env.Clock, env.Client, recorder)
 	healthController = health.NewController(env.Client, cloudProvider, env.Clock, recorder)
 })
 

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 
 	cloudProvider = fake.NewCloudProvider()
 	recorder = test.NewEventRecorder()
-	queue = terminator.NewQueue(env.Client, recorder)
+	queue = terminator.NewQueue(env.Clock, env.Client, recorder)
 	terminationController = termination.NewController(env.Clock, env.Client, cloudProvider, terminator.NewTerminator(env.Clock, env.Client, queue, recorder), recorder)
 })
 
@@ -90,7 +90,7 @@ var _ = Describe("Termination", func() {
 	BeforeEach(func() {
 		env.Clock.SetTime(time.Now())
 		cloudProvider.Reset()
-		*queue = lo.FromPtr(terminator.NewQueue(env.Client, recorder))
+		*queue = lo.FromPtr(terminator.NewQueue(env.Clock, env.Client, recorder))
 
 		nodePool = test.NodePool()
 		nodeClaim, node = test.NodeClaimAndNode(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{v1.TerminationFinalizer}}})
@@ -804,6 +804,7 @@ var _ = Describe("Termination", func() {
 			// The pod should be deleted 60 seconds before the node's TGP expires
 			env.Clock.Step(175 * time.Second)
 			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 			pod = ExpectExists(ctx, env.Client, pod)
 			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 
@@ -835,6 +836,7 @@ var _ = Describe("Termination", func() {
 			// expect pod still exists
 			env.Clock.Step(90 * time.Second)
 			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
+			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 			ExpectNodeWithNodeClaimDraining(env.Client, node.Name)
 			ExpectNodeExists(ctx, env.Client, node.Name)
 			pod = ExpectExists(ctx, env.Client, pod)

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -774,6 +774,39 @@ var _ = Describe("Termination", func() {
 			pod = ExpectExists(ctx, env.Client, pod)
 			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 		})
+		It("should not gate past-deadline pods behind graceful eviction of earlier tiers", func() {
+			// Regression guard: a critical pod past its force-delete threshold must be
+			// enqueued even when a non-critical pod is still a graceful-eviction candidate
+			// in an earlier tier. Otherwise, a PDB on the non-critical pod could hold up a
+			// past-deadline system-critical pod.
+			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
+			nodeClaim.Annotations = map[string]string{
+				v1.NodeClaimTerminationTimestampAnnotationKey: env.Clock.Now().Add(nodeClaim.Spec.TerminationGracePeriod.Duration).Format(time.RFC3339),
+			}
+			// Non-critical pod: TGP=30s fits in the remaining 300s → graceful eviction.
+			podNonCritical := test.Pod(test.PodOptions{
+				NodeName:                      node.Name,
+				ObjectMeta:                    metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs},
+				TerminationGracePeriodSeconds: new(int64(30)),
+			})
+			// Critical pod: TGP=600s would extend past the deadline → force-delete-eligible.
+			// Under the pre-split code this pod sat in a later tier and would never be
+			// enqueued while podNonCritical remained in tier 0.
+			podCritical := test.Pod(test.PodOptions{
+				NodeName:                      node.Name,
+				PriorityClassName:             "system-node-critical",
+				ObjectMeta:                    metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs},
+				TerminationGracePeriodSeconds: new(int64(600)),
+			})
+			ExpectApplied(ctx, env.Client, node, nodeClaim, nodePool, podNonCritical, podCritical)
+			Expect(env.Client.Delete(ctx, node)).To(Succeed())
+			env.Clock.Step(2 * termination.MinDrainTime)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node)) // DrainInitiation
+			ExpectObjectReconciled(ctx, env.Client, queue, podCritical)
+
+			podCritical = ExpectExists(ctx, env.Client, podCritical)
+			Expect(podCritical.DeletionTimestamp.IsZero()).To(BeFalse())
+		})
 		It("should only delete pods when their terminationGracePeriodSeconds is less than the the node's remaining terminationGracePeriod", func() {
 			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
 			nodeClaim.Annotations = map[string]string{

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -53,23 +53,11 @@ import (
 	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
-// evictionMode determines how the Queue removes a pod from its node.
-type evictionMode int
-
-const (
-	// modeEvict uses the Kubernetes eviction subresource and respects PDBs.
-	modeEvict evictionMode = iota
-	// modeForceDelete uses kubeClient.Delete with a clamped grace period and
-	// bypasses PDBs. Used when a pod's terminationGracePeriodSeconds would
-	// otherwise extend past the node's terminationGracePeriod.
-	modeForceDelete
-)
-
-// queueItem holds the per-pod state needed by the Queue's reconciler.
+// queueItem holds the per-pod state needed by the Queue's reconciler. The
+// reconciler decides at reconcile time whether to evict or force-delete based
+// on nodeTerminationTime and the pod's grace period — there is no upfront
+// per-pod mode. A nil nodeTerminationTime means "no deadline; always evict".
 type queueItem struct {
-	mode evictionMode
-	// nodeTerminationTime is set when mode == modeForceDelete. It is used to
-	// clamp the pod's grace period at delete time.
 	nodeTerminationTime *time.Time
 }
 
@@ -158,39 +146,19 @@ func (q *Queue) Register(ctx context.Context, m manager.Manager) error {
 		Complete(reconcile.AsReconciler(m.GetClient(), q))
 }
 
-// Add adds pods to the Queue for eviction via the Kubernetes eviction API.
-// Pods already enqueued (in any mode) are left untouched so that an in-flight
-// force-delete is not downgraded to an eviction.
-func (q *Queue) Add(pods ...*corev1.Pod) {
+// Add enqueues pods for drain. The queue decides per reconcile whether to
+// evict (respecting PDB) or force-delete based on whether the pod's grace
+// period would extend past nodeTerminationTime; pass nil to disable the
+// force-delete path entirely. Re-adding a pod overwrites its deadline so the
+// next reconcile picks up the latest value.
+func (q *Queue) Add(nodeTerminationTime *time.Time, pods ...*corev1.Pod) {
 	q.Lock()
 	defer q.Unlock()
 
 	for _, pod := range pods {
 		qk := NewQueueKey(pod)
-		if _, ok := q.items[qk]; ok {
-			continue
-		}
-		q.items[qk] = queueItem{mode: modeEvict}
-		q.source <- event.TypedGenericEvent[*corev1.Pod]{Object: pod}
-	}
-}
-
-// AddForceDelete adds pods to the Queue to be force-deleted with a grace period
-// clamped to the node's remaining terminationGracePeriod. This bypasses PDBs
-// and the do-not-disrupt annotation. If a pod is already enqueued for eviction,
-// its entry is upgraded to force-delete so that the next reconcile honors the
-// new mode.
-func (q *Queue) AddForceDelete(nodeTerminationTime *time.Time, pods ...*corev1.Pod) {
-	q.Lock()
-	defer q.Unlock()
-
-	for _, pod := range pods {
-		qk := NewQueueKey(pod)
-		// Overwrite any existing entry so a pod already enqueued for eviction is
-		// upgraded to force-delete. The reconciler reads the mode at the start of
-		// each reconcile, so the upgrade takes effect on the next attempt.
 		_, enqueued := q.items[qk]
-		q.items[qk] = queueItem{mode: modeForceDelete, nodeTerminationTime: nodeTerminationTime}
+		q.items[qk] = queueItem{nodeTerminationTime: nodeTerminationTime}
 		if !enqueued {
 			q.source <- event.TypedGenericEvent[*corev1.Pod]{Object: pod}
 		}
@@ -219,10 +187,40 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 		return reconcile.Result{}, nil
 	}
 
-	if item.mode == modeForceDelete {
+	if needsForceDelete(pod, item.nodeTerminationTime, q.clock) {
 		return q.forceDelete(ctx, pod, item.nodeTerminationTime)
 	}
+	// Pod is terminal (Failed/Succeeded) or terminating so drop the queue entry.
+	// Reconcile won't fire again once the pod is gone, so this is our only chance to clean up.
+	if !podutils.IsActive(pod) {
+		q.complete(pod)
+		return reconcile.Result{}, nil
+	}
+	// Active but not evictable (do-not-disrupt). Stay enqueued under the queue's exponential backoff.
+	// The next reconcile picks the right path when the
+	// annotation clears or the deadline crosses needsForceDelete's threshold.
+	if !podutils.IsEvictable(pod, q.clock, q.recorder) {
+		return reconcile.Result{Requeue: true}, nil
+	}
 	return q.evict(ctx, pod)
+}
+
+// needsForceDelete reports whether the pod should be force-deleted now: its
+// grace period would (or already does) extend past nodeTerminationTime if
+// allowed to run on its own. Re-evaluated on every reconcile, so a pod stuck
+// on a PDB upgrades to force-delete naturally once the deadline passes.
+func needsForceDelete(pod *corev1.Pod, nodeTerminationTime *time.Time, clk clock.Clock) bool {
+	if nodeTerminationTime == nil {
+		return false
+	}
+	if podutils.IsTerminating(pod) {
+		return podutils.IsPodEligibleForForcedEviction(pod, nodeTerminationTime)
+	}
+	if pod.Spec.TerminationGracePeriodSeconds == nil {
+		return false
+	}
+	deleteTime := nodeTerminationTime.Add(time.Duration(*pod.Spec.TerminationGracePeriodSeconds) * time.Second * -1)
+	return clk.Now().After(deleteTime)
 }
 
 // evict removes a pod via the Kubernetes eviction subresource, respecting PDBs.

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -53,14 +53,6 @@ import (
 	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
-// queueItem holds the per-pod state needed by the Queue's reconciler. The
-// reconciler decides at reconcile time whether to evict or force-delete based
-// on nodeTerminationTime and the pod's grace period — there is no upfront
-// per-pod mode. A nil nodeTerminationTime means "no deadline; always evict".
-type queueItem struct {
-	nodeTerminationTime *time.Time
-}
-
 const (
 	evictionQueueBaseDelay = 100 * time.Millisecond
 	evictionQueueMaxDelay  = 10 * time.Second
@@ -102,7 +94,11 @@ type Queue struct {
 	sync.Mutex
 
 	source chan event.TypedGenericEvent[*corev1.Pod]
-	items  map[QueueKey]queueItem
+	// items maps each enqueued pod to its node's terminationGracePeriod deadline.
+	// The reconciler decides evict vs force-delete per reconcile from that deadline
+	// plus the pod's own grace period — no upfront per-pod mode. A nil value means
+	// "no deadline; always evict".
+	items map[QueueKey]*time.Time
 
 	clock      clock.Clock
 	kubeClient client.Client
@@ -112,7 +108,7 @@ type Queue struct {
 func NewQueue(clk clock.Clock, kubeClient client.Client, recorder events.Recorder) *Queue {
 	return &Queue{
 		source:     make(chan event.TypedGenericEvent[*corev1.Pod], 10000),
-		items:      map[QueueKey]queueItem{},
+		items:      map[QueueKey]*time.Time{},
 		clock:      clk,
 		kubeClient: kubeClient,
 		recorder:   recorder,
@@ -149,20 +145,36 @@ func (q *Queue) Register(ctx context.Context, m manager.Manager) error {
 // Add enqueues pods for drain. The queue decides per reconcile whether to
 // evict (respecting PDB) or force-delete based on whether the pod's grace
 // period would extend past nodeTerminationTime; pass nil to disable the
-// force-delete path entirely. Re-adding a pod overwrites its deadline so the
-// next reconcile picks up the latest value.
+// force-delete path entirely. Re-adding a pod keeps the earlier of the
+// existing and new deadlines — a later Add can tighten the deadline but never
+// push it out or clear it, so an in-flight force-delete cannot be downgraded.
 func (q *Queue) Add(nodeTerminationTime *time.Time, pods ...*corev1.Pod) {
 	q.Lock()
 	defer q.Unlock()
 
 	for _, pod := range pods {
 		qk := NewQueueKey(pod)
-		_, enqueued := q.items[qk]
-		q.items[qk] = queueItem{nodeTerminationTime: nodeTerminationTime}
+		existing, enqueued := q.items[qk]
+		q.items[qk] = earlier(existing, nodeTerminationTime)
 		if !enqueued {
 			q.source <- event.TypedGenericEvent[*corev1.Pod]{Object: pod}
 		}
 	}
+}
+
+// earlier returns the earlier of a and b, treating nil as "no deadline" (+∞).
+// Returns nil only when both are nil.
+func earlier(a, b *time.Time) *time.Time {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if a.Before(*b) {
+		return a
+	}
+	return b
 }
 
 func (q *Queue) Has(pod *corev1.Pod) bool {
@@ -177,7 +189,7 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 	ctx = injection.WithControllerName(ctx, q.Name())
 
 	q.Lock()
-	item, ok := q.items[NewQueueKey(pod)]
+	nodeTerminationTime, ok := q.items[NewQueueKey(pod)]
 	q.Unlock()
 	if !ok {
 		//This is a different pod than the one the queue, we should exit without evicting
@@ -187,8 +199,8 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 		return reconcile.Result{}, nil
 	}
 
-	if needsForceDelete(pod, item.nodeTerminationTime, q.clock) {
-		return q.forceDelete(ctx, pod, item.nodeTerminationTime)
+	if q.needsForceDelete(pod, nodeTerminationTime) {
+		return q.forceDelete(ctx, pod, nodeTerminationTime)
 	}
 	// Pod is terminal (Failed/Succeeded) or terminating so drop the queue entry.
 	// Reconcile won't fire again once the pod is gone, so this is our only chance to clean up.
@@ -209,7 +221,7 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 // grace period would (or already does) extend past nodeTerminationTime if
 // allowed to run on its own. Re-evaluated on every reconcile, so a pod stuck
 // on a PDB upgrades to force-delete naturally once the deadline passes.
-func needsForceDelete(pod *corev1.Pod, nodeTerminationTime *time.Time, clk clock.Clock) bool {
+func (q *Queue) needsForceDelete(pod *corev1.Pod, nodeTerminationTime *time.Time) bool {
 	if nodeTerminationTime == nil {
 		return false
 	}
@@ -220,7 +232,7 @@ func needsForceDelete(pod *corev1.Pod, nodeTerminationTime *time.Time, clk clock
 		return false
 	}
 	deleteTime := nodeTerminationTime.Add(time.Duration(*pod.Spec.TerminationGracePeriodSeconds) * time.Second * -1)
-	return clk.Now().After(deleteTime)
+	return q.clock.Now().After(deleteTime)
 }
 
 // evict removes a pod via the Kubernetes eviction subresource, respecting PDBs.

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -31,9 +31,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -52,6 +52,26 @@ import (
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
+
+// evictionMode determines how the Queue removes a pod from its node.
+type evictionMode int
+
+const (
+	// modeEvict uses the Kubernetes eviction subresource and respects PDBs.
+	modeEvict evictionMode = iota
+	// modeForceDelete uses kubeClient.Delete with a clamped grace period and
+	// bypasses PDBs. Used when a pod's terminationGracePeriodSeconds would
+	// otherwise extend past the node's terminationGracePeriod.
+	modeForceDelete
+)
+
+// queueItem holds the per-pod state needed by the Queue's reconciler.
+type queueItem struct {
+	mode evictionMode
+	// nodeTerminationTime is set when mode == modeForceDelete. It is used to
+	// clamp the pod's grace period at delete time.
+	nodeTerminationTime *time.Time
+}
 
 const (
 	evictionQueueBaseDelay = 100 * time.Millisecond
@@ -94,16 +114,18 @@ type Queue struct {
 	sync.Mutex
 
 	source chan event.TypedGenericEvent[*corev1.Pod]
-	set    sets.Set[QueueKey]
+	items  map[QueueKey]queueItem
 
+	clock      clock.Clock
 	kubeClient client.Client
 	recorder   events.Recorder
 }
 
-func NewQueue(kubeClient client.Client, recorder events.Recorder) *Queue {
+func NewQueue(clk clock.Clock, kubeClient client.Client, recorder events.Recorder) *Queue {
 	return &Queue{
 		source:     make(chan event.TypedGenericEvent[*corev1.Pod], 10000),
-		set:        sets.New[QueueKey](),
+		items:      map[QueueKey]queueItem{},
+		clock:      clk,
 		kubeClient: kubeClient,
 		recorder:   recorder,
 	}
@@ -136,15 +158,40 @@ func (q *Queue) Register(ctx context.Context, m manager.Manager) error {
 		Complete(reconcile.AsReconciler(m.GetClient(), q))
 }
 
-// Add adds pods to the Queue
+// Add adds pods to the Queue for eviction via the Kubernetes eviction API.
+// Pods already enqueued (in any mode) are left untouched so that an in-flight
+// force-delete is not downgraded to an eviction.
 func (q *Queue) Add(pods ...*corev1.Pod) {
 	q.Lock()
 	defer q.Unlock()
 
 	for _, pod := range pods {
 		qk := NewQueueKey(pod)
-		if !q.set.Has(qk) {
-			q.set.Insert(qk)
+		if _, ok := q.items[qk]; ok {
+			continue
+		}
+		q.items[qk] = queueItem{mode: modeEvict}
+		q.source <- event.TypedGenericEvent[*corev1.Pod]{Object: pod}
+	}
+}
+
+// AddForceDelete adds pods to the Queue to be force-deleted with a grace period
+// clamped to the node's remaining terminationGracePeriod. This bypasses PDBs
+// and the do-not-disrupt annotation. If a pod is already enqueued for eviction,
+// its entry is upgraded to force-delete so that the next reconcile honors the
+// new mode.
+func (q *Queue) AddForceDelete(nodeTerminationTime *time.Time, pods ...*corev1.Pod) {
+	q.Lock()
+	defer q.Unlock()
+
+	for _, pod := range pods {
+		qk := NewQueueKey(pod)
+		// Overwrite any existing entry so a pod already enqueued for eviction is
+		// upgraded to force-delete. The reconciler reads the mode at the start of
+		// each reconcile, so the upgrade takes effect on the next attempt.
+		_, enqueued := q.items[qk]
+		q.items[qk] = queueItem{mode: modeForceDelete, nodeTerminationTime: nodeTerminationTime}
+		if !enqueued {
 			q.source <- event.TypedGenericEvent[*corev1.Pod]{Object: pod}
 		}
 	}
@@ -154,20 +201,32 @@ func (q *Queue) Has(pod *corev1.Pod) bool {
 	q.Lock()
 	defer q.Unlock()
 
-	return q.set.Has(NewQueueKey(pod))
+	_, ok := q.items[NewQueueKey(pod)]
+	return ok
 }
 
 func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Result, error) {
 	ctx = injection.WithControllerName(ctx, q.Name())
 
-	if !q.Has(pod) {
+	q.Lock()
+	item, ok := q.items[NewQueueKey(pod)]
+	q.Unlock()
+	if !ok {
 		//This is a different pod than the one the queue, we should exit without evicting
 		//This race happens when a pod is replaced with one that has the same namespace and name
 		//but a different UID after the original pod is added to the queue but before the
 		//controller can reconcile on it
 		return reconcile.Result{}, nil
 	}
-	// Evict the pod
+
+	if item.mode == modeForceDelete {
+		return q.forceDelete(ctx, pod, item.nodeTerminationTime)
+	}
+	return q.evict(ctx, pod)
+}
+
+// evict removes a pod via the Kubernetes eviction subresource, respecting PDBs.
+func (q *Queue) evict(ctx context.Context, pod *corev1.Pod) (reconcile.Result, error) {
 	if err := q.kubeClient.SubResource("eviction").Create(ctx,
 		pod,
 		&policyv1.Eviction{
@@ -191,6 +250,7 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 			// https://github.com/kubernetes/kubernetes/blob/ad19beaa83363de89a7772f4d5af393b85ce5e61/pkg/registry/core/pod/storage/eviction.go#L160
 			// 409 - The pod exists, but it is not the same pod that we initiated the eviction on
 			// https://github.com/kubernetes/kubernetes/blob/ad19beaa83363de89a7772f4d5af393b85ce5e61/pkg/registry/core/pod/storage/eviction.go#L318
+			q.complete(pod)
 			return reconcile.Result{}, nil
 		}
 		// The pod exists and is the same pod, we need to continue
@@ -213,11 +273,49 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 	reason := evictionReason(ctx, pod, q.kubeClient)
 	q.recorder.Publish(terminatorevents.EvictPod(pod, reason))
 	PodsDrainedTotal.Inc(map[string]string{ReasonLabel: reason})
+	q.complete(pod)
+	return reconcile.Result{}, nil
+}
 
+// forceDelete removes a pod via kubeClient.Delete with a grace period clamped
+// to the node's remaining terminationGracePeriod. PDBs and the
+// do-not-disrupt annotation are bypassed: the node is being forcefully
+// terminated and the pod's full grace period would otherwise extend past it.
+func (q *Queue) forceDelete(ctx context.Context, pod *corev1.Pod, nodeTerminationTime *time.Time) (reconcile.Result, error) {
+	// Clamp the grace period to the node's remaining terminationGracePeriod, with a minimum of 1s
+	// to prevent a force-deletion from etcd (gracePeriodSeconds=0), which would violate at-most-one
+	// pod semantics. The node's terminationGracePeriod may already have elapsed by the time we reconcile.
+	gracePeriodSeconds := lo.ToPtr(max(int64(lo.FromPtr(nodeTerminationTime).Sub(q.clock.Now()).Seconds()), 1))
+	q.recorder.Publish(terminatorevents.DisruptPodDelete(pod, gracePeriodSeconds, nodeTerminationTime))
+	if err := q.kubeClient.Delete(ctx, pod, &client.DeleteOptions{
+		GracePeriodSeconds: gracePeriodSeconds,
+		Preconditions: &metav1.Preconditions{
+			UID: new(pod.UID),
+		},
+	}); err != nil {
+		if apierrors.IsNotFound(err) {
+			q.complete(pod)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("force-deleting pod, %w", err)
+	}
+	log.FromContext(ctx).WithValues(
+		"namespace", pod.Namespace,
+		"name", pod.Name,
+		"pod.terminationGracePeriodSeconds", lo.FromPtr(pod.Spec.TerminationGracePeriodSeconds),
+		"delete.gracePeriodSeconds", lo.FromPtr(gracePeriodSeconds),
+		"nodeclaim.terminationTime", lo.FromPtr(nodeTerminationTime),
+	).V(1).Info("deleting pod")
+	PodsDrainedTotal.Inc(map[string]string{ReasonLabel: evictionReason(ctx, pod, q.kubeClient)})
+	q.complete(pod)
+	return reconcile.Result{}, nil
+}
+
+// complete removes the pod from the queue.
+func (q *Queue) complete(pod *corev1.Pod) {
 	q.Lock()
 	defer q.Unlock()
-	q.set.Delete(NewQueueKey(pod))
-	return reconcile.Result{}, nil
+	delete(q.items, NewQueueKey(pod))
 }
 
 func evictionReason(ctx context.Context, pod *corev1.Pod, kubeClient client.Client) string {

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -199,7 +199,7 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 		return reconcile.Result{}, nil
 	}
 
-	if q.needsForceDelete(pod, nodeTerminationTime) {
+	if needsForceDelete(pod, nodeTerminationTime, q.clock) {
 		return q.forceDelete(ctx, pod, nodeTerminationTime)
 	}
 	// Pod is terminal (Failed/Succeeded) or terminating so drop the queue entry.
@@ -219,9 +219,11 @@ func (q *Queue) Reconcile(ctx context.Context, pod *corev1.Pod) (reconcile.Resul
 
 // needsForceDelete reports whether the pod should be force-deleted now: its
 // grace period would (or already does) extend past nodeTerminationTime if
-// allowed to run on its own. Re-evaluated on every reconcile, so a pod stuck
-// on a PDB upgrades to force-delete naturally once the deadline passes.
-func (q *Queue) needsForceDelete(pod *corev1.Pod, nodeTerminationTime *time.Time) bool {
+// allowed to run on its own. Shared between Drain (which enqueues past-deadline
+// pods across all tiers immediately) and Queue.Reconcile (which re-evaluates on
+// every reconcile, so a pod stuck on a PDB upgrades to force-delete naturally
+// once the deadline passes).
+func needsForceDelete(pod *corev1.Pod, nodeTerminationTime *time.Time, clk clock.Clock) bool {
 	if nodeTerminationTime == nil {
 		return false
 	}
@@ -232,7 +234,7 @@ func (q *Queue) needsForceDelete(pod *corev1.Pod, nodeTerminationTime *time.Time
 		return false
 	}
 	deleteTime := nodeTerminationTime.Add(time.Duration(*pod.Spec.TerminationGracePeriodSeconds) * time.Second * -1)
-	return q.clock.Now().After(deleteTime)
+	return clk.Now().After(deleteTime)
 }
 
 // evict removes a pod via the Kubernetes eviction subresource, respecting PDBs.

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -251,6 +251,26 @@ var _ = Describe("Eviction/Queue", func() {
 			Expect(recorder.Calls(events.Disrupted)).To(Equal(1))
 			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: ""})
 		})
+		It("should keep the earlier deadline when Add is called again with a looser one", func() {
+			// Once a pod has a force-delete deadline, a later Add must not push it out — otherwise
+			// an in-flight force-delete could be downgraded to a PDB-respecting eviction.
+			pod.Spec.TerminationGracePeriodSeconds = lo.ToPtr[int64](120)
+			ExpectApplied(ctx, env.Client, pdb, pod, node)
+			ExpectManualBinding(ctx, env.Client, pod, node)
+
+			// Tight deadline first: TGP=120s doesn't fit in the remaining 60s → force-delete.
+			tightDeadline := env.Clock.Now().Add(time.Minute * 1)
+			queue.Add(&tightDeadline, pod)
+			// Looser deadline second: TGP=120s fits in the remaining 1h → normal eviction would suffice.
+			looseDeadline := env.Clock.Now().Add(time.Hour)
+			queue.Add(&looseDeadline, pod)
+
+			ExpectObjectReconciled(ctx, env.Client, queue, pod)
+			// Tight deadline retained, so force-delete triggers despite the blocking PDB.
+			pod = ExpectExists(ctx, env.Client, pod)
+			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
+			Expect(recorder.Calls(events.Disrupted)).To(Equal(1))
+		})
 		It("should clean up the queue entry when the pod is already gone", func() {
 			nodeTerminationTime := env.Clock.Now().Add(time.Minute * 1)
 			queue.Add(&nodeTerminationTime, pod)

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -107,13 +107,13 @@ var _ = Describe("Eviction/Queue", func() {
 		})
 		It("should succeed with no event when the pod UID conflicts", func() {
 			ExpectApplied(ctx, env.Client, pod, node)
-			queue.Add(pod)
+			queue.Add(nil, pod)
 			pod.UID = uuid.NewUUID()
 			Expect(queue.Has(pod)).To(BeFalse())
 		})
 		It("should succeed with an evicted event when there are no PDBs", func() {
 			ExpectApplied(ctx, env.Client, pod, node)
-			queue.Add(pod)
+			queue.Add(nil, pod)
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 			ExpectMetricCounterValue(terminator.PodsEvictionRequestsTotal, 1, map[string]string{terminator.CodeLabel: "200"})
 			Expect(recorder.Calls(events.Evicted)).To(Equal(1))
@@ -124,14 +124,14 @@ var _ = Describe("Eviction/Queue", func() {
 				MaxUnavailable: &intstr.IntOrString{IntVal: 1},
 			})
 			ExpectApplied(ctx, env.Client, pod, node)
-			queue.Add(pod)
+			queue.Add(nil, pod)
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 			Expect(recorder.Calls(events.Evicted)).To(Equal(1))
 		})
 		It("should return a NodeDrainError event when a PDB is blocking", func() {
 			ExpectApplied(ctx, env.Client, pdb, pod, node)
 			ExpectManualBinding(ctx, env.Client, pod, node)
-			queue.Add(pod)
+			queue.Add(nil, pod)
 			result := ExpectObjectReconciled(ctx, env.Client, queue, pod)
 			//nolint:staticcheck
 			Expect(result.Requeue).To(BeTrue())
@@ -148,7 +148,7 @@ var _ = Describe("Eviction/Queue", func() {
 			})
 			ExpectApplied(ctx, env.Client, pdb, pdb2, pod, node)
 			ExpectManualBinding(ctx, env.Client, pod, node)
-			queue.Add(pod)
+			queue.Add(nil, pod)
 			result := ExpectObjectReconciled(ctx, env.Client, queue, pod)
 			//nolint:staticcheck
 			Expect(result.Requeue).To(BeTrue())
@@ -170,7 +170,7 @@ var _ = Describe("Eviction/Queue", func() {
 						if cancelContext.Err() != nil {
 							return
 						}
-						queue.Add(pod)
+						queue.Add(nil, pod)
 					}
 				}()
 			}
@@ -182,7 +182,7 @@ var _ = Describe("Eviction/Queue", func() {
 		})
 		It("should increment PodsDrainedTotal metric when a pod is evicted", func() {
 			ExpectApplied(ctx, env.Client, pod, node)
-			queue.Add(pod)
+			queue.Add(nil, pod)
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: ""})
 			ExpectMetricCounterValue(terminator.PodsEvictionRequestsTotal, 1, map[string]string{terminator.CodeLabel: "200"})
@@ -207,7 +207,7 @@ var _ = Describe("Eviction/Queue", func() {
 
 			ExpectApplied(ctx, env.Client, nodeClaim, node, pod)
 			ExpectManualBinding(ctx, env.Client, pod, node)
-			queue.Add(pod)
+			queue.Add(nil, pod)
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 
 			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: "SpotInterruption"})
@@ -223,7 +223,7 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectManualBinding(ctx, env.Client, pod, node)
 
 			nodeTerminationTime := env.Clock.Now().Add(time.Minute * 1)
-			queue.AddForceDelete(&nodeTerminationTime, pod)
+			queue.Add(&nodeTerminationTime, pod)
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 			// The blocking PDB (MaxUnavailable: 0) would reject an eviction; force-delete
 			// issues a Delete directly, so the pod gets a deletion timestamp regardless.
@@ -239,12 +239,12 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectApplied(ctx, env.Client, pdb, pod, node)
 			ExpectManualBinding(ctx, env.Client, pod, node)
 
-			queue.Add(pod)
+			queue.Add(nil, pod)
 			nodeTerminationTime := env.Clock.Now().Add(time.Minute * 1)
-			queue.AddForceDelete(&nodeTerminationTime, pod)
+			queue.Add(&nodeTerminationTime, pod)
 
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
-			// Had the entry stayed modeEvict, the blocking PDB would reject the eviction and
+			// Had the deadline stayed nil, the blocking PDB would reject the eviction and
 			// the pod would have no deletion timestamp. The timestamp proves the upgrade took effect.
 			pod = ExpectExists(ctx, env.Client, pod)
 			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
@@ -253,7 +253,7 @@ var _ = Describe("Eviction/Queue", func() {
 		})
 		It("should clean up the queue entry when the pod is already gone", func() {
 			nodeTerminationTime := env.Clock.Now().Add(time.Minute * 1)
-			queue.AddForceDelete(&nodeTerminationTime, pod)
+			queue.Add(&nodeTerminationTime, pod)
 			// The pod was never created, so the force-delete sees a NotFound and clears the entry.
 			// Reconcile is called directly because AsReconciler (used by ExpectObjectReconciled)
 			// would short-circuit on the missing pod before reaching the queue.
@@ -278,7 +278,7 @@ var _ = Describe("Eviction/Queue", func() {
 			// Without the clamp the grace period would be <=0, sending gracePeriodSeconds=0
 			// to the API (force-delete). The clamp must produce >= 1.
 			pastTerminationTime := env.Clock.Now().Add(-1 * time.Hour)
-			queue.AddForceDelete(&pastTerminationTime, pod)
+			queue.Add(&pastTerminationTime, pod)
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 
 			// Verify the delete was graceful (not a force-delete): the Disrupted event must have

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -49,7 +49,6 @@ var queue *terminator.Queue
 var pdb *policyv1.PodDisruptionBudget
 var pod *corev1.Pod
 var node *corev1.Node
-var terminatorInstance *terminator.Terminator
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -65,8 +64,7 @@ var _ = BeforeSuite(func() {
 	)
 	ctx = options.ToContext(ctx, test.Options())
 	recorder = test.NewEventRecorder()
-	queue = terminator.NewQueue(env.Client, recorder)
-	terminatorInstance = terminator.NewTerminator(env.Clock, env.Client, queue, recorder)
+	queue = terminator.NewQueue(env.Clock, env.Client, recorder)
 })
 
 var _ = AfterSuite(func() {
@@ -76,7 +74,7 @@ var _ = AfterSuite(func() {
 var _ = BeforeEach(func() {
 	recorder.Reset() // Reset the events that we captured during the run
 	// Shut down the queue and restart it to ensure no races
-	*queue = lo.FromPtr(terminator.NewQueue(env.Client, recorder))
+	*queue = lo.FromPtr(terminator.NewQueue(env.Clock, env.Client, recorder))
 })
 
 var _ = AfterEach(func() {
@@ -218,31 +216,50 @@ var _ = Describe("Eviction/Queue", func() {
 		})
 	})
 
-	Context("Pod Deletion API", func() {
-		It("should not delete a pod with no nodeTerminationTime", func() {
-			ExpectApplied(ctx, env.Client, pod, node)
-
-			Expect(terminatorInstance.DeleteExpiringPods(ctx, []*corev1.Pod{pod}, nil)).To(Succeed())
-			ExpectExists(ctx, env.Client, pod)
-			Expect(recorder.Calls(events.Disrupted)).To(Equal(0))
-		})
-		It("should not delete a pod with terminationGracePeriodSeconds still remaining before nodeTerminationTime", func() {
-			pod.Spec.TerminationGracePeriodSeconds = lo.ToPtr[int64](60)
-			ExpectApplied(ctx, env.Client, pod, node)
-
-			nodeTerminationTime := time.Now().Add(time.Minute * 5)
-			Expect(terminatorInstance.DeleteExpiringPods(ctx, []*corev1.Pod{pod}, &nodeTerminationTime)).To(Succeed())
-			ExpectExists(ctx, env.Client, pod)
-			Expect(recorder.Calls(events.Disrupted)).To(Equal(0))
-		})
-		It("should delete a pod with less than terminationGracePeriodSeconds remaining before nodeTerminationTime", func() {
+	Context("Pod Force-Delete via Queue", func() {
+		It("should force-delete a pod via the queue, bypassing PDBs", func() {
 			pod.Spec.TerminationGracePeriodSeconds = lo.ToPtr[int64](120)
-			ExpectApplied(ctx, env.Client, pod)
+			ExpectApplied(ctx, env.Client, pdb, pod, node)
+			ExpectManualBinding(ctx, env.Client, pod, node)
 
-			nodeTerminationTime := time.Now().Add(time.Minute * 1)
-			Expect(terminatorInstance.DeleteExpiringPods(ctx, []*corev1.Pod{pod}, &nodeTerminationTime)).To(Succeed())
-			ExpectNotFound(ctx, env.Client, pod)
+			nodeTerminationTime := env.Clock.Now().Add(time.Minute * 1)
+			queue.AddForceDelete(&nodeTerminationTime, pod)
+			ExpectObjectReconciled(ctx, env.Client, queue, pod)
+			// The blocking PDB (MaxUnavailable: 0) would reject an eviction; force-delete
+			// issues a Delete directly, so the pod gets a deletion timestamp regardless.
+			pod = ExpectExists(ctx, env.Client, pod)
+			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 			Expect(recorder.Calls(events.Disrupted)).To(Equal(1))
+			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: ""})
+			// The queue entry is cleared once the force-delete succeeds.
+			Expect(queue.Has(pod)).To(BeFalse())
+		})
+		It("should upgrade a pod already enqueued for eviction to force-delete", func() {
+			pod.Spec.TerminationGracePeriodSeconds = lo.ToPtr[int64](120)
+			ExpectApplied(ctx, env.Client, pdb, pod, node)
+			ExpectManualBinding(ctx, env.Client, pod, node)
+
+			queue.Add(pod)
+			nodeTerminationTime := env.Clock.Now().Add(time.Minute * 1)
+			queue.AddForceDelete(&nodeTerminationTime, pod)
+
+			ExpectObjectReconciled(ctx, env.Client, queue, pod)
+			// Had the entry stayed modeEvict, the blocking PDB would reject the eviction and
+			// the pod would have no deletion timestamp. The timestamp proves the upgrade took effect.
+			pod = ExpectExists(ctx, env.Client, pod)
+			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
+			Expect(recorder.Calls(events.Disrupted)).To(Equal(1))
+			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: ""})
+		})
+		It("should clean up the queue entry when the pod is already gone", func() {
+			nodeTerminationTime := env.Clock.Now().Add(time.Minute * 1)
+			queue.AddForceDelete(&nodeTerminationTime, pod)
+			// The pod was never created, so the force-delete sees a NotFound and clears the entry.
+			// Reconcile is called directly because AsReconciler (used by ExpectObjectReconciled)
+			// would short-circuit on the missing pod before reaching the queue.
+			_, err := queue.Reconcile(ctx, pod)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(queue.Has(pod)).To(BeFalse())
 		})
 		It("should clamp gracePeriodSeconds to >= 1 when nodeTerminationTime is in the past", func() {
 			// Use a finalizer so envtest does not immediately garbage-collect the pod after the
@@ -261,7 +278,8 @@ var _ = Describe("Eviction/Queue", func() {
 			// Without the clamp the grace period would be <=0, sending gracePeriodSeconds=0
 			// to the API (force-delete). The clamp must produce >= 1.
 			pastTerminationTime := env.Clock.Now().Add(-1 * time.Hour)
-			Expect(terminatorInstance.DeleteExpiringPods(ctx, []*corev1.Pod{pod}, &pastTerminationTime)).To(Succeed())
+			queue.AddForceDelete(&pastTerminationTime, pod)
+			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 
 			// Verify the delete was graceful (not a force-delete): the Disrupted event must have
 			// been published and contain "1 seconds of grace-period" in the message, proving the

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -96,23 +96,13 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 	if err != nil {
 		return fmt.Errorf("listing pods on node, %w", err)
 	}
-	// Pods whose terminationGracePeriodSeconds would extend past the node's
-	// terminationGracePeriod are routed to the eviction queue's force-delete
-	// path so they get as much of their grace period as possible before the
-	// node is forcefully terminated. This bypasses PDBs and the
-	// do-not-disrupt annotation.
-	t.evictionQueue.AddForceDelete(nodeGracePeriodExpirationTime, lo.Filter(pods, func(p *corev1.Pod, _ int) bool {
-		return podutil.IsWaitingEviction(p, t.clock) &&
-			(!podutil.IsTerminating(p) || podutil.IsPodEligibleForForcedEviction(p, nodeGracePeriodExpirationTime)) &&
-			t.shouldForceDeleteNow(p, nodeGracePeriodExpirationTime)
-	})...)
-	// Monitor pods in pod groups that either haven't been evicted or are actively evicting
+	// Hand the queue every pod we're waiting on plus the node's deadline. The
+	// queue picks evict vs force-delete vs requeue per pod, per reconcile —
+	// the terminator does no per-pod drain decisioning.
 	podGroups := t.groupPodsByPriority(lo.Filter(pods, func(p *corev1.Pod, _ int) bool { return podutil.IsWaitingEviction(p, t.clock) }))
 	for _, group := range podGroups {
 		if len(group) > 0 {
-			// Only add pods to the eviction queue that haven't been evicted yet. Pods already enqueued
-			// for force-delete are skipped by Add, so this won't downgrade them to a PDB-respecting eviction.
-			t.evictionQueue.Add(lo.Filter(group, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p, t.clock, t.recorder) })...)
+			t.evictionQueue.Add(nodeGracePeriodExpirationTime, group...)
 			return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", lo.SumBy(podGroups, func(pods []*corev1.Pod) int { return len(pods) })))
 		}
 	}
@@ -138,17 +128,4 @@ func (t *Terminator) groupPodsByPriority(pods []*corev1.Pod) [][]*corev1.Pod {
 		}
 	}
 	return [][]*corev1.Pod{nonCriticalNonDaemon, nonCriticalDaemon, criticalNonDaemon, criticalDaemon}
-}
-
-// shouldForceDeleteNow reports whether the pod's terminationGracePeriodSeconds
-// would extend past the node's grace period expiration if eviction is allowed
-// to run its course, meaning the pod must be force-deleted now to give it as
-// much of its requested grace period as possible.
-func (t *Terminator) shouldForceDeleteNow(pod *corev1.Pod, nodeGracePeriodExpirationTime *time.Time) bool {
-	// k8s defaults TerminationGracePeriodSeconds to 30s, so we should never see a nil value.
-	if nodeGracePeriodExpirationTime == nil || pod.Spec.TerminationGracePeriodSeconds == nil {
-		return false
-	}
-	deleteTime := nodeGracePeriodExpirationTime.Add(time.Duration(*pod.Spec.TerminationGracePeriodSeconds) * time.Second * -1)
-	return t.clock.Now().After(deleteTime)
 }

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -24,12 +24,10 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
 	"sigs.k8s.io/karpenter/pkg/events"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	podutil "sigs.k8s.io/karpenter/pkg/utils/pod"
@@ -98,17 +96,22 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 	if err != nil {
 		return fmt.Errorf("listing pods on node, %w", err)
 	}
-	podsToDelete := lo.Filter(pods, func(p *corev1.Pod, _ int) bool {
-		return podutil.IsWaitingEviction(p, t.clock) && (!podutil.IsTerminating(p) || podutil.IsPodEligibleForForcedEviction(p, nodeGracePeriodExpirationTime))
-	})
-	if err := t.DeleteExpiringPods(ctx, podsToDelete, nodeGracePeriodExpirationTime); err != nil {
-		return fmt.Errorf("deleting expiring pods, %w", err)
-	}
+	// Pods whose terminationGracePeriodSeconds would extend past the node's
+	// terminationGracePeriod are routed to the eviction queue's force-delete
+	// path so they get as much of their grace period as possible before the
+	// node is forcefully terminated. This bypasses PDBs and the
+	// do-not-disrupt annotation.
+	t.evictionQueue.AddForceDelete(nodeGracePeriodExpirationTime, lo.Filter(pods, func(p *corev1.Pod, _ int) bool {
+		return podutil.IsWaitingEviction(p, t.clock) &&
+			(!podutil.IsTerminating(p) || podutil.IsPodEligibleForForcedEviction(p, nodeGracePeriodExpirationTime)) &&
+			t.shouldForceDeleteNow(p, nodeGracePeriodExpirationTime)
+	})...)
 	// Monitor pods in pod groups that either haven't been evicted or are actively evicting
 	podGroups := t.groupPodsByPriority(lo.Filter(pods, func(p *corev1.Pod, _ int) bool { return podutil.IsWaitingEviction(p, t.clock) }))
 	for _, group := range podGroups {
 		if len(group) > 0 {
-			// Only add pods to the eviction queue that haven't been evicted yet
+			// Only add pods to the eviction queue that haven't been evicted yet. Pods already enqueued
+			// for force-delete are skipped by Add, so this won't downgrade them to a PDB-respecting eviction.
 			t.evictionQueue.Add(lo.Filter(group, func(p *corev1.Pod, _ int) bool { return podutil.IsEvictable(p, t.clock, t.recorder) })...)
 			return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", lo.SumBy(podGroups, func(pods []*corev1.Pod) int { return len(pods) })))
 		}
@@ -137,42 +140,15 @@ func (t *Terminator) groupPodsByPriority(pods []*corev1.Pod) [][]*corev1.Pod {
 	return [][]*corev1.Pod{nonCriticalNonDaemon, nonCriticalDaemon, criticalNonDaemon, criticalDaemon}
 }
 
-func (t *Terminator) DeleteExpiringPods(ctx context.Context, pods []*corev1.Pod, nodeGracePeriodTerminationTime *time.Time) error {
-	for _, pod := range pods {
-		// check if the node has an expiration time and the pod needs to be deleted
-		deleteTime := t.podDeleteTimeWithGracePeriod(nodeGracePeriodTerminationTime, pod)
-		if deleteTime != nil && t.clock.Now().After(*deleteTime) {
-			// delete pod proactively to give as much of its terminationGracePeriodSeconds as possible for deletion
-			// ensure that we clamp the maximum pod terminationGracePeriodSeconds to the node's remaining expiration time in the delete command
-			// clamp to a minimum of 1s to prevent force-deletion from etcd (which would violate at-most-one pod semantics)
-			gracePeriodSeconds := lo.ToPtr(max(int64(nodeGracePeriodTerminationTime.Sub(t.clock.Now()).Seconds()), 1))
-			t.recorder.Publish(terminatorevents.DisruptPodDelete(pod, gracePeriodSeconds, nodeGracePeriodTerminationTime))
-			opts := &client.DeleteOptions{
-				GracePeriodSeconds: gracePeriodSeconds,
-			}
-			if err := t.kubeClient.Delete(ctx, pod, opts); err != nil && !apierrors.IsNotFound(err) { // ignore 404, not a problem
-				return fmt.Errorf("deleting pod, %w", err) // otherwise, bubble up the error
-			}
-			log.FromContext(ctx).WithValues(
-				"namespace", pod.Namespace,
-				"name", pod.Name,
-				"pod.terminationGracePeriodSeconds", *pod.Spec.TerminationGracePeriodSeconds,
-				"delete.gracePeriodSeconds", *gracePeriodSeconds,
-				"nodeclaim.terminationTime", *nodeGracePeriodTerminationTime,
-			).V(1).Info("deleting pod")
-		}
+// shouldForceDeleteNow reports whether the pod's terminationGracePeriodSeconds
+// would extend past the node's grace period expiration if eviction is allowed
+// to run its course, meaning the pod must be force-deleted now to give it as
+// much of its requested grace period as possible.
+func (t *Terminator) shouldForceDeleteNow(pod *corev1.Pod, nodeGracePeriodExpirationTime *time.Time) bool {
+	// k8s defaults TerminationGracePeriodSeconds to 30s, so we should never see a nil value.
+	if nodeGracePeriodExpirationTime == nil || pod.Spec.TerminationGracePeriodSeconds == nil {
+		return false
 	}
-	return nil
-}
-
-// if a pod should be deleted to give it the full terminationGracePeriodSeconds of time before the node will shut down, return the time the pod should be deleted
-func (t *Terminator) podDeleteTimeWithGracePeriod(nodeGracePeriodExpirationTime *time.Time, pod *corev1.Pod) *time.Time {
-	if nodeGracePeriodExpirationTime == nil || pod.Spec.TerminationGracePeriodSeconds == nil { // k8s defaults to 30s, so we should never see a nil TerminationGracePeriodSeconds
-		return nil
-	}
-
-	// calculate the time the pod should be deleted to allow it's full grace period for termination, equal to its terminationGracePeriodSeconds before the node's expiration time
-	// eg: if a node will be force terminated in 30m, but the current pod has a grace period of 45m, we return a time of 15m ago
 	deleteTime := nodeGracePeriodExpirationTime.Add(time.Duration(*pod.Spec.TerminationGracePeriodSeconds) * time.Second * -1)
-	return &deleteTime
+	return t.clock.Now().After(deleteTime)
 }

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -90,7 +90,7 @@ func (t *Terminator) Taint(ctx context.Context, node *corev1.Node, taint corev1.
 }
 
 // Drain evicts pods from the node and returns true when all pods are evicted
-// https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
+// https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/
 func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeriodExpirationTime *time.Time) error {
 	pods, err := nodeutils.GetPods(ctx, t.kubeClient, node)
 	if err != nil {
@@ -110,7 +110,7 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 }
 
 func (t *Terminator) groupPodsByPriority(pods []*corev1.Pod) [][]*corev1.Pod {
-	// 1. Prioritize noncritical pods, non-daemon pods https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
+	// 1. Prioritize noncritical pods, non-daemon pods https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/
 	var nonCriticalNonDaemon, nonCriticalDaemon, criticalNonDaemon, criticalDaemon []*corev1.Pod
 	for _, pod := range pods {
 		if pod.Spec.PriorityClassName == "system-cluster-critical" || pod.Spec.PriorityClassName == "system-node-critical" {

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -90,7 +90,7 @@ func (t *Terminator) Taint(ctx context.Context, node *corev1.Node, taint corev1.
 }
 
 // Drain evicts pods from the node and returns true when all pods are evicted
-// https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
+// https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/
 func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeriodExpirationTime *time.Time) error {
 	pods, err := nodeutils.GetPods(ctx, t.kubeClient, node.Name)
 	if err != nil {
@@ -110,7 +110,7 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 }
 
 func (t *Terminator) groupPodsByPriority(pods []*corev1.Pod) [][]*corev1.Pod {
-	// 1. Prioritize noncritical pods, non-daemon pods https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
+	// 1. Prioritize noncritical pods, non-daemon pods https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/
 	var nonCriticalNonDaemon, nonCriticalDaemon, criticalNonDaemon, criticalDaemon []*corev1.Pod
 	for _, pod := range pods {
 		if pod.Spec.PriorityClassName == "system-cluster-critical" || pod.Spec.PriorityClassName == "system-node-critical" {

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -96,15 +96,41 @@ func (t *Terminator) Drain(ctx context.Context, node *corev1.Node, nodeGracePeri
 	if err != nil {
 		return fmt.Errorf("listing pods on node, %w", err)
 	}
-	// Hand the queue every pod we're waiting on plus the node's deadline. The
-	// queue picks evict vs force-delete vs requeue per pod, per reconcile —
-	// the terminator does no per-pod drain decisioning.
-	podGroups := t.groupPodsByPriority(lo.Filter(pods, func(p *corev1.Pod, _ int) bool { return podutil.IsWaitingEviction(p, t.clock) }))
+	waiting := lo.Filter(pods, func(p *corev1.Pod, _ int) bool { return podutil.IsWaitingEviction(p, t.clock) })
+
+	// Split waiting pods into two disjoint sets:
+	//   - deleteEligible: past the force-delete threshold. Enqueue across ALL tiers
+	//     immediately — at the hard deadline we must not gate deletion behind
+	//     graceful eviction of an earlier tier (a PDB on a noncritical pod would
+	//     otherwise hold up a past-deadline critical pod).
+	//   - gracefulCandidates: candidates for the PDB-respecting eviction API.
+	//     Tier-gated so noncritical/non-daemon pods drain before critical/daemon
+	//     ones (k8s graceful shutdown ordering).
+	// The queue re-evaluates needsForceDelete on every reconcile, so a graceful
+	// candidate whose deadline crosses while it's enqueued upgrades to force-delete
+	// naturally.
+	var deleteEligible, gracefulCandidates []*corev1.Pod
+	for _, p := range waiting {
+		if needsForceDelete(p, nodeGracePeriodExpirationTime, t.clock) {
+			deleteEligible = append(deleteEligible, p)
+		} else {
+			gracefulCandidates = append(gracefulCandidates, p)
+		}
+	}
+	if len(deleteEligible) > 0 {
+		t.evictionQueue.Add(nodeGracePeriodExpirationTime, deleteEligible...)
+	}
+	podGroups := t.groupPodsByPriority(gracefulCandidates)
 	for _, group := range podGroups {
 		if len(group) > 0 {
 			t.evictionQueue.Add(nodeGracePeriodExpirationTime, group...)
-			return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", lo.SumBy(podGroups, func(pods []*corev1.Pod) int { return len(pods) })))
+			return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", len(waiting)))
 		}
+	}
+	// No graceful candidates remain, but we may still be waiting on the
+	// delete-eligible batch to finish being removed.
+	if len(deleteEligible) > 0 {
+		return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", len(waiting)))
 	}
 	return nil
 }


### PR DESCRIPTION


Fixes https://github.com/kubernetes-sigs/karpenter/issues/3030

**Description**

### Description

**What problem are you trying to solve?**

Currently there are two pod removal paths during node termination:

1. **Eviction Queue** (`terminator/eviction.go`): async, uses Kubernetes Eviction API, respects PDBs, exponential backoff, emits metrics and events
2. **Terminator.DeleteExpiringPods()** (`terminator/terminator.go:140`): synchronous `kubeClient.Delete()` in the reconcile loop, bypasses PDBs when terminationGracePeriod is expiring

This PR consolidates the  force-deletion path  into the eviction queue to:

- Unify observability (metrics, events) for all pod removals
- Avoid synchronous API calls in the reconcile loop
- Make the "bypasses PDBs" behavior explicit and configurable in one place
- Simplify the Terminator's `Drain()` method which currently mixes filtering, force-deletion, and queue submission

**How was this change tested?**
 - New unit tests in `terminator/suite_test.go` covering force-delete via the queue: bypassing a blocking PDB, upgrading an already-enqueued eviction to force-delete, and cleaning up the queue entry when the pod is already gone.
- Updated `node/termination/suite_test.go` for the now-asynchronous force-delete
    (the pod is removed via a queue reconcile rather than inline in `Drain`).

```
 KUBEBUILDER_ASSETS="$(setup-envtest use 1.34.1 -p path)" go test -race ./pkg/controllers/node/termination/...

ok  	sigs.k8s.io/karpenter/pkg/controllers/node/termination	110.124s
ok  	sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator	19.539s
?   	sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events	[no test files]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
