### PR TITLE
chore: bump max k8s version to 1.36

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -3,7 +3,7 @@ description: 'Installs Go Downloads and installs Karpenter Dependencies'
 inputs:
   k8sVersion:
     description: Kubernetes version to use when installing envtest binaries
-    default: "1.35.x"
+    default: "1.36.x"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,7 +4,7 @@ on:
     inputs:
       k8s_version:
         type: string
-        default: "1.35"
+        default: "1.36"
       suite:
         type: string
         required: true

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8sVersion: ["1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x"]
+        k8sVersion: ["1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x", "1.36.x"]
     uses: ./.github/workflows/e2e.yaml
     with: 
       k8s_version: ${{ matrix.k8sVersion }}

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8sVersion: ["1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x"]
+        k8sVersion: ["1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x", "1.36.x"]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/install-deps
@@ -25,7 +25,7 @@ jobs:
     - run: K8S_VERSION=${{ matrix.k8sVersion }} make presubmit
     - name: Send coverage
       # should only send converage once https://docs.coveralls.io/parallel-builds
-      if: matrix.k8sVersion == '1.35.x'
+      if: matrix.k8sVersion == '1.36.x'
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: go tool -modfile=go.tools.mod goveralls -coverprofile=coverage.out -service=github

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -142,7 +142,7 @@ func NewEnvironment(options ...option.Function[EnvironmentOptions]) *Environment
 	opts := option.Resolve(options...)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	version := version.MustParseSemantic(strings.ReplaceAll(env.WithDefaultString("K8S_VERSION", "1.35.x"), ".x", ".0"))
+	version := version.MustParseSemantic(strings.ReplaceAll(env.WithDefaultString("K8S_VERSION", "1.36.x"), ".x", ".0"))
 	environment := envtest.Environment{Scheme: scheme.Scheme, CRDs: opts.crds}
 	if version.Minor() >= 21 && version.Minor() < 32 {
 		// PodAffinityNamespaceSelector is used for label selectors in pod affinities.  If the feature-gate is turned off,


### PR DESCRIPTION
Fixes #N/A

**Description**
* bumps the max supported Kubernetes version to 1.36 and removes 1.29 from tested versions, similar to https://github.com/kubernetes-sigs/karpenter/pull/2828

**How was this change tested?**
* CI presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.