### PR TITLE
test: make ExpectApplied retry on conflict

### DIFF
--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -302,11 +303,7 @@ func ExpectFinalizersRemovedFromList(ctx context.Context, c client.Client, objec
 	for _, list := range objectLists {
 		Expect(c.List(ctx, list)).To(Succeed())
 		Expect(meta.EachListItem(list, func(o runtime.Object) error {
-			obj := o.(client.Object)
-			stored := obj.DeepCopyObject().(client.Object)
-			obj.SetFinalizers([]string{})
-			Expect(client.IgnoreNotFound(c.Patch(ctx, obj, client.MergeFrom(stored)))).To(Succeed())
-			return nil
+			return client.IgnoreNotFound(removeFinalizersWithRetry(ctx, c, o.(client.Object)))
 		})).To(Succeed())
 	}
 }
@@ -314,11 +311,22 @@ func ExpectFinalizersRemovedFromList(ctx context.Context, c client.Client, objec
 func ExpectFinalizersRemoved(ctx context.Context, c client.Client, objs ...client.Object) {
 	GinkgoHelper()
 	for _, obj := range objs {
-		Expect(client.IgnoreNotFound(c.Get(ctx, client.ObjectKeyFromObject(obj), obj))).To(Succeed())
+		Expect(client.IgnoreNotFound(removeFinalizersWithRetry(ctx, c, obj))).To(Succeed())
+	}
+}
+
+// removeFinalizersWithRetry clears finalizers on obj, re-fetching and retrying
+// on conflict. This makes the helper safe to call concurrently with controller
+// reconciles that may be updating the same object.
+func removeFinalizersWithRetry(ctx context.Context, c client.Client, obj client.Object) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return err
+		}
 		stored := obj.DeepCopyObject().(client.Object)
 		obj.SetFinalizers([]string{})
-		Expect(client.IgnoreNotFound(c.Patch(ctx, obj, client.MergeFrom(stored)))).To(Succeed())
-	}
+		return c.Patch(ctx, obj, client.MergeFrom(stored))
+	})
 }
 
 func ExpectProvisioned(ctx context.Context, c client.Client, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, pods ...*corev1.Pod) ProvisioningResult {

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -152,20 +153,30 @@ func ExpectApplied(ctx context.Context, c client.Client, objects ...client.Objec
 		current := object.DeepCopyObject().(client.Object)
 		statuscopy := object.DeepCopyObject().(client.Object) // Snapshot the status, since create/update may override
 
-		// Create or Update
-		if err := c.Get(ctx, client.ObjectKeyFromObject(current), current); err != nil {
-			if errors.IsNotFound(err) {
-				Expect(c.Create(ctx, object)).To(Succeed())
-			} else {
-				Expect(err).ToNot(HaveOccurred())
+		// Create or Update, retrying on conflict. Under parallel test workloads
+		// (e.g. workqueue.ParallelizeUntil), the controller informer can reconcile
+		// the same object between our Get and Update, so the Update returns 409.
+		// Each retry re-fetches the fresh resource version.
+		Expect(retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			if err := c.Get(ctx, client.ObjectKeyFromObject(current), current); err != nil {
+				if errors.IsNotFound(err) {
+					return c.Create(ctx, object)
+				}
+				return err
 			}
-		} else {
 			object.SetResourceVersion(current.GetResourceVersion())
-			Expect(c.Update(ctx, object)).To(Succeed())
-		}
-		// Update status
-		statuscopy.SetResourceVersion(object.GetResourceVersion())
-		Expect(c.Status().Update(ctx, statuscopy)).To(Or(Succeed(), MatchError("the server could not find the requested resource"))) // Some objects do not have a status
+			return c.Update(ctx, object)
+		})).To(Succeed())
+
+		// Update status, also retrying on conflict.
+		Expect(retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			fresh := statuscopy.DeepCopyObject().(client.Object)
+			if err := c.Get(ctx, client.ObjectKeyFromObject(statuscopy), fresh); err != nil {
+				return err
+			}
+			statuscopy.SetResourceVersion(fresh.GetResourceVersion())
+			return c.Status().Update(ctx, statuscopy)
+		})).To(Or(Succeed(), MatchError("the server could not find the requested resource"))) // Some objects do not have a status
 
 		// Re-get the object to grab the updated spec and status
 		Expect(c.Get(ctx, client.ObjectKeyFromObject(object), object)).To(Succeed())


### PR DESCRIPTION
`ExpectApplied` does `c.Get()` then `c.Update()` (and separately `c.Status().Update()`) with the fresh resource version set on the passed object. Under heavy parallelism, specifically `pkg/controllers/nodeclaim/garbagecollection/suite_test.go:153` where `workqueue.ParallelizeUntil` spins 100 goroutines each calling `ExpectNodeClaimDeployed` (which calls `ExpectApplied`), the controller-runtime informer can reconcile the same object between our `Get` and `Update`. The `Update` then returns `Operation cannot be fulfilled ... the object has been modified; please apply your changes to the latest version and try again` (409 Conflict), and the test fails.

Wrap both `Update` and `Status().Update()` in `retry.RetryOnConflict(retry.DefaultBackoff, ...)`. Each retry re-fetches the current object to pick up the fresh resource version. Behavior for non-conflict errors (including the "server could not find the requested resource" case for objects without a status subresource) is unchanged.

The initial version of this PR targeted `ExpectFinalizersRemoved`, which uses `client.Patch(ctx, obj, client.MergeFrom(stored))`. Thanks to @GaneshBannur for catching that `MergeFrom` skips the resource version and cannot produce the 409 we saw. Digging into the actual CI log confirmed the failure was in `ExpectNodeClaimDeployed → ExpectApplied → c.Update()`, not the finalizers helper.

## How was this change tested?

- `go build ./...` and `go vet ./pkg/test/...` clean.
- Validation of the fix in CI once this PR is up.
