### PR TITLE
feat: treat explicit limits.nodes: 0 as a NodePool disable toggle

### DIFF
--- a/pkg/controllers/provisioning/scheduling/events.go
+++ b/pkg/controllers/provisioning/scheduling/events.go
@@ -61,6 +61,17 @@ func NoCompatibleInstanceTypes(np *v1.NodePool, minValuesIncompatibleError bool)
 	}
 }
 
+func NoCapacity(np *v1.NodePool, resourceName corev1.ResourceName) events.Event {
+	return events.Event{
+		InvolvedObject: np,
+		Type:           corev1.EventTypeWarning,
+		Reason:         events.NoCapacity,
+		Message:        fmt.Sprintf("NodePool has no capacity due to zero %s limit", resourceName),
+		DedupeValues:   []string{string(np.UID)},
+		DedupeTimeout:  1 * time.Minute,
+	}
+}
+
 func PodFailedToScheduleEvent(pod *corev1.Pod, err error) events.Event {
 	return events.Event{
 		InvolvedObject: pod,

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -151,9 +151,14 @@ func NewScheduler(
 			}
 		}
 	}
-	// Pre-filter instance types eligible for NodePools to reduce work done during scheduling loops for pods
+	// Pre-filter NodePools to reduce work done during scheduling loops for pods
 	// if no templates remain, we still want to build the scheduler so that Karpenter can ack pods which can schedule to existing and in-flight capacity
 	templates := lo.FilterMap(nodePools, func(np *v1.NodePool, _ int) (*NodeClaimTemplate, bool) {
+		if nodeLimit, ok := np.Spec.Limits[resources.Node]; ok && nodeLimit.IsZero() {
+			recorder.Publish(NoCapacity(np, resources.Node))
+			log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Info("skipping, nodepool node limit is zero")
+			return nil, false
+		}
 		var err error
 		nct := NewNodeClaimTemplate(np)
 		nct.InstanceTypeOptions, _, err = filterInstanceTypesByRequirements(instanceTypes[np.Name], nct.Requirements, &corev1.Pod{}, corev1.ResourceList{}, []DaemonOverheadGroup{{InstanceTypes: instanceTypes[np.Name], HostPortUsage: scheduling.NewHostPortUsage()}}, corev1.ResourceList{}, minValuesPolicy == karpopts.MinValuesPolicyBestEffort)

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -36,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
@@ -67,6 +66,7 @@ var (
 	prov                *provisioning.Provisioner
 	env                 *test.Environment
 	instanceTypeMap     map[string]*cloudprovider.InstanceType
+	recorder            *test.EventRecorder
 )
 
 func TestAPIs(t *testing.T) {
@@ -81,7 +81,8 @@ var _ = BeforeSuite(func() {
 	cloudProvider = fake.NewCloudProvider()
 	cluster = state.NewCluster(env.Clock, env.Client, cloudProvider)
 	nodeController = informer.NewNodeController(env.Client, cluster)
-	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock, deviceallocation.NewController(env.Client), virtualpods.NewVirtualPodCache(env.Client))
+	recorder = test.NewEventRecorder()
+	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, env.Clock, deviceallocation.NewController(env.Client), virtualpods.NewVirtualPodCache(env.Client))
 	daemonsetController = informer.NewDaemonSetController(env.Client, cluster)
 	instanceTypes, _ := cloudProvider.GetInstanceTypes(ctx, nil)
 	instanceTypeMap = map[string]*cloudprovider.InstanceType{}
@@ -93,6 +94,7 @@ var _ = BeforeSuite(func() {
 var _ = BeforeEach(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider.Reset()
+	recorder.Reset()
 
 	// ensure any waiters on our clock are allowed to proceed before resetting our clock time
 	for env.Clock.HasWaiters() {
@@ -929,6 +931,17 @@ var _ = Describe("Provisioning", func() {
 			pod = test.UnschedulablePod(opts)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
+		})
+		It("should not schedule and should not launch a node when the node limit is zero", func() {
+			ExpectApplied(ctx, env.Client, test.NodePool(v1.NodePool{
+				Spec: v1.NodePoolSpec{
+					Limits: v1.Limits(corev1.ResourceList{resources.Node: resource.MustParse("0")}),
+				},
+			}))
+			pod := test.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(recorder.Calls(events.NoCapacity)).To(BeNumerically(">", 0))
 		})
 	})
 	Context("Daemonsets", func() {

--- a/pkg/events/reason.go
+++ b/pkg/events/reason.go
@@ -31,6 +31,7 @@ const (
 	// provisioning/scheduling
 	FailedScheduling          = "FailedScheduling"
 	NoCompatibleInstanceTypes = "NoCompatibleInstanceTypes"
+	NoCapacity                = "NoCapacity"
 	Nominated                 = "Nominated"
 
 	// node/health


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

As a cluster operator I want to define a disabled NodePool that I may enable later. The spec does not provide an explicit toggle so I use nodes limit of zero.

Currently Karpenter continuously logs "node limits have been exhausted" error.

Pre-filter NodePools with spec.limits.nodes == 0 out of scheduling instead of retrying every pending pod against them and logging an error. Also publish NoCapacity warning event on the NodePool so the disabled state is visible.

**How was this change tested?**

Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
