### PR TITLE
fix: tolerate missing PersistentVolume in driverFromVolume to prevent cluster sync paralysis

### DIFF
--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -170,6 +170,10 @@ func driverFromSC(ctx context.Context, kubeClient client.Client, storageClassNam
 func driverFromVolume(ctx context.Context, kubeClient client.Client, volumeName string) (string, error) {
 	var pv v1.PersistentVolume
 	if err := kubeClient.Get(ctx, client.ObjectKey{Name: volumeName}, &pv); err != nil {
+		if errors.IsNotFound(err) {
+			log.FromContext(ctx).WithValues("PersistentVolume", volumeName).V(1).Info("failed tracking CSI volume limits, PersistentVolume not found; ignoring volume")
+			return "", nil
+		}
 		return "", err
 	}
 	if pv.Spec.CSI != nil {

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -176,6 +176,10 @@ func driverFromSC(ctx context.Context, kubeClient client.Client, storageClassNam
 func driverFromVolume(ctx context.Context, kubeClient client.Client, volumeName string) (string, error) {
 	var pv v1.PersistentVolume
 	if err := kubeClient.Get(ctx, client.ObjectKey{Name: volumeName}, &pv); err != nil {
+		if errors.IsNotFound(err) {
+			log.FromContext(ctx).WithValues("PersistentVolume", volumeName).V(1).Info("failed tracking CSI volume limits, PersistentVolume not found; ignoring volume")
+			return "", nil
+		}
 		return "", err
 	}
 	if pv.Spec.CSI != nil {

--- a/pkg/scheduling/volumeusage_test.go
+++ b/pkg/scheduling/volumeusage_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakecr "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("VolumeUsage", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(v1.AddToScheme(scheme)).To(Succeed())
+		Expect(storagev1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	Describe("GetVolumes", func() {
+		newPod := func(claimName string) *v1.Pod {
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: v1.PodSpec{
+					Volumes: []v1.Volume{{
+						Name: "data",
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: claimName},
+						},
+					}},
+				},
+			}
+		}
+
+		It("should tolerate a missing PersistentVolume and not return an error", func() {
+			// PVC references a PV that has been deleted from the cluster (e.g. manually).
+			// Without this tolerance, one missing PV would fail node-state reconciliation
+			// and could block cluster sync after a controller restart.
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					VolumeName:       "test-pv",
+					StorageClassName: strPtr("test-storage-class"),
+				},
+			}
+			kubeClient := fakecr.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+
+			volumes, err := GetVolumes(ctx, kubeClient, newPod("test-pvc"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(volumes).To(BeEmpty())
+		})
+
+		It("should return volumes correctly when the PersistentVolume exists", func() {
+			pv := &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pv"},
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						CSI: &v1.CSIPersistentVolumeSource{Driver: "ebs.csi.aws.com", VolumeHandle: "vol-test"},
+					},
+				},
+			}
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					VolumeName:       "test-pv",
+					StorageClassName: strPtr("test-storage-class"),
+				},
+			}
+			kubeClient := fakecr.NewClientBuilder().WithScheme(scheme).WithObjects(pv, pvc).Build()
+
+			volumes, err := GetVolumes(ctx, kubeClient, newPod("test-pvc"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(volumes).To(HaveKey("ebs.csi.aws.com"))
+		})
+
+		It("should tolerate a missing PersistentVolumeClaim and not return an error", func() {
+			// Existing behavior: a missing PVC is already tolerated. This test guards it.
+			kubeClient := fakecr.NewClientBuilder().WithScheme(scheme).Build()
+
+			volumes, err := GetVolumes(ctx, kubeClient, newPod("nonexistent-pvc"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(volumes).To(BeEmpty())
+		})
+	})
+})
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/pkg/scheduling/volumeusage_test.go
+++ b/pkg/scheduling/volumeusage_test.go
@@ -17,12 +17,32 @@ limitations under the License.
 package scheduling
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	fakecr "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("VolumeUsage", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(v1.AddToScheme(scheme)).To(Succeed())
+		Expect(storagev1.AddToScheme(scheme)).To(Succeed())
+	})
+
 	It("should only use fallback limits until the driver is published", func() {
 		const driver = "fake.csi.provider"
 		usage := NewVolumeUsage()
@@ -38,5 +58,71 @@ var _ = Describe("VolumeUsage", func() {
 		usage.AddUnbounded(driver)
 		usage.AddFallbackLimit(driver, 1)
 		Expect(usage.ExceedsLimits(Volumes{driver: sets.New("volume-a", "volume-b", "volume-c")})).To(Succeed())
+	})
+
+	Describe("GetVolumes", func() {
+		newPod := func(claimName string) *v1.Pod {
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: v1.PodSpec{
+					Volumes: []v1.Volume{{
+						Name: "data",
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: claimName},
+						},
+					}},
+				},
+			}
+		}
+
+		It("should tolerate a missing PersistentVolume and not return an error", func() {
+			// PVC references a PV that has been deleted from the cluster (e.g. manually).
+			// Without this tolerance, one missing PV would fail node-state reconciliation
+			// and could block cluster sync after a controller restart.
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					VolumeName:       "test-pv",
+					StorageClassName: lo.ToPtr("test-storage-class"),
+				},
+			}
+			kubeClient := fakecr.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()
+
+			volumes, err := GetVolumes(ctx, kubeClient, newPod("test-pvc"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(volumes).To(BeEmpty())
+		})
+
+		It("should return volumes correctly when the PersistentVolume exists", func() {
+			pv := &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pv"},
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						CSI: &v1.CSIPersistentVolumeSource{Driver: "ebs.csi.aws.com", VolumeHandle: "vol-test"},
+					},
+				},
+			}
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					VolumeName:       "test-pv",
+					StorageClassName: lo.ToPtr("test-storage-class"),
+				},
+			}
+			kubeClient := fakecr.NewClientBuilder().WithScheme(scheme).WithObjects(pv, pvc).Build()
+
+			volumes, err := GetVolumes(ctx, kubeClient, newPod("test-pvc"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(volumes).To(HaveKey("ebs.csi.aws.com"))
+		})
+
+		It("should tolerate a missing PersistentVolumeClaim and not return an error", func() {
+			// Existing behavior: a missing PVC is already tolerated. This test guards it.
+			kubeClient := fakecr.NewClientBuilder().WithScheme(scheme).Build()
+
+			volumes, err := GetVolumes(ctx, kubeClient, newPod("nonexistent-pvc"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(volumes).To(BeEmpty())
+		})
 	})
 })


### PR DESCRIPTION
Fixes #3169

## Description

Fixes an issue where `driverFromVolume` returns a raw `NotFound` error when querying a missing `PersistentVolume` (e.g., when a PV is deleted out-of-band while a PVC remains in `Lost` phase).

Without this fix, a missing PV causes node state reconciliation to fail repeatedly. Upon a Karpenter controller restart, nodes failing reconciliation are excluded from the internal cluster map, preventing `Cluster.Synced()` from succeeding and pinning `karpenter_cluster_state_synced` at `0` indefinitely — halting all provisioning, consolidation, and disruption operations.

This PR adds `apierrors.IsNotFound(err)` handling to `driverFromVolume` (`pkg/scheduling/volumeusage.go:170`), aligning it with the existing tolerant behavior used for missing PVCs in `GetVolumes()` (line 88-94). That existing code already has a comment explaining why tolerance is needed:

> "If the PVC is not found it was manually deleted and its finalizer removed. We should ignore this volume when computing limits, otherwise Karpenter may never be able to update its cluster state."

The same logic applies to missing PVs — a deleted PV should not permanently block cluster state synchronization.

### Real-world incident

This exact scenario caused a 22-hour outage in a production-grade EKS cluster:
1. An SRE deleted a PV while its PVC was still `Bound` (PVC went to `Lost` phase)
2. Karpenter logged `"tracking volume usage, PersistentVolume not found"` every ~30s but continued operating (because `hasSynced` was already `true`)
3. 13 days later, the Karpenter controller pod was manually restarted
4. After restart, `hasSynced` reset to `false`, the full superset check ran, the affected node couldn't complete reconciliation, and `karpenter_cluster_state_synced` pinned at `0` permanently
5. All provisioning, consolidation, and disruption halted until the Lost PVC was manually deleted

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added unit tests in `pkg/scheduling/volumeusage_test.go` covering:
  - Pod → PVC → missing PV scenario (should return no error, empty volumes)
  - Pod → PVC → existing PV scenario (should return the CSI driver correctly)
  - Pod → missing PVC scenario (existing tolerance, regression test)

## Does this PR introduce a user-facing change?

```release-note
Fixed an issue where a missing PersistentVolume (e.g., manually deleted while PVC was Bound) could permanently prevent Karpenter cluster state from syncing after a controller restart, halting all provisioning operations.
```
