### PR TITLE
feat: add karpenter_pods_disrupted_total metric when NodeClaims are disrupted

### DIFF
--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -33,6 +33,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
@@ -90,21 +91,18 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
-			metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+			labels := map[string]string{
 				metrics.ReasonLabel:              "insufficient_capacity",
 				metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
 				metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
 				metrics.ConsolidationPolicyLabel: "",
 				metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
-			})
+			}
+			metrics.NodeClaimsDisruptedTotal.Inc(labels)
 			if pods, err := nodeutils.ReschedulablePods(ctx, l.kubeClient, nodeClaim.Status.NodeName); err != nil {
 				log.FromContext(ctx).Error(err, "failed getting reschedulable pods for failed nodeclaim")
 			} else {
-				metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), map[string]string{
-					metrics.ReasonLabel:       "insufficient_capacity",
-					metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
-					metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
-				})
+				metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), labels)
 			}
 			return nil, nil
 		case cloudprovider.IsNodeClassNotReadyError(err):
@@ -112,21 +110,18 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 			if err = l.kubeClient.Delete(ctx, nodeClaim); err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
-			metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+			labels := map[string]string{
 				metrics.ReasonLabel:              "nodeclass_not_ready",
 				metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
 				metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
 				metrics.ConsolidationPolicyLabel: "",
 				metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
-			})
+			}
+			metrics.NodeClaimsDisruptedTotal.Inc(labels)
 			if pods, err := nodeutils.ReschedulablePods(ctx, l.kubeClient, nodeClaim.Status.NodeName); err != nil {
 				log.FromContext(ctx).Error(err, "failed getting reschedulable pods for failed nodeclaim")
 			} else {
-				metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), map[string]string{
-					metrics.ReasonLabel:       "nodeclass_not_ready",
-					metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
-					metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
-				})
+				metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), labels)
 			}
 			return nil, nil
 		default:

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -33,7 +33,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
-	"sigs.k8s.io/karpenter/pkg/metrics"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
@@ -97,6 +97,15 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 				metrics.ConsolidationPolicyLabel: "",
 				metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
 			})
+			if pods, err := nodeutils.ReschedulablePods(ctx, l.kubeClient, nodeClaim.Status.NodeName); err != nil {
+				log.FromContext(ctx).Error(err, "failed getting reschedulable pods for failed nodeclaim")
+			} else {
+				metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), map[string]string{
+					metrics.ReasonLabel:       "insufficient_capacity",
+					metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
+					metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
+				})
+			}
 			return nil, nil
 		case cloudprovider.IsNodeClassNotReadyError(err):
 			log.FromContext(ctx).Error(err, "failed launching nodeclaim")
@@ -110,6 +119,15 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 				metrics.ConsolidationPolicyLabel: "",
 				metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
 			})
+			if pods, err := nodeutils.ReschedulablePods(ctx, l.kubeClient, nodeClaim.Status.NodeName); err != nil {
+				log.FromContext(ctx).Error(err, "failed getting reschedulable pods for failed nodeclaim")
+			} else {
+				metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), map[string]string{
+					metrics.ReasonLabel:       "nodeclass_not_ready",
+					metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
+					metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
+				})
+			}
 			return nil, nil
 		default:
 			var createError *cloudprovider.CreateError

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/metrics"
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
@@ -150,21 +152,18 @@ func (l *Liveness) deleteNodeClaimForTimeout(ctx context.Context, timeout time.D
 		return err
 	}
 	log.FromContext(ctx).V(1).WithValues("timeout", timeout, "reason", reason).Info("terminating due to timeout")
-	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+	labels := map[string]string{
 		metrics.ReasonLabel:              reason,
 		metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
 		metrics.ConsolidationPolicyLabel: "",
 		metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
-	})
+	}
+	metrics.NodeClaimsDisruptedTotal.Inc(labels)
 	if pods, err := nodeutils.ReschedulablePods(ctx, l.kubeClient, nodeClaim.Status.NodeName); err != nil {
 		log.FromContext(ctx).Error(err, "failed getting reschedulable pods for timed out nodeclaim")
 	} else {
-		metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), map[string]string{
-			metrics.ReasonLabel:       reason,
-			metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
-			metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
-		})
+		metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), labels)
 	}
 	return nil
 }

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -35,8 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
-	"sigs.k8s.io/karpenter/pkg/metrics"
-	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
@@ -158,5 +157,14 @@ func (l *Liveness) deleteNodeClaimForTimeout(ctx context.Context, timeout time.D
 		metrics.ConsolidationPolicyLabel: "",
 		metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
 	})
+	if pods, err := nodeutils.ReschedulablePods(ctx, l.kubeClient, nodeClaim.Status.NodeName); err != nil {
+		log.FromContext(ctx).Error(err, "failed getting reschedulable pods for timed out nodeclaim")
+	} else {
+		metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), map[string]string{
+			metrics.ReasonLabel:       timeout.reason,
+			metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
+			metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
+		})
+	}
 	return nil
 }

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -161,7 +161,7 @@ func (l *Liveness) deleteNodeClaimForTimeout(ctx context.Context, timeout time.D
 		log.FromContext(ctx).Error(err, "failed getting reschedulable pods for timed out nodeclaim")
 	} else {
 		metrics.PodsDisruptionInitiatedTotal.Add(float64(len(pods)), map[string]string{
-			metrics.ReasonLabel:       timeout.reason,
+			metrics.ReasonLabel:       reason,
 			metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
 		})


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/karpenter/issues/2020

## Summary

This PR implements a new Prometheus counter metric `karpenter_pods_disrupted_total` to track the total number of reschedulable pods disrupted by Karpenter. This helps users monitor and visualize the operational impact of various disruption reasons (like expiration, consolidation, emptiness, unhealthiness, etc.) across the cluster.

## Changes

1. **Metric Definition**:
   - Registered `karpenter_pods_disrupted_total` in `pkg/metrics/metrics.go` with subsystem `pods`.
   - Labeled by `reason`, `nodepool`, and `capacity_type` (mirroring `karpenter_nodeclaims_disrupted_total`).

2. **Helper Function**:
   - Added `GetReschedulablePods(ctx, kubeClient, nodeName)` helper to `pkg/utils/node/node.go` to safely list and filter pods bound to a node that satisfy the `pod.IsReschedulable` criteria.

3. **Metric Instrumentation**:
   - Incremented the new metric next to all existing `NodeClaimsDisruptedTotal` call sites:
     - `pkg/controllers/disruption/queue.go` (uses cached `reschedulablePods` on `Candidate` directly)
     - `pkg/controllers/node/health/controller.go`
     - `pkg/controllers/nodeclaim/expiration/controller.go`
     - `pkg/controllers/nodeclaim/lifecycle/launch.go`
     - `pkg/controllers/nodeclaim/lifecycle/liveness.go`
     - `pkg/controllers/nodeclaim/garbagecollection/controller.go`

4. **Testing**:
   - Added a new unit test in `pkg/controllers/nodeclaim/expiration/suite_test.go` verifying that the `karpenter_pods_disrupted_total` metric is fired and incremented accurately when an expired NodeClaim with pods is deleted.