### PR TITLE
fix: use max() of replicas and percentage in CapacityBuffer replica calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/pkg/controllers/capacitybuffer/controller.go
+++ b/pkg/controllers/capacitybuffer/controller.go
@@ -176,19 +176,37 @@ func (c *Controller) resolveAndUpdateStatus(ctx context.Context, cb *autoscaling
 	return true, nil
 }
 
+// computeReplicas combines the buffer's sizing signals following the upstream API
+// contract: replicas and percentage are combined with max(), then bounded by limits.
+// https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/buffers.md
+//
+// candidates carries sizing signals the caller already resolved (the percentage-derived
+// count from a scalableRef), since percentage needs the live scalable replica count.
 func computeReplicas(cb *autoscalingv1alpha1.CapacityBuffer, podSpec *v1.PodSpec, candidates []int32) int32 {
 	if cb.Spec.Replicas != nil {
 		candidates = append(candidates, *cb.Spec.Replicas)
 	}
+
+	var limitReplicas *int32
 	if cb.Spec.Limits != nil && podSpec != nil {
-		if limitReplicas, ok := calculateLimitReplicas(v1.ResourceList(cb.Spec.Limits), podSpec); ok {
-			candidates = append(candidates, limitReplicas)
+		if l, ok := calculateLimitReplicas(v1.ResourceList(cb.Spec.Limits), podSpec); ok {
+			limitReplicas = &l
 		}
 	}
+
+	// With no explicit sizing signals, limits alone determine the buffer size.
 	if len(candidates) == 0 {
+		if limitReplicas != nil {
+			return *limitReplicas
+		}
 		return 0
 	}
-	return lo.Min(candidates)
+
+	desired := lo.Max(candidates)
+	if limitReplicas != nil {
+		return lo.Min([]int32{desired, *limitReplicas})
+	}
+	return desired
 }
 
 // handleResolveError sets the ReadyForProvisioning condition to False and returns

--- a/pkg/controllers/capacitybuffer/suite_test.go
+++ b/pkg/controllers/capacitybuffer/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	autoscalingv1alpha1 "sigs.k8s.io/karpenter/pkg/apis/autoscaling/v1alpha1"
@@ -355,166 +356,93 @@ var _ = Describe("CapacityBuffer Controller", func() {
 	})
 
 	Context("Replica calculation", func() {
-		It("should use fixed replicas when only replicas is set", func() {
-			pt := &v1.PodTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fixed-template",
-					Namespace: "default",
-				},
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{{
-							Name:  "app",
-							Image: "pause:latest",
-						}},
-					},
-				},
-			}
-			cb := &autoscalingv1alpha1.CapacityBuffer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-fixed-replicas",
-					Namespace: "default",
-				},
-				Spec: autoscalingv1alpha1.CapacityBufferSpec{
-					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "fixed-template"},
+		// Each entry passes the backing workload and a buffer that references it; the body
+		// applies both, reconciles, and asserts the resolved status.Replicas.
+		DescribeTable("should resolve buffer replicas from replicas, percentage, and limits",
+			func(backing client.Object, cb *autoscalingv1alpha1.CapacityBuffer, expected int32) {
+				ExpectApplied(ctx, env.Client, backing, cb)
+				ExpectObjectReconciled(ctx, env.Client, cbController, cb)
+				Expect(ExpectExists(ctx, env.Client, cb).Status.Replicas).To(HaveValue(Equal(expected)))
+			},
+			// podTemplateRef: replicas and limits only (percentage requires a scalableRef).
+			Entry("fixed replicas only",
+				test.PodTemplate(test.PodTemplateOptions{ObjectMeta: metav1.ObjectMeta{Name: "pt-fixed"}}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "pt-fixed"},
 					Replicas:       lo.ToPtr(int32(7)),
-				},
-			}
-			ExpectApplied(ctx, env.Client, pt, cb)
-			ExpectObjectReconciled(ctx, env.Client, cbController, cb)
-
-			cb = ExpectExists(ctx, env.Client, cb)
-			Expect(cb.Status.Replicas).ToNot(BeNil())
-			Expect(*cb.Status.Replicas).To(Equal(int32(7)))
-		})
-
-		It("should use the minimum of replicas and limit-based replicas", func() {
-			pt := &v1.PodTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "limit-template",
-					Namespace: "default",
-				},
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{{
-							Name:  "app",
-							Image: "pause:latest",
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU: resource.MustParse("1"),
-								},
-							},
-						}},
-					},
-				},
-			}
-			cb := &autoscalingv1alpha1.CapacityBuffer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-limit-replicas",
-					Namespace: "default",
-				},
-				Spec: autoscalingv1alpha1.CapacityBufferSpec{
-					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "limit-template"},
+				}}),
+				int32(7)),
+			// replicas = 10, capped by limit (3 CPU / 1 CPU per pod = 3)
+			Entry("replicas capped by binding limit",
+				test.PodTemplate(test.PodTemplateOptions{ObjectMeta: metav1.ObjectMeta{Name: "pt-cap"}, PodOptions: cpuPod()}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "pt-cap"},
 					Replicas:       lo.ToPtr(int32(10)),
 					Limits:         autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("3")},
-				},
-			}
-			ExpectApplied(ctx, env.Client, pt, cb)
-			ExpectObjectReconciled(ctx, env.Client, cbController, cb)
-
-			cb = ExpectExists(ctx, env.Client, cb)
-			Expect(cb.Status.Replicas).ToNot(BeNil())
-			// Limit allows 3 CPUs / 1 CPU per pod = 3, but spec.replicas = 10
-			// min(10, 3) = 3
-			Expect(*cb.Status.Replicas).To(Equal(int32(3)))
-		})
-
-		It("should use limits as replica count when only limits is set", func() {
-			pt := &v1.PodTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "limits-only-template",
-					Namespace: "default",
-				},
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{{
-							Name:  "app",
-							Image: "pause:latest",
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU: resource.MustParse("1"),
-								},
-							},
-						}},
-					},
-				},
-			}
-			cb := &autoscalingv1alpha1.CapacityBuffer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-limits-only",
-					Namespace: "default",
-				},
-				Spec: autoscalingv1alpha1.CapacityBufferSpec{
-					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "limits-only-template"},
+				}}),
+				int32(3)),
+			// limit allows 80 pods, so the cap does not bind => 10
+			Entry("non-binding limit does not reduce (podTemplateRef)",
+				test.PodTemplate(test.PodTemplateOptions{ObjectMeta: metav1.ObjectMeta{Name: "pt-loose"}, PodOptions: cpuPod()}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "pt-loose"},
+					Replicas:       lo.ToPtr(int32(10)),
+					Limits:         autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("80")},
+				}}),
+				int32(10)),
+			// limits alone determine the count (5 CPU / 1 CPU per pod = 5)
+			Entry("limits only",
+				test.PodTemplate(test.PodTemplateOptions{ObjectMeta: metav1.ObjectMeta{Name: "pt-limit"}, PodOptions: cpuPod()}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "pt-limit"},
 					Limits:         autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("5")},
-				},
-			}
-			ExpectApplied(ctx, env.Client, pt, cb)
-			ExpectObjectReconciled(ctx, env.Client, cbController, cb)
-
-			cb = ExpectExists(ctx, env.Client, cb)
-			Expect(cb.Status.Replicas).ToNot(BeNil())
-			// 5 CPU limit / 1 CPU per pod = 5 replicas (limits is the only constraint)
-			Expect(*cb.Status.Replicas).To(Equal(int32(5)))
-		})
-
-		It("should use percentage with minimum of 1 replica", func() {
-			deploy := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "small-app",
-					Namespace: "default",
-				},
-				Spec: appsv1.DeploymentSpec{
-					Replicas: lo.ToPtr(int32(1)),
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "small-app"}},
-					Template: v1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "small-app"}},
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{{
-								Name:  "app",
-								Image: "pause:latest",
-								Resources: v1.ResourceRequirements{
-									Requests: v1.ResourceList{
-										v1.ResourceCPU: resource.MustParse("100m"),
-									},
-								},
-							}},
-						},
-					},
-				},
-			}
-			cb := &autoscalingv1alpha1.CapacityBuffer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pct-min",
-					Namespace: "default",
-				},
-				Spec: autoscalingv1alpha1.CapacityBufferSpec{
-					ScalableRef: &autoscalingv1alpha1.ScalableRef{
-						APIGroup: "apps",
-						Kind:     "Deployment",
-						Name:     "small-app",
-					},
-					Percentage: lo.ToPtr(int32(10)),
-				},
-			}
-			ExpectApplied(ctx, env.Client, deploy, cb)
-			ExpectObjectReconciled(ctx, env.Client, cbController, cb)
-
-			cb = ExpectExists(ctx, env.Client, cb)
-			Expect(cb.Status.Replicas).ToNot(BeNil())
-			// 10% of 1 = 0.1, ceil = 1, minimum 1
-			Expect(*cb.Status.Replicas).To(Equal(int32(1)))
-		})
+				}}),
+				int32(5)),
+			// scalableRef: max(replicas, percentage), then capped by limits.
+			Entry("replicas > percentage",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-repl"}, Replicas: 100}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					ScalableRef: deploymentRef("d-repl"),
+					Percentage:  lo.ToPtr(int32(20)),
+					Replicas:    lo.ToPtr(int32(50)),
+				}}),
+				int32(50)),
+			Entry("percentage > replicas",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-pct"}, Replicas: 100}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					ScalableRef: deploymentRef("d-pct"),
+					Percentage:  lo.ToPtr(int32(40)),
+					Replicas:    lo.ToPtr(int32(10)),
+				}}),
+				int32(40)),
+			// percentage rounds up to a floor of 1 (10% of 1 = 0.1 => 1).
+			Entry("percentage rounds up to a minimum of 1",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-min"}, Replicas: 1}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					ScalableRef: deploymentRef("d-min"),
+					Percentage:  lo.ToPtr(int32(10)),
+				}}),
+				int32(1)),
+			// limit caps the max() only when it binds (downward).
+			Entry("binding limit caps the max",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-cap"}, Replicas: 100, PodOptions: cpuPod()}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					ScalableRef: deploymentRef("d-cap"),
+					Percentage:  lo.ToPtr(int32(20)),
+					Replicas:    lo.ToPtr(int32(50)),
+					Limits:      autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("3")},
+				}}),
+				int32(3)),
+			Entry("non-binding limit does not reduce (scalableRef)",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-loose"}, Replicas: 100, PodOptions: cpuPod()}),
+				test.CapacityBuffer(autoscalingv1alpha1.CapacityBuffer{Spec: autoscalingv1alpha1.CapacityBufferSpec{
+					ScalableRef: deploymentRef("d-loose"),
+					Percentage:  lo.ToPtr(int32(20)),
+					Replicas:    lo.ToPtr(int32(50)),
+					Limits:      autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("80")},
+				}}),
+				int32(50)),
+		)
 	})
 
 	Context("PodTemplate watch", func() {
@@ -689,6 +617,21 @@ var _ = Describe("CapacityBuffer Controller", func() {
 		})
 	})
 })
+
+// cpuPod returns PodOptions requesting 1 CPU, so a buffer's CPU limit maps directly
+// to a pod count (limit N CPU / 1 CPU per pod = N) when exercising the limit cap.
+func cpuPod() test.PodOptions {
+	return test.PodOptions{
+		ResourceRequirements: v1.ResourceRequirements{
+			Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+		},
+	}
+}
+
+// deploymentRef is a scalableRef pointing at a Deployment of the given name.
+func deploymentRef(name string) *autoscalingv1alpha1.ScalableRef {
+	return &autoscalingv1alpha1.ScalableRef{APIGroup: "apps", Kind: "Deployment", Name: name}
+}
 
 //nolint:unparam
 func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {

--- a/pkg/test/podtemplate.go
+++ b/pkg/test/podtemplate.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/imdario/mergo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type PodTemplateOptions struct {
+	metav1.ObjectMeta
+	PodOptions PodOptions
+}
+
+func PodTemplate(overrides ...PodTemplateOptions) *v1.PodTemplate {
+	options := PodTemplateOptions{}
+	for _, opts := range overrides {
+		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("Failed to merge pod template options: %s", err))
+		}
+	}
+
+	if options.PodOptions.Image == "" {
+		options.PodOptions.Image = DefaultImage
+	}
+	pod := Pod(options.PodOptions)
+	return &v1.PodTemplate{
+		ObjectMeta: NamespacedObjectMeta(options.ObjectMeta),
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: pod.ObjectMeta,
+			Spec:       pod.Spec,
+		},
+	}
+}


### PR DESCRIPTION
Fixes #3125

**Description**

`computeReplicas` combined `replicas`, `percentage`, and `limits` into a single `min()`, which under-provisions the buffer when both `replicas` and `percentage` are set. The upstream CapacityBuffer API contract treats `replicas` and `percentage` as sizing signals combined with `max()` (both are floors — the larger wins), with `limits` applied as an upper-bound cap via `min()`.

This changes the calculation to `min( max(replicas, percentage), limits )`:

- `replicas` and `percentage` are combined with `max()` — an explicit `replicas` floor is never silently reduced by a smaller percentage-derived value (or vice versa).
- `limits` remains an upper-bound cap.
- When neither `replicas` nor `percentage` is set, `limits` alone determines the buffer size (unchanged).

Example (`scalableRef` replicas = 100, `percentage` = 20 → 20, `replicas` = 50):
- Before: `min(20, 50) = 20` (under-provisions the requested floor of 50)
- After: `max(20, 50) = 50`

This matches the documented API (`autoscaling.x-k8s.io` `Replicas` field doc-comment: "If both are set, the maximum of the two will be used") and the design proposal (`cluster-autoscaler/proposals/buffers.md`: "if both are set... max from these"), which have specified `max` since the original proposal (kubernetes/autoscaler#8151).

Note: the Cluster Autoscaler reference controller currently implements this with `min()`, contradicting its own API docs. Filed upstream as kubernetes/autoscaler#9948. This PR follows the documented `max()` semantics rather than CAS's current (buggy) implementation.

**How was this change tested?**

- Added a unit test covering the previously-uncovered case where both `replicas` and `percentage` are set, asserting `max()` wins.
- Updated the replicas-capped-by-limits test's rationale (result unchanged: `max(10)` capped by a limit of 3 = 3).
- `go test ./pkg/controllers/capacitybuffer/...` and the provisioning buffer suite pass against a Kubernetes 1.36 envtest apiserver.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.