### PR TITLE
fix: emit disruption budget metrics on every reconcile pass

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -163,6 +163,10 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 		return reconciler.Result{}, serrors.Wrap(fmt.Errorf("removing condition from nodeclaims, %w", err), "condition", v1.ConditionTypeDisruptionReason)
 	}
 
+	// Refresh budget metrics for every reason on each pass so the gauges track budget schedules
+	// even when a reason has no candidates.
+	UpdateDisruptionBudgetMetrics(ctx, c.cluster, c.clock, c.kubeClient, c.cloudProvider, lo.Uniq(lo.Map(c.methods, func(m Method, _ int) v1.DisruptionReason { return m.Reason() }))...)
+
 	// Attempt different disruption methods. We'll only let one method perform an action
 	for _, m := range c.methods {
 		c.recordRun(fmt.Sprintf("%T", m))

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -257,12 +257,50 @@ func BuildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 
 // BuildDisruptionBudgets prepares our disruption budget mapping. The disruption budget maps each disruption reason to the number of allowed disruptions.
 // We calculate allowed disruptions by taking the max disruptions allowed by disruption reason and subtracting the number of nodes that are NotReady and already being deleted by that disruption reason.
-//
-//nolint:gocyclo
 func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, reason v1.DisruptionReason) (map[string]int, error) {
 	disruptionBudgetMapping := map[string]int{}
-	numNodes := map[string]int{}   // map[nodepool] -> node count in nodepool
-	disrupting := map[string]int{} // map[nodepool] -> nodes undergoing disruption
+	numNodes, disrupting := disruptionBudgetCounts(cluster)
+	nodePools, err := nodepoolutils.ListManaged(ctx, kubeClient, cloudProvider)
+	if err != nil {
+		return disruptionBudgetMapping, fmt.Errorf("listing node pools, %w", err)
+	}
+	for _, nodePool := range nodePools {
+		allowedDisruptions := nodePool.MustGetAllowedDisruptions(clk, numNodes[nodePool.Name], reason)
+		disruptionBudgetMapping[nodePool.Name] = lo.Max([]int{allowedDisruptions - disrupting[nodePool.Name], 0})
+		if numNodes[nodePool.Name] != 0 && allowedDisruptions == 0 {
+			recorder.Publish(disruptionevents.NodePoolBlockedForDisruptionReason(nodePool, reason))
+		}
+	}
+	return disruptionBudgetMapping, nil
+}
+
+// UpdateDisruptionBudgetMetrics refreshes the allowed_disruptions and nodes_consuming_budgets gauges for every
+// nodepool and every given reason, independently of candidate discovery. Metric emission is best-effort and
+// must not block the disruption loop, so failures are logged rather than returned.
+func UpdateDisruptionBudgetMetrics(ctx context.Context, cluster *state.Cluster, clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, reasons ...v1.DisruptionReason) {
+	numNodes, disrupting := disruptionBudgetCounts(cluster)
+	nodePools, err := nodepoolutils.ListManaged(ctx, kubeClient, cloudProvider)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed listing nodepools")
+		return
+	}
+	for _, nodePool := range nodePools {
+		for _, reason := range reasons {
+			NodePoolAllowedDisruptions.Set(float64(nodePool.MustGetAllowedDisruptions(clk, numNodes[nodePool.Name], reason)), map[string]string{
+				metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+			})
+			NodePoolNodesConsumingBudgets.Set(float64(disrupting[nodePool.Name]), map[string]string{
+				metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+			})
+		}
+	}
+}
+
+// disruptionBudgetCounts returns the number of nodes counted towards disruption budgets and the number of
+// nodes currently consuming budgets, per nodepool.
+func disruptionBudgetCounts(cluster *state.Cluster) (numNodes, disrupting map[string]int) {
+	numNodes = map[string]int{}   // map[nodepool] -> node count in nodepool
+	disrupting = map[string]int{} // map[nodepool] -> nodes undergoing disruption
 	for _, node := range cluster.DeepCopyNodes() {
 		// We only consider nodes that we own and are initialized towards the total.
 		// If a node is launched/registered, but not initialized, pods aren't scheduled
@@ -292,24 +330,7 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 			disrupting[nodePool]++
 		}
 	}
-	nodePools, err := nodepoolutils.ListManaged(ctx, kubeClient, cloudProvider)
-	if err != nil {
-		return disruptionBudgetMapping, fmt.Errorf("listing node pools, %w", err)
-	}
-	for _, nodePool := range nodePools {
-		allowedDisruptions := nodePool.MustGetAllowedDisruptions(clk, numNodes[nodePool.Name], reason)
-		disruptionBudgetMapping[nodePool.Name] = lo.Max([]int{allowedDisruptions - disrupting[nodePool.Name], 0})
-		NodePoolAllowedDisruptions.Set(float64(allowedDisruptions), map[string]string{
-			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
-		})
-		NodePoolNodesConsumingBudgets.Set(float64(disrupting[nodePool.Name]), map[string]string{
-			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
-		})
-		if numNodes[nodePool.Name] != 0 && allowedDisruptions == 0 {
-			recorder.Publish(disruptionevents.NodePoolBlockedForDisruptionReason(nodePool, reason))
-		}
-	}
-	return disruptionBudgetMapping, nil
+	return numNodes, disrupting
 }
 
 // mapCandidates maps the list of proposed candidates with the current state

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -706,6 +706,24 @@ var _ = Describe("BuildDisruptionBudgetMapping", func() {
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, nodes, nodeClaims)
 	})
+	It("should update budget metrics for all reasons on reconcile even when there are no candidates", func() {
+		// An active schedule blocks all disruptions. None of the nodes are disruption candidates, so no
+		// disruption method evaluates this nodepool, but the gauges must still reflect the schedule.
+		nodePool.Spec.Disruption.Budgets = []v1.Budget{
+			{Nodes: "2"},
+			{Nodes: "0", Schedule: lo.ToPtr("* * * * *"), Duration: &metav1.Duration{Duration: time.Hour}},
+		}
+		ExpectApplied(ctx, env.Client, nodePool)
+		ExpectSingletonReconciled(ctx, disruptionController)
+		for _, reason := range allKnownDisruptionReasons {
+			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 0, map[string]string{
+				metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+			})
+			ExpectMetricGaugeValue(disruption.NodePoolNodesConsumingBudgets, 0, map[string]string{
+				metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+			})
+		}
+	})
 	It("should not consider nodes that are not managed as part of disruption count", func() {
 		nodePool.Spec.Disruption.Budgets = []v1.Budget{{Nodes: "100%"}}
 		ExpectApplied(ctx, env.Client, nodePool)


### PR DESCRIPTION
Fixes #2344

**Description**

`karpenter_nodepools_allowed_disruptions` and `karpenter_nodepools_nodes_consuming_budgets` were only set inside `BuildDisruptionBudgetMapping`, which a disruption method only reaches when it discovers at least one candidate for its reason. As a result:

- A reason with no eligible nodes (e.g. nothing drifted) never emitted a series at all.
- A reason whose last candidate appeared before a budget schedule boundary kept its stale pre-boundary value indefinitely, producing inconsistent readings like `Empty=2` alongside `Underutilized=0` for budgets that cover both reasons.

The budget schedule evaluation itself (`Budget.IsActive`) is correct only the metric was misleading.

This change decouples metric emission from candidate discovery: the per-nodepool node counting is extracted into a shared helper, and a new `UpdateDisruptionBudgetMetrics` emits both gauges for every nodepool and reason once per disruption loop pass. `BuildDisruptionBudgetMapping` no longer has a metrics side effect.

**How was this change tested?**

- Added a regression test: a NodePool with an active zero-budget schedule and no disruption candidates. Without the fix, the gauges are never emitted (the metric is entirely absent); with it, all reasons report the schedule-derived value on every pass.
- Full `pkg/controllers/disruption` suite passes with `-race`; lint clean.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.