### PR TITLE
fix: clear unbound-time metrics for pods stuck at PodScheduled=False

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -393,7 +393,10 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 		c.unscheduledPods.Insert(key)
 		return
 	}
-	if c.unscheduledPods.Has(key) && ok && cond.Status == corev1.ConditionTrue {
+	if !c.unscheduledPods.Has(key) {
+		return
+	}
+	if ok && cond.Status == corev1.ConditionTrue {
 		// Delete the unbound metric since the pod is now bound
 		PodUnboundTimeSeconds.Delete(map[string]string{
 			podName:      pod.Name,
@@ -408,6 +411,20 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 		if !schedulableTime.IsZero() {
 			PodProvisioningBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), nil)
 		}
+		c.unscheduledPods.Delete(key)
+	} else if pod.Spec.NodeName != "" || podutils.IsTerminal(pod) {
+		// The pod moved on (bound or terminal) without PodScheduled ever reaching True -- this can
+		// happen due to a kubelet/scheduler status-patch race (see #3120). Clear the unbound metric
+		// so it doesn't grow indefinitely, but skip the bound-duration observation since there's no
+		// valid PodScheduled transition timestamp to measure from.
+		PodUnboundTimeSeconds.Delete(map[string]string{
+			podName:      pod.Name,
+			podNamespace: pod.Namespace,
+		})
+		PodProvisioningUnboundTimeSeconds.Delete(map[string]string{
+			podName:      pod.Name,
+			podNamespace: pod.Namespace,
+		})
 		c.unscheduledPods.Delete(key)
 	}
 }

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -370,8 +370,9 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 	cond, ok := lo.Find(pod.Status.Conditions, func(c corev1.PodCondition) bool {
 		return c.Type == corev1.PodScheduled
 	})
+	scheduled := ok && cond.Status == corev1.ConditionTrue
 	if pod.Status.Phase == corev1.PodPending {
-		if !ok || cond.Status != corev1.ConditionTrue {
+		if !scheduled {
 			// If the podScheduled condition does not exist, or it exists and is not set to true, we emit pod_current_unbound_time_seconds metric.
 			PodUnboundTimeSeconds.Set(time.Since(pod.CreationTimestamp.Time).Seconds(), map[string]string{
 				podName:      pod.Name,
@@ -393,8 +394,9 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 		c.unscheduledPods.Insert(key)
 		return
 	}
-	if c.unscheduledPods.Has(key) && ok && cond.Status == corev1.ConditionTrue {
-		// Delete the unbound metric since the pod is now bound
+	// A pod can also become bound or terminal without PodScheduled ever reaching True (status-patch race).
+	if c.unscheduledPods.Has(key) && (scheduled || pod.Spec.NodeName != "" || podutils.IsTerminal(pod)) {
+		// The pod is no longer waiting to be bound, so delete the unbound metrics
 		PodUnboundTimeSeconds.Delete(map[string]string{
 			podName:      pod.Name,
 			podNamespace: pod.Namespace,
@@ -404,9 +406,13 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 			podNamespace: pod.Namespace,
 		})
 
-		PodBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(pod.CreationTimestamp.Time).Seconds(), nil)
-		if !schedulableTime.IsZero() {
-			PodProvisioningBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), nil)
+		// Only observe the bound duration if PodScheduled actually transitioned to True -- otherwise
+		// cond.LastTransitionTime isn't a bind time and the metric would take bogus or negative values.
+		if scheduled {
+			PodBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(pod.CreationTimestamp.Time).Seconds(), nil)
+			if !schedulableTime.IsZero() {
+				PodProvisioningBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), nil)
+			}
 		}
 		c.unscheduledPods.Delete(key)
 	}

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -206,6 +206,79 @@ var _ = Describe("Pod Metrics", func() {
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_bound_duration_seconds", map[string]string{})
 		Expect(found).To(BeTrue())
 	})
+	It("should delete unbound time metrics if the pod goes terminal without PodScheduled ever reaching True", func() {
+		p := test.Pod()
+		p.Status.Phase = corev1.PodPending
+
+		env.Clock.Step(1 * time.Hour)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {p}}, map[string][]*corev1.Pod{"nc1": {p}})
+
+		ExpectApplied(ctx, env.Client, p)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
+		_, found := FindMetricWithLabelValues("karpenter_pods_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeTrue())
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeTrue())
+
+		// Simulate the kubelet/scheduler race from #3120: the pod goes straight to a terminal
+		// phase without PodScheduled ever transitioning to True.
+		p.Status.Phase = corev1.PodFailed
+		p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodScheduled, Status: corev1.ConditionFalse, LastTransitionTime: metav1.Now()}}
+		ExpectApplied(ctx, env.Client, p)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
+
+		_, found = FindMetricWithLabelValues("karpenter_pods_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeFalse())
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeFalse())
+	})
+	It("should delete unbound time metrics if the pod becomes bound (NodeName set) without PodScheduled ever reaching True", func() {
+		// NodeName is immutable after creation, so it must be set upfront -- Phase starts Pending
+		// since the initial unbound-emit path only checks phase, not NodeName.
+		p := test.Pod(test.PodOptions{NodeName: "test-node"})
+		p.Status.Phase = corev1.PodPending
+
+		env.Clock.Step(1 * time.Hour)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {p}}, map[string][]*corev1.Pod{"nc1": {p}})
+
+		ExpectApplied(ctx, env.Client, p)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
+		_, found := FindMetricWithLabelValues("karpenter_pods_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeTrue())
+
+		// Pod transitions to Running (implying it's bound) but PodScheduled is still stuck at
+		// False -- same race as #3120, different symptom (non-terminal instead of terminal).
+		p.Status.Phase = corev1.PodRunning
+		p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodScheduled, Status: corev1.ConditionFalse, LastTransitionTime: metav1.Now()}}
+		ExpectApplied(ctx, env.Client, p)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
+
+		_, found = FindMetricWithLabelValues("karpenter_pods_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeFalse())
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeFalse())
+	})
 	It("should update the pod startup and unstarted time metrics", func() {
 		p := test.Pod()
 		p.Status.Phase = corev1.PodPending


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #3153

**Description**

`karpenter_pods_unbound_time_seconds` and `karpenter_pods_provisioning_unbound_time_seconds` were only ever cleared in `recordPodBoundMetric` when the `PodScheduled` condition transitioned to `True`. A kubelet/scheduler status-patch race (documented in #3120) can leave `PodScheduled` stuck at `False` even after a pod is bound or goes terminal, so these two metrics would keep growing indefinitely until the pod is fully deleted -- the same root cause #3120 fixed for the sibling `karpenter_pods_provisioning_scheduling_undecided_time_seconds` metric.

This adds the same two escape conditions #3120 used (`pod.Spec.NodeName != ""` and `podutils.IsTerminal(pod)`) to the clear path in `recordPodBoundMetric`. The bound duration histograms stay gated on `PodScheduled` actually reaching `True`, since `cond.LastTransitionTime` is the last scheduling failure rather than a bind timestamp otherwise.

**How was this change tested?**

Added two envtest cases mirroring the existing "should update the pod bound and unbound time metrics" test:
1. Pod goes straight from `Pending` to `Failed` with `PodScheduled` stuck at `False` -- confirmed both metrics get cleared (previously failed against unmodified code, with the metric still present after the transition).
2. Pod is bound (`NodeName` set at creation, since it's immutable afterward) and transitions to `Running` with `PodScheduled` stuck at `False` -- same result.

`go test ./pkg/controllers/metrics/pod/... -race --ginkgo.randomize-all` -- 15/15 passing.

**AI disclosure**

This PR was written in part with the assistance of generative AI. I have reviewed and verified every change myself.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

