### PR TITLE
feat: add NormalizedLabelValues for value translation during label normalization

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -121,6 +121,13 @@ var (
 		v1.LabelInstanceType:            v1.LabelInstanceTypeStable,
 		v1.LabelFailureDomainBetaRegion: v1.LabelTopologyRegion,
 	}
+
+	// NormalizedLabelValues translates label values when a label key is normalized
+	// via NormalizedLabels. The map key is the normalized (target) label key, and
+	// the value is a map from original values to their normalized equivalents.
+	// For example, a CSI driver may use "" for non-zonal topology while the cloud
+	// provider uses "0" — this mapping bridges that gap.
+	NormalizedLabelValues = map[string]map[string]string{}
 )
 
 // IsRestrictedLabel returns an error if the label is restricted.

--- a/pkg/scheduling/requirement.go
+++ b/pkg/scheduling/requirement.go
@@ -49,6 +49,14 @@ func NewRequirementWithFlexibility(key string, operator corev1.NodeSelectorOpera
 	if normalized, ok := v1.NormalizedLabels[key]; ok {
 		key = normalized
 	}
+	// Apply value normalization if registered for this (already-normalized) key.
+	if valueMap, ok := v1.NormalizedLabelValues[key]; ok && len(valueMap) > 0 {
+		for i, val := range values {
+			if mapped, exists := valueMap[val]; exists {
+				values[i] = mapped
+			}
+		}
+	}
 
 	// This is a super-common case, so optimize for it an inline everything.
 	if operator == corev1.NodeSelectorOpIn {


### PR DESCRIPTION
Add a `NormalizedLabelValues` map that allows cloud providers to register value translations alongside the existing key translations in `NormalizedLabels`. When a label key is normalized via `NormalizedLabels`, values are also checked against `NormalizedLabelValues` and translated if a mapping exists.

## Motivation

Different components in the Kubernetes ecosystem may use different string representations for the same logical topology concept. For example:

- **Azure Disk CSI driver** uses `""` (empty string) for non-zonal topology in `topology.disk.csi.azure.com/zone`
- **cloud-provider-azure** uses `"0"` (fault domain 0) for regional (non-zonal) VMs in `topology.kubernetes.io/zone`

When Karpenter normalizes the CSI topology key to the well-known key via `NormalizedLabels`, the value remains unchanged (`""`), which fails to match against offerings that use `"0"` for regional nodes.

## Changes

- Add `NormalizedLabelValues map[string]map[string]string` to `pkg/apis/v1/labels.go`
- Update `NewRequirementWithFlexibility` in `pkg/scheduling/requirement.go` to apply value translation after key normalization

## Usage (by cloud providers)

```go
func init() {
    karpv1.NormalizedLabels = lo.Assign(karpv1.NormalizedLabels, map[string]string{
        "topology.disk.csi.azure.com/zone": corev1.LabelTopologyZone,
    })
    // Translate CSI empty-zone value to cloud-provider-azure regional zone value
    karpv1.NormalizedLabelValues[corev1.LabelTopologyZone] = map[string]string{"": "0"}
}
```