### PR TITLE
fix: detect pod-level ResourceClaims in HasDRARequirements

### DIFF
--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -270,8 +270,12 @@ func HasPodAntiAffinity(pod *corev1.Pod) bool {
 			len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0)
 }
 
-// HasDRARequirements returns true if any pod containers consume ResourceClaims
+// HasDRARequirements returns true if the pod references any ResourceClaims,
+// either at the pod level or consumed by any of its containers.
 func HasDRARequirements(pod *corev1.Pod) bool {
+	if len(pod.Spec.ResourceClaims) > 0 {
+		return true
+	}
 	for _, container := range pod.Spec.InitContainers {
 		if len(container.Resources.Claims) > 0 {
 			return true

--- a/pkg/utils/pod/suite_test.go
+++ b/pkg/utils/pod/suite_test.go
@@ -244,3 +244,53 @@ var _ = Describe("IsDisruptable", func() {
 		Expect(pod.IsDisruptable(p, fakeClock, nil)).To(BeTrue())
 	})
 })
+
+var _ = Describe("HasDRARequirements", func() {
+	It("should return false when the pod references no ResourceClaims", func() {
+		p := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+		}
+		Expect(pod.HasDRARequirements(p)).To(BeFalse())
+	})
+
+	It("should return true when a pod-level ResourceClaim is referenced", func() {
+		p := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{{Name: "gpu-claim"}},
+				Containers:     []corev1.Container{{Name: "app"}},
+			},
+		}
+		Expect(pod.HasDRARequirements(p)).To(BeTrue())
+	})
+
+	It("should return true when a container consumes a ResourceClaim", func() {
+		p := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{{Name: "gpu-claim"}},
+					},
+				}},
+			},
+		}
+		Expect(pod.HasDRARequirements(p)).To(BeTrue())
+	})
+
+	It("should return true when an init container consumes a ResourceClaim", func() {
+		p := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name: "init",
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{{Name: "gpu-claim"}},
+					},
+				}},
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+		}
+		Expect(pod.HasDRARequirements(p)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
Fixes #N/A

**Description**

`HasDRARequirements` only inspected container-level `Resources.Claims` on init and regular containers. A pod that references a `ResourceClaim` at the pod level via `Spec.ResourceClaims` — without a container entry consuming it — was therefore misclassified as having no DRA requirements.

When such a pod is misclassified, Karpenter skips DRA-aware scheduling simulation (ResourceClaims, ResourceSlices, device allocation) for it, and can consider the pod schedulable onto a node that has no ResourceSlices published for it.

This change also checks `len(pod.Spec.ResourceClaims) > 0` so pod-level ResourceClaim references are correctly detected.

**How was this change tested?**

Added unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
