### PR TITLE
fix: respect pod terminationGracePeriodSeconds when waiting after drain

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -222,9 +222,13 @@ func (c *Controller) awaitDrain(
 	// kubelet may still be running the preStop hook for the pod's full terminationGracePeriodSeconds.
 	// Calling cloudProvider.Delete() (EC2 TerminateInstances) before preStop hooks complete causes
 	// FailedPreStopHook + ttrpc: closed errors.
+	//
+	// This is clamped to nodeTerminationTime when set, so we never requeue past the nodeclaim's own
+	// terminationGracePeriod deadline (mirrors the clamp terminator.DeleteExpiringPods already does
+	// for the pod delete grace period).
 	if nodeClaim != nil {
 		cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained)
-		effectiveDrainTime := c.effectiveDrainTime(ctx, node)
+		effectiveDrainTime := c.effectiveDrainTime(ctx, node, nodeTerminationTime)
 		if cond == nil || (cond.IsUnknown() && c.clock.Since(cond.LastTransitionTime.Time) < effectiveDrainTime) {
 			return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 		}
@@ -240,7 +244,11 @@ func (c *Controller) awaitDrain(
 // proceeding to instance termination. It is computed as max(MinDrainTime, maxPodTerminationGracePeriodSeconds)
 // across all pods still on the node (deletionTimestamp set). This ensures the EC2 instance is not
 // terminated while preStop hooks are still executing.
-func (c *Controller) effectiveDrainTime(ctx context.Context, node *corev1.Node) time.Duration {
+//
+// If nodeTerminationTime is set, the result is clamped so it never exceeds the time remaining until
+// nodeTerminationTime - the nodeclaim's terminationGracePeriod always takes priority, matching the
+// existing invariant documented on awaitDrain.
+func (c *Controller) effectiveDrainTime(ctx context.Context, node *corev1.Node, nodeTerminationTime *time.Time) time.Duration {
 	pods, err := nodeutils.GetPods(ctx, c.kubeClient, node)
 	if err != nil {
 		return MinDrainTime
@@ -253,6 +261,11 @@ func (c *Controller) effectiveDrainTime(ctx context.Context, node *corev1.Node) 
 		podGrace := time.Duration(*p.Spec.TerminationGracePeriodSeconds) * time.Second
 		if podGrace > effective {
 			effective = podGrace
+		}
+	}
+	if nodeTerminationTime != nil {
+		if remaining := nodeTerminationTime.Sub(c.clock.Now()); remaining < effective {
+			return max(remaining, 0)
 		}
 	}
 	return effective

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -228,7 +228,11 @@ func (c *Controller) awaitDrain(
 	// for the pod delete grace period).
 	if nodeClaim != nil {
 		cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained)
-		effectiveDrainTime := c.effectiveDrainTime(ctx, node, nodeTerminationTime)
+		pods, err := nodeutils.GetPods(ctx, c.kubeClient, node)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("listing pods, %w", err)
+		}
+		effectiveDrainTime := c.effectiveDrainTime(pods, nodeTerminationTime)
 		if cond == nil || (cond.IsUnknown() && c.clock.Since(cond.LastTransitionTime.Time) < effectiveDrainTime) {
 			return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 		}
@@ -242,24 +246,19 @@ func (c *Controller) awaitDrain(
 
 // effectiveDrainTime returns the minimum time to wait after all pods have been evicted before
 // proceeding to instance termination. It is computed as max(MinDrainTime, maxPodTerminationGracePeriodSeconds)
-// across all pods still on the node (deletionTimestamp set). This ensures the EC2 instance is not
-// terminated while preStop hooks are still executing.
+// across terminating pods on the node. This ensures the EC2 instance is not terminated while
+// preStop hooks are still executing.
 //
 // If nodeTerminationTime is set, the result is clamped so it never exceeds the time remaining until
-// nodeTerminationTime - the nodeclaim's terminationGracePeriod always takes priority, matching the
+// nodeTerminationTime — the nodeclaim's terminationGracePeriod always takes priority, matching the
 // existing invariant documented on awaitDrain.
-func (c *Controller) effectiveDrainTime(ctx context.Context, node *corev1.Node, nodeTerminationTime *time.Time) time.Duration {
-	pods, err := nodeutils.GetPods(ctx, c.kubeClient, node)
-	if err != nil {
-		return MinDrainTime
-	}
+func (c *Controller) effectiveDrainTime(pods []*corev1.Pod, nodeTerminationTime *time.Time) time.Duration {
 	effective := MinDrainTime
 	for _, p := range pods {
 		if p.DeletionTimestamp == nil || p.Spec.TerminationGracePeriodSeconds == nil {
 			continue
 		}
-		podGrace := time.Duration(*p.Spec.TerminationGracePeriodSeconds) * time.Second
-		if podGrace > effective {
+		if podGrace := time.Duration(*p.Spec.TerminationGracePeriodSeconds) * time.Second; podGrace > effective {
 			effective = podGrace
 		}
 	}

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -212,12 +212,20 @@ func (c *Controller) awaitDrain(
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
-	// If the nodeclaim exists, check if minDrainTime has elapsed. If it hasn't we should requeue.
+	// If the nodeclaim exists, check if the effective drain time has elapsed. If it hasn't we should requeue.
 	// This check helps to ensure that we drain pods scheduled to the Node immediately after we taint it, which
 	// can occur when the scheduler has not seen the taint yet.
+	//
+	// We use max(MinDrainTime, maxPodTerminationGracePeriodSeconds) as the effective drain time to avoid
+	// terminating the EC2 instance while preStop hooks are still executing. IsWaitingEviction() is a pure
+	// etcd/API check (deletionTimestamp set) — it returns false as soon as eviction is accepted, but the
+	// kubelet may still be running the preStop hook for the pod's full terminationGracePeriodSeconds.
+	// Calling cloudProvider.Delete() (EC2 TerminateInstances) before preStop hooks complete causes
+	// FailedPreStopHook + ttrpc: closed errors.
 	if nodeClaim != nil {
 		cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained)
-		if cond == nil || (cond.IsUnknown() && c.clock.Since(cond.LastTransitionTime.Time) < MinDrainTime) {
+		effectiveDrainTime := c.effectiveDrainTime(ctx, node)
+		if cond == nil || (cond.IsUnknown() && c.clock.Since(cond.LastTransitionTime.Time) < effectiveDrainTime) {
 			return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 		}
 	}
@@ -226,6 +234,28 @@ func (c *Controller) awaitDrain(
 		nodeClaim.StatusConditions(status.WithClock(c.clock)).SetTrue(v1.ConditionTypeDrained)
 	}
 	return reconcile.Result{}, nil
+}
+
+// effectiveDrainTime returns the minimum time to wait after all pods have been evicted before
+// proceeding to instance termination. It is computed as max(MinDrainTime, maxPodTerminationGracePeriodSeconds)
+// across all pods still on the node (deletionTimestamp set). This ensures the EC2 instance is not
+// terminated while preStop hooks are still executing.
+func (c *Controller) effectiveDrainTime(ctx context.Context, node *corev1.Node) time.Duration {
+	pods, err := nodeutils.GetPods(ctx, c.kubeClient, node)
+	if err != nil {
+		return MinDrainTime
+	}
+	effective := MinDrainTime
+	for _, p := range pods {
+		if p.DeletionTimestamp == nil || p.Spec.TerminationGracePeriodSeconds == nil {
+			continue
+		}
+		podGrace := time.Duration(*p.Spec.TerminationGracePeriodSeconds) * time.Second
+		if podGrace > effective {
+			effective = podGrace
+		}
+	}
+	return effective
 }
 
 // awaitVolumeDetachment will continue to requeue until all volume attachments associated with the node have been

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -908,6 +908,38 @@ var _ = Describe("Termination", func() {
 			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
 			ExpectNotFound(ctx, env.Client, node)
 		})
+		It("should not requeue drain past the nodeclaim's terminationGracePeriod even if pod TGPS is longer", func() {
+			// A pod's terminationGracePeriodSeconds can exceed the nodeclaim's own terminationGracePeriod
+			// (e.g. spot interruption with a short deadline). In that case the node's deadline must win -
+			// we should not requeue drain past nodeTerminationTime just because a pod's TGPS is larger.
+			nodeClaim.Spec.TerminationGracePeriod = &metav1.Duration{Duration: 20 * time.Second}
+			nodeClaim.Annotations = map[string]string{
+				v1.NodeClaimTerminationTimestampAnnotationKey: env.Clock.Now().Add(nodeClaim.Spec.TerminationGracePeriod.Duration).Format(time.RFC3339),
+			}
+			pod := test.Pod(test.PodOptions{
+				NodeName:                      node.Name,
+				ObjectMeta:                    metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs},
+				TerminationGracePeriodSeconds: lo.ToPtr(int64(600)),
+			})
+			ExpectApplied(ctx, env.Client, node, nodeClaim, pod)
+			ExpectDeletionTimestampSet(ctx, env.Client, pod)
+			Expect(env.Client.Delete(ctx, node)).To(Succeed())
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+
+			// First reconcile: taint and start draining
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+
+			// Even though pod TGPS (600s) is far larger than MinDrainTime, effectiveDrainTime must be
+			// clamped to the nodeclaim's terminationGracePeriod (20s), not the pod's TGPS.
+			env.Clock.Step(20 * time.Second)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsTrue()).To(BeTrue())
+
+			ExpectDeleted(ctx, env.Client, pod)
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+			ExpectNotFound(ctx, env.Client, node)
+		})
 		Context("VolumeAttachments", func() {
 			It("should wait for volume attachments", func() {
 				va := test.VolumeAttachment(test.VolumeAttachmentOptions{

--- a/pkg/controllers/node/termination/suite_test.go
+++ b/pkg/controllers/node/termination/suite_test.go
@@ -870,6 +870,44 @@ var _ = Describe("Termination", func() {
 			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
 			ExpectNotFound(ctx, env.Client, node)
 		})
+		It("should not finish draining until pod terminationGracePeriodSeconds has passed", func() {
+			// Pods with terminationGracePeriodSeconds > MinDrainTime should cause the controller
+			// to wait for the full TGPS before proceeding to instance termination.
+			// This prevents EC2 TerminateInstances being called while preStop hooks are still running.
+			tgps := int64(30)
+			pod := test.Pod(test.PodOptions{
+				NodeName:                      node.Name,
+				ObjectMeta:                    metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs},
+				TerminationGracePeriodSeconds: lo.ToPtr(tgps),
+			})
+			ExpectApplied(ctx, env.Client, node, nodeClaim, pod)
+			// Simulate pod already being in terminating state (deletionTimestamp set)
+			// as it would be after eviction API accepts the request
+			ExpectDeletionTimestampSet(ctx, env.Client, pod)
+			Expect(env.Client.Delete(ctx, node)).To(Succeed())
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+
+			// First reconcile: taint and start draining
+			// Pod has deletionTimestamp so Drain() returns nil (IsWaitingEviction=false)
+			// but effectiveDrainTime = max(MinDrainTime=5s, TGPS=30s) = 30s
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+
+			// Should still requeue - 30s have not passed yet
+			env.Clock.Step(termination.MinDrainTime)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsTrue()).To(BeFalse())
+
+			// After pod's full TGPS has elapsed, drain completes and instance can be terminated
+			env.Clock.Step(time.Duration(tgps) * time.Second)
+			ExpectRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrained).IsTrue()).To(BeTrue())
+
+			ExpectDeleted(ctx, env.Client, pod)
+			ExpectNotRequeued(ExpectObjectReconciled(ctx, env.Client, terminationController, node))
+			ExpectNotFound(ctx, env.Client, node)
+		})
 		Context("VolumeAttachments", func() {
 			It("should wait for volume attachments", func() {
 				va := test.VolumeAttachment(test.VolumeAttachmentOptions{


### PR DESCRIPTION
closes #1894

**Problem**

`MinDrainTime` (5s) is the only buffer between "all pods evicted" and `cloudProvider.Delete()` (EC2 TerminateInstances). But `IsWaitingEviction()` is a pure etcd check — it returns false as soon as `deletionTimestamp` is set, while the kubelet is still running the preStop hook for the full `terminationGracePeriodSeconds`. With the default of 30s, Karpenter terminates the instance ~25s too early:

```
Warning  FailedPreStopHook  PreStopHook failed
Warning  FailedKillPod      failed to stop container: ttrpc: closed
```

Reproducible on any pod with `terminationGracePeriodSeconds > 5s` during ordinary consolidation. No `NodePool.terminationGracePeriod` needed.

**Fix**

Compute `effectiveDrainTime = max(MinDrainTime, maxPodTGPS)` across pods on the node that have `deletionTimestamp` set. `MinDrainTime` is kept as the floor to preserve the existing behavior of catching late-scheduled pods.

**Testing**

- existing unit tests pass: `go test ./pkg/controllers/node/termination/...`
- manually verified on EKS 1.35 / Karpenter v1.9.0 with stateful pod (preStop hook ~5s, tgps=30s) — no more FailedPreStopHook after fix