### PR TITLE
fix: ResourceClaim hydration deadlock

### DIFF
--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -118,9 +118,7 @@ func NewController(kubeClient client.Client) *Controller {
 }
 
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	c.hydrationOnce.Do(func() {
-		c.Hydrate(ctx)
-	})
+	c.Hydrate(ctx)
 
 	claim := &resourcev1.ResourceClaim{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, claim, client.UnsafeDisableDeepCopy); err != nil {
@@ -135,13 +133,15 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 func (c *Controller) Hydrate(ctx context.Context) {
-	// SAFETY: This list hits the informer cache, and should not error since it's already guaranteed to be synced.
-	claimList := &resourcev1.ResourceClaimList{}
-	lo.Must0(c.kubeClient.List(ctx, claimList, client.UnsafeDisableDeepCopy))
-	for i := range claimList.Items {
-		c.reconcileClaim(ctx, client.ObjectKeyFromObject(&claimList.Items[i]), &claimList.Items[i])
-	}
-	close(c.hydrationCh)
+	c.hydrationOnce.Do(func() {
+		// SAFETY: This list hits the informer cache, and should not error since it's already guaranteed to be synced.
+		claimList := &resourcev1.ResourceClaimList{}
+		lo.Must0(c.kubeClient.List(ctx, claimList, client.UnsafeDisableDeepCopy))
+		for i := range claimList.Items {
+			c.reconcileClaim(ctx, client.ObjectKeyFromObject(&claimList.Items[i]), &claimList.Items[i])
+		}
+		close(c.hydrationCh)
+	})
 }
 
 //nolint:gocyclo
@@ -297,6 +297,12 @@ func (c *Controller) computeDeviceMetadata(device cloudprovider.DeviceID) Device
 }
 
 func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	if err := m.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		c.Hydrate(ctx)
+		return nil
+	})); err != nil {
+		return fmt.Errorf("adding hydration runnable, %w", err)
+	}
 	return controllerruntime.NewControllerManagedBy(m).
 		Named("dynamicresources.deviceallocation").
 		For(&resourcev1.ResourceClaim{}).

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -187,18 +187,16 @@ func deviceResultWithCapacity(device string, capacity map[resourcev1.QualifiedNa
 	}
 }
 
-// triggerHydration reconciles a no-allocation claim to fire the controller's hydrationOnce, making
-// subsequent AllocatedDevices calls non-blocking. Call this at the start of any test that is not
-// explicitly testing the hydration blocking behavior.
+// triggerHydration calls Hydrate() directly to close hydrationCh, making subsequent AllocatedDevices
+// calls non-blocking. In production this is triggered by a manager runnable after cache sync. Call
+// this at the start of any test that is not explicitly testing the hydration blocking behavior.
 func triggerHydration() {
-	dummy := resourceClaim("hydration-trigger")
-	ExpectApplied(ctx, env.Client, dummy)
-	ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(dummy))
+	controller.Hydrate(ctx)
 }
 
 var _ = Describe("DeviceAllocation Controller", func() {
 	Describe("Hydration", func() {
-		It("blocks until the first reconcile completes", func() {
+		It("blocks until hydration completes", func() {
 			results := make(chan map[cloudprovider.DeviceID]deviceallocation.DeviceMetadata, 1)
 			go func() {
 				defer GinkgoRecover()

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -582,17 +582,14 @@ func ExpectResourceClaimsProcessed(ctx context.Context, c client.Client, pod *co
 	ExpectApplied(ctx, c, pod)
 }
 
-// ExpectDeviceAllocationReconciled reconciles the deviceallocation controller across every ResourceClaim currently on
-// the cluster. The first call triggers the controller's hydration (which otherwise blocks AllocatedDevices, and thus
-// the provisioner's DRA path); subsequent calls refresh the tracked allocation state to reflect claims allocated in a
-// prior provisioning run. envtest has no running controller manager, so tests must drive this explicitly before a
-// provisioning round that relies on the in-cluster allocated-device set.
+// ExpectDeviceAllocationReconciled hydrates the deviceallocation controller (unblocking AllocatedDevices) and reconciles
+// every ResourceClaim currently on the cluster. In production, hydration is triggered by a manager runnable after cache
+// sync; in envtest there is no running controller manager, so tests must call this explicitly before a provisioning
+// round that relies on the in-cluster allocated-device set.
 func ExpectDeviceAllocationReconciled(ctx context.Context, c client.Client, controller *deviceallocation.Controller) {
 	GinkgoHelper()
-	// The controller hydrates on its first Reconcile (guarded by sync.Once), which lists all claims and unblocks
-	// AllocatedDevices. Reconciling a non-existent key is sufficient to trigger hydration without double-closing the
-	// hydration channel, and is a no-op for tracking state when the claim is absent.
-	ExpectReconciled(ctx, controller, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "device-allocation-hydration-trigger"}})
+	// Hydrate is guarded by sync.Once internally, so calling it multiple times is safe.
+	controller.Hydrate(ctx)
 	// Reconcile every existing claim to pick up allocation-status changes committed by prior provisioning runs.
 	claimList := &resourcev1.ResourceClaimList{}
 	Expect(c.List(ctx, claimList)).To(Succeed())


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Provisioning with DRA enabled deadlocks until ResourceClaim CRUD operations (even when no ResourceClaims exist in the cluster). This change fixes that.

#### Currently
In provisioning, if DRA is enabled then we gather the in-cluster allocated devices 
https://github.com/kubernetes-sigs/karpenter/blob/d5e91d67dae32d8c14230c51495fb26f8b59e6ca/pkg/controllers/provisioning/provisioner.go#L334-L339. 
As part of this gathering, we wait for a hydration channel to close to ensure we have synced ResourceClaims in the cluster 
https://github.com/kubernetes-sigs/karpenter/blob/d5e91d67dae32d8c14230c51495fb26f8b59e6ca/pkg/controllers/provisioning/dra.go#L94-L95
https://github.com/kubernetes-sigs/karpenter/blob/d5e91d67dae32d8c14230c51495fb26f8b59e6ca/pkg/controllers/dynamicresources/deviceallocation/controller.go#L244-L255

This hydration channel is only closed after the device allocation controller is reconciled, which only will happen when there is a CRUD to a ResourceClaim object:

https://github.com/kubernetes-sigs/karpenter/blob/d5e91d67dae32d8c14230c51495fb26f8b59e6ca/pkg/controllers/dynamicresources/deviceallocation/controller.go#L120-L123

Without any CRUD to ResourceClaims, then we wait for this channel to close indefinitely.

#### This Change
The fix adds a calls `Hydrate()` after informer caches sync in controller registration, independent of any ResourceClaim reconcile event. `Hydrate()` is wrapped in `sync.Once` so it's safe to call from both the runnable and reconciles (whichever fires first closes the channel and unblocks `AllocatedDevices()`)


**How was this change tested?**
* unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
