### PR TITLE
fix: prevent int64 overflow and divide-by-zero in DRA consumable-capacity rounding

### DIFF
--- a/pkg/scheduling/dynamicresources/consumable_capacity.go
+++ b/pkg/scheduling/dynamicresources/consumable_capacity.go
@@ -18,6 +18,7 @@ package dynamicresources
 
 import (
 	"fmt"
+	"math"
 
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -56,19 +57,33 @@ func (a *allocator) checkCapacity(device cloudprovider.Device, deviceID DeviceID
 		)
 	}
 	for name, qty := range consumed {
-		total := device.Capacity[name].Value
-		var used resource.Quantity
-		for _, src := range sources {
-			if q, ok := src[name]; ok {
-				used.Add(q)
-			}
-		}
-		used.Add(qty)
-		if used.Cmp(total) > 0 {
+		if !capacityFits(name, qty, device.Capacity[name].Value, sources) {
 			return nil, false
 		}
 	}
 	return consumed, true
+}
+
+// capacityFits reports whether the requested qty plus the persisted sources for a
+// single capacity dimension stays within total. It fails closed on any negative
+// quantity (total, qty, or a source): a negative value (for example an anomalous
+// ConsumedCapacity ingested from a ResourceClaim status without validation) would
+// offset the used total and over-admit the device.
+func capacityFits(name resourcev1.QualifiedName, qty, total resource.Quantity, sources []map[resourcev1.QualifiedName]resource.Quantity) bool {
+	if total.Sign() < 0 || qty.Sign() < 0 {
+		return false
+	}
+	var used resource.Quantity
+	for _, src := range sources {
+		if q, ok := src[name]; ok {
+			if q.Sign() < 0 {
+				return false
+			}
+			used.Add(q)
+		}
+	}
+	used.Add(qty)
+	return used.Cmp(total) <= 0
 }
 
 // deductAllocatingCapacity adds consumed capacity to the DFS-local allocating state.
@@ -303,6 +318,12 @@ func computeConsumedCapacity(
 			}
 		}
 		c := calculateConsumedCapacity(requestedVal, cap)
+		// Consumed capacity must never be negative: a negative request with no
+		// policy, or a negative RequestPolicy.Default for an empty request, would
+		// otherwise be stored as a negative "credit" and over-admit the device.
+		if c.Sign() < 0 {
+			return nil, fmt.Errorf("consumed capacity for dimension %s is negative", name)
+		}
 		if violatesPolicy(c, cap.RequestPolicy) {
 			return nil, fmt.Errorf("capacity request violates policy for dimension %s", name)
 		}
@@ -388,7 +409,14 @@ func fillEmptyRequest(capacity resourcev1.DeviceCapacity) resource.Quantity {
 // If requestedVal < Min, returns Min.
 // If Step is specified, rounds up to the nearest Min + N*Step.
 // If no Step is specified and requestedVal >= Min, it returns requestedVal as is.
-// Note: equivalent to upstream roundUpRange in k8s.io/dynamic-resource-allocation
+// Based on upstream roundUpRange in k8s.io/dynamic-resource-allocation, with
+// overflow and representability guards. The rounding is done in int64, and
+// Quantity.Value() truncates values outside the int64 range (and rounds a
+// fractional value away from zero), so if the request, Min or Step exceeds the
+// int64 magnitude the existing Value()-based path handles, the Step is not
+// positive, or the final Min + N*Step would overflow, the request is returned
+// unchanged so the exact policy and capacity comparisons (violatesPolicy,
+// checkCapacity) reject it rather than using a truncated or wrapped value.
 func roundUpRange(requestedVal *resource.Quantity, validRange *resourcev1.CapacityRequestPolicyRange) resource.Quantity {
 	if requestedVal.Cmp(*validRange.Min) < 0 {
 		return validRange.Min.DeepCopy()
@@ -396,13 +424,25 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourcev1.Capaci
 	if validRange.Step == nil {
 		return requestedVal.DeepCopy()
 	}
+	// Guard every operand before projecting it with Value(), which truncates
+	// out-of-range quantities. Anything not safely representable is returned
+	// unchanged for the exact comparisons downstream to reject.
+	if requestedVal.CmpInt64(math.MaxInt64) > 0 ||
+		validRange.Min.Sign() < 0 || validRange.Min.CmpInt64(math.MaxInt64) > 0 ||
+		validRange.Step.Sign() <= 0 || validRange.Step.CmpInt64(math.MaxInt64) > 0 {
+		return requestedVal.DeepCopy()
+	}
 	requestedInt64 := requestedVal.Value()
-	step := validRange.Step.Value()
 	min := validRange.Min.Value()
+	step := validRange.Step.Value()
 	added := requestedInt64 - min
 	n := added / step
 	if added%step != 0 {
 		n++
+	}
+	// Detect, rather than wrap, an overflow of the final Min + N*Step.
+	if n > (math.MaxInt64-min)/step {
+		return requestedVal.DeepCopy()
 	}
 	return *resource.NewQuantity(min+step*n, resource.BinarySI)
 }
@@ -425,6 +465,11 @@ func violatesPolicy(consumedVal resource.Quantity, policy *resourcev1.CapacityRe
 	if policy == nil {
 		return false
 	}
+	// A structurally malformed range is a violation even when the consumed value
+	// matches Default, so the Default short-circuit below cannot mask it.
+	if policy.ValidRange != nil && invalidRange(*policy.ValidRange) {
+		return true
+	}
 	if policy.Default != nil && consumedVal.Cmp(*policy.Default) == 0 {
 		return false
 	}
@@ -443,14 +488,31 @@ func violateValidRange(val resource.Quantity, validRange resourcev1.CapacityRequ
 		return true
 	}
 	if validRange.Step != nil {
-		requestedInt64 := val.Value()
+		// A malformed range, or a value not representable as int64, is a violation
+		// (fail-closed) rather than dereferencing a nil Min or ignoring the step.
+		if invalidRange(validRange) || val.CmpInt64(math.MaxInt64) > 0 {
+			return true
+		}
 		step := validRange.Step.Value()
 		min := validRange.Min.Value()
-		if (requestedInt64-min)%step != 0 {
+		if (val.Value()-min)%step != 0 {
 			return true
 		}
 	}
 	return false
+}
+
+// invalidRange reports whether a range is structurally malformed: a Step paired
+// with a nil, negative, or beyond-int64 Min, or a non-positive or beyond-int64
+// Step. Only Min and Step are checked, since they are the operands read as int64;
+// Max and Default are used only through Cmp and need no representability guard.
+func invalidRange(validRange resourcev1.CapacityRequestPolicyRange) bool {
+	if validRange.Step == nil {
+		return false
+	}
+	return validRange.Min == nil ||
+		validRange.Step.Sign() <= 0 || validRange.Step.CmpInt64(math.MaxInt64) > 0 ||
+		validRange.Min.Sign() < 0 || validRange.Min.CmpInt64(math.MaxInt64) > 0
 }
 
 // Note: equivalent to upstream violateValidValues in k8s.io/dynamic-resource-allocation

--- a/pkg/scheduling/dynamicresources/consumable_capacity_roundup_test.go
+++ b/pkg/scheduling/dynamicresources/consumable_capacity_roundup_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicresources
+
+import (
+	"math"
+	"testing"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+)
+
+func qBin(v int64) *resource.Quantity { return resource.NewQuantity(v, resource.BinarySI) }
+
+func qStr(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}
+
+func TestRoundUpRange(t *testing.T) {
+	cases := []struct {
+		name    string
+		request *resource.Quantity
+		min     *resource.Quantity
+		step    *resource.Quantity
+		// exactly one of wantValue / wantReturnsRequest applies
+		wantValue          int64
+		wantReturnsRequest bool
+	}{
+		{name: "normal rounds up", request: qBin(5), min: qBin(0), step: qBin(2), wantValue: 6},
+		{name: "below min returns min", request: qBin(1), min: qBin(4), step: qBin(2), wantValue: 4},
+		// The next valid point is already on the grid and representable, keep it.
+		{name: "on grid at MaxInt64", request: qBin(math.MaxInt64), min: qBin(1), step: qBin(2), wantValue: math.MaxInt64},
+		// Exercises n++ and the equality boundary of the overflow guard (must not over-reject).
+		{name: "largest safe round-up (n++ to MaxInt64)", request: qBin(math.MaxInt64 - 1), min: qBin(1), step: qBin(2), wantValue: math.MaxInt64},
+		// Final Min + N*Step overflows int64: reject rather than wrap negative.
+		{name: "final add overflow rejected", request: qBin(math.MaxInt64), min: qBin(0), step: qBin(2), wantReturnsRequest: true},
+		// Request above MaxInt64 (Value() would truncate to a negative int64).
+		{name: "request above MaxInt64 rejected", request: qStr("9223372036854775808"), min: qBin(0), step: qBin(2), wantReturnsRequest: true},
+		// Step of 2^64 truncates to 0 with Value(); 2^64+1 truncates to 1.
+		{name: "huge step 2^64 rejected", request: qBin(8), min: qBin(0), step: qStr("18446744073709551616"), wantReturnsRequest: true},
+		{name: "huge step 2^64+1 not treated as 1", request: qBin(8), min: qBin(0), step: qStr("18446744073709551617"), wantReturnsRequest: true},
+		{name: "zero step rejected", request: qBin(8), min: qBin(0), step: qBin(0), wantReturnsRequest: true},
+		{name: "negative step rejected", request: qBin(8), min: qBin(0), step: qBin(-2), wantReturnsRequest: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got resource.Quantity
+			mustNotPanic(t, "roundUpRange", func() {
+				got = roundUpRange(tc.request, &resourcev1.CapacityRequestPolicyRange{Min: tc.min, Step: tc.step})
+			})
+			// The consumed capacity must never be negative (that under-counts and over-admits).
+			if got.Sign() < 0 {
+				t.Fatalf("roundUpRange returned a negative value: %s", got.String())
+			}
+			if tc.wantReturnsRequest {
+				if got.Cmp(*tc.request) != 0 {
+					t.Fatalf("expected the request %s returned unchanged, got %s", tc.request.String(), got.String())
+				}
+				return
+			}
+			if got.Value() != tc.wantValue {
+				t.Fatalf("got %d, want %d", got.Value(), tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestViolateValidRangeFailsClosed(t *testing.T) {
+	// A malformed Step (zero, negative, or above MaxInt64) must be reported as a
+	// violation so violatesPolicy rejects it, rather than being silently ignored.
+	for _, step := range []*resource.Quantity{qBin(0), qBin(-2), qStr("18446744073709551616")} {
+		mustNotPanic(t, "violateValidRange", func() {
+			if !violateValidRange(*qBin(8), resourcev1.CapacityRequestPolicyRange{Min: qBin(0), Step: step}) {
+				t.Fatalf("expected malformed step %s to be a violation", step.String())
+			}
+		})
+	}
+	// A value on the grid is not a violation.
+	if violateValidRange(*qBin(6), resourcev1.CapacityRequestPolicyRange{Min: qBin(0), Step: qBin(2)}) {
+		t.Fatalf("6 should be on the grid min=0 step=2")
+	}
+}
+
+func mustNotPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked: %v", name, r)
+		}
+	}()
+	fn()
+}
+
+// TestCheckCapacityRejectsNegativePersistedSource asserts checkCapacity fails
+// closed when a persisted source (for example an anomalous ConsumedCapacity
+// ingested into PreallocatedConsumedCapacity without validation) is negative, which
+// would otherwise offset the used total and over-admit the device.
+func TestCheckCapacityRejectsNegativePersistedSource(t *testing.T) {
+	capName := resourcev1.QualifiedName("memory")
+	did := DeviceID{}
+	dev := cloudprovider.Device{
+		AllowMultipleAllocations: true,
+		Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+			capName: {Value: *qBin(4)},
+		},
+	}
+	rd := &RequestData{CapacityRequests: map[resourcev1.QualifiedName]resource.Quantity{capName: *qBin(5)}}
+	negative := func() map[DeviceID]map[resourcev1.QualifiedName]resource.Quantity {
+		return map[DeviceID]map[resourcev1.QualifiedName]resource.Quantity{did: {capName: *qBin(-1)}}
+	}
+	// A negative quantity in any individual non-template source must fail closed;
+	// otherwise it credits capacity and over-admits (used = -1 + 5 = 4 on capacity 4).
+	sources := map[string]func(*allocator){
+		"PreallocatedConsumedCapacity": func(a *allocator) { a.allocationTracker.PreallocatedConsumedCapacity = negative() },
+		"InflightConsumedCapacity":     func(a *allocator) { a.allocationTracker.InflightConsumedCapacity = negative() },
+		"allocatingCapacity":           func(a *allocator) { a.allocatingCapacity = negative() },
+	}
+	for name, inject := range sources {
+		t.Run(name, func(t *testing.T) {
+			a := &allocator{Allocator: &Allocator{allocationTracker: &AllocationTracker{}}}
+			inject(a)
+			if _, ok := a.checkCapacity(dev, did, rd); ok {
+				t.Fatalf("checkCapacity accepted a request with a negative %s credit", name)
+			}
+		})
+	}
+}
+
+// TestComputeConsumedCapacityRejectsMalformedRangeWithMatchingDefault asserts a
+// structurally malformed ValidRange is rejected even when the consumed value equals
+// RequestPolicy.Default, so the Default short-circuit cannot mask it.
+func TestComputeConsumedCapacityRejectsMalformedRangeWithMatchingDefault(t *testing.T) {
+	capName := resourcev1.QualifiedName("memory")
+	withRange := func(vr *resourcev1.CapacityRequestPolicyRange) map[resourcev1.QualifiedName]resourcev1.DeviceCapacity {
+		return map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+			capName: {Value: *qBin(4), RequestPolicy: &resourcev1.CapacityRequestPolicy{Default: qBin(4), ValidRange: vr}},
+		}
+	}
+	// An empty request fills the Default (4); the malformed range must still be rejected.
+	if _, err := computeConsumedCapacity(nil, withRange(&resourcev1.CapacityRequestPolicyRange{Step: qBin(1)})); err == nil {
+		t.Fatalf("a nil-Min range should be rejected even when consumed matches Default")
+	}
+	if _, err := computeConsumedCapacity(nil, withRange(&resourcev1.CapacityRequestPolicyRange{Min: qBin(0), Step: qBin(0)})); err == nil {
+		t.Fatalf("a zero-Step range should be rejected even when consumed matches Default")
+	}
+}
+
+// TestComputeConsumedCapacityRejectsNegative drives the real computeConsumedCapacity
+// path and asserts a negative consumed capacity (from a negative request with no
+// policy, or a negative RequestPolicy.Default for an empty request) is rejected
+// rather than stored as a negative credit that would over-admit the device.
+func TestComputeConsumedCapacityRejectsNegative(t *testing.T) {
+	capName := resourcev1.QualifiedName("memory")
+	noPolicy := map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+		capName: {Value: *qBin(4)},
+	}
+	if _, err := computeConsumedCapacity(
+		map[resourcev1.QualifiedName]resource.Quantity{capName: *qBin(-1)}, noPolicy); err == nil {
+		t.Fatalf("a negative request should be rejected")
+	}
+	negDefault := map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+		capName: {Value: *qBin(4), RequestPolicy: &resourcev1.CapacityRequestPolicy{Default: qBin(-1)}},
+	}
+	if _, err := computeConsumedCapacity(nil, negDefault); err == nil {
+		t.Fatalf("a negative RequestPolicy.Default should be rejected")
+	}
+	consumed, err := computeConsumedCapacity(
+		map[resourcev1.QualifiedName]resource.Quantity{capName: *qBin(2)}, noPolicy)
+	if err != nil {
+		t.Fatalf("a normal request should be accepted: %v", err)
+	}
+	if got := consumed[capName]; got.Value() != 2 {
+		t.Fatalf("consumed = %d, want 2", got.Value())
+	}
+}
+
+func TestViolateValidRangeNilMinNoPanic(t *testing.T) {
+	mustNotPanic(t, "violateValidRange with nil Min", func() {
+		if !violateValidRange(*qBin(4), resourcev1.CapacityRequestPolicyRange{Step: qBin(1)}) {
+			t.Fatalf("a Step with a nil Min should be treated as a violation")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #3155

### Description

The DRA consumable-capacity helpers in `pkg/scheduling/dynamicresources/consumable_capacity.go` (hand-copied from `k8s.io/dynamic-resource-allocation`) could produce a wrong or unsafe consumed-capacity value from a request or a cloud-provider device-capacity template, which the API server does not validate for these in-memory templates:

1. **int64 overflow in rounding.** `roundUpRange` did the rounding in int64 after `Quantity.Value()`, which truncates a value outside the int64 range, so a request, `Min`, or `Step` above `MaxInt64`, a non-positive `Step`, or an overflowing `Min + N*Step` produced a negative or wrong consumed value. It now guards every operand with `CmpInt64`/`Sign` before `Value()` and detects the multiply overflow in int64 (no `big.Int`), returning the request unchanged (not a truncated or wrapped value) so the exact int64-free comparisons bound it by the device's real capacity. A returned request that equals the policy `Default` is accepted by the `Default` short-circuit rather than rejected, but `capacityFits` still keeps it within real capacity.
2. **Negative consumed credit (computed).** `computeConsumedCapacity` stored a negative consumed value (from a negative request with no policy, or a negative `RequestPolicy.Default` for an empty request) as a negative "credit" that over-admits the device. It now rejects a negative consumed value at the computation boundary.
3. **Negative consumed credit (persisted source).** `checkCapacity` summed the persisted sources (`PreallocatedConsumedCapacity`, `InflightConsumedCapacity`, `allocatingCapacity`, and the template variants) without a sign check, so a negative `ConsumedCapacity` ingested from a `ResourceClaim` status (`NewAllocationTracker` copies it in unvalidated) could offset the used total and over-admit (`used = -1 + 5 = 4` on a capacity-4 device). It now fails closed on a negative total, request, or source quantity that reaches this check. Per-claim `ConsumedCapacity` contributions are aggregated in the device-allocation controller before this point, so a negative that is cancelled by a positive during that aggregation is not caught here; validating each contribution at the controller boundary is tracked in #3209.
4. **nil `Min` panic and `Default` bypass.** `violateValidRange` dereferenced `ValidRange.Min` without a nil check when `Step` was set (panicking on a `Step`-but-no-`Min` template), and the `Default` short-circuit in `violatesPolicy` accepted a value matching `Default` without checking the range structure. A shared `invalidRange` helper now treats a nil/negative/non-representable `Min` or a non-positive `Step` as a violation, checked before the `Default` short-circuit.

### Test

`TestComputeConsumedCapacityRejectsNegative` and `TestComputeConsumedCapacityRejectsMalformedRangeWithMatchingDefault` drive the real `computeConsumedCapacity` path (negative request/`Default`, and a malformed range whose consumed value equals `Default`). `TestCheckCapacityRejectsNegativePersistedSource` drives `checkCapacity` with a negative persisted `PreallocatedConsumedCapacity` and asserts the request is rejected. `TestViolateValidRangeNilMinNoPanic` covers the nil-`Min` panic. `TestRoundUpRange` covers the overflow boundaries, including the largest safe round-up (the `n++` equality boundary of the overflow guard, which must not over-reject).

Verified locally: the new tests fail before the change (negative request/source accepted, `Default` masks the malformed range, nil `Min` panics) and pass after; and the full `dynamicresources` envtest suite passes.

### Note for reviewers

These are defensive guards at the allocator boundary, since cloud-provider device-capacity templates and the `ConsumedCapacity` ingested from `ResourceClaim` status are not validated by the API server. They diverge from the upstream hand-copy; happy to instead track the upstream fixes and re-sync if you prefer that.

The persisted-source sign check here catches a negative that reaches `capacityFits`. A negative cancelled during the device-allocation controller's per-device aggregation is a separate gap that this allocator check cannot see, tracked in #3209.
