### PR TITLE
docs: add Hetzner to Karpenter implementations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Karpenter is a multi-cloud project with implementations by the following cloud p
 - [Cluster API](https://github.com/kubernetes-sigs/karpenter-provider-cluster-api)
 - [Exoscale](https://github.com/exoscale/karpenter-provider-exoscale/)
 - [GCP](https://github.com/cloudpilot-ai/karpenter-provider-gcp)
+- [Hetzner](https://github.com/paperclipinc/karpenter-provider-hetzner)
 - [Huawei Cloud](https://github.com/HuaweiCloudDeveloper/karpenter-provider-huawei)
 - [IBM Cloud](https://github.com/kubernetes-sigs/karpenter-provider-ibm-cloud)
 - [Proxmox](https://github.com/sergelogvinov/karpenter-provider-proxmox)


### PR DESCRIPTION
Adds the Hetzner Cloud provider to the implementations list in the README.

[karpenter-provider-hetzner](https://github.com/paperclipinc/karpenter-provider-hetzner) is an open-source (Apache-2.0) Karpenter cloud provider for Hetzner Cloud:
- implements the CloudProvider interface against the Hetzner Cloud API
- cost-optimal instance-type selection from live Hetzner pricing, x86 and arm64
- Talos and Ubuntu bootstrap, drift detection, consolidation
- v1.0.0: multi-arch cosign-signed images, SLSA provenance + SBOM, OCI Helm chart
- validated end-to-end on a live Talos cluster and run in production

Placed alphabetically between GCP and Huawei Cloud.