### PR TITLE
cherry-pick: add zone label to node/nodeclaim lifecycle metrics

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -371,6 +371,7 @@ func (c *Controller) removeFinalizer(ctx context.Context, n *corev1.Node) error 
 
 		metrics.NodesTerminatedTotal.Inc(map[string]string{
 			metrics.NodePoolLabel: n.Labels[v1.NodePoolLabelKey],
+			metrics.ZoneLabel:     n.Labels[corev1.LabelTopologyZone],
 		})
 
 		// We use stored.DeletionTimestamp since the api-server may give back a node after the patch without a deletionTimestamp

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -267,6 +267,7 @@ func (c *Controller) finalize(ctx context.Context, nodeClaim *v1.NodeClaim) (rec
 		metrics.NodeClaimsTerminatedTotal.Inc(map[string]string{
 			metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
+			metrics.ZoneLabel:         nodeClaim.Labels[corev1.LabelTopologyZone],
 		})
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -118,6 +118,7 @@ func (r *Registration) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (
 
 	metrics.NodesCreatedTotal.Inc(map[string]string{
 		metrics.NodePoolLabel: nodeClaim.Labels[v1.NodePoolLabelKey],
+		metrics.ZoneLabel:     nodeClaim.Labels[corev1.LabelTopologyZone],
 	})
 	if err := r.updateNodePoolRegistrationHealth(ctx, nodeClaim); client.IgnoreNotFound(err) != nil {
 		if errors.IsConflict(err) {

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -30,6 +30,7 @@ const (
 	ReasonLabel           = "reason"
 	ResourceTypeLabel     = "resource_type"
 	CapacityTypeLabel     = "capacity_type"
+	ZoneLabel             = "zone"
 	MinValuesRelaxedLabel = "min_values_relaxed"
 
 	// Reasons for CREATE/DELETE shared metrics

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -50,11 +50,12 @@ var (
 			Namespace: Namespace,
 			Subsystem: NodeClaimSubsystem,
 			Name:      "terminated_total",
-			Help:      "Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool.",
+			Help:      "Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool, capacity type, and zone.",
 		},
 		[]string{
 			NodePoolLabel,
 			CapacityTypeLabel,
+			ZoneLabel,
 		},
 	)
 	NodeClaimsDisruptedTotal = opmetrics.NewPrometheusCounter(
@@ -77,10 +78,11 @@ var (
 			Namespace: Namespace,
 			Subsystem: NodeSubsystem,
 			Name:      "created_total",
-			Help:      "Number of nodes created in total by Karpenter. Labeled by owning nodepool.",
+			Help:      "Number of nodes created in total by Karpenter. Labeled by owning nodepool and zone.",
 		},
 		[]string{
 			NodePoolLabel,
+			ZoneLabel,
 		},
 	)
 	NodesTerminatedTotal = opmetrics.NewPrometheusCounter(
@@ -89,10 +91,11 @@ var (
 			Namespace: Namespace,
 			Subsystem: NodeSubsystem,
 			Name:      "terminated_total",
-			Help:      "Number of nodes terminated in total by Karpenter. Labeled by owning nodepool.",
+			Help:      "Number of nodes terminated in total by Karpenter. Labeled by owning nodepool and zone.",
 		},
 		[]string{
 			NodePoolLabel,
+			ZoneLabel,
 		},
 	)
 )


### PR DESCRIPTION
## Summary
Cherry-pick of #3096 to release-v1.12.x.

Adds a `zone` label to `karpenter_nodes_created_total`, `karpenter_nodes_terminated_total`, and `karpenter_nodeclaims_terminated_total` counters for zonal observability.
