### PR TITLE
fix: propagate template labels to virtual buffer pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/pkg/apis/autoscaling/v1beta1/constants.go
+++ b/pkg/apis/autoscaling/v1beta1/constants.go
@@ -39,11 +39,11 @@ const (
 	FakePodAnnotationKey   = "karpenter.sh/capacity-buffer-fake-pod"
 	FakePodAnnotationValue = "true"
 
-	// BufferNameLabel records which CapacityBuffer a virtual pod belongs to.
-	BufferNameLabel = "karpenter.sh/capacity-buffer-name"
+	// BufferNameAnnotation records which CapacityBuffer a virtual pod belongs to.
+	BufferNameAnnotation = "karpenter.sh/capacity-buffer-name"
 
-	// BufferNamespaceLabel records the namespace of the CapacityBuffer a virtual pod belongs to.
-	BufferNamespaceLabel = "karpenter.sh/capacity-buffer-namespace"
+	// BufferNamespaceAnnotation records the namespace of the CapacityBuffer a virtual pod belongs to.
+	BufferNamespaceAnnotation = "karpenter.sh/capacity-buffer-namespace"
 
 	// VirtualPodPriority is the priority stamped onto virtual buffer pods so that
 	// future preemption / disruption logic can identify them as low-value.

--- a/pkg/controllers/capacitybuffer/controller.go
+++ b/pkg/controllers/capacitybuffer/controller.go
@@ -163,7 +163,7 @@ func (c *Controller) podTemplateToBuffers(ctx context.Context, obj client.Object
 // without re-fetching. Returns (false, nil, nil) for customer-induced errors
 // (not found, unsupported kind), or (false, nil, err) for unexpected failures
 // that should be retried.
-func (c *Controller) resolveAndUpdateStatus(ctx context.Context, cb *autoscalingv1beta1.CapacityBuffer) (bool, *v1.PodSpec, error) {
+func (c *Controller) resolveAndUpdateStatus(ctx context.Context, cb *autoscalingv1beta1.CapacityBuffer) (bool, *v1.PodTemplateSpec, error) {
 	if cb.Spec.PodTemplateRef == nil && cb.Spec.ScalableRef == nil {
 		cb.SetCondition(autoscalingv1beta1.ReadyForProvisioningCondition, metav1.ConditionFalse, ReasonResolutionFailed, "Neither podTemplateRef nor scalableRef is set")
 		return false, nil, nil
@@ -191,11 +191,10 @@ func (c *Controller) resolveAndUpdateStatus(ctx context.Context, cb *autoscaling
 	}
 
 	// Compute replicas from all applicable constraints.
-	podSpec := &result.PodSpec
-	replicas := computeReplicas(cb, podSpec, candidates)
+	replicas := computeReplicas(cb, &result.PodTemplateSpec.Spec, candidates)
 	cb.SetCondition(autoscalingv1beta1.ReadyForProvisioningCondition, metav1.ConditionTrue, ReasonResolved, "Pod template resolved successfully")
 	cb.Status.Replicas = &replicas
-	return true, podSpec, nil
+	return true, &result.PodTemplateSpec, nil
 }
 
 // computeReplicas derives the desired buffer replica count from the configured

--- a/pkg/controllers/capacitybuffer/controller.go
+++ b/pkg/controllers/capacitybuffer/controller.go
@@ -148,7 +148,7 @@ func (c *Controller) resolveAndUpdateStatus(ctx context.Context, cb *autoscaling
 		if err != nil {
 			return false, handleResolveError(cb, err, ReasonPodTemplateNotFound)
 		}
-		podSpec = &result.PodSpec
+		podSpec = &result.PodTemplateSpec.Spec
 		cb.Status.PodTemplateRef = &autoscalingv1beta1.LocalObjectRef{Name: result.Name}
 		cb.Status.PodTemplateGeneration = &result.Generation
 
@@ -157,7 +157,7 @@ func (c *Controller) resolveAndUpdateStatus(ctx context.Context, cb *autoscaling
 		if err != nil {
 			return false, handleResolveError(cb, err, ReasonScalableRefNotFound)
 		}
-		podSpec = &result.PodSpec
+		podSpec = &result.PodTemplateSpec.Spec
 		cb.Status.PodTemplateRef = nil
 		cb.Status.PodTemplateGeneration = nil
 		if cb.Spec.Percentage != nil && result.ScalableReplicas > 0 {

--- a/pkg/controllers/provisioning/buffers.go
+++ b/pkg/controllers/provisioning/buffers.go
@@ -76,42 +76,44 @@ func (p *Provisioner) appendVirtualPods(ctx context.Context, pods []*corev1.Pod)
 		return pods
 	}
 	for _, cb := range buffers {
-		spec, err := p.resolveVirtualPodSpec(ctx, cb)
+		spec, labels, err := p.resolveVirtualPodSpec(ctx, cb)
 		if err != nil {
 			log.FromContext(ctx).WithValues("capacitybuffer", client.ObjectKeyFromObject(cb)).V(1).Info("skipping buffer", "reason", err.Error())
 			continue
 		}
-		pods = append(pods, buildVirtualPods(cb, spec)...)
+		pods = append(pods, buildVirtualPods(cb, spec, labels)...)
 	}
 	return pods
 }
 
-// resolveVirtualPodSpec fetches the pod spec for a buffer using the shared
-// workload resolution utilities. Reads from spec (not status) to avoid stale
-// references when users switch between podTemplateRef and scalableRef.
-func (p *Provisioner) resolveVirtualPodSpec(ctx context.Context, cb *autoscalingv1beta1.CapacityBuffer) (corev1.PodSpec, error) {
+// resolveVirtualPodSpec fetches the pod spec and template labels for a buffer
+// using the shared workload resolution utilities. Reads from spec (not status)
+// to avoid stale references when users switch between podTemplateRef and scalableRef.
+func (p *Provisioner) resolveVirtualPodSpec(ctx context.Context, cb *autoscalingv1beta1.CapacityBuffer) (corev1.PodSpec, map[string]string, error) {
 	switch {
 	case cb.Spec.PodTemplateRef != nil:
 		result, err := apps.ResolvePodTemplateRef(ctx, p.kubeClient, cb.Spec.PodTemplateRef.Name, cb.Namespace)
 		if err != nil {
-			return corev1.PodSpec{}, err
+			return corev1.PodSpec{}, nil, err
 		}
-		return result.PodSpec, nil
+		return result.PodTemplateSpec.Spec, result.PodTemplateSpec.Labels, nil
 	case cb.Spec.ScalableRef != nil:
 		result, err := apps.ResolveScalableRef(ctx, p.kubeClient, cb.Spec.ScalableRef, cb.Namespace)
 		if err != nil {
-			return corev1.PodSpec{}, err
+			return corev1.PodSpec{}, nil, err
 		}
-		return result.PodSpec, nil
+		return result.PodTemplateSpec.Spec, result.PodTemplateSpec.Labels, nil
 	default:
-		return corev1.PodSpec{}, fmt.Errorf("buffer %q has neither podTemplateRef nor scalableRef in spec", cb.Name)
+		return corev1.PodSpec{}, nil, fmt.Errorf("buffer %q has neither podTemplateRef nor scalableRef in spec", cb.Name)
 	}
 }
 
 // buildVirtualPods materializes N identical placeholder pods for a buffer using
 // the given pod spec. Deterministic names and UIDs let downstream components
 // associate results back to the owning buffer without additional bookkeeping.
-func buildVirtualPods(cb *autoscalingv1beta1.CapacityBuffer, spec corev1.PodSpec) []*corev1.Pod {
+// Template labels are merged into the pod metadata so that inter-pod affinity
+// and anti-affinity selectors that reference template labels match correctly.
+func buildVirtualPods(cb *autoscalingv1beta1.CapacityBuffer, spec corev1.PodSpec, templateLabels map[string]string) []*corev1.Pod {
 	if cb.Status.Replicas == nil || *cb.Status.Replicas <= 0 {
 		return nil
 	}
@@ -130,10 +132,10 @@ func buildVirtualPods(cb *autoscalingv1beta1.CapacityBuffer, spec corev1.PodSpec
 				Annotations: map[string]string{
 					autoscalingv1beta1.FakePodAnnotationKey: autoscalingv1beta1.FakePodAnnotationValue,
 				},
-				Labels: map[string]string{
+				Labels: lo.Assign(templateLabels, map[string]string{
 					autoscalingv1beta1.BufferNameLabel:      cb.Name,
 					autoscalingv1beta1.BufferNamespaceLabel: cb.Namespace,
-				},
+				}),
 				CreationTimestamp: metav1.NewTime(time.Now()),
 			},
 			Spec: strippedSpec,

--- a/pkg/controllers/provisioning/buffers.go
+++ b/pkg/controllers/provisioning/buffers.go
@@ -71,8 +71,8 @@ func bufferKeyOf(pod *corev1.Pod) string {
 	if !IsVirtualPod(pod) {
 		return ""
 	}
-	ns := pod.Labels[autoscalingv1beta1.BufferNamespaceLabel]
-	name := pod.Labels[autoscalingv1beta1.BufferNameLabel]
+	ns := pod.Annotations[autoscalingv1beta1.BufferNamespaceAnnotation]
+	name := pod.Annotations[autoscalingv1beta1.BufferNameAnnotation]
 	if ns == "" || name == "" {
 		return ""
 	}

--- a/pkg/controllers/provisioning/buffers_test.go
+++ b/pkg/controllers/provisioning/buffers_test.go
@@ -50,7 +50,7 @@ var _ = Describe("bufferKeyOf", func() {
 				autoscalingv1beta1.FakePodAnnotationKey: autoscalingv1beta1.FakePodAnnotationValue,
 			},
 			Labels: map[string]string{
-				autoscalingv1beta1.BufferNameLabel: "my-buffer",
+				autoscalingv1beta1.BufferNameAnnotation: "my-buffer",
 			},
 		}}
 		Expect(bufferKeyOf(pod)).To(Equal(""))
@@ -64,7 +64,7 @@ var _ = Describe("bufferKeyOf", func() {
 				autoscalingv1beta1.FakePodAnnotationKey: autoscalingv1beta1.FakePodAnnotationValue,
 			},
 			Labels: map[string]string{
-				autoscalingv1beta1.BufferNamespaceLabel: "default",
+				autoscalingv1beta1.BufferNamespaceAnnotation: "default",
 			},
 		}}
 		Expect(bufferKeyOf(pod)).To(Equal(""))
@@ -78,8 +78,8 @@ var _ = Describe("bufferKeyOf", func() {
 				autoscalingv1beta1.FakePodAnnotationKey: autoscalingv1beta1.FakePodAnnotationValue,
 			},
 			Labels: map[string]string{
-				autoscalingv1beta1.BufferNameLabel:      "my-buffer",
-				autoscalingv1beta1.BufferNamespaceLabel: "default",
+				autoscalingv1beta1.BufferNameAnnotation:      "my-buffer",
+				autoscalingv1beta1.BufferNamespaceAnnotation: "default",
 			},
 		}}
 		Expect(bufferKeyOf(pod)).To(Equal("default/my-buffer"))
@@ -116,7 +116,7 @@ var _ = Describe("classifyBufferPods", func() {
 		cbA := test.ReadyBuffer("a", 3)
 		cbB := test.ReadyBuffer("b", 2)
 		buffers := map[string]*autoscalingv1beta1.CapacityBuffer{"default/a": cbA, "default/b": cbB}
-		spec := corev1.PodSpec{}
+		spec := corev1.PodTemplateSpec{}
 
 		aPods := virtualpods.BuildVirtualPods(cbA, spec)
 		bPods := virtualpods.BuildVirtualPods(cbB, spec)
@@ -151,7 +151,7 @@ var _ = Describe("classifyBufferPods", func() {
 			"ns-a/buffer": cbA,
 			"ns-b/buffer": cbB,
 		}
-		spec := corev1.PodSpec{}
+		spec := corev1.PodTemplateSpec{}
 
 		aPods := virtualpods.BuildVirtualPods(cbA, spec)
 		bPods := virtualpods.BuildVirtualPods(cbB, spec)
@@ -217,7 +217,7 @@ var _ = Describe("bufferPodCountsFromResults", func() {
 	It("should count virtual pods per providerID on existing nodes", func() {
 		cbA := test.ReadyBuffer("a", 3)
 		cbB := test.ReadyBuffer("b", 2)
-		spec := corev1.PodSpec{}
+		spec := corev1.PodTemplateSpec{}
 
 		aPods := virtualpods.BuildVirtualPods(cbA, spec)
 		bPods := virtualpods.BuildVirtualPods(cbB, spec)
@@ -279,7 +279,7 @@ var _ = Describe("computeProvisioningCondition with scalableRef buffer", func() 
 var _ = Describe("filterVirtualPodErrors", func() {
 	It("should remove virtual pods from error map", func() {
 		cb := test.ReadyBuffer("web", 2)
-		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodTemplateSpec{})
 		realPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "real", Namespace: "default"}}
 
 		input := map[*corev1.Pod]error{
@@ -295,7 +295,7 @@ var _ = Describe("filterVirtualPodErrors", func() {
 
 	It("should return empty map when all pods are virtual", func() {
 		cb := test.ReadyBuffer("web", 2)
-		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodTemplateSpec{})
 
 		input := map[*corev1.Pod]error{
 			virtualPods[0]: fmt.Errorf("err"),
@@ -328,7 +328,7 @@ var _ = Describe("filterVirtualPodErrors", func() {
 var _ = Describe("filterVirtualPodMapping", func() {
 	It("should remove virtual pods from pod slices", func() {
 		cb := test.ReadyBuffer("web", 2)
-		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodTemplateSpec{})
 		realPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "real", Namespace: "default"}}
 
 		input := map[string][]*corev1.Pod{
@@ -343,7 +343,7 @@ var _ = Describe("filterVirtualPodMapping", func() {
 
 	It("should drop keys entirely when only virtual pods remain", func() {
 		cb := test.ReadyBuffer("web", 2)
-		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodTemplateSpec{})
 		realPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "real", Namespace: "default"}}
 
 		input := map[string][]*corev1.Pod{
@@ -359,7 +359,7 @@ var _ = Describe("filterVirtualPodMapping", func() {
 
 	It("should return empty map when all pods are virtual", func() {
 		cb := test.ReadyBuffer("web", 2)
-		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := virtualpods.BuildVirtualPods(cb, corev1.PodTemplateSpec{})
 
 		input := map[string][]*corev1.Pod{
 			"nodepool-a": {virtualPods[0], virtualPods[1]},

--- a/pkg/controllers/provisioning/buffers_test.go
+++ b/pkg/controllers/provisioning/buffers_test.go
@@ -38,8 +38,9 @@ var _ = Describe("buildVirtualPods", func() {
 		spec := corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "app", Image: "pause:v1"}},
 		}
+		templateLabels := map[string]string{"app": "my-app", "tier": "frontend"}
 
-		pods := buildVirtualPods(cb, spec)
+		pods := buildVirtualPods(cb, spec, templateLabels)
 		Expect(pods).To(HaveLen(3))
 
 		for i, p := range pods {
@@ -48,6 +49,8 @@ var _ = Describe("buildVirtualPods", func() {
 			Expect(p.Namespace).To(Equal("default"))
 			Expect(string(p.UID)).To(Equal("uid-web-" + itoa(idx)))
 			Expect(p.Annotations[autoscalingv1beta1.FakePodAnnotationKey]).To(Equal("true"))
+			Expect(p.Labels["app"]).To(Equal("my-app"))
+			Expect(p.Labels["tier"]).To(Equal("frontend"))
 			Expect(p.Labels[autoscalingv1beta1.BufferNameLabel]).To(Equal("web"))
 			Expect(p.Labels[autoscalingv1beta1.BufferNamespaceLabel]).To(Equal("default"))
 			Expect(p.Spec.Priority).ToNot(BeNil())
@@ -67,18 +70,40 @@ var _ = Describe("buildVirtualPods", func() {
 	It("should produce deterministic UIDs across calls", func() {
 		cb := readyBuffer("web", 2)
 		spec := corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}}
-		a := buildVirtualPods(cb, spec)
-		b := buildVirtualPods(cb, spec)
+		a := buildVirtualPods(cb, spec, nil)
+		b := buildVirtualPods(cb, spec, nil)
 		Expect(a).To(HaveLen(len(b)))
 		for i := range a {
 			Expect(a[i].UID).To(Equal(b[i].UID))
 		}
 	})
 
+	It("should let buffer labels take precedence over conflicting template labels", func() {
+		cb := readyBuffer("web", 1)
+		spec := corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}}
+		templateLabels := map[string]string{
+			autoscalingv1beta1.BufferNameLabel: "should-be-overridden",
+		}
+
+		pods := buildVirtualPods(cb, spec, templateLabels)
+		Expect(pods).To(HaveLen(1))
+		Expect(pods[0].Labels[autoscalingv1beta1.BufferNameLabel]).To(Equal("web"))
+	})
+
+	It("should handle nil template labels gracefully", func() {
+		cb := readyBuffer("web", 1)
+		spec := corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}}
+
+		pods := buildVirtualPods(cb, spec, nil)
+		Expect(pods).To(HaveLen(1))
+		Expect(pods[0].Labels[autoscalingv1beta1.BufferNameLabel]).To(Equal("web"))
+		Expect(pods[0].Labels[autoscalingv1beta1.BufferNamespaceLabel]).To(Equal("default"))
+	})
+
 	It("should return nil for zero replicas", func() {
 		cb := readyBuffer("web", 0)
 		spec := corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}}
-		Expect(buildVirtualPods(cb, spec)).To(BeNil())
+		Expect(buildVirtualPods(cb, spec, nil)).To(BeNil())
 	})
 })
 
@@ -290,8 +315,8 @@ var _ = Describe("classifyBufferPods", func() {
 		buffers := map[string]*autoscalingv1beta1.CapacityBuffer{"default/a": cbA, "default/b": cbB}
 		spec := corev1.PodSpec{}
 
-		aPods := buildVirtualPods(cbA, spec)
-		bPods := buildVirtualPods(cbB, spec)
+		aPods := buildVirtualPods(cbA, spec, nil)
+		bPods := buildVirtualPods(cbB, spec, nil)
 
 		results := scheduler.Results{
 			ExistingNodes: []*scheduler.ExistingNode{{Pods: []*corev1.Pod{aPods[0], aPods[1]}}},
@@ -325,8 +350,8 @@ var _ = Describe("classifyBufferPods", func() {
 		}
 		spec := corev1.PodSpec{}
 
-		aPods := buildVirtualPods(cbA, spec)
-		bPods := buildVirtualPods(cbB, spec)
+		aPods := buildVirtualPods(cbA, spec, nil)
+		bPods := buildVirtualPods(cbB, spec, nil)
 
 		results := scheduler.Results{
 			ExistingNodes: []*scheduler.ExistingNode{{Pods: []*corev1.Pod{aPods[0], bPods[0], bPods[1]}}},
@@ -391,8 +416,8 @@ var _ = Describe("bufferPodCountsFromResults", func() {
 		cbB := readyBuffer("b", 2)
 		spec := corev1.PodSpec{}
 
-		aPods := buildVirtualPods(cbA, spec)
-		bPods := buildVirtualPods(cbB, spec)
+		aPods := buildVirtualPods(cbA, spec, nil)
+		bPods := buildVirtualPods(cbB, spec, nil)
 		realPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "real-pod", Namespace: "default"}}
 
 		nodeA := makeExistingNode("provider-a")
@@ -484,7 +509,7 @@ var _ = Describe("buildVirtualPods with scalableRef buffer", func() {
 			Containers: []corev1.Container{{Name: "app", Image: "nginx:latest"}},
 		}
 
-		pods := buildVirtualPods(cb, spec)
+		pods := buildVirtualPods(cb, spec, nil)
 		Expect(pods).To(HaveLen(2))
 
 		for i, p := range pods {
@@ -520,7 +545,7 @@ var _ = Describe("computeProvisioningCondition with scalableRef buffer", func() 
 var _ = Describe("filterVirtualPodErrors", func() {
 	It("should remove virtual pods from error map", func() {
 		cb := readyBuffer("web", 2)
-		virtualPods := buildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := buildVirtualPods(cb, corev1.PodSpec{}, nil)
 		realPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "real", Namespace: "default"}}
 
 		input := map[*corev1.Pod]error{
@@ -536,7 +561,7 @@ var _ = Describe("filterVirtualPodErrors", func() {
 
 	It("should return empty map when all pods are virtual", func() {
 		cb := readyBuffer("web", 2)
-		virtualPods := buildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := buildVirtualPods(cb, corev1.PodSpec{}, nil)
 
 		input := map[*corev1.Pod]error{
 			virtualPods[0]: fmt.Errorf("err"),
@@ -569,7 +594,7 @@ var _ = Describe("filterVirtualPodErrors", func() {
 var _ = Describe("filterVirtualPodMapping", func() {
 	It("should remove virtual pods from pod slices", func() {
 		cb := readyBuffer("web", 2)
-		virtualPods := buildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := buildVirtualPods(cb, corev1.PodSpec{}, nil)
 		realPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "real", Namespace: "default"}}
 
 		input := map[string][]*corev1.Pod{
@@ -584,7 +609,7 @@ var _ = Describe("filterVirtualPodMapping", func() {
 
 	It("should drop keys entirely when only virtual pods remain", func() {
 		cb := readyBuffer("web", 2)
-		virtualPods := buildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := buildVirtualPods(cb, corev1.PodSpec{}, nil)
 		realPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "real", Namespace: "default"}}
 
 		input := map[string][]*corev1.Pod{
@@ -600,7 +625,7 @@ var _ = Describe("filterVirtualPodMapping", func() {
 
 	It("should return empty map when all pods are virtual", func() {
 		cb := readyBuffer("web", 2)
-		virtualPods := buildVirtualPods(cb, corev1.PodSpec{})
+		virtualPods := buildVirtualPods(cb, corev1.PodSpec{}, nil)
 
 		input := map[string][]*corev1.Pod{
 			"nodepool-a": {virtualPods[0], virtualPods[1]},

--- a/pkg/controllers/provisioning/buffers_test.go
+++ b/pkg/controllers/provisioning/buffers_test.go
@@ -42,28 +42,24 @@ var _ = Describe("bufferKeyOf", func() {
 		Expect(bufferKeyOf(pod)).To(Equal(""))
 	})
 
-	It("should return empty string when namespace label is missing", func() {
+	It("should return empty string when namespace annotation is missing", func() {
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Name:      "virt",
 			Namespace: "default",
 			Annotations: map[string]string{
 				autoscalingv1beta1.FakePodAnnotationKey: autoscalingv1beta1.FakePodAnnotationValue,
-			},
-			Labels: map[string]string{
 				autoscalingv1beta1.BufferNameAnnotation: "my-buffer",
 			},
 		}}
 		Expect(bufferKeyOf(pod)).To(Equal(""))
 	})
 
-	It("should return empty string when name label is missing", func() {
+	It("should return empty string when name annotation is missing", func() {
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Name:      "virt",
 			Namespace: "default",
 			Annotations: map[string]string{
-				autoscalingv1beta1.FakePodAnnotationKey: autoscalingv1beta1.FakePodAnnotationValue,
-			},
-			Labels: map[string]string{
+				autoscalingv1beta1.FakePodAnnotationKey:      autoscalingv1beta1.FakePodAnnotationValue,
 				autoscalingv1beta1.BufferNamespaceAnnotation: "default",
 			},
 		}}
@@ -75,9 +71,7 @@ var _ = Describe("bufferKeyOf", func() {
 			Name:      "virt",
 			Namespace: "default",
 			Annotations: map[string]string{
-				autoscalingv1beta1.FakePodAnnotationKey: autoscalingv1beta1.FakePodAnnotationValue,
-			},
-			Labels: map[string]string{
+				autoscalingv1beta1.FakePodAnnotationKey:      autoscalingv1beta1.FakePodAnnotationValue,
 				autoscalingv1beta1.BufferNameAnnotation:      "my-buffer",
 				autoscalingv1beta1.BufferNamespaceAnnotation: "default",
 			},

--- a/pkg/state/virtualpods/utilities.go
+++ b/pkg/state/virtualpods/utilities.go
@@ -65,25 +65,27 @@ func isBufferReadyForProvisioning(cb *autoscalingv1beta1.CapacityBuffer) bool {
 // resolveVirtualPodSpec fetches the pod spec for a buffer using the shared
 // workload resolution utilities. Reads from spec (not status) to avoid stale
 // references when users switch between podTemplateRef and scalableRef.
-func resolveVirtualPodSpec(ctx context.Context, kubeClient client.Client, cb *autoscalingv1beta1.CapacityBuffer) (corev1.PodSpec, error) {
+func resolveVirtualPodSpec(ctx context.Context, kubeClient client.Client, cb *autoscalingv1beta1.CapacityBuffer) (corev1.PodTemplateSpec, error) {
 	result, err := apps.ResolveCapacityBuffer(ctx, kubeClient, cb)
 	if err != nil {
-		return corev1.PodSpec{}, err
+		return corev1.PodTemplateSpec{}, err
 	}
-	return result.PodSpec, nil
+	return result.PodTemplateSpec, nil
 }
 
 // BuildVirtualPods materializes N identical placeholder pods for a buffer using
-// the given pod spec. Deterministic names and UIDs let downstream components
-// associate results back to the owning buffer without additional bookkeeping.
-func BuildVirtualPods(cb *autoscalingv1beta1.CapacityBuffer, spec corev1.PodSpec) []*corev1.Pod {
+// the given pod template spec. Template labels are propagated to virtual pods so that
+// topology spread constraints and affinity rules are evaluated correctly.
+// Deterministic names and UIDs let downstream components associate results back
+// to the owning buffer without additional bookkeeping.
+func BuildVirtualPods(cb *autoscalingv1beta1.CapacityBuffer, spec corev1.PodTemplateSpec) []*corev1.Pod {
 	if cb.Status.Replicas == nil || *cb.Status.Replicas <= 0 {
 		return nil
 	}
 	count := int(*cb.Status.Replicas)
 	out := make([]*corev1.Pod, 0, count)
 	// Strip anything that would make the scheduler call the API server.
-	strippedSpec := sanitizeVirtualPodSpec(spec)
+	strippedSpec := sanitizeVirtualPodSpec(spec.Spec)
 	strippedSpec.Priority = lo.ToPtr(autoscalingv1beta1.VirtualPodPriority)
 
 	for i := 1; i <= count; i++ {
@@ -92,12 +94,12 @@ func BuildVirtualPods(cb *autoscalingv1beta1.CapacityBuffer, spec corev1.PodSpec
 				Name:      fmt.Sprintf("capacity-buffer-%s-%d", cb.Name, i),
 				Namespace: cb.Namespace,
 				UID:       types.UID(fmt.Sprintf("%s-%d", cb.UID, i)),
+				Labels:    spec.Labels,
+
 				Annotations: map[string]string{
-					autoscalingv1beta1.FakePodAnnotationKey: autoscalingv1beta1.FakePodAnnotationValue,
-				},
-				Labels: map[string]string{
-					autoscalingv1beta1.BufferNameLabel:      cb.Name,
-					autoscalingv1beta1.BufferNamespaceLabel: cb.Namespace,
+					autoscalingv1beta1.FakePodAnnotationKey:      autoscalingv1beta1.FakePodAnnotationValue,
+					autoscalingv1beta1.BufferNameAnnotation:      cb.Name,
+					autoscalingv1beta1.BufferNamespaceAnnotation: cb.Namespace,
 				},
 				CreationTimestamp: metav1.NewTime(time.Now()),
 			},

--- a/pkg/state/virtualpods/utilities_test.go
+++ b/pkg/state/virtualpods/utilities_test.go
@@ -32,8 +32,9 @@ import (
 var _ = Describe("buildVirtualPods", func() {
 	It("should create the correct number of pods with expected metadata", func() {
 		cb := test.ReadyBuffer("web", 3)
-		spec := corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "app", Image: "pause:v1"}},
+		spec := corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "web", "env": "prod"}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "pause:v1"}}},
 		}
 
 		pods := BuildVirtualPods(cb, spec)
@@ -45,8 +46,10 @@ var _ = Describe("buildVirtualPods", func() {
 			Expect(p.Namespace).To(Equal("default"))
 			Expect(string(p.UID)).To(Equal("uid-web-" + strconv.Itoa(idx)))
 			Expect(p.Annotations[autoscalingv1beta1.FakePodAnnotationKey]).To(Equal("true"))
-			Expect(p.Labels[autoscalingv1beta1.BufferNameLabel]).To(Equal("web"))
-			Expect(p.Labels[autoscalingv1beta1.BufferNamespaceLabel]).To(Equal("default"))
+			Expect(p.Annotations[autoscalingv1beta1.BufferNameAnnotation]).To(Equal("web"))
+			Expect(p.Annotations[autoscalingv1beta1.BufferNamespaceAnnotation]).To(Equal("default"))
+			Expect(p.Labels).To(HaveKeyWithValue("app", "web"))
+			Expect(p.Labels).To(HaveKeyWithValue("env", "prod"))
 			Expect(p.Spec.Priority).ToNot(BeNil())
 			Expect(*p.Spec.Priority).To(Equal(autoscalingv1beta1.VirtualPodPriority))
 			Expect(p.Spec.NodeName).To(BeEmpty())
@@ -63,18 +66,23 @@ var _ = Describe("buildVirtualPods", func() {
 
 	It("should produce deterministic UIDs across calls", func() {
 		cb := test.ReadyBuffer("web", 2)
-		spec := corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}}
+		spec := corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		}
 		a := BuildVirtualPods(cb, spec)
 		b := BuildVirtualPods(cb, spec)
 		Expect(a).To(HaveLen(len(b)))
 		for i := range a {
 			Expect(a[i].UID).To(Equal(b[i].UID))
+			Expect(a[i].Labels).To(BeNil())
 		}
 	})
 
 	It("should return nil for zero replicas", func() {
 		cb := test.ReadyBuffer("web", 0)
-		spec := corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}}
+		spec := corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		}
 		Expect(BuildVirtualPods(cb, spec)).To(BeNil())
 	})
 })
@@ -251,8 +259,9 @@ var _ = Describe("listBuffersReadyForProvisioning", func() {
 var _ = Describe("buildVirtualPods with scalableRef buffer", func() {
 	It("should create pods with expected metadata for scalableRef buffers", func() {
 		cb := test.ReadyScalableRefBuffer("scalable-app", 2)
-		spec := corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "app", Image: "nginx:latest"}},
+		spec := corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "scalable"}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "nginx:latest"}}},
 		}
 
 		pods := BuildVirtualPods(cb, spec)
@@ -263,8 +272,9 @@ var _ = Describe("buildVirtualPods with scalableRef buffer", func() {
 			Expect(p.Name).To(Equal("capacity-buffer-scalable-app-" + strconv.Itoa(idx)))
 			Expect(p.Namespace).To(Equal("default"))
 			Expect(p.Annotations[autoscalingv1beta1.FakePodAnnotationKey]).To(Equal("true"))
-			Expect(p.Labels[autoscalingv1beta1.BufferNameLabel]).To(Equal("scalable-app"))
-			Expect(p.Labels[autoscalingv1beta1.BufferNamespaceLabel]).To(Equal("default"))
+			Expect(p.Annotations[autoscalingv1beta1.BufferNameAnnotation]).To(Equal("scalable-app"))
+			Expect(p.Annotations[autoscalingv1beta1.BufferNamespaceAnnotation]).To(Equal("default"))
+			Expect(p.Labels).To(HaveKeyWithValue("app", "scalable"))
 			Expect(*p.Spec.Priority).To(Equal(autoscalingv1beta1.VirtualPodPriority))
 		}
 	})

--- a/pkg/state/virtualpods/virtualpods.go
+++ b/pkg/state/virtualpods/virtualpods.go
@@ -52,7 +52,7 @@ func NewVirtualPodCache(kubeClient client.Client) *Cache {
 // already-resolved pod spec. The caller resolves
 // the spec once to compute replicas and status, then passes it here so the cache
 // doesn't re-fetch the same PodTemplate/workload
-func (v *Cache) UpdateEntry(cb *autoscalingv1beta1.CapacityBuffer, spec corev1.PodSpec) {
+func (v *Cache) UpdateEntry(cb *autoscalingv1beta1.CapacityBuffer, spec corev1.PodTemplateSpec) {
 	if !isBufferReadyForProvisioning(cb) {
 		v.RemoveEntry(client.ObjectKeyFromObject(cb))
 		return

--- a/pkg/state/virtualpods/virtualpods_test.go
+++ b/pkg/state/virtualpods/virtualpods_test.go
@@ -119,7 +119,7 @@ var _ = Describe("VirtualPodCache", func() {
 			pods := cache.GetAll(ctx)
 			Expect(pods).To(HaveLen(3))
 			for _, p := range pods {
-				Expect(p.Labels[autoscalingv1beta1.BufferNameLabel]).To(Equal("web"))
+				Expect(p.Annotations[autoscalingv1beta1.BufferNameAnnotation]).To(Equal("web"))
 			}
 		})
 
@@ -146,7 +146,7 @@ var _ = Describe("VirtualPodCache", func() {
 			// Flip the buffer to not-ready and update. UpdateEntry drops the entry
 			// regardless of the spec it is handed.
 			cb.Status.Conditions[0].Status = metav1.ConditionFalse
-			cache.UpdateEntry(cb, corev1.PodSpec{})
+			cache.UpdateEntry(cb, corev1.PodTemplateSpec{})
 			Expect(cache.GetAll(ctx)).To(BeEmpty())
 		})
 
@@ -202,7 +202,7 @@ var _ = Describe("VirtualPodCache", func() {
 			pods := cache.GetAll(ctx)
 			Expect(pods).To(HaveLen(3))
 			for _, p := range pods {
-				Expect(p.Labels[autoscalingv1beta1.BufferNameLabel]).To(Equal("web"))
+				Expect(p.Annotations[autoscalingv1beta1.BufferNameAnnotation]).To(Equal("web"))
 			}
 		})
 
@@ -232,7 +232,7 @@ var _ = Describe("VirtualPodCache", func() {
 			pods := cache.GetAll(ctx)
 			Expect(pods).To(HaveLen(2))
 			for _, p := range pods {
-				Expect(p.Labels[autoscalingv1beta1.BufferNameLabel]).To(Equal("api"))
+				Expect(p.Annotations[autoscalingv1beta1.BufferNameAnnotation]).To(Equal("api"))
 			}
 		})
 

--- a/pkg/utils/apps/resolve.go
+++ b/pkg/utils/apps/resolve.go
@@ -60,7 +60,7 @@ type ScalableRefResult struct {
 // PodTemplateName/PodTemplateGeneration for podTemplateRef, ScalableReplicas for
 // scalableRef.
 type BufferResolution struct {
-	PodSpec               corev1.PodSpec
+	PodTemplateSpec       corev1.PodTemplateSpec
 	UsesPodTemplate       bool
 	PodTemplateName       string
 	PodTemplateGeneration int64
@@ -79,7 +79,7 @@ func ResolveCapacityBuffer(ctx context.Context, c client.Client, cb *autoscaling
 			return nil, err
 		}
 		return &BufferResolution{
-			PodSpec:               result.PodSpec,
+			PodTemplateSpec:       result.PodTemplateSpec,
 			UsesPodTemplate:       true,
 			PodTemplateName:       result.Name,
 			PodTemplateGeneration: result.Generation,
@@ -90,7 +90,7 @@ func ResolveCapacityBuffer(ctx context.Context, c client.Client, cb *autoscaling
 			return nil, err
 		}
 		return &BufferResolution{
-			PodSpec:          result.PodSpec,
+			PodTemplateSpec:  result.PodTemplateSpec,
 			ScalableReplicas: result.ScalableReplicas,
 		}, nil
 	default:

--- a/pkg/utils/apps/resolve.go
+++ b/pkg/utils/apps/resolve.go
@@ -31,9 +31,9 @@ import (
 
 // PodTemplateResult holds the resolved data from a PodTemplate lookup.
 type PodTemplateResult struct {
-	PodSpec    corev1.PodSpec
-	Name       string
-	Generation int64
+	PodTemplateSpec corev1.PodTemplateSpec
+	Name            string
+	Generation      int64
 }
 
 // ResolvePodTemplateRef fetches a PodTemplate by name and namespace.
@@ -43,15 +43,15 @@ func ResolvePodTemplateRef(ctx context.Context, c client.Client, name, namespace
 		return nil, err
 	}
 	return &PodTemplateResult{
-		PodSpec:    pt.Template.Spec,
-		Name:       pt.Name,
-		Generation: pt.Generation,
+		PodTemplateSpec: pt.Template,
+		Name:            pt.Name,
+		Generation:      pt.Generation,
 	}, nil
 }
 
 // ScalableRefResult holds the resolved data from a scalableRef lookup.
 type ScalableRefResult struct {
-	PodSpec          corev1.PodSpec
+	PodTemplateSpec  corev1.PodTemplateSpec
 	ScalableReplicas int32
 }
 
@@ -116,19 +116,19 @@ func ResolveScalableRef(ctx context.Context, c client.Client, ref *autoscalingv1
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil, err
 		}
-		return &ScalableRefResult{PodSpec: obj.Spec.Template.Spec, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
+		return &ScalableRefResult{PodTemplateSpec: obj.Spec.Template, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
 	case autoscalingv1beta1.KindStatefulSet:
 		obj := &appsv1.StatefulSet{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil, err
 		}
-		return &ScalableRefResult{PodSpec: obj.Spec.Template.Spec, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
+		return &ScalableRefResult{PodTemplateSpec: obj.Spec.Template, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
 	case autoscalingv1beta1.KindReplicaSet:
 		obj := &appsv1.ReplicaSet{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil, err
 		}
-		return &ScalableRefResult{PodSpec: obj.Spec.Template.Spec, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
+		return &ScalableRefResult{PodTemplateSpec: obj.Spec.Template, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
 	default:
 		return nil, fmt.Errorf("unsupported kind %q", ref.Kind)
 	}

--- a/pkg/utils/apps/resolve.go
+++ b/pkg/utils/apps/resolve.go
@@ -31,9 +31,9 @@ import (
 
 // PodTemplateResult holds the resolved data from a PodTemplate lookup.
 type PodTemplateResult struct {
-	PodSpec    corev1.PodSpec
-	Name       string
-	Generation int64
+	PodTemplateSpec corev1.PodTemplateSpec
+	Name            string
+	Generation      int64
 }
 
 // ResolvePodTemplateRef fetches a PodTemplate by name and namespace.
@@ -43,15 +43,15 @@ func ResolvePodTemplateRef(ctx context.Context, c client.Client, name, namespace
 		return nil, err
 	}
 	return &PodTemplateResult{
-		PodSpec:    pt.Template.Spec,
-		Name:       pt.Name,
-		Generation: pt.Generation,
+		PodTemplateSpec: pt.Template,
+		Name:            pt.Name,
+		Generation:      pt.Generation,
 	}, nil
 }
 
 // ScalableRefResult holds the resolved data from a scalableRef lookup.
 type ScalableRefResult struct {
-	PodSpec          corev1.PodSpec
+	PodTemplateSpec  corev1.PodTemplateSpec
 	ScalableReplicas int32
 }
 
@@ -73,19 +73,19 @@ func ResolveScalableRef(ctx context.Context, c client.Client, ref *autoscalingv1
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil, err
 		}
-		return &ScalableRefResult{PodSpec: obj.Spec.Template.Spec, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
+		return &ScalableRefResult{PodTemplateSpec: obj.Spec.Template, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
 	case autoscalingv1beta1.KindStatefulSet:
 		obj := &appsv1.StatefulSet{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil, err
 		}
-		return &ScalableRefResult{PodSpec: obj.Spec.Template.Spec, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
+		return &ScalableRefResult{PodTemplateSpec: obj.Spec.Template, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
 	case autoscalingv1beta1.KindReplicaSet:
 		obj := &appsv1.ReplicaSet{}
 		if err := c.Get(ctx, key, obj); err != nil {
 			return nil, err
 		}
-		return &ScalableRefResult{PodSpec: obj.Spec.Template.Spec, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
+		return &ScalableRefResult{PodTemplateSpec: obj.Spec.Template, ScalableReplicas: lo.FromPtrOr(obj.Spec.Replicas, 1)}, nil
 	default:
 		return nil, fmt.Errorf("unsupported kind %q", ref.Kind)
 	}

--- a/test/suites/regression/capacitybuffer_test.go
+++ b/test/suites/regression/capacitybuffer_test.go
@@ -762,9 +762,6 @@ var _ = Describe("CapacityBuffer", func() {
 	})
 	Context("Anti-Affinity", func() {
 		It("should respect pod anti-affinity between virtual buffer pods", func() {
-			// Create a PodTemplate with labels and anti-affinity referencing those labels.
-			// This tests that template labels are propagated to virtual pods so that
-			// anti-affinity selectors match correctly between them.
 			antiAffinityTemplate := &corev1.PodTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "anti-affinity-template",
@@ -813,10 +810,57 @@ var _ = Describe("CapacityBuffer", func() {
 			env.ExpectCreated(antiAffinityTemplate, buffer)
 
 			EventuallyExpectCapacityBufferReplicas(env, env.Client, buffer, 3)
-
-			// Anti-affinity requires one pod per node, so 3 replicas should create 3 nodes
 			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
 			env.EventuallyExpectInitializedNodeCount("==", 3)
+
+			EventuallyExpectCapacityBufferProvisionedWithReason(env, env.Client, buffer, "FitsExistingCapacity")
+		})
+
+		It("should respect pod anti-affinity between virtual buffer pods using scalableRef", func() {
+			deployment := test.Deployment(test.DeploymentOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spread-deploy",
+					Namespace: "default",
+				},
+				Replicas: 1,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "spread-scalable"}},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+					PodAntiRequirements: []corev1.PodAffinityTerm{{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "spread-scalable"},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					}},
+				},
+			})
+
+			env.ExpectCreated(deployment)
+			selector := labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels)
+			env.EventuallyExpectHealthyPodCountWithTimeout(2*time.Minute, selector, 1)
+
+			buffer := test.CapacityBuffer(autoscalingv1beta1.CapacityBuffer{
+				Spec: autoscalingv1beta1.CapacityBufferSpec{
+					ScalableRef: &autoscalingv1beta1.ScalableRef{
+						APIGroup: "apps",
+						Kind:     "Deployment",
+						Name:     "spread-deploy",
+					},
+					Replicas: lo.ToPtr(int32(3)),
+				},
+			})
+
+			env.ExpectCreated(buffer)
+
+			EventuallyExpectCapacityBufferReplicas(env, env.Client, buffer, 3)
+			// 1 node for the deployment pod + 3 nodes for buffer pods = 4 total
+			env.EventuallyExpectCreatedNodeClaimCount("==", 4)
+			env.EventuallyExpectInitializedNodeCount("==", 4)
 
 			EventuallyExpectCapacityBufferProvisionedWithReason(env, env.Client, buffer, "FitsExistingCapacity")
 		})

--- a/test/suites/regression/capacitybuffer_test.go
+++ b/test/suites/regression/capacitybuffer_test.go
@@ -760,4 +760,66 @@ var _ = Describe("CapacityBuffer", func() {
 			EventuallyExpectCapacityBufferProvisioned(env, env.Client, buffer)
 		})
 	})
+	Context("Anti-Affinity", func() {
+		It("should respect pod anti-affinity between virtual buffer pods", func() {
+			// Create a PodTemplate with labels and anti-affinity referencing those labels.
+			// This tests that template labels are propagated to virtual pods so that
+			// anti-affinity selectors match correctly between them.
+			antiAffinityTemplate := &corev1.PodTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "anti-affinity-template",
+					Namespace: "default",
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "spread-buffer",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "pause",
+							Image: "registry.k8s.io/pause:3.10",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						}},
+						Affinity: &corev1.Affinity{
+							PodAntiAffinity: &corev1.PodAntiAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "spread-buffer",
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								}},
+							},
+						},
+					},
+				},
+			}
+
+			buffer := test.CapacityBuffer(autoscalingv1beta1.CapacityBuffer{
+				Spec: autoscalingv1beta1.CapacityBufferSpec{
+					PodTemplateRef: &autoscalingv1beta1.LocalObjectRef{Name: "anti-affinity-template"},
+					Replicas:       lo.ToPtr(int32(3)),
+				},
+			})
+
+			env.ExpectCreated(antiAffinityTemplate, buffer)
+
+			EventuallyExpectCapacityBufferReplicas(env, env.Client, buffer, 3)
+
+			// Anti-affinity requires one pod per node, so 3 replicas should create 3 nodes
+			env.EventuallyExpectCreatedNodeClaimCount("==", 3)
+			env.EventuallyExpectInitializedNodeCount("==", 3)
+
+			EventuallyExpectCapacityBufferProvisionedWithReason(env, env.Client, buffer, "FitsExistingCapacity")
+		})
+	})
+
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #3166

**Description**
Virtual pods created by CapacityBuffer were missing the labels from the PodTemplate/Deployment template metadata. This caused inter-pod anti-affinity selectors referencing those labels to be ineffective, as the virtual pods could not match each other.

Thread template labels through resolveVirtualPodSpec and merge them into virtual pod ObjectMeta in buildVirtualPods, with buffer-internal labels taking precedence on conflict.

**How was this change tested?**
- Unit tests pass (buildVirtualPods, bufferKeyOf, computeProvisioningCondition, capacitybuffer controller)
- Reproduced the bug on a live cluster: 11 existing nodes, CapacityBuffer with 14 replicas and hostname anti affinity. Without the fix, status shows "All 14 virtual pods fit on existing capacity" and no new NodeClaims are created
- Confirmed the fix works for podTemplateRef: status shows "3/14 virtual pods required new capacity", 3 new NodeClaims created
- Confirmed the fix works for scalableRef (Deployment with replicas: 0): same correct behavior, 3 new NodeClaims created
- Verified real pods (Deployment with 14 replicas and same anti-affinity) correctly provision 3 nodes, confirming the bug was specific to virtual pod simulation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
