### PR TITLE
chore: support consumable capacity and partitionable device fields in core DRA types

### DIFF
--- a/pkg/cloudprovider/dynamicresources.go
+++ b/pkg/cloudprovider/dynamicresources.go
@@ -45,6 +45,8 @@ type ResourceSliceTemplate struct {
 	Pool ResourcePool
 	// Devices is the list of expected devices in this slice.
 	Devices []Device
+	// SharedCounters is the list of expected counter sets in this slice.
+	SharedCounters []resourcev1.CounterSet
 }
 
 // ResourcePool identifies a pool of devices within a driver.
@@ -60,6 +62,14 @@ type Device struct {
 	// Attributes are the device's properties used for CEL selector evaluation and
 	// MatchAttribute constraint checking.
 	Attributes map[resourcev1.QualifiedName]resourcev1.DeviceAttribute
+	// Capacity defines the set of capacities for this device.
+	Capacity map[resourcev1.QualifiedName]resourcev1.DeviceCapacity
+	// AllowMultipleAllocations marks whether the device is allowed to be allocated
+	// to multiple DeviceRequests.
+	AllowMultipleAllocations bool
+	// ConsumesCounters declares which sharedCounters this device consumes from
+	// on allocation.
+	ConsumesCounters []resourcev1.DeviceCounterConsumption
 }
 
 // AttributeBinding declares that a set of devices on an instance type will share a common

--- a/pkg/cloudprovider/dynamicresources_deepcopy.go
+++ b/pkg/cloudprovider/dynamicresources_deepcopy.go
@@ -57,6 +57,18 @@ func (in *ResourceSliceTemplate) DeepCopyInto(out *ResourceSliceTemplate) {
 			in.Devices[i].DeepCopyInto(&out.Devices[i])
 		}
 	}
+	if in.SharedCounters != nil {
+		out.SharedCounters = make([]resourcev1.CounterSet, len(in.SharedCounters))
+		for i, cs := range in.SharedCounters {
+			out.SharedCounters[i].Name = cs.Name
+			if cs.Counters != nil {
+				out.SharedCounters[i].Counters = make(map[string]resourcev1.Counter, len(cs.Counters))
+				for k, v := range cs.Counters {
+					out.SharedCounters[i].Counters[k] = resourcev1.Counter{Value: v.Value.DeepCopy()}
+				}
+			}
+		}
+	}
 }
 
 func (in *ResourceSliceTemplate) DeepCopy() *ResourceSliceTemplate {
@@ -74,6 +86,24 @@ func (in *Device) DeepCopyInto(out *Device) {
 		out.Attributes = make(map[resourcev1.QualifiedName]resourcev1.DeviceAttribute, len(in.Attributes))
 		for key, val := range in.Attributes {
 			out.Attributes[key] = *val.DeepCopy()
+		}
+	}
+	if in.Capacity != nil {
+		out.Capacity = make(map[resourcev1.QualifiedName]resourcev1.DeviceCapacity, len(in.Capacity))
+		for key, val := range in.Capacity {
+			out.Capacity[key] = *val.DeepCopy()
+		}
+	}
+	if in.ConsumesCounters != nil {
+		out.ConsumesCounters = make([]resourcev1.DeviceCounterConsumption, len(in.ConsumesCounters))
+		for i, consumption := range in.ConsumesCounters {
+			out.ConsumesCounters[i].CounterSet = consumption.CounterSet
+			if consumption.Counters != nil {
+				out.ConsumesCounters[i].Counters = make(map[string]resourcev1.Counter, len(consumption.Counters))
+				for k, v := range consumption.Counters {
+					out.ConsumesCounters[i].Counters[k] = resourcev1.Counter{Value: v.Value.DeepCopy()}
+				}
+			}
 		}
 	}
 }

--- a/pkg/cloudprovider/dynamicresources_test.go
+++ b/pkg/cloudprovider/dynamicresources_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -41,6 +42,10 @@ var _ = Describe("DynamicResources", func() {
 								Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 									"gpu.nvidia.com/model": {StringValue: ptr.To("H100")},
 								},
+								Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+									"gpu.nvidia.com/memory": {Value: resource.MustParse("80Gi")},
+								},
+								AllowMultipleAllocations: true,
 							},
 						},
 					},
@@ -64,11 +69,19 @@ var _ = Describe("DynamicResources", func() {
 			Expect(copied.AttributeBindings).To(HaveLen(1))
 			Expect(copied.AttributeBindings[0].Devices).To(HaveLen(2))
 
+			dev := copied.ResourceSliceTemplates[0].Devices[0]
+			Expect(dev.AllowMultipleAllocations).To(BeTrue())
+			Expect(dev.Capacity).To(HaveLen(1))
+			Expect(dev.Capacity["gpu.nvidia.com/memory"].Value.Equal(resource.MustParse("80Gi"))).To(BeTrue())
+
 			// Mutating the copy should not affect the original
 			copied.ResourceSliceTemplates[0].Devices[0].Attributes["gpu.nvidia.com/model"] = resourcev1.DeviceAttribute{
 				StringValue: ptr.To("A100"),
 			}
 			Expect(*original.ResourceSliceTemplates[0].Devices[0].Attributes["gpu.nvidia.com/model"].StringValue).To(Equal("H100"))
+
+			dev.Capacity["gpu.nvidia.com/memory"] = resourcev1.DeviceCapacity{Value: resource.MustParse("40Gi")}
+			Expect(original.ResourceSliceTemplates[0].Devices[0].Capacity["gpu.nvidia.com/memory"].Value.Equal(resource.MustParse("80Gi"))).To(BeTrue())
 
 			copied.AttributeBindings[0].Devices = copied.AttributeBindings[0].Devices[:1]
 			Expect(original.AttributeBindings[0].Devices).To(HaveLen(2))
@@ -84,6 +97,60 @@ var _ = Describe("DynamicResources", func() {
 			copied := original.DeepCopy()
 			Expect(copied.ResourceSliceTemplates).To(BeNil())
 			Expect(copied.AttributeBindings).To(BeNil())
+		})
+
+		It("should deep copy SharedCounters and ConsumesCounters", func() {
+			original := cloudprovider.DynamicResources{
+				ResourceSliceTemplates: []*cloudprovider.ResourceSliceTemplate{
+					{
+						Driver: unique.Make("gpu.nvidia.com"),
+						Pool:   cloudprovider.ResourcePool{Name: unique.Make("mig-pool")},
+						SharedCounters: []resourcev1.CounterSet{
+							{
+								Name: "gpu-slices",
+								Counters: map[string]resourcev1.Counter{
+									"memory":        {Value: resource.MustParse("80Gi")},
+									"compute-units": {Value: resource.MustParse("7")},
+								},
+							},
+						},
+						Devices: []cloudprovider.Device{
+							{
+								Name: unique.Make("mig-3g.40gb-0"),
+								ConsumesCounters: []resourcev1.DeviceCounterConsumption{
+									{
+										CounterSet: "gpu-slices",
+										Counters: map[string]resourcev1.Counter{
+											"memory":        {Value: resource.MustParse("40Gi")},
+											"compute-units": {Value: resource.MustParse("3")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			copied := original.DeepCopy()
+
+			// Verify structural correctness
+			Expect(copied.ResourceSliceTemplates).To(HaveLen(1))
+			tmpl := copied.ResourceSliceTemplates[0]
+			Expect(tmpl.SharedCounters).To(HaveLen(1))
+			Expect(tmpl.SharedCounters[0].Name).To(Equal("gpu-slices"))
+			Expect(tmpl.SharedCounters[0].Counters).To(HaveLen(2))
+			Expect(tmpl.Devices[0].ConsumesCounters).To(HaveLen(1))
+			Expect(tmpl.Devices[0].ConsumesCounters[0].CounterSet).To(Equal("gpu-slices"))
+			Expect(tmpl.Devices[0].ConsumesCounters[0].Counters).To(HaveLen(2))
+
+			// Mutating SharedCounters on the copy should not affect the original
+			tmpl.SharedCounters[0].Counters["memory"] = resourcev1.Counter{Value: resource.MustParse("10Gi")}
+			Expect(original.ResourceSliceTemplates[0].SharedCounters[0].Counters["memory"].Value.Equal(resource.MustParse("80Gi"))).To(BeTrue())
+
+			// Mutating ConsumesCounters on the copy should not affect the original
+			tmpl.Devices[0].ConsumesCounters[0].Counters["memory"] = resourcev1.Counter{Value: resource.MustParse("5Gi")}
+			Expect(original.ResourceSliceTemplates[0].Devices[0].ConsumesCounters[0].Counters["memory"].Value.Equal(resource.MustParse("40Gi"))).To(BeTrue())
 		})
 	})
 })

--- a/pkg/scheduling/dynamicresources/types.go
+++ b/pkg/scheduling/dynamicresources/types.go
@@ -100,6 +100,9 @@ type ResourceSlice interface {
 	// ResourceSliceCount returns the total number of slices expected in this pool.
 	// Used to determine pool completeness. Template slices return 1.
 	ResourceSliceCount() int64
+	// SharedCounters returns the counter set definitions declared by this slice.
+	// Returns nil if the slice declares no counter sets.
+	SharedCounters() []resourcev1.CounterSet
 }
 
 // apiServerSlice adapts a resourcev1.ResourceSlice from the API server to the ResourceSlice interface.
@@ -132,9 +135,16 @@ func (s *apiServerSlice) Devices() []cloudprovider.Device {
 			for k, v := range d.Attributes {
 				attrs[k] = v
 			}
+			capacity := make(map[resourcev1.QualifiedName]resourcev1.DeviceCapacity, len(d.Capacity))
+			for k, v := range d.Capacity {
+				capacity[k] = v
+			}
 			s.devices[i] = cloudprovider.Device{
-				Name:       unique.Make(d.Name),
-				Attributes: attrs,
+				Name:                     unique.Make(d.Name),
+				Attributes:               attrs,
+				Capacity:                 capacity,
+				AllowMultipleAllocations: lo.FromPtr(d.AllowMultipleAllocations),
+				ConsumesCounters:         d.ConsumesCounters,
 			}
 		}
 	}
@@ -162,6 +172,10 @@ func (s *apiServerSlice) Generation() int64 {
 
 func (s *apiServerSlice) ResourceSliceCount() int64 {
 	return s.slice.Spec.Pool.ResourceSliceCount
+}
+
+func (s *apiServerSlice) SharedCounters() []resourcev1.CounterSet {
+	return s.slice.Spec.SharedCounters
 }
 
 // templateSlice adapts a cloudprovider.ResourceSliceTemplate to the ResourceSlice interface.
@@ -204,6 +218,10 @@ func (s *templateSlice) Generation() int64 {
 
 func (s *templateSlice) ResourceSliceCount() int64 {
 	return 1
+}
+
+func (s *templateSlice) SharedCounters() []resourcev1.CounterSet {
+	return s.template.SharedCounters
 }
 
 // nodeSelectorsToRequirements extracts scheduling requirements from a NodeSelector.

--- a/pkg/scheduling/dynamicresources/types_test.go
+++ b/pkg/scheduling/dynamicresources/types_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -55,6 +56,10 @@ var _ = Describe("ResourceSlice Interface", func() {
 								"gpu.nvidia.com/model":  {StringValue: ptr.To("H100")},
 								"gpu.nvidia.com/memory": {IntValue: ptr.To(int64(80))},
 							},
+							Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+								"gpu.nvidia.com/vram": {Value: resource.MustParse("80Gi")},
+							},
+							AllowMultipleAllocations: ptr.To(true),
 						},
 						{
 							Name: "gpu-1",
@@ -62,6 +67,7 @@ var _ = Describe("ResourceSlice Interface", func() {
 								"gpu.nvidia.com/model":  {StringValue: ptr.To("H100")},
 								"gpu.nvidia.com/memory": {IntValue: ptr.To(int64(80))},
 							},
+							AllowMultipleAllocations: nil,
 						},
 					},
 				},
@@ -81,14 +87,19 @@ var _ = Describe("ResourceSlice Interface", func() {
 			Expect(slice.Potential()).To(BeFalse())
 		})
 
-		It("should convert devices with interned names and attributes", func() {
+		It("should convert devices with interned names, attributes, capacity, and AllowMultipleAllocations", func() {
 			devices := slice.Devices()
 			Expect(devices).To(HaveLen(2))
 			Expect(devices[0].Name).To(Equal(unique.Make("gpu-0")))
 			Expect(devices[0].Attributes).To(HaveLen(2))
 			Expect(devices[0].Attributes["gpu.nvidia.com/model"].StringValue).To(Equal(ptr.To("H100")))
 			Expect(devices[0].Attributes["gpu.nvidia.com/memory"].IntValue).To(Equal(ptr.To(int64(80))))
+			Expect(devices[0].Capacity).To(HaveLen(1))
+			Expect(devices[0].Capacity["gpu.nvidia.com/vram"].Value.Equal(resource.MustParse("80Gi"))).To(BeTrue())
+			Expect(devices[0].AllowMultipleAllocations).To(BeTrue())
 			Expect(devices[1].Name).To(Equal(unique.Make("gpu-1")))
+			Expect(devices[1].Capacity).To(BeEmpty())
+			Expect(devices[1].AllowMultipleAllocations).To(BeFalse())
 		})
 
 		It("should cache devices on repeated calls", func() {
@@ -140,6 +151,50 @@ var _ = Describe("ResourceSlice Interface", func() {
 			slice = dynamicresources.NewAPIServerSlice(apiSlice)
 			Expect(slice.Devices()).To(BeEmpty())
 		})
+
+		It("should convert devices with ConsumesCounters", func() {
+			apiSlice.Spec.Devices = []resourcev1.Device{
+				{
+					Name: "mig-3g.40gb-0",
+					ConsumesCounters: []resourcev1.DeviceCounterConsumption{
+						{
+							CounterSet: "gpu-slices",
+							Counters: map[string]resourcev1.Counter{
+								"memory":        {Value: resource.MustParse("40Gi")},
+								"compute-units": {Value: resource.MustParse("3")},
+							},
+						},
+					},
+				},
+			}
+			slice = dynamicresources.NewAPIServerSlice(apiSlice)
+			devices := slice.Devices()
+			Expect(devices).To(HaveLen(1))
+			Expect(devices[0].ConsumesCounters).To(HaveLen(1))
+			Expect(devices[0].ConsumesCounters[0].CounterSet).To(Equal("gpu-slices"))
+			Expect(devices[0].ConsumesCounters[0].Counters).To(HaveLen(2))
+			Expect(devices[0].ConsumesCounters[0].Counters["memory"].Value.Equal(resource.MustParse("40Gi"))).To(BeTrue())
+			Expect(devices[0].ConsumesCounters[0].Counters["compute-units"].Value.Equal(resource.MustParse("3"))).To(BeTrue())
+		})
+
+		It("should return SharedCounters from the API object", func() {
+			apiSlice.Spec.SharedCounters = []resourcev1.CounterSet{
+				{
+					Name: "gpu-slices",
+					Counters: map[string]resourcev1.Counter{
+						"memory":        {Value: resource.MustParse("80Gi")},
+						"compute-units": {Value: resource.MustParse("7")},
+					},
+				},
+			}
+			slice = dynamicresources.NewAPIServerSlice(apiSlice)
+			counters := slice.SharedCounters()
+			Expect(counters).To(HaveLen(1))
+			Expect(counters[0].Name).To(Equal("gpu-slices"))
+			Expect(counters[0].Counters).To(HaveLen(2))
+			Expect(counters[0].Counters["memory"].Value.Equal(resource.MustParse("80Gi"))).To(BeTrue())
+		})
+
 	})
 
 	Describe("TemplateSlice", func() {
@@ -158,6 +213,10 @@ var _ = Describe("ResourceSlice Interface", func() {
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							"gpu.nvidia.com/model": {StringValue: ptr.To("A100")},
 						},
+						Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+							"gpu.nvidia.com/memory": {Value: resource.MustParse("80Gi")},
+						},
+						AllowMultipleAllocations: true,
 					},
 				},
 			}
@@ -181,6 +240,9 @@ var _ = Describe("ResourceSlice Interface", func() {
 			Expect(devices).To(HaveLen(1))
 			Expect(devices[0].Name).To(Equal(unique.Make("gpu-0")))
 			Expect(devices[0].Attributes["gpu.nvidia.com/model"].StringValue).To(Equal(ptr.To("A100")))
+			Expect(devices[0].Capacity).To(HaveLen(1))
+			Expect(devices[0].Capacity["gpu.nvidia.com/memory"].Value.Equal(resource.MustParse("80Gi"))).To(BeTrue())
+			Expect(devices[0].AllowMultipleAllocations).To(BeTrue())
 		})
 
 		It("should return nil NodeSelector", func() {
@@ -189,6 +251,48 @@ var _ = Describe("ResourceSlice Interface", func() {
 
 		It("should return false for AllNodes", func() {
 			Expect(slice.AllNodes()).To(BeFalse())
+		})
+
+		It("should return SharedCounters from the template", func() {
+			template.SharedCounters = []resourcev1.CounterSet{
+				{
+					Name: "gpu-slices",
+					Counters: map[string]resourcev1.Counter{
+						"memory":        {Value: resource.MustParse("80Gi")},
+						"compute-units": {Value: resource.MustParse("7")},
+					},
+				},
+			}
+			slice = dynamicresources.NewTemplateSlice(template)
+			counters := slice.SharedCounters()
+			Expect(counters).To(HaveLen(1))
+			Expect(counters[0].Name).To(Equal("gpu-slices"))
+			Expect(counters[0].Counters).To(HaveLen(2))
+			Expect(counters[0].Counters["memory"].Value.Equal(resource.MustParse("80Gi"))).To(BeTrue())
+		})
+
+		It("should return devices with ConsumesCounters", func() {
+			template.Devices = []cloudprovider.Device{
+				{
+					Name: unique.Make("mig-3g.40gb-0"),
+					ConsumesCounters: []resourcev1.DeviceCounterConsumption{
+						{
+							CounterSet: "gpu-slices",
+							Counters: map[string]resourcev1.Counter{
+								"memory":        {Value: resource.MustParse("40Gi")},
+								"compute-units": {Value: resource.MustParse("3")},
+							},
+						},
+					},
+				},
+			}
+			slice = dynamicresources.NewTemplateSlice(template)
+			devices := slice.Devices()
+			Expect(devices).To(HaveLen(1))
+			Expect(devices[0].ConsumesCounters).To(HaveLen(1))
+			Expect(devices[0].ConsumesCounters[0].CounterSet).To(Equal("gpu-slices"))
+			Expect(devices[0].ConsumesCounters[0].Counters["memory"].Value.Equal(resource.MustParse("40Gi"))).To(BeTrue())
+			Expect(devices[0].ConsumesCounters[0].Counters["compute-units"].Value.Equal(resource.MustParse("3"))).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
The first out of 2 PRs to support consumable to integrate partitionable devices and consumable capacity support in Karpenter. This PR adds the necessary fields to the core dynamic resources type.

References:
* Consumable Capacity KEP - https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5075-dra-consumable-capacity
* Partitionable Devices KEP - https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4815-dra-partitionable-devices

**How was this change tested?**
* unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
