### PR TITLE
fix!: reset unschedulable_pods_count metric to 0 when no pods are pending

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -380,6 +380,9 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	pods := append(pendingPods, deletingNodePods...)
 	// nothing to schedule, so just return success
 	if len(pods) == 0 {
+		// No pods means no unschedulable pods either -- Solve() won't run to report this, so
+		// reset it directly or it will keep reporting its last value indefinitely.
+		scheduler.UnschedulablePodsCount.Set(0, nil)
 		return scheduler.Results{}, nil
 	}
 	deletingPodUIDs := sets.New(lo.Map(deletingNodePods, func(p *corev1.Pod, _ int) types.UID { return p.UID })...)
@@ -432,9 +435,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	scheduler.UnschedulablePodsCount.Set(
 		// A reserved offering error doesn't indicate a pod is unschedulable, just that the scheduling decision was deferred.
 		float64(len(results.PodErrors)-len(reservedOfferingErrors)),
-		map[string]string{
-			scheduler.ControllerLabel: injection.GetControllerName(ctx),
-		},
+		nil,
 	)
 	if len(results.NewNodeClaims) > 0 {
 		log.FromContext(ctx).WithValues(

--- a/pkg/controllers/provisioning/scheduling/metrics.go
+++ b/pkg/controllers/provisioning/scheduling/metrics.go
@@ -88,9 +88,7 @@ var (
 			Name:      "unschedulable_pods_count",
 			Help:      "The number of unschedulable Pods.",
 		},
-		[]string{
-			ControllerLabel,
-		},
+		[]string{},
 	)
 	PendingPodsByEffectiveZone = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -446,7 +446,9 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, err
 	// We need to schedule them alternating, A, B, A, B, .... and this solution also solves that as well.
 	podErrors := map[*corev1.Pod]error{}
 	// Reset the metric for the controller, so we don't keep old ids around
-	UnschedulablePodsCount.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
+	// UnschedulablePodsCount is intentionally not touched here: it carries no scheduling-run-scoped
+	// labels, and it's only ever set from the provisioning controller (see provisioner.go), which
+	// resets it to 0 directly once there's nothing left to schedule.
 	PendingPodsByEffectiveZone.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
 	QueueDepth.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
 	podCountByZone := make(map[string]int)

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -4380,10 +4380,48 @@ var _ = Context("Scheduling", func() {
 				ExpectApplied(ctx, env.Client, i)
 			}
 			_, err := prov.Schedule(injection.WithControllerName(ctx, "provisioner"))
-			m, ok := FindMetricWithLabelValues("karpenter_scheduler_unschedulable_pods_count", map[string]string{"controller": "provisioner"})
+			m, ok := FindMetricWithLabelValues("karpenter_scheduler_unschedulable_pods_count", nil)
 			Expect(ok).To(BeTrue())
 			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", 10))
 			Expect(err).To(BeNil())
+		})
+		It("should reset the UnschedulablePodsCount metric to 0 once all unschedulable pods clear", func() {
+			nodePool = test.NodePool(v1.NodePool{
+				Spec: v1.NodePoolSpec{
+					Template: v1.NodeClaimTemplate{
+						Spec: v1.NodeClaimTemplateSpec{
+							Requirements: []v1.NodeSelectorRequirementWithMinValues{
+								{
+									Key:      corev1.LabelInstanceTypeStable,
+									Operator: corev1.NodeSelectorOpIn,
+									Values: []string{
+										"default-instance-type",
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodePool)
+			podsUnschedulable := test.UnschedulablePods(test.PodOptions{NodeSelector: map[string]string{corev1.LabelInstanceTypeStable: "unknown"}}, 10)
+			for _, i := range podsUnschedulable {
+				ExpectApplied(ctx, env.Client, i)
+			}
+			_, err := prov.Schedule(injection.WithControllerName(ctx, "provisioner"))
+			Expect(err).To(BeNil())
+			m, ok := FindMetricWithLabelValues("karpenter_scheduler_unschedulable_pods_count", nil)
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", 10))
+
+			// All unschedulable pods clear (deleted) -- there is nothing left pending, so the
+			// Schedule() loop exits early before Solve() ever runs.
+			ExpectDeleted(ctx, env.Client, lo.Map(podsUnschedulable, func(p *corev1.Pod, _ int) client.Object { return p })...)
+			_, err = prov.Schedule(injection.WithControllerName(ctx, "provisioner"))
+			Expect(err).To(BeNil())
+			m, ok = FindMetricWithLabelValues("karpenter_scheduler_unschedulable_pods_count", nil)
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", 0))
 		})
 		It("should surface the schedulingDuration metric after executing a scheduling loop", func() {
 			nodePool = test.NodePool()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #1993

**Description**

`karpenter_scheduler_unschedulable_pods_count` is only ever `.Set()` from the provisioning controller (`provisioner.go`), never from disruption, so the `DeletePartialMatch` on it at the top of every `Scheduler.Solve()` call was dead code when invoked from the disruption path — removed. Since the metric is provisioning-only, the now-unnecessary `controller` label is also dropped from the metric definition and both `.Set()` call sites, matching the other zero-label gauges in this file (e.g. `IgnoredPodCount`).

Two prior attempts at this issue (#2049, #2006) were closed without addressing review feedback: in both, @jonathan-innis pointed out that simply removing the delete isn't sufficient on its own, since the metric also needs to be reset to 0 when the provisioning loop has no pending pods to process (`Schedule()` returns early before `Solve()`/`Set()` ever run, so the metric would otherwise keep reporting its last stale value indefinitely). This PR adds that explicit reset in the early-return path.

**How was this change tested?**

Added a test that drives 10 unschedulable pods to raise the metric to 10, then deletes them and re-reconciles, asserting the metric returns to 0. Confirmed it fails against the old code (metric stays stuck at 10) and passes with this fix.

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
