### PR TITLE
chore: make NodeClaim launch timeout configurable

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -46,31 +46,17 @@ type Liveness struct {
 }
 
 // registrationTimeout is a heuristic time that we expect the node to register within
-// launchTimeout is a heuristic time that we expect to be able to launch within
 // If we don't see the node within this time, then we should delete the NodeClaim and try again
 
 const (
 	registrationTimeout       = time.Minute * 15
 	registrationTimeoutReason = "registration_timeout"
-	launchTimeout             = time.Minute * 5
 	launchTimeoutReason       = "launch_timeout"
 )
 
-type NodeClaimTimeout struct {
-	duration time.Duration
-	reason   string
-}
-
-var (
-	RegistrationTimeout = NodeClaimTimeout{
-		duration: registrationTimeout,
-		reason:   registrationTimeoutReason,
-	}
-	LaunchTimeout = NodeClaimTimeout{
-		duration: launchTimeout,
-		reason:   launchTimeoutReason,
-	}
-)
+// LaunchTimeout is a heuristic time that we expect to be able to launch within
+// If we don't launch within this time, then we should delete the NodeClaim and try again
+var LaunchTimeout = time.Minute * 5
 
 //nolint:gocyclo
 func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
@@ -83,7 +69,7 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 		return reconcile.Result{Requeue: true}, nil
 	}
 	if !launched.IsTrue() {
-		if timeUntilTimeout := launchTimeout - l.clock.Since(launched.LastTransitionTime.Time); timeUntilTimeout > 0 {
+		if timeUntilTimeout := LaunchTimeout - l.clock.Since(launched.LastTransitionTime.Time); timeUntilTimeout > 0 {
 			// This should never occur because if we failed to launch we requeue the object with error instead of this requeueAfter
 			return reconcile.Result{RequeueAfter: timeUntilTimeout}, nil
 		}
@@ -93,7 +79,7 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 			}
 			return reconcile.Result{}, err
 		}
-		if err := l.deleteNodeClaimForTimeout(ctx, LaunchTimeout, nodeClaim); err != nil {
+		if err := l.deleteNodeClaimForTimeout(ctx, LaunchTimeout, launchTimeoutReason, nodeClaim); err != nil {
 			if client.IgnoreNotFound(err) != nil {
 				return reconcile.Result{}, err
 			}
@@ -115,7 +101,7 @@ func (l *Liveness) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reco
 		return reconcile.Result{}, err
 	}
 	// Delete the NodeClaim if we believe the NodeClaim won't register since we haven't seen the node
-	if err := l.deleteNodeClaimForTimeout(ctx, RegistrationTimeout, nodeClaim); err != nil {
+	if err := l.deleteNodeClaimForTimeout(ctx, registrationTimeout, registrationTimeoutReason, nodeClaim); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return reconcile.Result{}, err
 		}
@@ -159,13 +145,13 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 	return nil
 }
 
-func (l *Liveness) deleteNodeClaimForTimeout(ctx context.Context, timeout NodeClaimTimeout, nodeClaim *v1.NodeClaim) error {
+func (l *Liveness) deleteNodeClaimForTimeout(ctx context.Context, timeout time.Duration, reason string, nodeClaim *v1.NodeClaim) error {
 	if err := l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 		return err
 	}
-	log.FromContext(ctx).V(1).WithValues("timeout", timeout.duration, "reason", timeout.reason).Info("terminating due to timeout")
+	log.FromContext(ctx).V(1).WithValues("timeout", timeout, "reason", reason).Info("terminating due to timeout")
 	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-		metrics.ReasonLabel:       timeout.reason,
+		metrics.ReasonLabel:       reason,
 		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
 	})

--- a/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	nodeclaimlifecycle "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
@@ -183,6 +184,42 @@ var _ = Describe("Liveness", func() {
 		_ = operatorpkg.ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
 		// expect that the nodeclaim was not deleted
 		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should respect a custom launch timeout configured via the LaunchTimeout var", func() {
+		nodeclaimlifecycle.LaunchTimeout = 45 * time.Second
+		DeferCleanup(func() { nodeclaimlifecycle.LaunchTimeout = 5 * time.Minute })
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey: nodePool.Name,
+				},
+			},
+			Spec: v1.NodeClaimSpec{
+				Resources: v1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:      resource.MustParse("2"),
+						corev1.ResourceMemory:   resource.MustParse("50Mi"),
+						corev1.ResourcePods:     resource.MustParse("5"),
+						fake.ResourceGPUVendorA: resource.MustParse("1"),
+					},
+				},
+			},
+		})
+		cloudProvider.AllowedCreateCalls = 0 // Don't allow Create() calls to succeed
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+
+		// Before the custom 45s timeout, the NodeClaim should still exist
+		env.Clock.Step(time.Second * 30)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
+		ExpectExists(ctx, env.Client, nodeClaim)
+
+		// Past the custom 45s timeout but well before the default 5m timeout, it should be deleted
+		env.Clock.Step(time.Second * 30)
+		_ = ExpectObjectReconcileFailed(ctx, env.Client, nodeClaimController, nodeClaim)
+		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
+		ExpectNotFound(ctx, env.Client, nodeClaim)
 	})
 	It("should use the status condition transition time for launch timeout, not the creation timestamp", func() {
 		nodeClaim := test.NodeClaim(v1.NodeClaim{


### PR DESCRIPTION
Fixes #N/A

**Description**

The NodeClaim launch timeout is currently hard-coded to 5 minutes (`launchTimeout = time.Minute * 5` in `pkg/controllers/nodeclaim/lifecycle/liveness.go`). When a NodeClaim fails to launch, scheduling simulations are blocked until this timeout expires and the NodeClaim is cleaned up, which can cause pending pods to breach pod scheduling/binding latency thresholds.

The expected launch latency is inherently cloud-provider-dependent, so rather than hard-coding (or globally lowering) the timeout, this change exposes it as an exported package variable that cloud providers can override at startup.

**How was this change tested?**

`make presubmit`, added two unit tests 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.