### PR TITLE
fix: prevent scheduling starvation with attempt-count fairness

### DIFF
--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -125,7 +125,7 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 		return client.ObjectKeyFromObject(p), nil
 	})
 
-	results, err := scheduler.Solve(log.IntoContext(ctx, operatorlogging.NopLogger), pods)
+	results, err := scheduler.Solve(log.IntoContext(ctx, operatorlogging.NopLogger), pods, nil)
 	if err != nil {
 		return scheduling.Results{}, fmt.Errorf("scheduling pods, %w", err)
 	}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -89,6 +89,9 @@ type Provisioner struct {
 	cm                         *pretty.ChangeMonitor
 	clock                      clock.Clock
 	deviceAllocationController *deviceallocation.Controller
+	// attemptCounts tracks how many scheduling loops each pod has been evaluated in.
+	// Used to ensure fairness: pods with fewer attempts are scheduled first.
+	attemptCounts map[types.UID]int
 }
 
 func NewProvisioner(kubeClient client.Client, recorder events.Recorder,
@@ -105,6 +108,7 @@ func NewProvisioner(kubeClient client.Client, recorder events.Recorder,
 		cm:                         pretty.NewChangeMonitor(),
 		clock:                      clock,
 		deviceAllocationController: deviceAllocationController,
+		attemptCounts:              make(map[types.UID]int),
 	}
 	return p
 }
@@ -415,10 +419,21 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	results, err := s.Solve(timeoutCtx, pods)
+	results, err := s.Solve(timeoutCtx, pods, p.attemptCounts)
 	// context errors are ignored because we want to finish provisioning for what has already been scheduled
 	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		return scheduler.Results{}, err
+	}
+	// Update attempt counts: increment for all pods in this batch, then prune
+	// entries for pods no longer pending to prevent memory leaks.
+	pendingUIDs := sets.New(lo.Map(pods, func(po *corev1.Pod, _ int) types.UID { return po.UID })...)
+	for _, po := range pods {
+		p.attemptCounts[po.UID]++
+	}
+	for uid := range p.attemptCounts {
+		if !pendingUIDs.Has(uid) {
+			delete(p.attemptCounts, uid)
+		}
 	}
 	results = results.TruncateInstanceTypes(ctx, scheduler.MaxInstanceTypes)
 	reservedOfferingErrors := results.ReservedOfferingErrors()

--- a/pkg/controllers/provisioning/scheduling/queue.go
+++ b/pkg/controllers/provisioning/scheduling/queue.go
@@ -33,9 +33,11 @@ type Queue struct {
 	lastLen map[types.UID]int
 }
 
-// NewQueue constructs a new queue given the input pods, sorting them to optimize for bin-packing into nodes.
-func NewQueue(pods []*v1.Pod, podData map[types.UID]*PodData) *Queue {
-	sort.Slice(pods, byCPUAndMemoryDescending(pods, podData))
+// NewQueue constructs a new queue given the input pods, sorting them to ensure fairness
+// across scheduling loops. Pods with fewer prior scheduling attempts are evaluated first,
+// with CPU/memory descending as a tiebreaker within the same attempt count for bin-packing.
+func NewQueue(pods []*v1.Pod, podData map[types.UID]*PodData, attemptCounts map[types.UID]int) *Queue {
+	sort.Slice(pods, byAttemptsThenCPUAndMemory(pods, podData, attemptCounts))
 	return &Queue{
 		pods:    pods,
 		lastLen: map[types.UID]int{},
@@ -67,6 +69,19 @@ func (q *Queue) Push(pod *v1.Pod) {
 
 func (q *Queue) List() []*v1.Pod {
 	return q.pods
+}
+
+func byAttemptsThenCPUAndMemory(pods []*v1.Pod, podData map[types.UID]*PodData, attemptCounts map[types.UID]int) func(i int, j int) bool {
+	if len(attemptCounts) == 0 {
+		return byCPUAndMemoryDescending(pods, podData)
+	}
+	return func(i, j int) bool {
+		ci, cj := attemptCounts[pods[i].UID], attemptCounts[pods[j].UID]
+		if ci != cj {
+			return ci < cj
+		}
+		return byCPUAndMemoryDescending(pods, podData)(i, j)
+	}
 }
 
 func byCPUAndMemoryDescending(pods []*v1.Pod, podData map[types.UID]*PodData) func(i int, j int) bool {

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -437,7 +437,7 @@ func (r Results) TruncateInstanceTypes(ctx context.Context, maxInstanceTypes int
 }
 
 //nolint:gocyclo
-func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, error) {
+func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod, attemptCounts map[types.UID]int) (Results, error) {
 	defer metrics.Measure(DurationSeconds, map[string]string{ControllerLabel: injection.GetControllerName(ctx)})()
 	// We loop trying to schedule unschedulable pods as long as we are making progress.  This solves a few
 	// issues including pods with affinity to another pod in the batch. We could topo-sort to solve this, but it wouldn't
@@ -458,7 +458,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, err
 		}
 	}
 
-	q := NewQueue(pods, s.cachedPodData)
+	q := NewQueue(pods, s.cachedPodData, attemptCounts)
 
 	startTime := s.clock.Now()
 	for {


### PR DESCRIPTION
When the number of pending pods exceeds what the scheduler can evaluate within its 1-minute timeout, pods at the tail of the queue are never evaluated. The queue is sorted by CPU/memory descending, so the same high-resource pods are always processed first and the same low-resource pods are permanently starved.

This commit introduces attempt-count fairness: the Provisioner tracks how many scheduling loops each pod has been through, and the queue sorts by attempt-count ascending first (then CPU/memory for bin-packing within the same count). This guarantees every pod is evaluated within 2 scheduling loops regardless of queue depth.

The fix adds minimal overhead (one map lookup per pod per sort) and preserves bin-packing behavior within each fairness band.

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
