### PR TITLE
chore: use status resources in pod resource calculation

### DIFF
--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -109,10 +109,12 @@ func SubtractFrom(dest v1.ResourceList, src v1.ResourceList) {
 }
 
 // Ceiling computes the effective resource requirements for a given Pod,
-// using the same logic as the scheduler.
+// using the same logic as the scheduler. When InPlacePodVerticalScaling is enabled,
+// this returns max(spec.requests, status.allocatedResources) to reflect what the
+// kubelet actually holds during active resize transitions.
 func Ceiling(pod *v1.Pod) v1.ResourceRequirements {
 	return v1.ResourceRequirements{
-		Requests: resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{}),
+		Requests: resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{UseStatusResources: true}),
 		Limits:   resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{}),
 	}
 }

--- a/pkg/utils/resources/suite_test.go
+++ b/pkg/utils/resources/suite_test.go
@@ -648,4 +648,56 @@ var _ = Describe("Resources", func() {
 			})
 		})
 	})
+	Context("UseStatusResources", func() {
+		It("should use allocatedResources when higher than spec requests (resize-down in progress)", func() {
+			pod := test.Pod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("512Mi")},
+				},
+			})
+			pod.Status.ContainerStatuses = []v1.ContainerStatus{{
+				Name:               pod.Spec.Containers[0].Name,
+				AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("6"), v1.ResourceMemory: resource.MustParse("2Gi")},
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("512Mi")},
+				},
+			}}
+			podResources := resources.Ceiling(pod)
+			ExpectResources(podResources.Requests, v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("6"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			})
+		})
+		It("should use spec requests when higher than allocatedResources (resize-up in progress)", func() {
+			pod := test.Pod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("8"), v1.ResourceMemory: resource.MustParse("4Gi")},
+				},
+			})
+			pod.Status.ContainerStatuses = []v1.ContainerStatus{{
+				Name:               pod.Spec.Containers[0].Name,
+				AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("1Gi")},
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("8"), v1.ResourceMemory: resource.MustParse("4Gi")},
+				},
+			}}
+			podResources := resources.Ceiling(pod)
+			ExpectResources(podResources.Requests, v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("8"),
+				v1.ResourceMemory: resource.MustParse("4Gi"),
+			})
+		})
+		It("should use spec requests when allocatedResources is not set (no resize)", func() {
+			pod := test.Pod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4"), v1.ResourceMemory: resource.MustParse("2Gi")},
+				},
+			})
+			podResources := resources.Ceiling(pod)
+			ExpectResources(podResources.Requests, v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			})
+		})
+	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Sets `UseStatusResources: true` so that pod resource calculations account for in-place resized pods.

With in-place pod vertical scaling, a pod's actual resource allocation can differ from `spec.requests` (e.g. during an in-progress resize-down, the pod still holds its old allocation). The kube-scheduler already uses UseStatusResources to account for this. Without this change, Karpenter's scheduling simulation diverges from the scheduler, causing consolidation decisions the scheduler may not be able to fulfill.

**How was this change tested?**
Added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
