### PR TITLE
fix: expiration respects NodePool disruption budgets

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -105,7 +105,7 @@ func NewControllers(
 		provisioning.NewPodController(kubeClient, p, cluster),
 		provisioning.NewNodeController(kubeClient, p),
 		nodepoolhash.NewController(kubeClient, cloudProvider),
-		expiration.NewController(clock, kubeClient, cloudProvider),
+		expiration.NewController(clock, kubeClient, cloudProvider, cluster, recorder),
 		informer.NewDaemonSetController(kubeClient, cluster),
 		informer.NewNodeController(kubeClient, cluster),
 		informer.NewPodController(kubeClient, cluster),

--- a/pkg/controllers/nodeclaim/expiration/controller.go
+++ b/pkg/controllers/nodeclaim/expiration/controller.go
@@ -18,6 +18,7 @@ package expiration
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -34,6 +35,9 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
@@ -43,14 +47,18 @@ type Controller struct {
 	clock         clock.Clock
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
+	cluster       *state.Cluster
+	recorder      events.Recorder
 }
 
 // NewController constructs a nodeclaim disruption controller
-func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) *Controller {
+func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster, recorder events.Recorder) *Controller {
 	return &Controller{
 		clock:         clk,
 		kubeClient:    kubeClient,
 		cloudProvider: cloudProvider,
+		cluster:       cluster,
+		recorder:      recorder,
 	}
 }
 
@@ -76,6 +84,22 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 	if c.clock.Now().Before(expirationTime) {
 		// Use t.Sub(clock.Now()) instead of time.Until() to ensure we're using the injected clock.
 		return reconcile.Result{RequeueAfter: expirationTime.Sub(c.clock.Now())}, nil
+	}
+	// 2b. The NodeClaim is expired, but only disrupt it if the owning NodePool has disruption budget
+	// available right now. Upstream Karpenter v1 deletes expired NodeClaims without consulting
+	// NodePool disruption budgets (kubernetes-sigs/karpenter#1750) — the subsequent node drain still
+	// honors PDBs, but nothing rate-limits how many nodes expire at once. This gate restores the
+	// v0.37 "soft expiration" behavior so expiry-driven node rotation respects availability targets.
+	// Scoped to the Drifted reason because there is no Expired DisruptionReason; a budget with no
+	// `reasons` (the common case) applies to all reasons regardless.
+	budgets, err := disruption.BuildDisruptionBudgetMapping(ctx, c.cluster, c.clock, c.kubeClient, c.cloudProvider, c.recorder, v1.DisruptionReasonDrifted)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("building disruption budget mapping, %w", err)
+	}
+	if budgets[nodeClaim.Labels[v1.NodePoolLabelKey]] <= 0 {
+		log.FromContext(ctx).V(1).Info("deferring expiration: nodepool disruption budget exhausted")
+		// Requeue so the NodeClaim is expired as soon as budget frees up.
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 	// 3. Otherwise, if the NodeClaim is expired we can forcefully expire the nodeclaim (by deleting it)
 	if err := c.kubeClient.Delete(ctx, nodeClaim); err != nil {

--- a/pkg/controllers/nodeclaim/expiration/suite_test.go
+++ b/pkg/controllers/nodeclaim/expiration/suite_test.go
@@ -30,8 +30,11 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	"sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/expiration"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
@@ -42,6 +45,10 @@ var ctx context.Context
 var expirationController *expiration.Controller
 var env *test.Environment
 var cp *fake.CloudProvider
+var cluster *state.Cluster
+var clusterCost *cost.ClusterCost
+var nodeStateController *informer.NodeController
+var nodeClaimStateController *informer.NodeClaimController
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -53,7 +60,11 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...), test.WithFieldIndexers(test.NodeProviderIDFieldIndexer(ctx)))
 	ctx = options.ToContext(ctx, test.Options())
 	cp = fake.NewCloudProvider()
-	expirationController = expiration.NewController(env.Clock, env.Client, cp)
+	cluster = state.NewCluster(env.Clock, env.Client, cp)
+	clusterCost = cost.NewClusterCost(ctx, cp, env.Client)
+	nodeStateController = informer.NewNodeController(env.Client, cluster)
+	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cp, cluster, clusterCost)
+	expirationController = expiration.NewController(env.Clock, env.Client, cp, cluster, test.NewEventRecorder())
 })
 
 var _ = AfterSuite(func() {
@@ -87,7 +98,8 @@ var _ = Describe("Expiration", func() {
 	})
 	Context("Metrics", func() {
 		It("should fire a karpenter_nodeclaims_disrupted_total metric when expired", func() {
-			ExpectApplied(ctx, env.Client, nodeClaim)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			// step forward to make the node expired
 			env.Clock.Step(60 * time.Second)
@@ -102,7 +114,8 @@ var _ = Describe("Expiration", func() {
 		})
 		It("should fire a karpenter_nodeclaims_disrupted_total metric when expired", func() {
 			nodeClaim.Labels[v1.CapacityTypeLabelKey] = v1.CapacityTypeSpot
-			ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			// step forward to make the node expired
 			env.Clock.Step(60 * time.Second)
@@ -126,14 +139,15 @@ var _ = Describe("Expiration", func() {
 					Name:  "default",
 				}
 			}
-			ExpectApplied(ctx, env.Client, nodeClaim)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 			// step forward to make the node expired
 			env.Clock.Step(60 * time.Second)
 			ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
 			if isNodeClaimManaged {
-				// with forceful termination, when we see a nodeclaim meets the conditions for expiration
-				// we should remove it
+				// when we see a managed nodeclaim that meets the conditions for expiration and the
+				// owning NodePool has disruption budget available, we should remove it
 				ExpectNotFound(ctx, env.Client, nodeClaim)
 			} else {
 				ExpectExists(ctx, env.Client, nodeClaim)
@@ -157,11 +171,11 @@ var _ = Describe("Expiration", func() {
 	})
 	It("should delete NodeClaims if the nodeClaim is expired but the node isn't", func() {
 		nodeClaim.Spec.ExpireAfter = v1.MustParseNillableDuration("30s")
-		ExpectApplied(ctx, env.Client, nodeClaim)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		// step forward to make the node expired
 		env.Clock.Step(60 * time.Second)
-		ExpectApplied(ctx, env.Client, node) // node shouldn't be expired, but nodeClaim will be
 		ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
 
 		ExpectNotFound(ctx, env.Client, nodeClaim)
@@ -177,7 +191,8 @@ var _ = Describe("Expiration", func() {
 	})
 	It("shouldn't expire the same NodeClaim multiple times", func() {
 		nodeClaim.Finalizers = append(nodeClaim.Finalizers, "test-finalizer")
-		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
 
 		// step forward to make the node expired
 		env.Clock.Step(60 * time.Second)
@@ -191,6 +206,54 @@ var _ = Describe("Expiration", func() {
 		ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
 			metrics.ReasonLabel:   metrics.ExpiredReason,
 			metrics.NodePoolLabel: nodePool.Name,
+		})
+	})
+	Context("Disruption Budgets", func() {
+		It("should not expire a NodeClaim when the NodePool disruption budget disallows it", func() {
+			// A budget of "0" leaves no room to disrupt, so the expired NodeClaim must be deferred
+			// rather than forcefully deleted (kubernetes-sigs/karpenter#1750).
+			nodePool.Spec.Disruption.Budgets = []v1.Budget{{Nodes: "0"}}
+			nodeClaim.Spec.ExpireAfter = v1.MustParseNillableDuration("30s")
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
+
+			// step forward to make the node expired
+			env.Clock.Step(60 * time.Second)
+			result := ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
+
+			// The NodeClaim is expired but the budget is exhausted, so it should be requeued, not deleted.
+			ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+		})
+		It("should expire a NodeClaim once the NodePool disruption budget allows it", func() {
+			nodePool.Spec.Disruption.Budgets = []v1.Budget{{Nodes: "1"}}
+			nodeClaim.Spec.ExpireAfter = v1.MustParseNillableDuration("30s")
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
+
+			// step forward to make the node expired
+			env.Clock.Step(60 * time.Second)
+			ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
+
+			ExpectNotFound(ctx, env.Client, nodeClaim)
+			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
+				metrics.ReasonLabel:   metrics.ExpiredReason,
+				metrics.NodePoolLabel: nodePool.Name,
+			})
+		})
+		It("should not be blocked by a budget scoped to a different disruption reason", func() {
+			// Expiration is gated by the Drifted reason, so a budget scoped only to Empty must not
+			// block it. The expired NodeClaim should still be removed.
+			nodePool.Spec.Disruption.Budgets = []v1.Budget{{Nodes: "0", Reasons: []v1.DisruptionReason{v1.DisruptionReasonEmpty}}}
+			nodeClaim.Spec.ExpireAfter = v1.MustParseNillableDuration("30s")
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
+
+			// step forward to make the node expired
+			env.Clock.Step(60 * time.Second)
+			ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
+
+			ExpectNotFound(ctx, env.Client, nodeClaim)
 		})
 	})
 })


### PR DESCRIPTION
Fixes #1750

### Description

In v1, the nodeclaim expiration controller (`pkg/controllers/nodeclaim/expiration`) forcefully deletes an expired NodeClaim as soon as its `expireAfter` elapses, without consulting the owning NodePool's disruption budgets. Disruption budgets are only enforced by the disruption controller (drift / emptiness / consolidation); expiration bypasses them entirely.

As a result, a set of nodes that expire around the same time can all be terminated simultaneously, ignoring the availability protection that disruption budgets are meant to provide. This is a regression from the v0.37 "soft expiration" behavior described in #1750.

This change gates expiration on the NodePool's available disruption budget before deleting an expired NodeClaim:

- The expiration controller now receives the cluster state and event recorder, and calls `disruption.BuildDisruptionBudgetMapping` to compute how many more nodes may be disrupted in the NodePool right now.
- If no budget is available, the NodeClaim is requeued (30s) instead of being deleted, so it expires as soon as budget frees up.
- If budget is available, behavior is unchanged — the NodeClaim is deleted and drains as before (PDBs are still honored during the drain; `terminationGracePeriod` remains the upper bound).

The budget is looked up under the `Drifted` reason, since there is no dedicated `Expired` `DisruptionReason`. A budget with no `reasons` set — the common case — applies to all reasons regardless, so it gates expiration as expected. Happy to add a dedicated `Expired` reason (with the corresponding CRD enum change) if maintainers prefer that approach.

### How was this change tested?

`make test` for the expiration controller (`go test ./pkg/controllers/nodeclaim/expiration/...`), all green. Added cases:

- An expired NodeClaim is **not** deleted when the NodePool budget is `0`, and the reconcile requeues.
- An expired NodeClaim **is** deleted once the budget allows it (`nodes: "1"`).
- A budget scoped to a different reason (`Empty`) does **not** block expiration (verifies the `Drifted` scoping).

Existing expiration tests were updated to register nodes in cluster state (via `ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated`) so the budget is computed against a known node count; with the default (no-budget) NodePool, expiration proceeds exactly as before.

I also manually tested this change against an EKS cluster with expiry set to 15 minutes with a disruption budget of 1. I provisioned 5 nodes at the same time and validated that only 1 was terminated at a time. I increased expiry to 24 hours and let it bake through other development work and confirmed only 1 node ever terminated at the same time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.