### PR TITLE
chore: add managed dimension to node and pod metrics

### DIFF
--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -140,7 +140,7 @@ func initializeMetrics() {
 			Name:      "utilization_percent",
 			Help:      "Utilization of allocatable resources by pod requests",
 		},
-		[]string{metrics.ResourceTypeLabel, managed},
+		[]string{metrics.ResourceTypeLabel},
 	)
 }
 
@@ -207,19 +207,7 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 }
 
 func buildClusterUtilizationMetric(nodes state.StateNodes) []*metrics.StoreMetric {
-	// Partition nodes by whether they are managed by this Karpenter instance (i.e. have a
-	// NodeClaim owned by the configured cloud provider). Emitting utilization with a "managed"
-	// dimension lets dashboards filter out nodes Karpenter doesn't manage, which would otherwise
-	// skew the cluster utilization numbers.
-	managedNodes, unmanagedNodes := lo.FilterReject(nodes, func(n *state.StateNode, _ int) bool {
-		return n.Managed()
-	})
 
-	res := buildUtilizationForNodes(managedNodes, true)
-	return append(res, buildUtilizationForNodes(unmanagedNodes, false)...)
-}
-
-func buildUtilizationForNodes(nodes state.StateNodes, isManaged bool) []*metrics.StoreMetric {
 	// Aggregate resources allocated/utilized for all the nodes and pods inside the nodes
 	allocatableAggregate, utilizedAggregate := corev1.ResourceList{}, corev1.ResourceList{}
 
@@ -248,10 +236,7 @@ func buildUtilizationForNodes(nodes state.StateNodes, isManaged bool) []*metrics
 		res = append(res, &metrics.StoreMetric{
 			GaugeMetric: ClusterUtilization,
 			Value:       utilizationPercentage,
-			Labels: map[string]string{
-				metrics.ResourceTypeLabel: resourceNameToString(resourceName),
-				managed:                   strconv.FormatBool(isManaged),
-			},
+			Labels:      map[string]string{metrics.ResourceTypeLabel: resourceNameToString(resourceName)},
 		})
 	}
 
@@ -259,7 +244,6 @@ func buildUtilizationForNodes(nodes state.StateNodes, isManaged bool) []*metrics
 }
 
 func buildMetrics(n *state.StateNode) (res []*metrics.StoreMetric) {
-	isManaged := strconv.FormatBool(n.Managed())
 	for gaugeMetric, resourceList := range map[opmetrics.GaugeMetric]corev1.ResourceList{
 		SystemOverhead:      resources.Subtract(n.Node.Status.Capacity, n.Node.Status.Allocatable),
 		TotalPodRequests:    n.PodRequests(),
@@ -269,35 +253,33 @@ func buildMetrics(n *state.StateNode) (res []*metrics.StoreMetric) {
 		Allocatable:         n.Node.Status.Allocatable,
 	} {
 		for resourceName, quantity := range resourceList {
-			labels := getNodeLabelsWithResourceType(n.Node, resourceNameToString(resourceName))
-			labels[managed] = isManaged
 			res = append(res, &metrics.StoreMetric{
 				GaugeMetric: gaugeMetric,
 				Value:       lo.Ternary(resourceName == corev1.ResourceCPU, float64(quantity.MilliValue())/float64(1000), float64(quantity.Value())),
-				Labels:      labels,
+				Labels:      getNodeLabelsWithResourceType(n, resourceNameToString(resourceName)),
 			})
 		}
 	}
-	labels := getNodeLabels(n.Node)
-	labels[managed] = isManaged
 	return append(res,
 		&metrics.StoreMetric{
 			GaugeMetric: Lifetime,
 			Value:       time.Since(n.Node.GetCreationTimestamp().Time).Seconds(),
-			Labels:      labels,
+			Labels:      getNodeLabels(n),
 		})
 }
 
-func getNodeLabelsWithResourceType(node *corev1.Node, resourceTypeName string) prometheus.Labels {
-	metricLabels := getNodeLabels(node)
+func getNodeLabelsWithResourceType(n *state.StateNode, resourceTypeName string) prometheus.Labels {
+	metricLabels := getNodeLabels(n)
 	metricLabels[metrics.ResourceTypeLabel] = resourceTypeName
 	return metricLabels
 }
 
-func getNodeLabels(node *corev1.Node) prometheus.Labels {
+func getNodeLabels(n *state.StateNode) prometheus.Labels {
+	node := n.Node
 	metricLabels := map[string]string{}
 	metricLabels[nodeName] = node.Name
 	metricLabels[nodePhase] = string(node.Status.Phase)
+	metricLabels[managed] = strconv.FormatBool(n.Managed())
 
 	// Populate well known labels
 	for wellKnownLabel, label := range getWellKnownLabels() {

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -44,6 +45,7 @@ import (
 const (
 	nodeName  = "node_name"
 	nodePhase = "phase"
+	managed   = "managed"
 )
 
 var (
@@ -138,7 +140,7 @@ func initializeMetrics() {
 			Name:      "utilization_percent",
 			Help:      "Utilization of allocatable resources by pod requests",
 		},
-		[]string{metrics.ResourceTypeLabel},
+		[]string{metrics.ResourceTypeLabel, managed},
 	)
 }
 
@@ -156,6 +158,7 @@ func nodeLabelNames() []string {
 		sets.New(lo.Values(getWellKnownLabels())...).UnsortedList(),
 		nodeName,
 		nodePhase,
+		managed,
 	)
 }
 
@@ -204,7 +207,19 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 }
 
 func buildClusterUtilizationMetric(nodes state.StateNodes) []*metrics.StoreMetric {
+	// Partition nodes by whether they are managed by this Karpenter instance (i.e. have a
+	// NodeClaim owned by the configured cloud provider). Emitting utilization with a "managed"
+	// dimension lets dashboards filter out nodes Karpenter doesn't manage, which would otherwise
+	// skew the cluster utilization numbers.
+	managedNodes, unmanagedNodes := lo.FilterReject(nodes, func(n *state.StateNode, _ int) bool {
+		return n.Managed()
+	})
 
+	res := buildUtilizationForNodes(managedNodes, true)
+	return append(res, buildUtilizationForNodes(unmanagedNodes, false)...)
+}
+
+func buildUtilizationForNodes(nodes state.StateNodes, isManaged bool) []*metrics.StoreMetric {
 	// Aggregate resources allocated/utilized for all the nodes and pods inside the nodes
 	allocatableAggregate, utilizedAggregate := corev1.ResourceList{}, corev1.ResourceList{}
 
@@ -233,7 +248,10 @@ func buildClusterUtilizationMetric(nodes state.StateNodes) []*metrics.StoreMetri
 		res = append(res, &metrics.StoreMetric{
 			GaugeMetric: ClusterUtilization,
 			Value:       utilizationPercentage,
-			Labels:      map[string]string{metrics.ResourceTypeLabel: resourceNameToString(resourceName)},
+			Labels: map[string]string{
+				metrics.ResourceTypeLabel: resourceNameToString(resourceName),
+				managed:                   strconv.FormatBool(isManaged),
+			},
 		})
 	}
 
@@ -241,6 +259,7 @@ func buildClusterUtilizationMetric(nodes state.StateNodes) []*metrics.StoreMetri
 }
 
 func buildMetrics(n *state.StateNode) (res []*metrics.StoreMetric) {
+	isManaged := strconv.FormatBool(n.Managed())
 	for gaugeMetric, resourceList := range map[opmetrics.GaugeMetric]corev1.ResourceList{
 		SystemOverhead:      resources.Subtract(n.Node.Status.Capacity, n.Node.Status.Allocatable),
 		TotalPodRequests:    n.PodRequests(),
@@ -250,18 +269,22 @@ func buildMetrics(n *state.StateNode) (res []*metrics.StoreMetric) {
 		Allocatable:         n.Node.Status.Allocatable,
 	} {
 		for resourceName, quantity := range resourceList {
+			labels := getNodeLabelsWithResourceType(n.Node, resourceNameToString(resourceName))
+			labels[managed] = isManaged
 			res = append(res, &metrics.StoreMetric{
 				GaugeMetric: gaugeMetric,
 				Value:       lo.Ternary(resourceName == corev1.ResourceCPU, float64(quantity.MilliValue())/float64(1000), float64(quantity.Value())),
-				Labels:      getNodeLabelsWithResourceType(n.Node, resourceNameToString(resourceName)),
+				Labels:      labels,
 			})
 		}
 	}
+	labels := getNodeLabels(n.Node)
+	labels[managed] = isManaged
 	return append(res,
 		&metrics.StoreMetric{
 			GaugeMetric: Lifetime,
 			Value:       time.Since(n.Node.GetCreationTimestamp().Time).Seconds(),
-			Labels:      getNodeLabels(n.Node),
+			Labels:      labels,
 		})
 }
 

--- a/pkg/controllers/metrics/node/suite_test.go
+++ b/pkg/controllers/metrics/node/suite_test.go
@@ -141,39 +141,11 @@ var _ = Describe("Node Metrics", func() {
 		Expect(metric.GetGauge().GetValue()).To(BeNumerically(">=", 0))
 
 		for resourceName := range resources {
-			// A plain node with no NodeClaim is not managed by Karpenter, so its utilization
-			// is reported under the managed="false" series.
 			metric, found := FindMetricWithLabelValues("karpenter_cluster_utilization_percent", map[string]string{
 				metrics.ResourceTypeLabel: resourceName.String(),
-				"managed":                 "false",
 			})
 			Expect(found).To(BeTrue())
 			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 0))
-		}
-	})
-	It("should report cluster utilization with the managed dimension set for Karpenter-managed nodes", func() {
-		nodeClaim := test.NodeClaim(v1.NodeClaim{
-			Status: v1.NodeClaimStatus{
-				ProviderID:  test.RandomProviderID(),
-				Allocatable: resources,
-			},
-		})
-		managedNode := test.Node(test.NodeOptions{
-			ProviderID:  nodeClaim.Status.ProviderID,
-			Allocatable: resources,
-		})
-
-		ExpectApplied(ctx, env.Client, managedNode, nodeClaim)
-		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeController, nodeClaimController, []*corev1.Node{managedNode}, []*v1.NodeClaim{nodeClaim})
-		ExpectSingletonReconciled(ctx, metricsStateController)
-
-		for resourceName := range resources {
-			metric, found := FindMetricWithLabelValues("karpenter_cluster_utilization_percent", map[string]string{
-				metrics.ResourceTypeLabel: resourceName.String(),
-				"managed":                 "true",
-			})
-			Expect(found).To(BeTrue())
-			Expect(metric.GetGauge().GetValue()).To(BeNumerically(">=", 0))
 		}
 	})
 	It("should remove the node metric gauge when the node is deleted", func() {

--- a/pkg/controllers/metrics/node/suite_test.go
+++ b/pkg/controllers/metrics/node/suite_test.go
@@ -27,12 +27,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	"sigs.k8s.io/karpenter/pkg/controllers/metrics/node"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
@@ -43,6 +45,7 @@ var ctx context.Context
 var env *test.Environment
 var cluster *state.Cluster
 var nodeController *informer.NodeController
+var nodeClaimController *informer.NodeClaimController
 var metricsStateController *node.Controller
 var cloudProvider *fake.CloudProvider
 
@@ -59,7 +62,9 @@ var _ = BeforeSuite(func() {
 	cloudProvider = fake.NewCloudProvider()
 	cloudProvider.InstanceTypes = fake.InstanceTypesAssorted()
 	cluster = state.NewCluster(env.Clock, env.Client, cloudProvider)
+	clusterCost := cost.NewClusterCost(ctx, cloudProvider, env.Client)
 	nodeController = informer.NewNodeController(env.Client, cluster)
+	nodeClaimController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 	metricsStateController = node.NewController(cluster)
 })
 
@@ -86,9 +91,37 @@ var _ = Describe("Node Metrics", func() {
 		ExpectSingletonReconciled(ctx, metricsStateController)
 
 		for k, v := range resources {
+			// A plain node with no NodeClaim is not managed by Karpenter.
 			metric, found := FindMetricWithLabelValues("karpenter_nodes_allocatable", map[string]string{
 				"node_name":               node.GetName(),
 				metrics.ResourceTypeLabel: k.String(),
+				"managed":                 "false",
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("~", v.AsApproximateFloat64()))
+		}
+	})
+	It("should set the managed label on per-node metrics for Karpenter-managed nodes", func() {
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			Status: v1.NodeClaimStatus{
+				ProviderID:  test.RandomProviderID(),
+				Allocatable: resources,
+			},
+		})
+		managedNode := test.Node(test.NodeOptions{
+			ProviderID:  nodeClaim.Status.ProviderID,
+			Allocatable: resources,
+		})
+
+		ExpectApplied(ctx, env.Client, managedNode, nodeClaim)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeController, nodeClaimController, []*corev1.Node{managedNode}, []*v1.NodeClaim{nodeClaim})
+		ExpectSingletonReconciled(ctx, metricsStateController)
+
+		for k, v := range resources {
+			metric, found := FindMetricWithLabelValues("karpenter_nodes_allocatable", map[string]string{
+				"node_name":               managedNode.GetName(),
+				metrics.ResourceTypeLabel: k.String(),
+				"managed":                 "true",
 			})
 			Expect(found).To(BeTrue())
 			Expect(metric.GetGauge().GetValue()).To(BeNumerically("~", v.AsApproximateFloat64()))
@@ -102,16 +135,45 @@ var _ = Describe("Node Metrics", func() {
 
 		metric, found := FindMetricWithLabelValues("karpenter_nodes_current_lifetime_seconds", map[string]string{
 			"node_name": node.GetName(),
+			"managed":   "false",
 		})
 		Expect(found).To(BeTrue())
 		Expect(metric.GetGauge().GetValue()).To(BeNumerically(">=", 0))
 
 		for resourceName := range resources {
+			// A plain node with no NodeClaim is not managed by Karpenter, so its utilization
+			// is reported under the managed="false" series.
 			metric, found := FindMetricWithLabelValues("karpenter_cluster_utilization_percent", map[string]string{
 				metrics.ResourceTypeLabel: resourceName.String(),
+				"managed":                 "false",
 			})
 			Expect(found).To(BeTrue())
 			Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 0))
+		}
+	})
+	It("should report cluster utilization with the managed dimension set for Karpenter-managed nodes", func() {
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			Status: v1.NodeClaimStatus{
+				ProviderID:  test.RandomProviderID(),
+				Allocatable: resources,
+			},
+		})
+		managedNode := test.Node(test.NodeOptions{
+			ProviderID:  nodeClaim.Status.ProviderID,
+			Allocatable: resources,
+		})
+
+		ExpectApplied(ctx, env.Client, managedNode, nodeClaim)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeController, nodeClaimController, []*corev1.Node{managedNode}, []*v1.NodeClaim{nodeClaim})
+		ExpectSingletonReconciled(ctx, metricsStateController)
+
+		for resourceName := range resources {
+			metric, found := FindMetricWithLabelValues("karpenter_cluster_utilization_percent", map[string]string{
+				metrics.ResourceTypeLabel: resourceName.String(),
+				"managed":                 "true",
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically(">=", 0))
 		}
 	})
 	It("should remove the node metric gauge when the node is deleted", func() {

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -53,6 +54,7 @@ const (
 	podPhase            = "phase"
 	podScheduled        = "scheduled"
 	podReady            = "ready"
+	managed             = "managed"
 )
 
 var (
@@ -191,6 +193,7 @@ func labelNames() []string {
 		podHostInstanceType,
 		podPhase,
 		podReady,
+		managed,
 	}
 }
 
@@ -442,6 +445,7 @@ func (c *Controller) makeLabels(ctx context.Context, pod *corev1.Pod) (prometheu
 	metricLabels[metrics.CapacityTypeLabel] = node.Labels[v1.CapacityTypeLabelKey]
 	metricLabels[podHostInstanceType] = node.Labels[corev1.LabelInstanceTypeStable]
 	metricLabels[metrics.NodePoolLabel] = node.Labels[v1.NodePoolLabelKey]
+	metricLabels[managed] = strconv.FormatBool(node.Labels[v1.NodePoolLabelKey] != "")
 	return metricLabels, nil
 }
 

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	"sigs.k8s.io/karpenter/pkg/controllers/metrics/pod"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
@@ -75,6 +76,34 @@ var _ = Describe("Pod Metrics", func() {
 		_, found := FindMetricWithLabelValues("karpenter_pods_state", map[string]string{
 			"name":      p.GetName(),
 			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeTrue())
+	})
+	It("should set the managed label based on whether the pod's node is Karpenter-managed", func() {
+		// Pod scheduled onto a Karpenter-managed node (identified by the nodepool label).
+		managedNode := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+			v1.NodePoolLabelKey: "default",
+		}}})
+		managedPod := test.Pod(test.PodOptions{NodeName: managedNode.Name})
+		// Pod scheduled onto a node not managed by Karpenter (no nodepool label).
+		unmanagedNode := test.Node()
+		unmanagedPod := test.Pod(test.PodOptions{NodeName: unmanagedNode.Name})
+
+		ExpectApplied(ctx, env.Client, managedNode, managedPod, unmanagedNode, unmanagedPod)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(managedPod))
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(unmanagedPod))
+
+		_, found := FindMetricWithLabelValues("karpenter_pods_state", map[string]string{
+			"name":      managedPod.GetName(),
+			"namespace": managedPod.GetNamespace(),
+			"managed":   "true",
+		})
+		Expect(found).To(BeTrue())
+
+		_, found = FindMetricWithLabelValues("karpenter_pods_state", map[string]string{
+			"name":      unmanagedPod.GetName(),
+			"namespace": unmanagedPod.GetNamespace(),
+			"managed":   "false",
 		})
 		Expect(found).To(BeTrue())
 	})


### PR DESCRIPTION
Fixes #N/A

**Description**

Karpenter's node and pod metrics are emitted for every node and pod, including those not managed by Karpenter. When these metrics are aggregated downstream (e.g. computing cluster resource utilization as `sum(pod_requests) / sum(allocatable)`), the non-Karpenter nodes and pods skew the numbers, and there's no way to scope the result to just the capacity Karpenter manages.

This change adds a `managed` label to the node and pod metrics so operators can filter them to Karpenter-managed capacity:

- The per-node metrics: `karpenter_nodes_allocatable`, `karpenter_nodes_total_pod_requests`, `karpenter_nodes_total_pod_limits`, `karpenter_nodes_total_daemon_requests`, `karpenter_nodes_total_daemon_limits`, `karpenter_nodes_system_overhead`, and `karpenter_nodes_current_lifetime_seconds`.
- `karpenter_pods_state`.

For node metrics, a node is considered managed when it has an associated NodeClaim (`StateNode.Managed()`). For pod metrics, a pod is considered managed when it is scheduled onto a node that carries the nodepool label, consistent with how cluster state determines node management.

These are all additive raw-value metrics, so adding the label is backwards compatible: existing queries that don't reference `managed` continue to work unchanged, and the un-labeled total is still recoverable by aggregating across the label (e.g. `sum without (managed) (...)`). The `managed` label is a boolean, so it adds minimal cardinality.

**How was this change tested?**

`make test` for the node and pod metrics suites. Added assertions covering both the `managed="true"` and `managed="false"` cases for the per-node and pod state metrics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
