### PR TITLE
perf: memory optimizations in cluster cost tracking

### DIFF
--- a/pkg/controllers/state/informer/pricing.go
+++ b/pkg/controllers/state/informer/pricing.go
@@ -23,9 +23,7 @@ import (
 
 	"github.com/awslabs/operatorpkg/reconciler"
 	"github.com/awslabs/operatorpkg/singleton"
-	"github.com/mitchellh/hashstructure/v2"
 	"go.uber.org/multierr"
-	"k8s.io/apimachinery/pkg/types"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +42,6 @@ type PricingController struct {
 	client        client.Client
 	cloudProvider cloudprovider.CloudProvider
 	clusterCost   *cost.ClusterCost
-	npOfMap       map[types.NamespacedName]uint64
 }
 
 func NewPricingController(client client.Client, cloudProvider cloudprovider.CloudProvider, clusterCost *cost.ClusterCost) *PricingController {
@@ -52,7 +49,6 @@ func NewPricingController(client client.Client, cloudProvider cloudprovider.Clou
 		client:        client,
 		cloudProvider: cloudProvider,
 		clusterCost:   clusterCost,
-		npOfMap:       make(map[types.NamespacedName]uint64),
 	}
 }
 
@@ -63,7 +59,6 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 		return reconciler.Result{}, err
 	}
 
-	newNpOfMap := make(map[types.NamespacedName]uint64, len(npl.Items))
 	var errs error
 	for _, np := range npl.Items {
 		newIts, err := c.cloudProvider.GetInstanceTypes(ctx, &np)
@@ -71,44 +66,13 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 			errs = multierr.Append(errs, err)
 			continue
 		}
-
-		key := client.ObjectKeyFromObject(&np)
-		hash := hashOfferings(newIts)
-		newNpOfMap[key] = hash
-
-		if oldHash, exists := c.npOfMap[key]; exists && oldHash == hash {
-			continue
-		}
 		c.clusterCost.UpdateOfferings(ctx, &np, newIts)
 	}
 	if errs != nil {
 		return reconciler.Result{}, fmt.Errorf("refreshing pricing info, %w", errs)
 	}
-	c.npOfMap = newNpOfMap
 
 	return reconciler.Result{RequeueAfter: 1 * time.Hour}, nil
-}
-
-func hashOfferings(instanceTypes []*cloudprovider.InstanceType) uint64 {
-	type offeringSnapshot struct {
-		InstanceName string
-		Zone         string
-		CapacityType string
-		Price        float64
-	}
-	var snapshots []offeringSnapshot
-	for _, it := range instanceTypes {
-		for _, o := range it.Offerings {
-			snapshots = append(snapshots, offeringSnapshot{
-				InstanceName: it.Name,
-				Zone:         o.Zone(),
-				CapacityType: o.CapacityType(),
-				Price:        o.Price,
-			})
-		}
-	}
-	h, _ := hashstructure.Hash(snapshots, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	return h
 }
 
 func (c *PricingController) Name() string {

--- a/pkg/controllers/state/informer/pricing.go
+++ b/pkg/controllers/state/informer/pricing.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/awslabs/operatorpkg/reconciler"
 	"github.com/awslabs/operatorpkg/singleton"
-	"github.com/samber/lo"
+	"github.com/mitchellh/hashstructure/v2"
 	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -44,7 +44,7 @@ type PricingController struct {
 	client        client.Client
 	cloudProvider cloudprovider.CloudProvider
 	clusterCost   *cost.ClusterCost
-	npOfMap       map[types.NamespacedName]map[cost.OfferingKey]float64
+	npHashMap     map[types.NamespacedName]uint64
 }
 
 func NewPricingController(client client.Client, cloudProvider cloudprovider.CloudProvider, clusterCost *cost.ClusterCost) *PricingController {
@@ -52,6 +52,7 @@ func NewPricingController(client client.Client, cloudProvider cloudprovider.Clou
 		client:        client,
 		cloudProvider: cloudProvider,
 		clusterCost:   clusterCost,
+		npHashMap:     make(map[types.NamespacedName]uint64),
 	}
 }
 
@@ -62,26 +63,20 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 		return reconciler.Result{}, err
 	}
 
-	newNpOfMap := make(map[types.NamespacedName]map[cost.OfferingKey]float64)
+	newNpHashMap := make(map[types.NamespacedName]uint64, len(npl.Items))
 	var errs error
 	for _, np := range npl.Items {
-		oldOfs, exists := c.npOfMap[client.ObjectKeyFromObject(&np)]
 		newIts, err := c.cloudProvider.GetInstanceTypes(ctx, &np)
 		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue
 		}
 
-		newNpOfMap[client.ObjectKeyFromObject(&np)] = make(map[cost.OfferingKey]float64)
+		key := client.ObjectKeyFromObject(&np)
+		h := hashOfferings(newIts)
+		newNpHashMap[key] = h
 
-		for _, it := range newIts {
-			for _, o := range it.Offerings {
-				offeringKey := cost.OfferingKey{InstanceName: it.Name, Zone: o.Zone(), CapacityType: o.CapacityType()}
-				newNpOfMap[client.ObjectKeyFromObject(&np)][offeringKey] = o.Price
-			}
-		}
-
-		if exists && equal(oldOfs, newNpOfMap[client.ObjectKeyFromObject(&np)]) {
+		if oldHash, exists := c.npHashMap[key]; exists && oldHash == h {
 			continue
 		}
 		c.clusterCost.UpdateOfferings(ctx, &np, newIts)
@@ -89,25 +84,31 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 	if errs != nil {
 		return reconciler.Result{}, fmt.Errorf("refreshing pricing info, %w", errs)
 	}
-	c.npOfMap = newNpOfMap
+	c.npHashMap = newNpHashMap
 
 	return reconciler.Result{RequeueAfter: 1 * time.Hour}, nil
 }
 
-func equal(oldOfs map[cost.OfferingKey]float64, newOfs map[cost.OfferingKey]float64) bool {
-	if len(lo.Values(oldOfs)) != len(newOfs) {
-		return false
+func hashOfferings(instanceTypes []*cloudprovider.InstanceType) uint64 {
+	type offeringSnapshot struct {
+		InstanceName string
+		Zone         string
+		CapacityType string
+		Price        float64
 	}
-	for newOf, newPrice := range newOfs {
-		oldPrice, exists := oldOfs[newOf]
-		if !exists {
-			return false
-		}
-		if oldPrice != newPrice {
-			return false
+	snapshots := make([]offeringSnapshot, 0, len(instanceTypes)*3)
+	for _, it := range instanceTypes {
+		for _, o := range it.Offerings {
+			snapshots = append(snapshots, offeringSnapshot{
+				InstanceName: it.Name,
+				Zone:         o.Zone(),
+				CapacityType: o.CapacityType(),
+				Price:        o.Price,
+			})
 		}
 	}
-	return true
+	h, _ := hashstructure.Hash(snapshots, hashstructure.FormatV2, nil)
+	return h
 }
 
 func (c *PricingController) Name() string {

--- a/pkg/controllers/state/informer/pricing.go
+++ b/pkg/controllers/state/informer/pricing.go
@@ -44,7 +44,7 @@ type PricingController struct {
 	client        client.Client
 	cloudProvider cloudprovider.CloudProvider
 	clusterCost   *cost.ClusterCost
-	npHashMap     map[types.NamespacedName]uint64
+	npOfMap       map[types.NamespacedName]uint64
 }
 
 func NewPricingController(client client.Client, cloudProvider cloudprovider.CloudProvider, clusterCost *cost.ClusterCost) *PricingController {
@@ -52,7 +52,7 @@ func NewPricingController(client client.Client, cloudProvider cloudprovider.Clou
 		client:        client,
 		cloudProvider: cloudProvider,
 		clusterCost:   clusterCost,
-		npHashMap:     make(map[types.NamespacedName]uint64),
+		npOfMap:       make(map[types.NamespacedName]uint64),
 	}
 }
 
@@ -63,7 +63,7 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 		return reconciler.Result{}, err
 	}
 
-	newNpHashMap := make(map[types.NamespacedName]uint64, len(npl.Items))
+	newNpOfMap := make(map[types.NamespacedName]uint64, len(npl.Items))
 	var errs error
 	for _, np := range npl.Items {
 		newIts, err := c.cloudProvider.GetInstanceTypes(ctx, &np)
@@ -73,10 +73,10 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 		}
 
 		key := client.ObjectKeyFromObject(&np)
-		h := hashOfferings(newIts)
-		newNpHashMap[key] = h
+		hash := hashOfferings(newIts)
+		newNpOfMap[key] = hash
 
-		if oldHash, exists := c.npHashMap[key]; exists && oldHash == h {
+		if oldHash, exists := c.npOfMap[key]; exists && oldHash == hash {
 			continue
 		}
 		c.clusterCost.UpdateOfferings(ctx, &np, newIts)
@@ -84,7 +84,7 @@ func (c *PricingController) Reconcile(ctx context.Context) (reconciler.Result, e
 	if errs != nil {
 		return reconciler.Result{}, fmt.Errorf("refreshing pricing info, %w", errs)
 	}
-	c.npHashMap = newNpHashMap
+	c.npOfMap = newNpOfMap
 
 	return reconciler.Result{RequeueAfter: 1 * time.Hour}, nil
 }
@@ -96,7 +96,7 @@ func hashOfferings(instanceTypes []*cloudprovider.InstanceType) uint64 {
 		CapacityType string
 		Price        float64
 	}
-	snapshots := make([]offeringSnapshot, 0, len(instanceTypes)*3)
+	var snapshots []offeringSnapshot
 	for _, it := range instanceTypes {
 		for _, o := range it.Offerings {
 			snapshots = append(snapshots, offeringSnapshot{
@@ -107,7 +107,7 @@ func hashOfferings(instanceTypes []*cloudprovider.InstanceType) uint64 {
 			})
 		}
 	}
-	h, _ := hashstructure.Hash(snapshots, hashstructure.FormatV2, nil)
+	h, _ := hashstructure.Hash(snapshots, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	return h
 }
 

--- a/pkg/state/cost/cost.go
+++ b/pkg/state/cost/cost.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -78,7 +79,7 @@ type ClusterCost struct {
 // It maintains the current cost, available instance types, and count of active offerings.
 type NodePoolCost struct {
 	cost float64
-	// offeringCounts only contains entries for offerings with active NodeClaims (Count > 0)
+	// offeringCounts tracks how many instances of each offering type are currently active (Count > 0)
 	offeringCounts map[OfferingKey]OfferingCount
 }
 
@@ -92,7 +93,7 @@ type OfferingKey struct {
 // OfferingCount tracks the number and cost of instances for a specific offering.
 type OfferingCount struct {
 	Count int
-	Price float64
+	Price float64 // Price of the offering, not Price * count
 }
 
 type NodeClaimMetaData struct {
@@ -124,25 +125,14 @@ func (cc *ClusterCost) UpdateOfferings(ctx context.Context, np *v1.NodePool, ins
 	cc.internalUpdateOfferings(np, instanceTypes)
 }
 
-func (cc *ClusterCost) internalNodepoolUpdate(ctx context.Context, np *v1.NodePool) error {
-	instanceTypes, err := cc.cloudProvider.GetInstanceTypes(ctx, np)
-	if err != nil {
-		return fmt.Errorf("failed to get instance types for nodepool %q, %w", np.Name, err)
-	}
-	cc.internalUpdateOfferings(np, instanceTypes)
-	return nil
-}
-
 func (cc *ClusterCost) internalUpdateOfferings(np *v1.NodePool, instanceTypes []*cloudprovider.InstanceType) {
 	instanceTypes = lo.Filter(instanceTypes, func(it *cloudprovider.InstanceType, _ int) bool {
 		return it != nil
 	})
 
-	npc, exists := cc.npCostMap[np.Name]
+	npCost, exists := cc.npCostMap[np.Name]
 	if !exists {
-		cc.npCostMap[np.Name] = &NodePoolCost{
-			offeringCounts: make(map[OfferingKey]OfferingCount),
-		}
+		cc.npCostMap[np.Name] = &NodePoolCost{offeringCounts: make(map[OfferingKey]OfferingCount), cost: 0.0}
 		return
 	}
 
@@ -156,14 +146,14 @@ func (cc *ClusterCost) internalUpdateOfferings(np *v1.NodePool, instanceTypes []
 
 	// Update prices on active offerings and recalculate cost
 	cost := 0.0
-	for key, oc := range npc.offeringCounts {
+	for key, oc := range npCost.offeringCounts {
 		if newPrice, ok := prices[key]; ok {
 			oc.Price = newPrice
-			npc.offeringCounts[key] = oc
+			npCost.offeringCounts[key] = oc
 		}
 		cost += float64(oc.Count) * oc.Price
 	}
-	npc.cost = cost
+	npCost.cost = cost
 }
 
 // UpdateNodeClaim adds a NodeClaim to cost tracking. The NodeClaim must have
@@ -247,6 +237,9 @@ func (cc *ClusterCost) DeleteNodePool(ctx context.Context, npName string) {
 	delete(cc.npCostMap, npName)
 }
 
+// internalAddOffering updates the internal clusterCost state to include a new offering for a given nodepool.
+// It is used to increment the overall cost when a node joins the cluster. It is only called by UpdateNodeClaim
+// after that function has determined if a nodeclaim is new.
 func (cc *ClusterCost) internalAddOffering(ctx context.Context, npName string, offeringKey OfferingKey) error {
 	np := &v1.NodePool{}
 	if err := cc.client.Get(ctx, client.ObjectKey{Name: npName}, np, &client.GetOptions{}); err != nil {
@@ -254,22 +247,24 @@ func (cc *ClusterCost) internalAddOffering(ctx context.Context, npName string, o
 	}
 
 	if _, exists := cc.npCostMap[npName]; !exists {
-		cc.npCostMap[npName] = &NodePoolCost{offeringCounts: make(map[OfferingKey]OfferingCount)}
+		cc.npCostMap[npName] = &NodePoolCost{offeringCounts: make(map[OfferingKey]OfferingCount), cost: 0.0}
 	}
-	npc := cc.npCostMap[npName]
 
-	oc, exists := npc.offeringCounts[offeringKey]
+	oc, exists := cc.npCostMap[npName].offeringCounts[offeringKey]
 	if !exists {
 		instanceTypes, err := cc.cloudProvider.GetInstanceTypes(ctx, np)
 		if err != nil {
 			return fmt.Errorf("failed to get instance types for nodepool %q while adding offering for instance %q, %w", np.Name, offeringKey.InstanceName, err)
 		}
-		price, _ := findOfferingPrice(instanceTypes, offeringKey)
-		oc = OfferingCount{Price: price}
+		price, found := findOfferingPrice(instanceTypes, offeringKey)
+		if !found {
+			log.FromContext(ctx).Error(fmt.Errorf("failed to find offering for instance %q in zone %q with capacity %q in nodepool %q", offeringKey.InstanceName, offeringKey.Zone, offeringKey.CapacityType, npName), "offering price unknown — cost tracking will undercount for this nodeclaim until next update")
+		}
+		oc = OfferingCount{Count: 0, Price: price}
 	}
 	oc.Count++
-	npc.offeringCounts[offeringKey] = oc
-	npc.cost += oc.Price
+	cc.npCostMap[npName].offeringCounts[offeringKey] = oc
+	cc.npCostMap[npName].cost += oc.Price
 	return nil
 }
 
@@ -288,12 +283,11 @@ func (cc *ClusterCost) internalRemoveOffering(npName string, offeringKey Offerin
 	}
 
 	oc.Count--
+	npc.offeringCounts[offeringKey] = oc
+	npc.cost -= oc.Price
 	if oc.Count == 0 {
 		delete(npc.offeringCounts, offeringKey)
-	} else {
-		npc.offeringCounts[offeringKey] = oc
 	}
-	npc.cost -= oc.Price
 	if len(npc.offeringCounts) == 0 {
 		delete(cc.npCostMap, npName)
 	}

--- a/pkg/state/cost/cost.go
+++ b/pkg/state/cost/cost.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -68,7 +67,7 @@ var (
 type ClusterCost struct {
 	sync.RWMutex
 	npCostMap map[string]*NodePoolCost // nodepool.Name -> NodePoolCost
-	// nodeClaimSet tracks which NodeClaims are currently being monitored for cost
+	// nodeClaimMap tracks which NodeClaims are currently being monitored for cost
 	nodeClaimMap map[types.NamespacedName]NodeClaimMetaData // nodeClaim object key -> NodeClaimMetaData
 
 	cloudProvider cloudprovider.CloudProvider
@@ -79,7 +78,7 @@ type ClusterCost struct {
 // It maintains the current cost, available instance types, and count of active offerings.
 type NodePoolCost struct {
 	cost float64
-	// offeringCounts tracks how many instances of each offering type are currently active
+	// offeringCounts only contains entries for offerings with active NodeClaims (Count > 0)
 	offeringCounts map[OfferingKey]OfferingCount
 }
 
@@ -93,7 +92,7 @@ type OfferingKey struct {
 // OfferingCount tracks the number and cost of instances for a specific offering.
 type OfferingCount struct {
 	Count int
-	Price float64 // Price of the offering, not Price * count
+	Price float64
 }
 
 type NodeClaimMetaData struct {
@@ -103,7 +102,7 @@ type NodeClaimMetaData struct {
 
 // NewClusterCost creates and initializes a new ClusterCost instance for tracking
 // compute costs across the cluster. It requires a cloud provider for accessing
-// instance type and pricing information, and a Kubernetes client for NodePool loofferingKeyups.
+// instance type and pricing information, and a Kubernetes client for NodePool lookups.
 func NewClusterCost(ctx context.Context, cloudProvider cloudprovider.CloudProvider, client client.Client) *ClusterCost {
 	return &ClusterCost{
 		npCostMap:     make(map[string]*NodePoolCost),
@@ -135,65 +134,36 @@ func (cc *ClusterCost) internalNodepoolUpdate(ctx context.Context, np *v1.NodePo
 }
 
 func (cc *ClusterCost) internalUpdateOfferings(np *v1.NodePool, instanceTypes []*cloudprovider.InstanceType) {
-	npCost, exists := cc.npCostMap[np.Name]
+	instanceTypes = lo.Filter(instanceTypes, func(it *cloudprovider.InstanceType, _ int) bool {
+		return it != nil
+	})
 
+	npc, exists := cc.npCostMap[np.Name]
 	if !exists {
-		cc.createNewNodePoolCost(np.Name, instanceTypes)
-	} else {
-		instanceTypes = lo.Filter(instanceTypes, func(it *cloudprovider.InstanceType, _ int) bool {
-			return it != nil
-		})
-		newMap := map[OfferingKey]OfferingCount{}
-		for _, it := range instanceTypes {
-			for _, o := range it.Offerings {
-				offeringKey := OfferingKey{InstanceName: it.Name, Zone: o.Zone(), CapacityType: o.CapacityType()}
-				oldCount, exists := npCost.offeringCounts[offeringKey]
-				newMap[offeringKey] = OfferingCount{
-					Count: lo.Ternary(exists, oldCount.Count, 0),
-					Price: o.Price,
-				}
-			}
+		cc.npCostMap[np.Name] = &NodePoolCost{
+			offeringCounts: make(map[OfferingKey]OfferingCount),
 		}
-		// Add back all of the offering counts that don't exist in the new instance types
-		// This can't occur on container restart, so we may lose cost data from offerings that are no longer returned
-		// from the cloud provider but still have nodeclaims.
-		for key, count := range npCost.offeringCounts {
-			_, exists := newMap[key]
-			if !exists {
-				newMap[key] = count
-			}
-		}
-
-		npCost.offeringCounts = newMap
-		// re-calculate the cost as the instances have changed
-		cost := npCost.updateCost()
-		cc.npCostMap[np.Name].cost = cost
+		return
 	}
-}
 
-func (npc *NodePoolCost) updateCost() float64 {
-	cost := 0.0
-	for _, oc := range npc.offeringCounts {
-		// add the new price times the count of that offering
-		cost = cost + (float64(oc.Count) * oc.Price)
-	}
-	return cost
-}
-
-func (cc *ClusterCost) createNewNodePoolCost(npName string, instanceTypes []*cloudprovider.InstanceType) {
-	// create the new npc
-	cc.npCostMap[npName] = &NodePoolCost{
-		offeringCounts: make(map[OfferingKey]OfferingCount),
-		cost:           0.0,
-	}
+	// Build a temporary price index from the new instance types
+	prices := make(map[OfferingKey]float64, len(instanceTypes)*3)
 	for _, it := range instanceTypes {
 		for _, o := range it.Offerings {
-			cc.npCostMap[npName].offeringCounts[OfferingKey{InstanceName: it.Name, Zone: o.Zone(), CapacityType: o.CapacityType()}] = OfferingCount{
-				Count: 0,
-				Price: o.Price,
-			}
+			prices[OfferingKey{InstanceName: it.Name, Zone: o.Zone(), CapacityType: o.CapacityType()}] = o.Price
 		}
 	}
+
+	// Update prices on active offerings and recalculate cost
+	cost := 0.0
+	for key, oc := range npc.offeringCounts {
+		if newPrice, ok := prices[key]; ok {
+			oc.Price = newPrice
+			npc.offeringCounts[key] = oc
+		}
+		cost += float64(oc.Count) * oc.Price
+	}
+	npc.cost = cost
 }
 
 // UpdateNodeClaim adds a NodeClaim to cost tracking. The NodeClaim must have
@@ -277,47 +247,34 @@ func (cc *ClusterCost) DeleteNodePool(ctx context.Context, npName string) {
 	delete(cc.npCostMap, npName)
 }
 
-// internalAddOffering updates the internal clusterCost state to include a new offering for a given nodepool.
-// It is used to increment the overall cost when a node joins the cluster. It is only called by UpdateNodeClaim
-// after that function has determined if a nodeclaim is new.
 func (cc *ClusterCost) internalAddOffering(ctx context.Context, npName string, offeringKey OfferingKey) error {
 	np := &v1.NodePool{}
 	if err := cc.client.Get(ctx, client.ObjectKey{Name: npName}, np, &client.GetOptions{}); err != nil {
 		return err
 	}
 
-	_, exists := cc.npCostMap[npName]
+	if _, exists := cc.npCostMap[npName]; !exists {
+		cc.npCostMap[npName] = &NodePoolCost{offeringCounts: make(map[OfferingKey]OfferingCount)}
+	}
+	npc := cc.npCostMap[npName]
+
+	oc, exists := npc.offeringCounts[offeringKey]
 	if !exists {
-		// create the new npc
 		instanceTypes, err := cc.cloudProvider.GetInstanceTypes(ctx, np)
 		if err != nil {
-			return fmt.Errorf("failed to get instance types for new nodepool %q while adding offering for instance %q, %w", np.Name, offeringKey.InstanceName, err)
+			return fmt.Errorf("failed to get instance types for nodepool %q while adding offering for instance %q, %w", np.Name, offeringKey.InstanceName, err)
 		}
-		cc.createNewNodePoolCost(npName, instanceTypes)
+		price, _ := findOfferingPrice(instanceTypes, offeringKey)
+		oc = OfferingCount{Price: price}
 	}
-
-	oc, exists := cc.npCostMap[npName].offeringCounts[offeringKey]
-	if !exists {
-		// our offerings must be out of date, we should update and retry
-		err := cc.internalNodepoolUpdate(ctx, np)
-		if err != nil {
-			return fmt.Errorf("failed to update nodepool %q during retry while searching for offering for instance %q in zone %q with capacity %q, %w", np.Name, offeringKey.InstanceName, offeringKey.Zone, offeringKey.CapacityType, err)
-		}
-		oc, exists = cc.npCostMap[npName].offeringCounts[offeringKey]
-		if !exists {
-			// Start at 0; the unconditional oc.Count += 1 below accounts for this add.
-			oc = OfferingCount{Count: 0, Price: 0.0}
-			log.FromContext(ctx).Error(fmt.Errorf("failed to find offering %q during retry while searching for instance %q in zone %q with capacity %q in nodepool %q", offeringKey, offeringKey.InstanceName, offeringKey.Zone, offeringKey.CapacityType, npName), "offering price unknown after retry — cost tracking will undercount for this nodeclaim until next UpdateOfferings")
-		}
-	}
-	oc.Count += 1
-	cc.npCostMap[npName].offeringCounts[offeringKey] = oc
-	cc.npCostMap[npName].cost += oc.Price
+	oc.Count++
+	npc.offeringCounts[offeringKey] = oc
+	npc.cost += oc.Price
 	return nil
 }
 
 // internalRemoveOffering updates the internal clusterCost state to remove an existing offering for a given nodepool.
-// It is used to decrement the overall cost when a node leeaves the cluster. It is only called by DeleteNodeClaim
+// It is used to decrement the overall cost when a node leaves the cluster. It is only called by DeleteNodeClaim
 // after that function has determined if a nodeclaim is already being accounted for.
 func (cc *ClusterCost) internalRemoveOffering(npName string, offeringKey OfferingKey) error {
 	npc, exists := cc.npCostMap[npName]
@@ -330,13 +287,14 @@ func (cc *ClusterCost) internalRemoveOffering(npName string, offeringKey Offerin
 		return fmt.Errorf("attempted to remove nonexistent offering from nodepool %q (instance, %q, zone, %q, capacity, %q)", npName, offeringKey.InstanceName, offeringKey.Zone, offeringKey.CapacityType)
 	}
 
-	oc.Count -= 1
-	npc.offeringCounts[offeringKey] = oc
-	npc.cost -= oc.Price
+	oc.Count--
 	if oc.Count == 0 {
 		delete(npc.offeringCounts, offeringKey)
+	} else {
+		npc.offeringCounts[offeringKey] = oc
 	}
-	if len(lo.Values(npc.offeringCounts)) == 0 {
+	npc.cost -= oc.Price
+	if len(npc.offeringCounts) == 0 {
 		delete(cc.npCostMap, npName)
 	}
 	return nil
@@ -367,6 +325,20 @@ func (cc *ClusterCost) GetNodepoolCost(np *v1.NodePool) float64 {
 		return 0
 	}
 	return npc.cost
+}
+
+func findOfferingPrice(instanceTypes []*cloudprovider.InstanceType, key OfferingKey) (float64, bool) {
+	for _, it := range instanceTypes {
+		if it == nil || it.Name != key.InstanceName {
+			continue
+		}
+		for _, o := range it.Offerings {
+			if o.Zone() == key.Zone && o.CapacityType() == key.CapacityType {
+				return o.Price, true
+			}
+		}
+	}
+	return 0, false
 }
 
 func nodeClaimMissingLabels(nc v1.NodeClaim) bool {

--- a/pkg/state/cost/cost.go
+++ b/pkg/state/cost/cost.go
@@ -283,10 +283,11 @@ func (cc *ClusterCost) internalRemoveOffering(npName string, offeringKey Offerin
 	}
 
 	oc.Count--
-	npc.offeringCounts[offeringKey] = oc
 	npc.cost -= oc.Price
 	if oc.Count == 0 {
 		delete(npc.offeringCounts, offeringKey)
+	} else {
+		npc.offeringCounts[offeringKey] = oc
 	}
 	if len(npc.offeringCounts) == 0 {
 		delete(cc.npCostMap, npName)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds 2 memory optimizations for node pool cluster cost tracking:
1. Hash Based Change Detection
> Previously we stored `map[OfferingKey]float64` per NodePool and doing map equality comparison
  each reconcile. This PR changes it to a single hash which reduces memory from `O(offerings)`
  to `O(1)` per NodePool for the diff check.

2. Lazy Offering Tracking
> Previously we tracked the price of every offering for every NodePool, even if the instance was not in use. This PR changes it so we only track the price of offerings when there is an active NodeClaim for that offering.

**Testing Scenario**: 25 wide-open NodePools with 1 NodeClaim per NodePool launched

<img width="1169" height="230" alt="Screenshot 2026-06-03 at 11 13 56 AM" src="https://github.com/user-attachments/assets/6cbc7d97-7e1f-44a0-bd69-2d8c301acb58" />

> Yellow - v1.9.0 (without cluster cost)
Green - mainline
Blue - this PR


**How was this change tested?**
`make presubmit`

**Testing Scenario (between commits during development)**: 25 wide-open NodePools with 1 NodeClaim per NodePool launched

<img width="643" height="230" alt="Screenshot 2026-06-02 at 10 05 15 PM" src="https://github.com/user-attachments/assets/545238af-3c77-42b6-b00f-f5c7ec9071c6" />

> Yellow - v1.9.0 (without cluster cost)
Blue - v1.10.0 (with cluster cost)
Red - commit 193d066f0b6516b8c39019e43721f04116da668d (only store prices of used instances)
Orange - commit b941319b14fa3e4448ea67c26ce38e746ce9033c (hashing offerings)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
