### PR TITLE
feat: allow CPU NodeOverlay capacity overrides

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodeoverlays.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodeoverlays.yaml
@@ -60,13 +60,14 @@ spec:
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   description: |-
-                    Capacity adds extended resources only, and does not replace any existing resources.
-                    These extended resources are appended to the node's existing resource list.
-                    Note: This field does not modify or override standard resources like cpu, memory, ephemeral-storage, or pods.
+                    Capacity adds resources for scheduling simulation and does not replace any existing resources.
+                    These resources are appended to the node's existing resource list.
+                    Note: This field does not modify or override standard resources like memory, ephemeral-storage, or pods.
+                    CPU overlays are supported to calibrate simulations for cases where effective CPU differs from cloud instance metadata (for example, SMT-disabled nodes).
                   type: object
                   x-kubernetes-validations:
                     - message: invalid resource restricted
-                      rule: self.all(x, !(x in ['cpu', 'memory', 'ephemeral-storage', 'pods']))
+                      rule: self.all(x, !(x in ['memory', 'ephemeral-storage', 'pods']))
                 price:
                   description: Price specifies amount for an instance types that match the specified labels. Users can override prices using a signed float representing the price override
                   pattern: ^\d+(\.\d+)?$

--- a/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
@@ -60,13 +60,14 @@ spec:
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   description: |-
-                    Capacity adds extended resources only, and does not replace any existing resources.
-                    These extended resources are appended to the node's existing resource list.
-                    Note: This field does not modify or override standard resources like cpu, memory, ephemeral-storage, or pods.
+                    Capacity adds resources for scheduling simulation and does not replace any existing resources.
+                    These resources are appended to the node's existing resource list.
+                    Note: This field does not modify or override standard resources like memory, ephemeral-storage, or pods.
+                    CPU overlays are supported to calibrate simulations for cases where effective CPU differs from cloud instance metadata (for example, SMT-disabled nodes).
                   type: object
                   x-kubernetes-validations:
                     - message: invalid resource restricted
-                      rule: self.all(x, !(x in ['cpu', 'memory', 'ephemeral-storage', 'pods']))
+                      rule: self.all(x, !(x in ['memory', 'ephemeral-storage', 'pods']))
                 price:
                   description: Price specifies amount for an instance types that match the specified labels. Users can override prices using a signed float representing the price override
                   pattern: ^\d+(\.\d+)?$

--- a/pkg/apis/v1alpha1/nodeoverlay.go
+++ b/pkg/apis/v1alpha1/nodeoverlay.go
@@ -81,10 +81,12 @@ type NodeOverlaySpec struct {
 	// +optional
 	Price *string `json:"price,omitempty"`
 	//nolint:kubeapilinter
-	// Capacity adds extended resources only, and does not replace any existing resources.
-	// These extended resources are appended to the node's existing resource list.
-	// Note: This field does not modify or override standard resources like cpu, memory, ephemeral-storage, or pods.
-	// +kubebuilder:validation:XValidation:message="invalid resource restricted",rule="self.all(x, !(x in ['cpu', 'memory', 'ephemeral-storage', 'pods']))"
+	// Capacity adds resources for scheduling simulation and does not replace any existing resources.
+	// These resources are appended to the node's existing resource list.
+	// Note: This field does not modify or override standard resources like memory, ephemeral-storage, or pods.
+	// CPU overlays are supported to calibrate simulations for cases where effective CPU differs from
+	// cloud instance metadata (for example, SMT-disabled nodes).
+	// +kubebuilder:validation:XValidation:message="invalid resource restricted",rule="self.all(x, !(x in ['memory', 'ephemeral-storage', 'pods']))"
 	// +optional
 	Capacity corev1.ResourceList `json:"capacity,omitempty"`
 	//nolint:kubeapilinter

--- a/pkg/apis/v1alpha1/nodeoverlay_validation.go
+++ b/pkg/apis/v1alpha1/nodeoverlay_validation.go
@@ -48,7 +48,8 @@ func (in *NodeOverlaySpec) validateRequirements(ctx context.Context) (errs error
 
 func (in *NodeOverlaySpec) validateCapacity() (errs error) {
 	for n := range in.Capacity {
-		if v1.WellKnownResources.Has(n) {
+		// CPU is intentionally supported for simulation calibration use cases (e.g. SMT disabled nodes).
+		if n == corev1.ResourceMemory || n == corev1.ResourceEphemeralStorage || n == corev1.ResourcePods {
 			errs = multierr.Append(errs, fmt.Errorf("invalid capacity: %s in resource, restricted", n))
 		}
 	}

--- a/pkg/apis/v1alpha1/nodeoverlay_validation_test.go
+++ b/pkg/apis/v1alpha1/nodeoverlay_validation_test.go
@@ -352,16 +352,23 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(env.Client.Create(ctx, nodeOverlay)).To(Succeed())
 			Expect(nodeOverlay.RuntimeValidate(ctx)).To(Succeed())
 		})
-		It("should not allow cpu resources override", func() {
+		It("should allow cpu resources override", func() {
 			nodeOverlay.Spec.Capacity = corev1.ResourceList{
 				corev1.ResourceCPU: resource.MustParse("1"),
 			}
-			Expect(env.Client.Create(ctx, nodeOverlay)).ToNot(Succeed())
-			Expect(nodeOverlay.RuntimeValidate(ctx)).ToNot(Succeed())
+			Expect(env.Client.Create(ctx, nodeOverlay)).To(Succeed())
+			Expect(nodeOverlay.RuntimeValidate(ctx)).To(Succeed())
 		})
 		It("should not allow memory resources override", func() {
 			nodeOverlay.Spec.Capacity = corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("34Gi"),
+			}
+			Expect(env.Client.Create(ctx, nodeOverlay)).ToNot(Succeed())
+			Expect(nodeOverlay.RuntimeValidate(ctx)).ToNot(Succeed())
+		})
+		It("should not allow ephemeral-storage resources override", func() {
+			nodeOverlay.Spec.Capacity = corev1.ResourceList{
+				corev1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
 			}
 			Expect(env.Client.Create(ctx, nodeOverlay)).ToNot(Succeed())
 			Expect(nodeOverlay.RuntimeValidate(ctx)).ToNot(Succeed())


### PR DESCRIPTION
Fixes #3149

**Description**
- allow `NodeOverlay.spec.capacity` to include `cpu` while continuing to reject `memory`, `ephemeral-storage`, and `pods`
- update runtime validation (`validateCapacity`) to align with CPU-allowed behavior
- update NodeOverlay API/CRD validation text and generated CRD manifests to reflect this contract
- update validation tests to ensure CPU is accepted and restricted resources remain rejected

**How was this change tested?**
- [x] `go test ./pkg/apis/v1alpha1 -run TestDoesNotExist`
- [ ] `go test ./pkg/apis/v1alpha1/...` *(fails locally due to missing envtest binary `/usr/local/kubebuilder/bin/etcd`)*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.