### PR TITLE
fix: fix capacity and overhead override semantic

### DIFF
--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -172,54 +172,13 @@ var _ = Describe("Instance Type", func() {
 		Expect(groups[0].Allocatable[extendedResource]).To(BeZero())
 		Expect(groups[0].Offerings).To(HaveLen(2)) // two base offerings
 
-		// Override allocatable: has extended resource, reduced memory due to overhead override (max of base and override)
+		// Override allocatable: has extended resource, reduced memory due to overhead override (replaces base)
 		Expect(groups[1].Allocatable.Cpu().MilliValue()).To(BeNumerically("==", 3900))
 		expectedOverrideMem := resource.MustParse("13Gi")
 		Expect(groups[1].Allocatable.Memory().Value()).To(BeNumerically("==", expectedOverrideMem.Value()))
 		slotQty := groups[1].Allocatable[extendedResource]
 		Expect(slotQty.Value()).To(BeNumerically("==", 12))
 		Expect(groups[1].Offerings).To(HaveLen(2)) // two override offerings
-	})
-	It("should not reduce overhead when base overhead is greater than override", func() {
-		extendedResource := v1.ResourceName("test.com/extended-slots")
-		it := cloudprovider.InstanceType{
-			Capacity: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("4"),
-				v1.ResourceMemory: resource.MustParse("16Gi"),
-				v1.ResourcePods:   resource.MustParse("110"),
-			},
-			Overhead: &cloudprovider.InstanceTypeOverhead{
-				KubeReserved: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("100m"),
-					v1.ResourceMemory: resource.MustParse("5Gi"),
-				},
-			},
-			Offerings: []*cloudprovider.Offering{
-				{Available: true},
-				{
-					Available:        true,
-					CapacityOverride: v1.ResourceList{extendedResource: resource.MustParse("8")},
-					OverheadOverride: &cloudprovider.InstanceTypeOverhead{
-						SystemReserved: v1.ResourceList{v1.ResourceMemory: resource.MustParse("3Gi")},
-					},
-				},
-			},
-		}
-		groups := it.AllocatableOfferingsList()
-		Expect(groups).To(HaveLen(2))
-
-		// Base allocatable: memory = 16Gi - 5Gi = 11Gi
-		Expect(groups[0].Allocatable.Cpu().MilliValue()).To(BeNumerically("==", 3900))
-		expectedBaseMem := resource.MustParse("11Gi")
-		Expect(groups[0].Allocatable.Memory().Value()).To(BeNumerically("==", expectedBaseMem.Value()))
-
-		// Override allocatable: override overhead (3Gi) is less than base (5Gi), so base is preserved
-		// memory = 16Gi - 5Gi = 11Gi (NOT 16Gi - 3Gi = 13Gi)
-		Expect(groups[1].Allocatable.Cpu().MilliValue()).To(BeNumerically("==", 3900))
-		expectedOverrideMem := resource.MustParse("11Gi")
-		Expect(groups[1].Allocatable.Memory().Value()).To(BeNumerically("==", expectedOverrideMem.Value()))
-		slotQty := groups[1].Allocatable[extendedResource]
-		Expect(slotQty.Value()).To(BeNumerically("==", 8))
 	})
 	Context("AdjustedPrice", func() {
 		DescribeTable("should adjust price based overlay values",

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -172,13 +172,54 @@ var _ = Describe("Instance Type", func() {
 		Expect(groups[0].Allocatable[extendedResource]).To(BeZero())
 		Expect(groups[0].Offerings).To(HaveLen(2)) // two base offerings
 
-		// Override allocatable: has extended resource, reduced memory due to additional overhead
+		// Override allocatable: has extended resource, reduced memory due to overhead override (max of base and override)
 		Expect(groups[1].Allocatable.Cpu().MilliValue()).To(BeNumerically("==", 3900))
-		expectedOverrideMem := resource.MustParse("12Gi")
+		expectedOverrideMem := resource.MustParse("13Gi")
 		Expect(groups[1].Allocatable.Memory().Value()).To(BeNumerically("==", expectedOverrideMem.Value()))
 		slotQty := groups[1].Allocatable[extendedResource]
 		Expect(slotQty.Value()).To(BeNumerically("==", 12))
 		Expect(groups[1].Offerings).To(HaveLen(2)) // two override offerings
+	})
+	It("should not reduce overhead when base overhead is greater than override", func() {
+		extendedResource := v1.ResourceName("test.com/extended-slots")
+		it := cloudprovider.InstanceType{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("16Gi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+			Overhead: &cloudprovider.InstanceTypeOverhead{
+				KubeReserved: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+			},
+			Offerings: []*cloudprovider.Offering{
+				{Available: true},
+				{
+					Available:        true,
+					CapacityOverride: v1.ResourceList{extendedResource: resource.MustParse("8")},
+					OverheadOverride: &cloudprovider.InstanceTypeOverhead{
+						SystemReserved: v1.ResourceList{v1.ResourceMemory: resource.MustParse("3Gi")},
+					},
+				},
+			},
+		}
+		groups := it.AllocatableOfferingsList()
+		Expect(groups).To(HaveLen(2))
+
+		// Base allocatable: memory = 16Gi - 5Gi = 11Gi
+		Expect(groups[0].Allocatable.Cpu().MilliValue()).To(BeNumerically("==", 3900))
+		expectedBaseMem := resource.MustParse("11Gi")
+		Expect(groups[0].Allocatable.Memory().Value()).To(BeNumerically("==", expectedBaseMem.Value()))
+
+		// Override allocatable: override overhead (3Gi) is less than base (5Gi), so base is preserved
+		// memory = 16Gi - 5Gi = 11Gi (NOT 16Gi - 3Gi = 13Gi)
+		Expect(groups[1].Allocatable.Cpu().MilliValue()).To(BeNumerically("==", 3900))
+		expectedOverrideMem := resource.MustParse("11Gi")
+		Expect(groups[1].Allocatable.Memory().Value()).To(BeNumerically("==", expectedOverrideMem.Value()))
+		slotQty := groups[1].Allocatable[extendedResource]
+		Expect(slotQty.Value()).To(BeNumerically("==", 8))
 	})
 	Context("AdjustedPrice", func() {
 		DescribeTable("should adjust price based overlay values",

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -275,12 +275,7 @@ func (i *InstanceType) computeAllocatable(capacityOverride corev1.ResourceList, 
 	}
 	overhead := i.Overhead.Total()
 	if overheadOverride != nil {
-		overheadOverrideTotal := overheadOverride.Total()
-		for resource, overrideQuantity := range overheadOverrideTotal {
-			if baseQuantity, exists := overhead[resource]; !exists || overrideQuantity.Cmp(baseQuantity) > 0 {
-				overhead[resource] = overrideQuantity
-			}
-		}
+		overhead = lo.Assign(overhead, overheadOverride.Total())
 	}
 	allocatable := resources.Subtract(capacity, overhead)
 
@@ -483,8 +478,8 @@ type Offering struct {
 	// existing keys are replaced. If nil, the offering uses the base capacity as-is.
 	CapacityOverride corev1.ResourceList
 	// OverheadOverride specifies overhead overrides for this offering.
-	// For each resource, the maximum of the base overhead and the override value is used,
-	// ensuring overhead can only increase (never decrease). If nil, the offering uses the base overhead as-is.
+	// Values are merged with the instance type's base overhead — new keys are added,
+	// existing keys are replaced. If nil, the offering uses the base overhead as-is.
 	OverheadOverride *InstanceTypeOverhead
 
 	priceOverlayApplied bool

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -271,11 +271,16 @@ func (i *InstanceType) groupOfferingsByOverride() []AllocatableOfferings {
 func (i *InstanceType) computeAllocatable(capacityOverride corev1.ResourceList, overheadOverride *InstanceTypeOverhead) corev1.ResourceList {
 	capacity := i.Capacity
 	if len(capacityOverride) > 0 {
-		capacity = resources.Merge(i.Capacity, capacityOverride)
+		capacity = lo.Assign(i.Capacity, capacityOverride)
 	}
 	overhead := i.Overhead.Total()
 	if overheadOverride != nil {
-		overhead = resources.Merge(overhead, overheadOverride.Total())
+		overheadOverrideTotal := overheadOverride.Total()
+		for resource, overrideQuantity := range overheadOverrideTotal {
+			if baseQuantity, exists := overhead[resource]; !exists || overrideQuantity.Cmp(baseQuantity) > 0 {
+				overhead[resource] = overrideQuantity
+			}
+		}
 	}
 	allocatable := resources.Subtract(capacity, overhead)
 
@@ -478,8 +483,8 @@ type Offering struct {
 	// existing keys are replaced. If nil, the offering uses the base capacity as-is.
 	CapacityOverride corev1.ResourceList
 	// OverheadOverride specifies overhead overrides for this offering.
-	// Values are merged with the instance type's base overhead — new keys are added,
-	// existing keys are replaced. If nil, the offering uses the base overhead as-is.
+	// For each resource, the maximum of the base overhead and the override value is used,
+	// ensuring overhead can only increase (never decrease). If nil, the offering uses the base overhead as-is.
 	OverheadOverride *InstanceTypeOverhead
 
 	priceOverlayApplied bool


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
ComputeAllocatable previously used `resources.Merge` for both capacity and overhead overrides. `resources.Merge` is additive, it sums values for matching keys. This is incorrect because the intent is to specify an alternative value for a resource, not to add to the existing capacity.

- CapacityOverride and OverheadOverride: Switch from resources.Merge (additive) to lo.Assign (replace). Override values replace matching keys in base capacity, keys not in the override are preserved.

**How was this change tested?**
Updated unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
