### PR TITLE
feat: publish pod event for insufficient capacity error

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -121,7 +121,7 @@ func NewControllers(
 		nodepoolvalidation.NewController(clock, kubeClient, cloudProvider),
 		podevents.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimconsistency.NewController(clock, kubeClient, cloudProvider, recorder),
-		nodeclaimlifecycle.NewController(clock, kubeClient, cloudProvider, recorder, npState, o.registrationHooks),
+		nodeclaimlifecycle.NewController(clock, kubeClient, cloudProvider, recorder, cluster, npState, o.registrationHooks),
 		nodeclaimgarbagecollection.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimdisruption.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimhydration.NewController(kubeClient, cloudProvider),

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -126,7 +126,7 @@ func NewControllers(
 		nodepoolvalidation.NewController(clock, kubeClient, cloudProvider),
 		podevents.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimconsistency.NewController(clock, kubeClient, cloudProvider, recorder),
-		nodeclaimlifecycle.NewController(clock, kubeClient, cloudProvider, recorder, npState, o.registrationHooks),
+		nodeclaimlifecycle.NewController(clock, kubeClient, cloudProvider, recorder, cluster, npState, o.registrationHooks),
 		nodeclaimgarbagecollection.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimdisruption.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimhydration.NewController(kubeClient, cloudProvider),

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	nodeclaimgarbagecollection "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/garbagecollection"
 	nodeclaimlifcycle "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
@@ -50,6 +51,7 @@ var (
 	garbageCollectionController *nodeclaimgarbagecollection.Controller
 	env                         *test.Environment
 	cloudProvider               *fake.CloudProvider
+	cluster                     *state.Cluster
 )
 
 func TestAPIs(t *testing.T) {
@@ -62,8 +64,9 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...), test.WithFieldIndexers(test.NodeProviderIDFieldIndexer(ctx)))
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
+	cluster = state.NewCluster(env.Clock, env.Client, cloudProvider)
 	garbageCollectionController = nodeclaimgarbagecollection.NewController(env.Clock, env.Client, cloudProvider)
-	nodeClaimController = nodeclaimlifcycle.NewController(env.Clock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(), nil)
+	nodeClaimController = nodeclaimlifcycle.NewController(env.Clock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(), nil)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -78,7 +79,7 @@ type Controller struct {
 	liveness       *Liveness
 }
 
-func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, nodePoolState *nodepoolhealth.State, registrationHooks []cloudprovider.NodeLifecycleHook) *Controller {
+func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, cluster *state.Cluster, nodePoolState *nodepoolhealth.State, registrationHooks []cloudprovider.NodeLifecycleHook) *Controller {
 	return &Controller{
 		clock:         clk,
 		kubeClient:    kubeClient,
@@ -86,7 +87,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider clou
 		recorder:      recorder,
 		nodePoolState: nodePoolState,
 
-		launch:         &Launch{kubeClient: kubeClient, cloudProvider: cloudProvider, cache: cache.New(time.Hour, time.Minute), recorder: recorder, clock: clk},
+		launch:         &Launch{kubeClient: kubeClient, cloudProvider: cloudProvider, cluster: cluster, cache: cache.New(time.Hour, time.Minute), recorder: recorder, clock: clk},
 		registration:   &Registration{kubeClient: kubeClient, recorder: recorder, npState: nodePoolState, registrationHooks: registrationHooks, clock: clk},
 		initialization: &Initialization{kubeClient: kubeClient, clock: clk},
 		liveness:       &Liveness{clock: clk, kubeClient: kubeClient, npState: nodePoolState},

--- a/pkg/controllers/nodeclaim/lifecycle/events.go
+++ b/pkg/controllers/nodeclaim/lifecycle/events.go
@@ -35,6 +35,16 @@ func InsufficientCapacityErrorEvent(nodeClaim *v1.NodeClaim, err error) events.E
 	}
 }
 
+func InsufficientCapacityErrorPodEvent(pod *corev1.Pod, nodeClaim *v1.NodeClaim, err error) events.Event {
+	return events.Event{
+		InvolvedObject: pod,
+		Type:           corev1.EventTypeWarning,
+		Reason:         events.InsufficientCapacityError,
+		Message:        fmt.Sprintf("NodeClaim %s nominated for this pod failed to launch: %s", nodeClaim.Name, truncateMessage(err.Error())),
+		DedupeValues:   []string{string(pod.UID)},
+	}
+}
+
 func NodeClassNotReadyEvent(nodeClaim *v1.NodeClaim, err error) events.Event {
 	return events.Event{
 		InvolvedObject: nodeClaim,

--- a/pkg/controllers/nodeclaim/lifecycle/events.go
+++ b/pkg/controllers/nodeclaim/lifecycle/events.go
@@ -30,7 +30,7 @@ func InsufficientCapacityErrorEvent(nodeClaim *v1.NodeClaim, err error) events.E
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
 		Reason:         events.InsufficientCapacityError,
-		Message:        fmt.Sprintf("NodeClaim %s event: %s", nodeClaim.Name, truncateMessage(err.Error())),
+		Message:        truncateMessage(fmt.Sprintf("NodeClaim %s event: %s", nodeClaim.Name, err.Error())),
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}
 }
@@ -40,7 +40,7 @@ func InsufficientCapacityErrorPodEvent(pod *corev1.Pod, nodeClaim *v1.NodeClaim,
 		InvolvedObject: pod,
 		Type:           corev1.EventTypeWarning,
 		Reason:         events.InsufficientCapacityError,
-		Message:        fmt.Sprintf("NodeClaim %s nominated for this pod failed to launch: %s", nodeClaim.Name, truncateMessage(err.Error())),
+		Message:        truncateMessage(fmt.Sprintf("NodeClaim %s nominated for this pod failed to launch: %s", nodeClaim.Name, err.Error())),
 		DedupeValues:   []string{string(pod.UID)},
 	}
 }
@@ -50,7 +50,7 @@ func NodeClassNotReadyEvent(nodeClaim *v1.NodeClaim, err error) events.Event {
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
 		Reason:         events.NodeClassNotReady,
-		Message:        fmt.Sprintf("NodeClaim %s event: %s", nodeClaim.Name, truncateMessage(err.Error())),
+		Message:        truncateMessage(fmt.Sprintf("NodeClaim %s event: %s", nodeClaim.Name, err.Error())),
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}
 }

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -32,13 +32,16 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
+	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
 type Launch struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
+	cluster       *state.Cluster
 	cache         *cache.Cache // exists due to eventual consistency on the cache
 	recorder      events.Recorder
 	clock         clock.Clock
@@ -84,6 +87,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 		switch {
 		case cloudprovider.IsInsufficientCapacityError(err):
 			l.recorder.Publish(InsufficientCapacityErrorEvent(nodeClaim, err))
+			l.publishNominatedPodEvents(ctx, nodeClaim, err)
 			log.FromContext(ctx).Error(err, "failed launching nodeclaim")
 
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
@@ -123,6 +127,26 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 		"capacity-type", created.Labels[v1.CapacityTypeLabelKey],
 		"allocatable", created.Status.Allocatable).Info("launched nodeclaim")
 	return created, nil
+}
+
+// publishNominatedPodEvents emits an InsufficientCapacityError event for each pod that was nominated to schedule
+// against the NodeClaim, so that users can discover that insufficient capacity is preventing their pods from
+// scheduling without requiring access to the Karpenter logs.
+func (l *Launch) publishNominatedPodEvents(ctx context.Context, nodeClaim *v1.NodeClaim, launchErr error) {
+	for _, podKey := range l.cluster.NominatedPodsForNodeClaim(nodeClaim.Name) {
+		pod := &corev1.Pod{}
+		// This also skips CapacityBuffer virtual pods since they never exist in the API server
+		if err := l.kubeClient.Get(ctx, podKey, pod); err != nil {
+			continue
+		}
+		// Only emit events for pods that are still unscheduled and alive. Between the nomination and this
+		// launch failure, the pod may have been bound to a node (still in Pending phase while its containers
+		// start), reached a terminal phase, or been deleted. In any of those cases, the event would be misleading.
+		if podutils.IsScheduled(pod) || podutils.IsTerminal(pod) || podutils.IsTerminating(pod) {
+			continue
+		}
+		l.recorder.Publish(InsufficientCapacityErrorPodEvent(pod, nodeClaim, launchErr))
+	}
 }
 
 func PopulateNodeClaimDetails(nodeClaim, retrieved *v1.NodeClaim) *v1.NodeClaim {

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -39,6 +39,13 @@ import (
 	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
+const (
+	// maxEventMessageLength is the maximum length of an Event message. Kubernetes rejects Events whose message
+	// exceeds this limit at validation time, so the message has to be truncated before the Event is created.
+	// https://github.com/kubernetes/kubernetes/blob/564b0e55c7007745500d579356897848aaacb9dd/pkg/apis/core/validation/events.go#L38
+	maxEventMessageLength = 1024
+)
+
 type Launch struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
@@ -169,9 +176,11 @@ func PopulateNodeClaimDetails(nodeClaim, retrieved *v1.NodeClaim) *v1.NodeClaim 
 	return nodeClaim
 }
 
+// truncateMessage truncates the message so that it fits within the Event message length limit.
 func truncateMessage(msg string) string {
-	if len(msg) < 300 {
+	if len(msg) <= maxEventMessageLength {
 		return msg
 	}
-	return msg[:300] + "..."
+	const suffix = "..."
+	return msg[:maxEventMessageLength-len(suffix)] + suffix
 }

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -32,14 +32,17 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
+	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
 type Launch struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
+	cluster       *state.Cluster
 	cache         *cache.Cache // exists due to eventual consistency on the cache
 	recorder      events.Recorder
 	clock         clock.Clock
@@ -85,6 +88,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 		switch {
 		case cloudprovider.IsInsufficientCapacityError(err):
 			l.recorder.Publish(InsufficientCapacityErrorEvent(nodeClaim, err))
+			l.publishNominatedPodEvents(ctx, nodeClaim, err)
 			log.FromContext(ctx).Error(err, "failed launching nodeclaim")
 
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
@@ -128,6 +132,26 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 		"capacity-type", created.Labels[v1.CapacityTypeLabelKey],
 		"allocatable", created.Status.Allocatable).Info("launched nodeclaim")
 	return created, nil
+}
+
+// publishNominatedPodEvents emits an InsufficientCapacityError event for each pod that was nominated to schedule
+// against the NodeClaim, so that users can discover that insufficient capacity is preventing their pods from
+// scheduling without requiring access to the Karpenter logs.
+func (l *Launch) publishNominatedPodEvents(ctx context.Context, nodeClaim *v1.NodeClaim, launchErr error) {
+	for _, podKey := range l.cluster.NominatedPodsForNodeClaim(nodeClaim.Name) {
+		pod := &corev1.Pod{}
+		// This also skips CapacityBuffer virtual pods since they never exist in the API server
+		if err := l.kubeClient.Get(ctx, podKey, pod); err != nil {
+			continue
+		}
+		// Only emit events for pods that are still unscheduled and alive. Between the nomination and this
+		// launch failure, the pod may have been bound to a node (still in Pending phase while its containers
+		// start), reached a terminal phase, or been deleted. In any of those cases, the event would be misleading.
+		if podutils.IsScheduled(pod) || podutils.IsTerminal(pod) || podutils.IsTerminating(pod) {
+			continue
+		}
+		l.recorder.Publish(InsufficientCapacityErrorPodEvent(pod, nodeClaim, launchErr))
+	}
 }
 
 func PopulateNodeClaimDetails(nodeClaim, retrieved *v1.NodeClaim) *v1.NodeClaim {

--- a/pkg/controllers/nodeclaim/lifecycle/launch_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch_test.go
@@ -22,10 +22,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
@@ -93,6 +95,33 @@ var _ = Describe("Launch", func() {
 		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
 		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
 		ExpectNotFound(ctx, env.Client, nodeClaim)
+	})
+	It("should emit InsufficientCapacityError events for the pods nominated to the nodeclaim", func() {
+		recorder.Reset()
+		cloudProvider.NextCreateErr = cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all instance types were unavailable"))
+		nodeClaim := test.NodeClaim()
+		pod := test.Pod()
+		scheduledPod := test.Pod(test.PodOptions{NodeName: "scheduled-node"})
+		ExpectApplied(ctx, env.Client, nodeClaim, pod, scheduledPod)
+		cluster.UpdatePodToNodeClaimMapping(map[string][]*corev1.Pod{nodeClaim.Name: {pod, scheduledPod}})
+
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
+		ExpectNotFound(ctx, env.Client, nodeClaim)
+
+		var podEventNames []string
+		recorder.ForEachEvent(func(evt events.Event) {
+			if evt.Reason != events.InsufficientCapacityError {
+				return
+			}
+			if p, ok := evt.InvolvedObject.(*corev1.Pod); ok {
+				podEventNames = append(podEventNames, p.Name)
+				Expect(evt.Message).To(ContainSubstring(nodeClaim.Name))
+				Expect(evt.Message).To(ContainSubstring("all instance types were unavailable"))
+			}
+		})
+		// The event should only be emitted for the pod that is still unscheduled
+		Expect(podEventNames).To(ConsistOf(pod.Name))
 	})
 	It("should delete the nodeclaim if NodeClassNotReady is returned from the cloudprovider", func() {
 		cloudProvider.NextCreateErr = cloudprovider.NewNodeClassNotReadyError(fmt.Errorf("nodeClass isn't ready"))

--- a/pkg/controllers/nodeclaim/lifecycle/registration_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration_test.go
@@ -667,7 +667,7 @@ var _ = Describe("Registration", func() {
 	Context("RegistrationHooks", func() {
 		It("should complete registration when a single hook passes", func() {
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(),
 				[]cloudprovider.NodeLifecycleHook{
 					testHook{
 						name: "always-pass",
@@ -696,7 +696,7 @@ var _ = Describe("Registration", func() {
 		})
 		It("should defer registration when a hook returns false", func() {
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(),
 				[]cloudprovider.NodeLifecycleHook{
 					testHook{
 						name: "capacity-reservation",
@@ -732,7 +732,7 @@ var _ = Describe("Registration", func() {
 		})
 		It("should return error when a hook returns an error", func() {
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(),
 				[]cloudprovider.NodeLifecycleHook{
 					testHook{
 						name: "failing-hook",
@@ -761,7 +761,7 @@ var _ = Describe("Registration", func() {
 		})
 		It("should defer registration when the second hook returns false with multiple hooks", func() {
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(),
 				[]cloudprovider.NodeLifecycleHook{
 					testHook{
 						name: "pass-hook",
@@ -798,7 +798,7 @@ var _ = Describe("Registration", func() {
 		})
 		It("should complete registration when multiple hooks all pass", func() {
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(),
 				[]cloudprovider.NodeLifecycleHook{
 					testHook{
 						name: "hook-one",
@@ -834,7 +834,7 @@ var _ = Describe("Registration", func() {
 		It("should call all hooks in parallel and list all pending hooks in status", func() {
 			var secondHookCalls atomic.Int32
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(),
 				[]cloudprovider.NodeLifecycleHook{
 					testHook{
 						name: "blocking-hook",
@@ -876,7 +876,7 @@ var _ = Describe("Registration", func() {
 		It("should complete registration after a hook transitions from not ready to ready", func() {
 			ready := atomic.Bool{}
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(),
 				[]cloudprovider.NodeLifecycleHook{
 					testHook{
 						name: "eventually-ready",
@@ -916,7 +916,7 @@ var _ = Describe("Registration", func() {
 		})
 		It("should complete registration with empty hooks slice", func() {
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(), []cloudprovider.NodeLifecycleHook{})
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(), []cloudprovider.NodeLifecycleHook{})
 			nodeClaim := test.NodeClaim(v1.NodeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name},
@@ -936,7 +936,7 @@ var _ = Describe("Registration", func() {
 		})
 		It("should complete registration with nil hooks slice", func() {
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(), nil)
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(), nil)
 			nodeClaim := test.NodeClaim(v1.NodeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name},
@@ -956,7 +956,7 @@ var _ = Describe("Registration", func() {
 		})
 		It("should propagate labels added by a registration hook to both the node and the nodeclaim", func() {
 			hookController := nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider,
-				events.NewRecorder(&record.FakeRecorder{}), nodepoolhealth.NewState(),
+				events.NewRecorder(&record.FakeRecorder{}), cluster, nodepoolhealth.NewState(),
 				[]cloudprovider.NodeLifecycleHook{
 					testHook{
 						name: "label-mutating-hook",

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -41,6 +41,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	nodeclaimlifecycle "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
@@ -57,6 +58,7 @@ var (
 	nodeClaimController *nodeclaimlifecycle.Controller
 	env                 *test.Environment
 	cloudProvider       *fake.CloudProvider
+	cluster             *state.Cluster
 	recorder            *test.EventRecorder
 	npState             *nodepoolhealth.State
 )
@@ -85,8 +87,9 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 
 	cloudProvider = fake.NewCloudProvider()
+	cluster = state.NewCluster(env.Clock, env.Client, cloudProvider)
 	npState = nodepoolhealth.NewState()
-	nodeClaimController = nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider, recorder, npState, nil)
+	nodeClaimController = nodeclaimlifecycle.NewController(env.Clock, env.Client, cloudProvider, recorder, cluster, npState, nil)
 })
 
 var _ = AfterSuite(func() {
@@ -97,6 +100,7 @@ var _ = AfterEach(func() {
 	env.Clock.SetTime(time.Now())
 	ExpectCleanedUp(ctx, env.Client)
 	cloudProvider.Reset()
+	cluster.Reset()
 })
 
 var _ = Describe("Finalizer", func() {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -558,6 +558,19 @@ func (c *Cluster) PodNodeClaimMapping(podKey types.NamespacedName) string {
 	return ""
 }
 
+// NominatedPodsForNodeClaim returns the keys of the pods that were simulated to schedule against the given nodeClaim
+// during the most recent scheduling decision for each pod
+func (c *Cluster) NominatedPodsForNodeClaim(nodeClaimName string) []types.NamespacedName {
+	var podKeys []types.NamespacedName
+	c.podToNodeClaim.Range(func(k, v any) bool {
+		if v.(string) == nodeClaimName {
+			podKeys = append(podKeys, k.(types.NamespacedName))
+		}
+		return true
+	})
+	return podKeys
+}
+
 // PodSchedulingSuccessTimeRegistrationHealthyCheck returns when Karpenter first thought it could schedule a pod in its scheduling simulation.
 // This returns 0, false if the pod was never considered in scheduling as a pending pod.
 func (c *Cluster) PodSchedulingSuccessTimeRegistrationHealthyCheck(podKey types.NamespacedName) time.Time {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -566,6 +566,19 @@ func (c *Cluster) PodNodeClaimMapping(podKey types.NamespacedName) string {
 	return ""
 }
 
+// NominatedPodsForNodeClaim returns the keys of the pods that were simulated to schedule against the given nodeClaim
+// during the most recent scheduling decision for each pod
+func (c *Cluster) NominatedPodsForNodeClaim(nodeClaimName string) []types.NamespacedName {
+	var podKeys []types.NamespacedName
+	c.podToNodeClaim.Range(func(k, v any) bool {
+		if v.(string) == nodeClaimName {
+			podKeys = append(podKeys, k.(types.NamespacedName))
+		}
+		return true
+	})
+	return podKeys
+}
+
 // PodSchedulingSuccessTimeRegistrationHealthyCheck returns when Karpenter first thought it could schedule a pod in its scheduling simulation.
 // This returns 0, false if the pod was never considered in scheduling as a pending pod.
 func (c *Cluster) PodSchedulingSuccessTimeRegistrationHealthyCheck(podKey types.NamespacedName) time.Time {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/kubernetes-sigs/karpenter/issues/2159
Ref: https://github.com/aws/karpenter-provider-aws/issues/4346

**Description**

When a NodeClaim launch fails with an insufficient capacity error, Karpenter deletes the NodeClaim and logs the failure, but nothing is surfaced on the pods that were waiting for that capacity. Users constrained to specific instance types or zones (e.g. via node selectors) just see their pods stuck in Pending with no indication of why, and confirming an `InsufficientCapacityError` requires access to the Karpenter controller logs. This has been a recurring source of support escalations for cluster operators.

This change makes the launch failure visible where users actually look (i.e., on the pod). When cloud provider returns an insufficient capacity error, the nodeclaim lifecycle controller now publishes a warning event with `InsufficientCapacityError` reason on every pod that was nominated to schedule against the failed NodeClaim, alongside the existing NodeClaim event.

```
Warning  InsufficientCapacityError  NodeClaim default-xxxxx, nominated for this pod failed to launch: InsufficientInstanceCapacity: We currently do not have sufficient g5.12xlarge capacity in the Availability Zone you requested (us-west-2a). Our system will be working on provisioning additional capacity. You can currently get g5.12xlarge capacity by not specifying an Availability Zone in your request or choosing us-west-2b, us-west-2c.
```

A few notes on the implementation:

- The launch controller is the only place where the `InsufficientCapacityError` actually surfaces, but a NodeClaim doesn't carry any record of the pods it was created for. Rather than adding a new annotation or status field to the NodeClaim, this reuses the Pod→NodeClaim mapping that cluster state already maintains for scheduling latency metrics and wiring cluster state into the lifecycle controller.
- Pods that have been scheduled elsewhere, are terminal, or are terminating in the meantime are skipped, since the event would be stale or misleading for them. `CapacityBuffer` virtual pods are also skipped naturally, since they never exist in the API server.
- Events are deduped per pod UID by the event recorder, using its default 2-minute window. While insufficient capacity persists, each provisioning loop creates a NodeClaim with a new name and hits `InsufficientCapacityError` again, but since the suppression is keyed on the reason and pod UID only (not the message), a pod gets at most one event every 2 minutes rather than one per retry.

**How was this change tested?**

Added a test to the lifecycle suite verifying that on an `InsufficientCapacityError` launch failure the event is emitted for the nominated pending pod and not for an already-scheduled one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
