### PR TITLE
feat(metrics): add karpenter_pods_disrupted_total counter metric

### DIFF
--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -103,6 +103,72 @@ var _ = Describe("Drift", func() {
 			ExpectSingletonReconciled(ctx, disruptionController)
 			ExpectMetricGaugeValue(disruption.EligibleNodes, 1, eligibleNodesLabels)
 		})
+		It("should fire NodeClaimsDisruptedTotal and PodsDisruptedTotal metrics when a drifted node is disrupted", func() {
+			labels := map[string]string{"app": "test"}
+			rs := test.ReplicaSet()
+			ExpectApplied(ctx, env.Client, rs)
+			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
+
+			// Create 3 RS-owned (reschedulable) pods on the drifted nodeClaim
+			pods := test.Pods(3, test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "ReplicaSet",
+							Name:               rs.Name,
+							UID:                rs.UID,
+							Controller:         lo.ToPtr(true),
+							BlockOwnerDeletion: lo.ToPtr(true),
+						},
+					},
+				},
+			})
+
+			// Create a second node to absorb the rescheduled pods
+			nodeClaim2, node2 := test.NodeClaimAndNode(v1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NodePoolLabelKey:            nodePool.Name,
+						corev1.LabelInstanceTypeStable: mostExpensiveInstance.Name,
+						v1.CapacityTypeLabelKey:        mostExpensiveOffering.Requirements.Get(v1.CapacityTypeLabelKey).Any(),
+						corev1.LabelTopologyZone:       mostExpensiveOffering.Requirements.Get(corev1.LabelTopologyZone).Any(),
+					},
+				},
+				Status: v1.NodeClaimStatus{
+					ProviderID: test.RandomProviderID(),
+					Allocatable: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("32"),
+						corev1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+
+			nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeDrifted)
+			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodePool, nodeClaim, node, nodeClaim2, node2)
+			ExpectManualBinding(ctx, env.Client, pods[0], node)
+			ExpectManualBinding(ctx, env.Client, pods[1], node)
+			ExpectManualBinding(ctx, env.Client, pods[2], node)
+
+			// Inform cluster state about nodes and nodeclaims
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController,
+				[]*corev1.Node{node, node2}, []*v1.NodeClaim{nodeClaim, nodeClaim2})
+
+			ExpectSingletonReconciled(ctx, disruptionController)
+			// Reconcile the queue to execute termination of the drifted node
+			ExpectObjectReconciled(ctx, env.Client, queue, nodeClaim)
+			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
+
+			capacityType := nodeClaim.Labels[v1.CapacityTypeLabelKey]
+			metricLabels := map[string]string{
+				metrics.ReasonLabel:       "drifted",
+				metrics.NodePoolLabel:     nodePool.Name,
+				metrics.CapacityTypeLabel: capacityType,
+			}
+			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, metricLabels)
+			ExpectMetricCounterValue(metrics.PodsDisruptedTotal, 3, metricLabels)
+		})
 	})
 	Context("Budgets", func() {
 		var numNodes = 10

--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -239,11 +239,13 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 			return
 		}
 		q.recorder.Publish(disruptionevents.Terminating(cmd.Candidates[i].Node, cmd.Candidates[i].NodeClaim, string(cmd.Reason()))...)
-		metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+		labels := map[string]string{
 			metrics.ReasonLabel:       pretty.ToSnakeCase(string(cmd.Reason())),
 			metrics.NodePoolLabel:     cmd.Candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel: cmd.Candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
-		})
+		}
+		metrics.NodeClaimsDisruptedTotal.Inc(labels)
+		metrics.PodsDisruptedTotal.Add(float64(cmd.Candidates[i].ReschedulablePodCount()), labels)
 	})
 	// If there were any deletion failures, we should requeue.
 	// In the case where we requeue, but the timeout for the command is reached, we'll mark this as a failure.

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -166,6 +166,8 @@ var _ = AfterEach(func() {
 	// Reset the metrics collectors
 	disruption.DecisionsPerformedTotal.Reset()
 	disruption.NodepoolDecisionsPerformed.Reset()
+	metrics.NodeClaimsDisruptedTotal.Reset()
+	metrics.PodsDisruptedTotal.Reset()
 })
 
 var _ = Describe("Simulate Scheduling", func() {

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -85,6 +85,10 @@ func (c *Candidate) OwnedByStaticNodePool() bool {
 	return c.NodePool.Spec.Replicas != nil
 }
 
+func (c *Candidate) ReschedulablePodCount() int {
+	return len(c.reschedulablePods)
+}
+
 //nolint:gocyclo
 func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events.Recorder, clk clock.Clock, node *state.StateNode, pdbs pdb.Limits,
 	nodePoolMap map[string]*v1.NodePool, nodePoolToInstanceTypesMap map[string]map[string]*cloudprovider.InstanceType, queue *Queue, disruptionClass string,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,6 +71,20 @@ var (
 			CapacityTypeLabel,
 		},
 	)
+	PodsDisruptedTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: PodSubsystem,
+			Name:      "disrupted_total",
+			Help:      "Number of reschedulable pods disrupted in total by Karpenter. Labeled by reason the pods were disrupted and the owning nodepool.",
+		},
+		[]string{
+			ReasonLabel,
+			NodePoolLabel,
+			CapacityTypeLabel,
+		},
+	)
 	NodesCreatedTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
 		prometheus.CounterOpts{


### PR DESCRIPTION
## Summary

Add a new Prometheus counter metric `karpenter_pods_disrupted_total` to track the number of reschedulable pods disrupted by Karpenter.

Resolves #2020

## Changes

- **`pkg/metrics/metrics.go`**: Add `PodsDisruptedTotal` counter with labels `reason`, `nodepool`, `capacity_type` (matching `NodeClaimsDisruptedTotal`)
- **`pkg/controllers/disruption/types.go`**: Add `ReschedulablePodCount()` accessor on `Candidate` to expose the unexported `reschedulablePods` count
- **`pkg/controllers/disruption/queue.go`**: Increment `PodsDisruptedTotal` by `ReschedulablePodCount()` right next to `NodeClaimsDisruptedTotal.Inc()`
- **`pkg/controllers/disruption/drift_test.go`**: Add integration test verifying both metrics are incremented correctly when a drifted node with reschedulable pods is disrupted
- **`pkg/controllers/disruption/suite_test.go`**: Reset both new metrics in the global `AfterEach`

## Testing

Added a new test in the `Drift/Metrics` context that:
1. Creates a drifted NodeClaim with 3 RS-owned (reschedulable) pods
2. Creates a second node to absorb the rescheduled pods
3. Runs the disruption controller + queue reconciliation
4. Asserts `karpenter_nodeclaims_disrupted_total{reason="drifted",...} == 1`
5. Asserts `karpenter_pods_disrupted_total{reason="drifted",...} == 3`