### PR TITLE
docs: add Clever Cloud provider to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Karpenter is a multi-cloud project with implementations by the following cloud p
 - [Azure](https://github.com/Azure/karpenter-provider-azure)
 - [AlibabaCloud](https://github.com/cloudpilot-ai/karpenter-provider-alibabacloud)
 - [Bizfly Cloud](https://github.com/bizflycloud/karpenter-provider-bizflycloud)
+- [Clever Cloud](https://github.com/CleverCloud/karpenter-provider-clever-cloud)
 - [Cluster API](https://github.com/kubernetes-sigs/karpenter-provider-cluster-api)
 - [Exoscale](https://github.com/exoscale/karpenter-provider-exoscale/)
 - [GCP](https://github.com/cloudpilot-ai/karpenter-provider-gcp)


### PR DESCRIPTION
Fixes #N/A

**Description**

Adds the [Clever Cloud](https://github.com/CleverCloud/karpenter-provider-clever-cloud) implementation to the list of Karpenter cloud provider implementations in the README, inserted in alphabetical order between Bizfly Cloud and Cluster API.

The provider implements Karpenter's CloudProvider interface for Clever Kubernetes Engine (CKE) clusters, provisioning nodes through Clever Cloud's in-cluster NodeGroup custom resources (no external credentials required). It ships a built-in flavor catalog (2XS–XL) with custom-flavor overrides, and supports consolidation and drift detection for rolling node replacements. It is licensed under Apache-2.0, targets Kubernetes >= 1.34, and is currently community-maintained under the CleverCloud organization (v0.9.2, under active development).

**How was this change tested?**

Documentation-only change. Verified the rendered Markdown list and confirmed the provider repository link resolves.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.