### PR TITLE
fix: buffer computeReplicas must take the max of desired replicas and percentage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/go.tools.mod
+++ b/go.tools.mod
@@ -3,7 +3,7 @@ module tools
 // Tool dependencies isolated from main module to avoid conflicts.
 // Usage: go tool -modfile=go.tools.mod <toolname>
 
-go 1.26.3
+go 1.26.5
 
 tool (
 	github.com/B1NARY-GR0UP/nwa

--- a/pkg/controllers/capacitybuffer/controller.go
+++ b/pkg/controllers/capacitybuffer/controller.go
@@ -176,19 +176,34 @@ func (c *Controller) resolveAndUpdateStatus(ctx context.Context, cb *autoscaling
 	return true, nil
 }
 
+// computeReplicas derives the desired buffer replica count from the configured
+// constraints, following Cluster Autoscaler's semantics:
+//   - replicas and percentage are combined by taking the MAX of the two.
+//   - limits act as an upper bound (MIN) on that value.
+//   - if neither replicas nor percentage is set, limits alone determine how many
+//     units fit within the resource limits.
+//
+// candidates holds the percentage-derived replica count (if percentage is set);
+// the fixed replicas value is added here.
 func computeReplicas(cb *autoscalingv1alpha1.CapacityBuffer, podSpec *v1.PodSpec, candidates []int32) int32 {
 	if cb.Spec.Replicas != nil {
 		candidates = append(candidates, *cb.Spec.Replicas)
 	}
+
+	// desired is the max of replicas and percentage. hasSizeConstraint is false
+	// when neither is set, in which case limits alone determine the count.
+	hasSizeConstraint := len(candidates) > 0
+	desired := lo.Max(candidates)
+
 	if cb.Spec.Limits != nil && podSpec != nil {
 		if limitReplicas, ok := calculateLimitReplicas(v1.ResourceList(cb.Spec.Limits), podSpec); ok {
-			candidates = append(candidates, limitReplicas)
+			if hasSizeConstraint {
+				return lo.Min([]int32{desired, limitReplicas})
+			}
+			return limitReplicas
 		}
 	}
-	if len(candidates) == 0 {
-		return 0
-	}
-	return lo.Min(candidates)
+	return desired
 }
 
 // handleResolveError sets the ReadyForProvisioning condition to False and returns

--- a/pkg/controllers/capacitybuffer/suite_test.go
+++ b/pkg/controllers/capacitybuffer/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	autoscalingv1alpha1 "sigs.k8s.io/karpenter/pkg/apis/autoscaling/v1alpha1"
@@ -355,95 +356,117 @@ var _ = Describe("CapacityBuffer Controller", func() {
 	})
 
 	Context("Replica calculation", func() {
-		// replicaCase parametrizes the desired-replica computation. When deployReplicas
-		// is set, the buffer references a Deployment of that size via scalableRef;
-		// otherwise it references a PodTemplate. podCPU (if set) is the per-pod CPU
-		// request, and limitCPU (if set) is the buffer's CPU limit.
-		type replicaCase struct {
-			podCPU         string
-			deployReplicas *int32
-			replicas       *int32
-			percentage     *int32
-			limitCPU       string
-			expected       int32
-		}
-
-		DescribeTable("computing desired replicas",
-			func(tc replicaCase) {
-				container := v1.Container{Name: "app", Image: "pause:latest"}
-				if tc.podCPU != "" {
-					container.Resources = v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse(tc.podCPU)},
-					}
-				}
-				podSpec := v1.PodSpec{Containers: []v1.Container{container}}
-
-				cbSpec := autoscalingv1alpha1.CapacityBufferSpec{
-					Replicas:   tc.replicas,
-					Percentage: tc.percentage,
-				}
-				if tc.limitCPU != "" {
-					cbSpec.Limits = autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse(tc.limitCPU)}
-				}
-
-				if tc.deployReplicas != nil {
-					deploy := &appsv1.Deployment{
-						ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: "default"},
-						Spec: appsv1.DeploymentSpec{
-							Replicas: tc.deployReplicas,
-							Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "workload"}},
-							Template: v1.PodTemplateSpec{
-								ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "workload"}},
-								Spec:       podSpec,
-							},
-						},
-					}
-					cbSpec.ScalableRef = &autoscalingv1alpha1.ScalableRef{APIGroup: "apps", Kind: "Deployment", Name: "workload"}
-					ExpectApplied(ctx, env.Client, deploy)
-				} else {
-					pt := &v1.PodTemplate{
-						ObjectMeta: metav1.ObjectMeta{Name: "template", Namespace: "default"},
-						Template:   v1.PodTemplateSpec{Spec: podSpec},
-					}
-					cbSpec.PodTemplateRef = &autoscalingv1alpha1.LocalObjectRef{Name: "template"}
-					ExpectApplied(ctx, env.Client, pt)
-				}
-
-				cb := &autoscalingv1alpha1.CapacityBuffer{
-					ObjectMeta: metav1.ObjectMeta{Name: "buffer", Namespace: "default"},
-					Spec:       cbSpec,
-				}
-				ExpectApplied(ctx, env.Client, cb)
+		// Each entry passes the backing workload and a buffer that references it; the body
+		// applies both, reconciles, and asserts the resolved status.Replicas.
+		DescribeTable("should resolve buffer replicas from replicas, percentage, and limits",
+			func(backing client.Object, cb *autoscalingv1alpha1.CapacityBuffer, expected int32) {
+				ExpectApplied(ctx, env.Client, backing, cb)
 				ExpectObjectReconciled(ctx, env.Client, cbController, cb)
-
-				cb = ExpectExists(ctx, env.Client, cb)
-				Expect(cb.Status.Replicas).ToNot(BeNil())
-				Expect(*cb.Status.Replicas).To(Equal(tc.expected))
+				Expect(ExpectExists(ctx, env.Client, cb).Status.Replicas).To(HaveValue(Equal(expected)))
 			},
-			Entry("fixed replicas only", replicaCase{
-				replicas: lo.ToPtr(int32(7)), expected: 7,
-			}),
-			Entry("replicas capped by binding limit (podTemplateRef)", replicaCase{
-				podCPU: "1", replicas: lo.ToPtr(int32(10)), limitCPU: "3", expected: 3,
-			}),
-			Entry("non-binding limit does not reduce (podTemplateRef)", replicaCase{
-				podCPU: "1", replicas: lo.ToPtr(int32(3)), limitCPU: "10", expected: 3,
-			}),
-			Entry("limits only", replicaCase{
-				podCPU: "1", limitCPU: "5", expected: 5,
-			}),
-			Entry("percentage only (scalableRef)", replicaCase{
-				podCPU: "500m", deployReplicas: lo.ToPtr(int32(10)), percentage: lo.ToPtr(int32(20)), expected: 2,
-			}),
-			Entry("max of replicas and percentage (scalableRef)", replicaCase{
-				podCPU: "500m", deployReplicas: lo.ToPtr(int32(10)), replicas: lo.ToPtr(int32(5)), percentage: lo.ToPtr(int32(80)), expected: 8,
-			}),
-			Entry("max of replicas and percentage capped by limit (scalableRef)", replicaCase{
-				podCPU: "1", deployReplicas: lo.ToPtr(int32(10)), replicas: lo.ToPtr(int32(5)), percentage: lo.ToPtr(int32(80)), limitCPU: "4", expected: 4,
-			}),
-			Entry("percentage rounds up to minimum 1 (scalableRef)", replicaCase{
-				podCPU: "100m", deployReplicas: lo.ToPtr(int32(1)), percentage: lo.ToPtr(int32(10)), expected: 1,
-			}),
+			// podTemplateRef: replicas and limits only (percentage requires a scalableRef).
+			Entry("fixed replicas only",
+				test.PodTemplate(test.PodTemplateOptions{ObjectMeta: metav1.ObjectMeta{Name: "pt-fixed"}}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-fixed", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "pt-fixed"},
+						Replicas:       lo.ToPtr(int32(7)),
+					},
+				},
+				int32(7)),
+			// replicas = 10, capped by limit (3 CPU / 1 CPU per pod = 3)
+			Entry("replicas capped by binding limit",
+				test.PodTemplate(test.PodTemplateOptions{ObjectMeta: metav1.ObjectMeta{Name: "pt-cap"}, PodOptions: cpuPod()}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-cap", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "pt-cap"},
+						Replicas:       lo.ToPtr(int32(10)),
+						Limits:         autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("3")},
+					},
+				},
+				int32(3)),
+			// limit allows 10 pods, so the cap does not bind => 3
+			Entry("non-binding limit does not reduce (podTemplateRef)",
+				test.PodTemplate(test.PodTemplateOptions{ObjectMeta: metav1.ObjectMeta{Name: "pt-loose"}, PodOptions: cpuPod()}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-loose", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "pt-loose"},
+						Replicas:       lo.ToPtr(int32(3)),
+						Limits:         autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("10")},
+					},
+				},
+				int32(3)),
+			// limits alone determine the count (5 CPU / 1 CPU per pod = 5)
+			Entry("limits only",
+				test.PodTemplate(test.PodTemplateOptions{ObjectMeta: metav1.ObjectMeta{Name: "pt-limit"}, PodOptions: cpuPod()}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-limit", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "pt-limit"},
+						Limits:         autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("5")},
+					},
+				},
+				int32(5)),
+			// scalableRef: max(replicas, percentage), then capped by limits.
+			Entry("percentage only",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-pct-only"}, Replicas: 10}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-pct-only", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						ScalableRef: deploymentRef("d-pct-only"),
+						Percentage:  lo.ToPtr(int32(20)),
+					},
+				},
+				int32(2)),
+			Entry("replicas > percentage",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-repl"}, Replicas: 10}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-repl", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						ScalableRef: deploymentRef("d-repl"),
+						Replicas:    lo.ToPtr(int32(5)),
+						Percentage:  lo.ToPtr(int32(20)), // 20% of 10 = 2 => max(5, 2) = 5
+					},
+				},
+				int32(5)),
+			Entry("percentage > replicas",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-pct"}, Replicas: 10}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-pct", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						ScalableRef: deploymentRef("d-pct"),
+						Replicas:    lo.ToPtr(int32(5)),
+						Percentage:  lo.ToPtr(int32(80)), // 80% of 10 = 8 => max(5, 8) = 8
+					},
+				},
+				int32(8)),
+			// limit caps the max() only when it binds (downward).
+			Entry("max of replicas and percentage capped by limit",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-cap"}, Replicas: 10, PodOptions: cpuPod()}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-scap", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						ScalableRef: deploymentRef("d-cap"),
+						Replicas:    lo.ToPtr(int32(5)),
+						Percentage:  lo.ToPtr(int32(80)), // max(5, 8) = 8
+						Limits:      autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("4")},
+					},
+				},
+				int32(4)),
+			// percentage rounds up to a floor of 1 (10% of 1 = 0.1 => 1).
+			Entry("percentage rounds up to a minimum of 1",
+				test.Deployment(test.DeploymentOptions{ObjectMeta: metav1.ObjectMeta{Name: "d-min"}, Replicas: 1}),
+				&autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "cb-min", Namespace: "default"},
+					Spec: autoscalingv1alpha1.CapacityBufferSpec{
+						ScalableRef: deploymentRef("d-min"),
+						Percentage:  lo.ToPtr(int32(10)),
+					},
+				},
+				int32(1)),
 		)
 	})
 
@@ -619,6 +642,21 @@ var _ = Describe("CapacityBuffer Controller", func() {
 		})
 	})
 })
+
+// cpuPod returns PodOptions requesting 1 CPU, so a buffer's CPU limit maps directly
+// to a pod count (limit N CPU / 1 CPU per pod = N) when exercising the limit cap.
+func cpuPod() test.PodOptions {
+	return test.PodOptions{
+		ResourceRequirements: v1.ResourceRequirements{
+			Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+		},
+	}
+}
+
+// deploymentRef is a scalableRef pointing at a Deployment of the given name.
+func deploymentRef(name string) *autoscalingv1alpha1.ScalableRef {
+	return &autoscalingv1alpha1.ScalableRef{APIGroup: "apps", Kind: "Deployment", Name: name}
+}
 
 //nolint:unparam
 func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {

--- a/pkg/controllers/capacitybuffer/suite_test.go
+++ b/pkg/controllers/capacitybuffer/suite_test.go
@@ -355,166 +355,96 @@ var _ = Describe("CapacityBuffer Controller", func() {
 	})
 
 	Context("Replica calculation", func() {
-		It("should use fixed replicas when only replicas is set", func() {
-			pt := &v1.PodTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fixed-template",
-					Namespace: "default",
-				},
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{{
-							Name:  "app",
-							Image: "pause:latest",
-						}},
-					},
-				},
-			}
-			cb := &autoscalingv1alpha1.CapacityBuffer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-fixed-replicas",
-					Namespace: "default",
-				},
-				Spec: autoscalingv1alpha1.CapacityBufferSpec{
-					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "fixed-template"},
-					Replicas:       lo.ToPtr(int32(7)),
-				},
-			}
-			ExpectApplied(ctx, env.Client, pt, cb)
-			ExpectObjectReconciled(ctx, env.Client, cbController, cb)
+		// replicaCase parametrizes the desired-replica computation. When deployReplicas
+		// is set, the buffer references a Deployment of that size via scalableRef;
+		// otherwise it references a PodTemplate. podCPU (if set) is the per-pod CPU
+		// request, and limitCPU (if set) is the buffer's CPU limit.
+		type replicaCase struct {
+			podCPU         string
+			deployReplicas *int32
+			replicas       *int32
+			percentage     *int32
+			limitCPU       string
+			expected       int32
+		}
 
-			cb = ExpectExists(ctx, env.Client, cb)
-			Expect(cb.Status.Replicas).ToNot(BeNil())
-			Expect(*cb.Status.Replicas).To(Equal(int32(7)))
-		})
+		DescribeTable("computing desired replicas",
+			func(tc replicaCase) {
+				container := v1.Container{Name: "app", Image: "pause:latest"}
+				if tc.podCPU != "" {
+					container.Resources = v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse(tc.podCPU)},
+					}
+				}
+				podSpec := v1.PodSpec{Containers: []v1.Container{container}}
 
-		It("should use the minimum of replicas and limit-based replicas", func() {
-			pt := &v1.PodTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "limit-template",
-					Namespace: "default",
-				},
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{{
-							Name:  "app",
-							Image: "pause:latest",
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU: resource.MustParse("1"),
-								},
+				cbSpec := autoscalingv1alpha1.CapacityBufferSpec{
+					Replicas:   tc.replicas,
+					Percentage: tc.percentage,
+				}
+				if tc.limitCPU != "" {
+					cbSpec.Limits = autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse(tc.limitCPU)}
+				}
+
+				if tc.deployReplicas != nil {
+					deploy := &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: "default"},
+						Spec: appsv1.DeploymentSpec{
+							Replicas: tc.deployReplicas,
+							Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "workload"}},
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "workload"}},
+								Spec:       podSpec,
 							},
-						}},
-					},
-				},
-			}
-			cb := &autoscalingv1alpha1.CapacityBuffer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-limit-replicas",
-					Namespace: "default",
-				},
-				Spec: autoscalingv1alpha1.CapacityBufferSpec{
-					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "limit-template"},
-					Replicas:       lo.ToPtr(int32(10)),
-					Limits:         autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("3")},
-				},
-			}
-			ExpectApplied(ctx, env.Client, pt, cb)
-			ExpectObjectReconciled(ctx, env.Client, cbController, cb)
-
-			cb = ExpectExists(ctx, env.Client, cb)
-			Expect(cb.Status.Replicas).ToNot(BeNil())
-			// Limit allows 3 CPUs / 1 CPU per pod = 3, but spec.replicas = 10
-			// min(10, 3) = 3
-			Expect(*cb.Status.Replicas).To(Equal(int32(3)))
-		})
-
-		It("should use limits as replica count when only limits is set", func() {
-			pt := &v1.PodTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "limits-only-template",
-					Namespace: "default",
-				},
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{{
-							Name:  "app",
-							Image: "pause:latest",
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU: resource.MustParse("1"),
-								},
-							},
-						}},
-					},
-				},
-			}
-			cb := &autoscalingv1alpha1.CapacityBuffer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-limits-only",
-					Namespace: "default",
-				},
-				Spec: autoscalingv1alpha1.CapacityBufferSpec{
-					PodTemplateRef: &autoscalingv1alpha1.LocalObjectRef{Name: "limits-only-template"},
-					Limits:         autoscalingv1alpha1.Limits{v1.ResourceCPU: resource.MustParse("5")},
-				},
-			}
-			ExpectApplied(ctx, env.Client, pt, cb)
-			ExpectObjectReconciled(ctx, env.Client, cbController, cb)
-
-			cb = ExpectExists(ctx, env.Client, cb)
-			Expect(cb.Status.Replicas).ToNot(BeNil())
-			// 5 CPU limit / 1 CPU per pod = 5 replicas (limits is the only constraint)
-			Expect(*cb.Status.Replicas).To(Equal(int32(5)))
-		})
-
-		It("should use percentage with minimum of 1 replica", func() {
-			deploy := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "small-app",
-					Namespace: "default",
-				},
-				Spec: appsv1.DeploymentSpec{
-					Replicas: lo.ToPtr(int32(1)),
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "small-app"}},
-					Template: v1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "small-app"}},
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{{
-								Name:  "app",
-								Image: "pause:latest",
-								Resources: v1.ResourceRequirements{
-									Requests: v1.ResourceList{
-										v1.ResourceCPU: resource.MustParse("100m"),
-									},
-								},
-							}},
 						},
-					},
-				},
-			}
-			cb := &autoscalingv1alpha1.CapacityBuffer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pct-min",
-					Namespace: "default",
-				},
-				Spec: autoscalingv1alpha1.CapacityBufferSpec{
-					ScalableRef: &autoscalingv1alpha1.ScalableRef{
-						APIGroup: "apps",
-						Kind:     "Deployment",
-						Name:     "small-app",
-					},
-					Percentage: lo.ToPtr(int32(10)),
-				},
-			}
-			ExpectApplied(ctx, env.Client, deploy, cb)
-			ExpectObjectReconciled(ctx, env.Client, cbController, cb)
+					}
+					cbSpec.ScalableRef = &autoscalingv1alpha1.ScalableRef{APIGroup: "apps", Kind: "Deployment", Name: "workload"}
+					ExpectApplied(ctx, env.Client, deploy)
+				} else {
+					pt := &v1.PodTemplate{
+						ObjectMeta: metav1.ObjectMeta{Name: "template", Namespace: "default"},
+						Template:   v1.PodTemplateSpec{Spec: podSpec},
+					}
+					cbSpec.PodTemplateRef = &autoscalingv1alpha1.LocalObjectRef{Name: "template"}
+					ExpectApplied(ctx, env.Client, pt)
+				}
 
-			cb = ExpectExists(ctx, env.Client, cb)
-			Expect(cb.Status.Replicas).ToNot(BeNil())
-			// 10% of 1 = 0.1, ceil = 1, minimum 1
-			Expect(*cb.Status.Replicas).To(Equal(int32(1)))
-		})
+				cb := &autoscalingv1alpha1.CapacityBuffer{
+					ObjectMeta: metav1.ObjectMeta{Name: "buffer", Namespace: "default"},
+					Spec:       cbSpec,
+				}
+				ExpectApplied(ctx, env.Client, cb)
+				ExpectObjectReconciled(ctx, env.Client, cbController, cb)
+
+				cb = ExpectExists(ctx, env.Client, cb)
+				Expect(cb.Status.Replicas).ToNot(BeNil())
+				Expect(*cb.Status.Replicas).To(Equal(tc.expected))
+			},
+			Entry("fixed replicas only", replicaCase{
+				replicas: lo.ToPtr(int32(7)), expected: 7,
+			}),
+			Entry("replicas capped by binding limit (podTemplateRef)", replicaCase{
+				podCPU: "1", replicas: lo.ToPtr(int32(10)), limitCPU: "3", expected: 3,
+			}),
+			Entry("non-binding limit does not reduce (podTemplateRef)", replicaCase{
+				podCPU: "1", replicas: lo.ToPtr(int32(3)), limitCPU: "10", expected: 3,
+			}),
+			Entry("limits only", replicaCase{
+				podCPU: "1", limitCPU: "5", expected: 5,
+			}),
+			Entry("percentage only (scalableRef)", replicaCase{
+				podCPU: "500m", deployReplicas: lo.ToPtr(int32(10)), percentage: lo.ToPtr(int32(20)), expected: 2,
+			}),
+			Entry("max of replicas and percentage (scalableRef)", replicaCase{
+				podCPU: "500m", deployReplicas: lo.ToPtr(int32(10)), replicas: lo.ToPtr(int32(5)), percentage: lo.ToPtr(int32(80)), expected: 8,
+			}),
+			Entry("max of replicas and percentage capped by limit (scalableRef)", replicaCase{
+				podCPU: "1", deployReplicas: lo.ToPtr(int32(10)), replicas: lo.ToPtr(int32(5)), percentage: lo.ToPtr(int32(80)), limitCPU: "4", expected: 4,
+			}),
+			Entry("percentage rounds up to minimum 1 (scalableRef)", replicaCase{
+				podCPU: "100m", deployReplicas: lo.ToPtr(int32(1)), percentage: lo.ToPtr(int32(10)), expected: 1,
+			}),
+		)
 	})
 
 	Context("PodTemplate watch", func() {

--- a/pkg/test/podtemplate.go
+++ b/pkg/test/podtemplate.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/imdario/mergo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type PodTemplateOptions struct {
+	metav1.ObjectMeta
+	PodOptions PodOptions
+}
+
+func PodTemplate(overrides ...PodTemplateOptions) *v1.PodTemplate {
+	options := PodTemplateOptions{}
+	for _, opts := range overrides {
+		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("Failed to merge pod template options: %s", err))
+		}
+	}
+	if options.PodOptions.Image == "" {
+		options.PodOptions.Image = DefaultImage
+	}
+	pod := Pod(options.PodOptions)
+	return &v1.PodTemplate{
+		ObjectMeta: NamespacedObjectMeta(options.ObjectMeta),
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: pod.ObjectMeta,
+			Spec:       pod.Spec,
+		},
+	}
+}


### PR DESCRIPTION
Fixes #3125 

**Description**

Changes how the CapacityBuffer controller computes the desired buffer replica count to align
with Cluster Autoscaler's buffer semantics.

Before: the controller took the minimum across all configured constraints — min(replicas,
percentage, limits). This meant setting both replicas and percentage produced the smaller of the
two, which is surprising and inconsistent with Cluster Autoscaler.

After: replicas and percentage are combined by taking the maximum, and limits acts as an upper
bound on that value:

min( max(replicas, percentage), limits )

- If both replicas and percentage are set, the larger wins (they express two ways of asking for
capacity; the user gets whichever is bigger).
- limits always caps the result so the buffer never exceeds the configured resource budget.
- If neither replicas nor percentage is set, limits alone determines how many chunks fit.
- If no constraints are set, the count is 0.

This matches Cluster Autoscaler's documented behavior: "If both are set, [the autoscaler] uses
the maximum of the two values provided they both fit within the limits."


This is a behavior change only for buffers that set both replicas and percentage. Buffers using
a single constraint (replicas only, percentage only, or limits only) are unaffected.


**How was this change tested?**

Unit tests and make presubmit 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
