### PR TITLE
test: set NodeClassRef on synthesized NodePool and migrate stale InstanceTypeOptions literals

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -5397,13 +5397,10 @@ var _ = Context("Scheduling", func() {
 		It("should only select instance types whose offerings have CapacityOverride when pod requests an override resource", func() {
 			extendedResource := corev1.ResourceName("test.com/extended-slots")
 			// Create instance types with default offerings
-			overrideInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "override-capable",
-				Resources: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("4"),
-					corev1.ResourceMemory: resource.MustParse("8Gi"),
-				},
-			})
+			overrideInstanceType := fake.NewInstanceType("override-capable", fake.WithResources(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}))
 			// Append offerings with overrides cloned from existing base offerings
 			baseOfferings := make([]*cloudprovider.Offering, len(overrideInstanceType.Offerings))
 			copy(baseOfferings, overrideInstanceType.Offerings)
@@ -5419,13 +5416,10 @@ var _ = Context("Scheduling", func() {
 				}
 				overrideInstanceType.Offerings = append(overrideInstanceType.Offerings, overrideOffering)
 			}
-			normalInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "normal",
-				Resources: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("4"),
-					corev1.ResourceMemory: resource.MustParse("8Gi"),
-				},
-			})
+			normalInstanceType := fake.NewInstanceType("normal", fake.WithResources(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}))
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{overrideInstanceType, normalInstanceType}
 			ExpectApplied(ctx, env.Client, nodePool)
 			pod := test.UnschedulablePod(test.PodOptions{
@@ -5447,13 +5441,10 @@ var _ = Context("Scheduling", func() {
 		It("should reject instance type when override allocatable fits but override offerings are unavailable", func() {
 			extendedResource := corev1.ResourceName("test.com/extended-slots")
 			// Create instance type with default offerings
-			overrideInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "override-capable",
-				Resources: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("4"),
-					corev1.ResourceMemory: resource.MustParse("8Gi"),
-				},
-			})
+			overrideInstanceType := fake.NewInstanceType("override-capable", fake.WithResources(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			}))
 			// Append override offerings but mark them all as UNAVAILABLE
 			baseOfferings := make([]*cloudprovider.Offering, len(overrideInstanceType.Offerings))
 			copy(baseOfferings, overrideInstanceType.Offerings)

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -453,6 +453,7 @@ func expectResourceSlicesCreated(ctx context.Context, c client.Client, cp cloudp
 		return
 	}
 	np := &v1.NodePool{ObjectMeta: metav1.ObjectMeta{Name: nc.Labels[v1.NodePoolLabelKey]}}
+	np.Spec.Template.Spec.NodeClassRef = nc.Spec.NodeClassRef
 	instanceTypes, err := cp.GetInstanceTypes(ctx, np)
 	Expect(err).ToNot(HaveOccurred())
 	it, found := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Sets the NodeClassRef in the new expectResourceSlicesCreated test function. Also fixes build failures from [this PR](https://github.com/kubernetes-sigs/karpenter/pull/3113)

Ex - https://github.com/kubernetes-sigs/karpenter/actions/runs/28394162571/job/84128488396?pr=3117

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
