### PR TITLE
fix: skip deviceallocation tests when resource.k8s.io/v1 unavailable

### DIFF
--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -57,6 +57,12 @@ var _ = BeforeSuite(func() {
 	if env.Version.Minor() < 34 {
 		Skip("ResourceClaims are only available starting in K8s version >= 1.34.x")
 	}
+	// The resource.k8s.io/v1 API group requires runtime components that envtest
+	// may not provide. Skip if the apiserver doesn't actually serve it.
+	dc := env.KubernetesInterface.Discovery()
+	if _, err := dc.ServerResourcesForGroupVersion("resource.k8s.io/v1"); err != nil {
+		Skip("resource.k8s.io/v1 API group not available in this envtest environment")
+	}
 	ctx = options.ToContext(ctx, test.Options())
 })
 


### PR DESCRIPTION
## Summary

- The `deviceallocation` test suite fails in envtest environments where `resource.k8s.io/v1` isn't served. The existing version check (`Minor() < 34`) is insufficient because envtest binaries at 1.35+ don't necessarily serve DRA APIs without additional runtime components.
- Adds a discovery check that skips the suite when the API group is actually unavailable, matching the pattern used by the DRA e2e tests.

## Test plan

- [x] `go test ./pkg/controllers/dynamicresources/deviceallocation/` passes locally (25 skipped via discovery check)
- [ ] CI with full DRA support runs tests normally (version + discovery both pass)

cc @jmdeal @ryan-mist