### PR TITLE
fix: defer nodeclaim disruption transition logs until status patch succeeds

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/consolidation.go
+++ b/pkg/controllers/nodeclaim/disruption/consolidation.go
@@ -23,7 +23,6 @@ import (
 	"github.com/samber/lo"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -37,7 +36,7 @@ type Consolidation struct {
 }
 
 //nolint:gocyclo
-func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
+func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, nodeClaim *v1.NodeClaim, transitions *transitionLogger) (reconcile.Result, error) {
 	clockOpt := status.WithClock(c.clock)
 	hasConsolidatableCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeConsolidatable) != nil
 
@@ -45,7 +44,7 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	if nodePool.Spec.Disruption.ConsolidateAfter.Duration == nil {
 		if hasConsolidatableCondition {
 			_ = nodeClaim.StatusConditions(clockOpt).Clear(v1.ConditionTypeConsolidatable)
-			log.FromContext(ctx).V(1).Info("removing consolidatable status condition", "reason", "consolidation is disabled")
+			transitions.Record("removing consolidatable status condition", "reason", "consolidation is disabled")
 		}
 		return reconcile.Result{}, nil
 	}
@@ -54,7 +53,7 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	if !initialized.IsTrue() {
 		if hasConsolidatableCondition {
 			_ = nodeClaim.StatusConditions(clockOpt).Clear(v1.ConditionTypeConsolidatable)
-			log.FromContext(ctx).V(1).Info("removing consolidatable status condition", "reason", "nodeclaim isn't initialized")
+			transitions.Record("removing consolidatable status condition", "reason", "nodeclaim isn't initialized")
 		}
 		return reconcile.Result{}, nil
 	}
@@ -65,7 +64,7 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	if disruption.IsUnderConsolidateAfter(nodePool, nodeClaim, c.clock) {
 		if hasConsolidatableCondition {
 			_ = nodeClaim.StatusConditions(clockOpt).Clear(v1.ConditionTypeConsolidatable)
-			log.FromContext(ctx).V(1).Info("removing consolidatable status condition",
+			transitions.Record("removing consolidatable status condition",
 				"reason", "consolidateAfter window not yet elapsed",
 				"lastPodEventTime", timeToCheck,
 				"consolidateAfter", lo.FromPtr(nodePool.Spec.Disruption.ConsolidateAfter.Duration),
@@ -79,7 +78,7 @@ func (c *Consolidation) Reconcile(ctx context.Context, nodePool *v1.NodePool, no
 	// 6. Otherwise, add the consolidatable status condition
 	nodeClaim.StatusConditions(clockOpt).SetTrue(v1.ConditionTypeConsolidatable)
 	if !hasConsolidatableCondition {
-		log.FromContext(ctx).V(1).Info("marking consolidatable")
+		transitions.Record("marking consolidatable")
 	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclaim/disruption/consolidation_test.go
+++ b/pkg/controllers/nodeclaim/disruption/consolidation_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package disruption_test
 
 import (
+	"strings"
 	"time"
 
+	"github.com/go-logr/logr/funcr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/test"
@@ -95,6 +99,30 @@ var _ = Describe("Underutilized", func() {
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimDisruptionController, nodeClaim)
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeConsolidatable).IsTrue()).To(BeTrue())
+	})
+	It("should not log marking consolidatable again when reconciling against a stale NodeClaim", func() {
+		// A reconcile can run against a stale informer cache after a prior reconcile
+		// already persisted the Consolidatable condition; it must not log the transition again.
+		var messages []string
+		logCtx := log.IntoContext(ctx, funcr.New(func(_, args string) { messages = append(messages, args) }, funcr.Options{Verbosity: 1}))
+		countMarkingLogs := func() int {
+			return lo.CountBy(messages, func(m string) bool { return strings.Contains(m, "marking consolidatable") })
+		}
+
+		stale := ExpectExists(ctx, env.Client, nodeClaim).DeepCopy()
+		_, err := nodeClaimDisruptionController.Reconcile(logCtx, ExpectExists(ctx, env.Client, nodeClaim))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(countMarkingLogs()).To(Equal(1))
+		marked := ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(marked.StatusConditions().Get(v1.ConditionTypeConsolidatable).IsTrue()).To(BeTrue())
+
+		// The stale copy predates the patch, so it's missing the condition and carries an old resourceVersion.
+		// The reconcile re-applies the condition, but its patch must fail the optimistic lock
+		// without emitting a duplicate log or writing anything to the API server.
+		_, err = nodeClaimDisruptionController.Reconcile(logCtx, stale)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(countMarkingLogs()).To(Equal(1))
+		Expect(ExpectExists(ctx, env.Client, nodeClaim).ResourceVersion).To(Equal(marked.ResourceVersion))
 	})
 	It("should mark NodeClaims as consolidatable based on the nodeclaim initialized time", func() {
 		// set the lastPodEvent as zero, so it's like no pods have scheduled

--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -45,7 +45,29 @@ import (
 )
 
 type nodeClaimReconciler interface {
-	Reconcile(context.Context, *v1.NodePool, *v1.NodeClaim) (reconcile.Result, error)
+	Reconcile(context.Context, *v1.NodePool, *v1.NodeClaim, *transitionLogger) (reconcile.Result, error)
+}
+
+// transitionLogger buffers condition transition logs until the status patch succeeds,
+// so reconciles racing a stale informer cache don't log the same transition twice
+type transitionLogger struct {
+	entries []transitionLogEntry
+}
+
+type transitionLogEntry struct {
+	message       string
+	keysAndValues []any
+}
+
+func (t *transitionLogger) Record(message string, keysAndValues ...any) {
+	t.entries = append(t.entries, transitionLogEntry{message: message, keysAndValues: keysAndValues})
+}
+
+func (t *transitionLogger) Flush(ctx context.Context) {
+	for _, e := range t.entries {
+		log.FromContext(ctx).V(1).Info(e.message, e.keysAndValues...)
+	}
+	t.entries = nil
 }
 
 // Controller is a disruption controller that adds StatusConditions to nodeclaims when they meet certain disruption conditions
@@ -93,7 +115,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	results, errs := c.runReconcilers(ctx, nodePool, nodeClaim)
+	results, transitions, errs := c.runReconcilers(ctx, nodePool, nodeClaim)
 	if !equality.Semantic.DeepEqual(stored, nodeClaim) {
 		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 		// can cause races due to the fact that it fully replaces the list on a change
@@ -105,6 +127,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 			return reconcile.Result{}, client.IgnoreNotFound(err)
 		}
 	}
+	transitions.Flush(ctx)
 	if errs != nil {
 		return reconcile.Result{}, errs
 	}
@@ -133,7 +156,8 @@ func (c *Controller) runReconcilers(
 	ctx context.Context,
 	np *v1.NodePool,
 	nc *v1.NodeClaim,
-) ([]reconcile.Result, error) {
+) ([]reconcile.Result, *transitionLogger, error) {
+	transitions := &transitionLogger{}
 	reconcilers := []nodeClaimReconciler{c.drift}
 	// NodeClaims belonging to static NodePools are never eligible for consolidation, so we shouldn't mark them as consolidatable
 	if np.Spec.Replicas == nil {
@@ -142,9 +166,9 @@ func (c *Controller) runReconcilers(
 	results := make([]reconcile.Result, 0, len(reconcilers))
 	var errs error
 	for _, r := range reconcilers {
-		res, err := r.Reconcile(ctx, np, nc)
+		res, err := r.Reconcile(ctx, np, nc, transitions)
 		errs = multierr.Append(errs, err)
 		results = append(results, res)
 	}
-	return results, errs
+	return results, transitions, errs
 }

--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -25,7 +25,6 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 	"k8s.io/utils/clock"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +47,7 @@ type Drift struct {
 	instanceTypeNotFoundCheckCache *cache.Cache
 }
 
-func (d *Drift) Reconcile(ctx context.Context, nodePool *v1.NodePool, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
+func (d *Drift) Reconcile(ctx context.Context, nodePool *v1.NodePool, nodeClaim *v1.NodeClaim, transitions *transitionLogger) (reconcile.Result, error) {
 	clockOpt := status.WithClock(d.clock)
 	hasDriftedCondition := nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted) != nil
 
@@ -57,7 +56,7 @@ func (d *Drift) Reconcile(ctx context.Context, nodePool *v1.NodePool, nodeClaim 
 	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeLaunched).IsTrue() {
 		_ = nodeClaim.StatusConditions(clockOpt).Clear(v1.ConditionTypeDrifted)
 		if hasDriftedCondition {
-			log.FromContext(ctx).V(1).Info("removing drift status condition, isn't launched")
+			transitions.Record("removing drift status condition, isn't launched")
 		}
 		return reconcile.Result{}, nil
 	}
@@ -69,14 +68,14 @@ func (d *Drift) Reconcile(ctx context.Context, nodePool *v1.NodePool, nodeClaim 
 	if driftedReason == "" {
 		if hasDriftedCondition {
 			_ = nodeClaim.StatusConditions(clockOpt).Clear(v1.ConditionTypeDrifted)
-			log.FromContext(ctx).V(1).Info("removing drifted status condition, not drifted")
+			transitions.Record("removing drifted status condition, not drifted")
 		}
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 	// 3. Finally, if the NodeClaim is drifted, but doesn't have status condition, add it.
 	nodeClaim.StatusConditions(clockOpt).SetTrueWithReason(v1.ConditionTypeDrifted, string(driftedReason), string(driftedReason))
 	if !hasDriftedCondition {
-		log.FromContext(ctx).V(1).WithValues("reason", string(driftedReason)).Info("marking drifted")
+		transitions.Record("marking drifted", "reason", string(driftedReason))
 	}
 	// Requeue after 5 minutes for the cache TTL
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -18,14 +18,17 @@ package disruption_test
 
 import (
 	"slices"
+	"strings"
 	"time"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/imdario/mergo"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -83,6 +86,33 @@ var _ = Describe("Drift", func() {
 		Entry("should detect drift", true),
 		Entry("should ignore drift for NodeClaims not managed by this instance of Karpenter", false),
 	)
+	It("should not log marking drifted again when reconciling against a stale NodeClaim", func() {
+		// A reconcile can run against a stale informer cache after a prior reconcile
+		// already persisted the Drifted condition; it must not log the transition again.
+		cp.Drifted = "drifted"
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+
+		var messages []string
+		logCtx := log.IntoContext(ctx, funcr.New(func(_, args string) { messages = append(messages, args) }, funcr.Options{Verbosity: 1}))
+		countMarkingLogs := func() int {
+			return lo.CountBy(messages, func(m string) bool { return strings.Contains(m, "marking drifted") })
+		}
+
+		stale := ExpectExists(ctx, env.Client, nodeClaim).DeepCopy()
+		_, err := nodeClaimDisruptionController.Reconcile(logCtx, ExpectExists(ctx, env.Client, nodeClaim))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(countMarkingLogs()).To(Equal(1))
+		marked := ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(marked.StatusConditions().Get(v1.ConditionTypeDrifted).IsTrue()).To(BeTrue())
+
+		// The stale copy predates the patch, so it's missing the condition and carries an old resourceVersion.
+		// The reconcile re-applies the condition, but its patch must fail the optimistic lock
+		// without emitting a duplicate log or writing anything to the API server.
+		_, err = nodeClaimDisruptionController.Reconcile(logCtx, stale)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(countMarkingLogs()).To(Equal(1))
+		Expect(ExpectExists(ctx, env.Client, nodeClaim).ResourceVersion).To(Equal(marked.ResourceVersion))
+	})
 	It("should detect stale instance type drift if the instance type label doesn't exist", func() {
 		delete(nodeClaim.Labels, corev1.LabelInstanceTypeStable)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)


### PR DESCRIPTION
Fixes #2002

**Description**

**Why this approach**

The stale read itself can't be fixed — that's just how informer caches work. So the question is what we can actually trust.

I went through the other options first:

- Sleeping after the patch (#2018): blocks a worker and the race is still there.
- Event filter on the `NodeClaim` watch: the racing trigger usually comes from the Pod watch, and we need those events, so there's nothing to filter.
- Checking `SetTrue`'s return value: the stale copy doesn't have the condition, so it returns `true` again. Same double log.

The one thing we can trust is the API server. The status patch already uses an optimistic lock, so a stale reconcile always gets a 409. That's a reliable "did my write land" signal, and we weren't using it.

**The idea**

Don't log when we mutate the object — log when the patch goes through. If the patch hits a 409, the buffered lines get thrown away. The log ends up describing what actually happened instead of what a reconcile thought it did.

**How was this change tested?**

- Regression test: reconcile a stale copy (old resourceVersion, no condition) right after a successful one, assert the log fires exactly once and the stale one requeues. It fails on `main` without the fix.
- Full `nodeclaim/disruption` suite passes with `-race`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.