### PR TITLE
docs: add Hetzner Cloud to Karpenter Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Karpenter is a multi-cloud project with implementations by the following cloud p
 - [Cluster API](https://github.com/kubernetes-sigs/karpenter-provider-cluster-api)
 - [Exoscale](https://github.com/exoscale/karpenter-provider-exoscale/)
 - [GCP](https://github.com/cloudpilot-ai/karpenter-provider-gcp)
+- [Hetzner Cloud](https://github.com/paperclipinc/karpenter-provider-hetzner)
 - [Huawei Cloud](https://github.com/HuaweiCloudDeveloper/karpenter-provider-huawei)
 - [IBM Cloud](https://github.com/kubernetes-sigs/karpenter-provider-ibm-cloud)
 - [Proxmox](https://github.com/sergelogvinov/karpenter-provider-proxmox)


### PR DESCRIPTION
<!-- /kind documentation -->

**Description**

Adds the community Karpenter provider for Hetzner Cloud to the `## Karpenter Implementations` list, alphabetically between GCP and Huawei Cloud.

- Repo: https://github.com/paperclipinc/karpenter-provider-hetzner
- License: Apache-2.0
- It implements the Karpenter cloud-provider interface against the Hetzner Cloud API: provisions servers as nodes from live Hetzner pricing, supports `HCloudNodeClass`, and consolidates idle nodes. Tagged `v1.0.0`, with a signed image and an OCI Helm chart, and runs in production at Paperclip.inc.

This is a docs-only change (one line added to the implementations list).

**How was this change tested?**

N/A (documentation only).

**Does this change impact docs?**

Yes, this is the docs change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
