### PR TITLE
perf: controller-runtime enable unstructured cache

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -186,6 +186,11 @@ func NewOperator(o ...option.Function[Options]) (context.Context, *Operator) {
 			ctx = injection.WithOptionsOrDie(ctx, options.Injectables...)
 			return ctx
 		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				Unstructured: true,
+			},
+		},
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&coordinationv1.Lease{}: {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

During Karpenter's idle operation, tens of thousands of Get Node requests are sent to the Apiserver per minute (visible in audit logs), which imposes a huge burden on the Apiserver.

However, I believe this request doesn't necessarily have to access the Apiserver, as the data obtained via the informer's watch is fresh enough.

The following is the path where the issue occurs:
```
When registering status.NewGenericObjectController[*corev1.Node]
For(&corev1.Node{}) → watches all Nodes in the cluster

In Reconcile, uses UnstructuredAdapter to call kubeClient.Get()
↓
UnstructuredAdapter embeds unstructured.Unstructured → implements runtime.Unstructured interface
↓
controller-runtime cached client checks shouldBypassCache():
cacheUnstructured defaults to false + object is runtime.Unstructured → bypasses cache
↓
Direct HTTP GET /api/v1/nodes/ to apiserver → visible in audit log
↓
At the end of Reconcile, returns RequeueAfter: 10s → reconciles again after 10 seconds
```

**How was this change tested?**

Startup is normal, and the get operations in the audit logs decrease.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
