### PR TITLE
fix: relax minValues against narrowed NodeClaim requirements

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -410,7 +410,12 @@ func (its InstanceTypes) SatisfiesMinValues(requirements scheduling.Requirements
 				if _, ok := valuesForKey[req.Key]; !ok {
 					valuesForKey[req.Key] = sets.New[string]()
 				}
-				valuesForKey[req.Key] = valuesForKey[req.Key].Insert(it.Requirements.Get(req.Key).Values()...)
+				// Only count values that the requirement allows. The instance type may offer values (e.g. zones)
+				// that the requirements exclude after being narrowed by pod constraints such as volume topology
+				// or topology spread, and those values can't be satisfied by the resulting NodeClaim.
+				valuesForKey[req.Key] = valuesForKey[req.Key].Insert(lo.Filter(it.Requirements.Get(req.Key).Values(), func(value string, _ int) bool {
+					return req.Has(value)
+				})...)
 			}
 		}
 		for k, v := range valuesForKey {

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -3248,6 +3248,29 @@ var _ = Describe("Provisioning", func() {
 					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 					ExpectNotScheduled(ctx, env.Client, pod)
 				})
+
+				It("should not schedule when pod volume topology narrows zones below minValues", func() {
+					// The instance type offers all three zones, but the pod's volume topology narrows the
+					// NodeClaim requirements to a single zone, which can't satisfy minValues=3
+					cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{multiZoneInstanceType("instance-type-1", "test-zone-1", "test-zone-2", "test-zone-3")}
+
+					storageClass := test.StorageClass(test.StorageClassOptions{
+						Zones:             []string{"test-zone-1"},
+						VolumeBindingMode: lo.ToPtr(storagev1.VolumeBindingWaitForFirstConsumer),
+					})
+					persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass.Name})
+					ExpectApplied(ctx, env.Client, nodePool, storageClass, persistentVolumeClaim)
+					pod := test.UnschedulablePod(test.PodOptions{
+						PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+						ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0.9"),
+							corev1.ResourceMemory: resource.MustParse("0.9Gi")},
+						},
+					})
+
+					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+					ExpectNotScheduled(ctx, env.Client, pod)
+				})
 			})
 
 			Context("with MinValuesPolicy set to BestEffort", func() {
@@ -3307,6 +3330,42 @@ var _ = Describe("Provisioning", func() {
 							Values:   []string{"test-zone-1", "test-zone-2", "test-zone-3"},
 
 							MinValues: new(2),
+						}))
+				})
+
+				It("should relax minValues when pod volume topology narrows zones below minValues", func() {
+					// The instance type offers all three zones, but the pod's volume topology narrows the
+					// NodeClaim requirements to a single zone. minValues must be relaxed against the narrowed
+					// requirements, otherwise the NodeClaim is created with one zone value and minValues=3,
+					// which fails CRD validation
+					cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{multiZoneInstanceType("instance-type-1", "test-zone-1", "test-zone-2", "test-zone-3")}
+
+					storageClass := test.StorageClass(test.StorageClassOptions{
+						Zones:             []string{"test-zone-1"},
+						VolumeBindingMode: lo.ToPtr(storagev1.VolumeBindingWaitForFirstConsumer),
+					})
+					persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass.Name})
+					ExpectApplied(ctx, env.Client, nodePool, storageClass, persistentVolumeClaim)
+					pod := test.UnschedulablePod(test.PodOptions{
+						PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+						ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0.9"),
+							corev1.ResourceMemory: resource.MustParse("0.9Gi")},
+						},
+					})
+
+					ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+					node := ExpectScheduled(ctx, env.Client, pod)
+					nodeClaim := cloudProvider.CreateCalls[0]
+					Expect(node.Labels[corev1.LabelTopologyZone]).To(Equal("test-zone-1"))
+					Expect(node.Annotations[v1.NodeClaimMinValuesRelaxedAnnotationKey]).To(Equal("true"))
+					Expect(nodeClaim.Spec.Requirements).To(ContainElements(
+						v1.NodeSelectorRequirementWithMinValues{
+							Key:      corev1.LabelTopologyZone,
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"test-zone-1"},
+
+							MinValues: new(1),
 						}))
 				})
 			})
@@ -3436,6 +3495,24 @@ func ExpectNodeClaimRequests(nodeClaim *v1.NodeClaim, resources corev1.ResourceL
 		v := nodeClaim.Spec.Resources.Requests[name]
 		Expect(v.AsApproximateFloat64()).To(BeNumerically("~", value.AsApproximateFloat64(), 10))
 	}
+}
+
+func multiZoneInstanceType(name string, zones ...string) *cloudprovider.InstanceType {
+	return fake.NewInstanceType(name,
+		fake.WithArchitecture(v1.ArchitectureArm64),
+		fake.WithOperatingSystems(string(corev1.Linux)),
+		fake.WithResources(corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4"),
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+		}),
+		fake.WithOfferings(lo.Map(zones, func(zone string, _ int) cloudprovider.Offering {
+			return cloudprovider.Offering{
+				Available:    true,
+				Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: zone}),
+				Price:        0.52,
+			}
+		})...),
+	)
 }
 
 func AddInstanceResources(instanceTypes []*cloudprovider.InstanceType, resources corev1.ResourceList) []*cloudprovider.InstanceType {


### PR DESCRIPTION
Fixes #2999

**Description**

`SatisfiesMinValues` counts each instance type's raw offered values instead of intersecting them with the NodeClaim's requirements. When pod constraints (PVC volume topology, topology spread) narrow a requirement that carries `minValues` e.g. zone `In [a, b] minValues: 2` narrowed to `In [a]` the check still sees every zone the instance types offer, reports minValues as satisfied, and the BestEffort relaxation never triggers. The NodeClaim is then created with fewer values than `minValues` and rejected by the CRD CEL validation, blocking capacity for affected workloads.

This change filters each instance type's values through `Requirement.Has()` before counting, so only values the narrowed requirement still allows count toward minValues. BestEffort then relaxes correctly (with the relaxed annotation set), and Strict fails at scheduling simulation with a clear error instead of failing at NodeClaim creation.

Note on Strict mode: requirements whose achievable value set is genuinely smaller than `minValues` (e.g. `NotIn`/bounded operators) now fail scheduling simulation rather than producing a NodeClaim that would be rejected downstream a correction, but an observable behavior change.

**How was this change tested?**

- Added regression tests reproducing the reported scenario (`WaitForFirstConsumer` StorageClass pinned to one zone + `minValues` on the NodePool zone requirement): without the fix the NodeClaim fails CEL validation and the pod stays pending; with it the pod schedules into the pinned zone with `minValues` relaxed to 1 and the relaxed annotation set. Also covers Strict mode (pod correctly not scheduled).
- Full `provisioning`, `provisioning/scheduling`, `cloudprovider`, `scheduling`, and `disruption` suites pass with `-race` (disruption/consolidation also calls `SatisfiesMinValues`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.