### PR TITLE
chore: bump Go to 1.26.5 to fix GO-2026-5856 vulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Bump Go to 1.26.5 to fix GO-2026-5856 vulncheck

**How was this change tested?**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
