### PR TITLE
feat: add nodeclaim condition metrics by nodepool

### DIFF
--- a/pkg/controllers/metrics/nodepool/controller.go
+++ b/pkg/controllers/metrics/nodepool/controller.go
@@ -38,7 +38,13 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	"sigs.k8s.io/karpenter/pkg/state/cost"
+	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	nodepoolutils "sigs.k8s.io/karpenter/pkg/utils/nodepool"
+)
+
+const (
+	conditionLabel       = "condition"
+	conditionStatusLabel = "status"
 )
 
 var (
@@ -78,6 +84,20 @@ var (
 		},
 		[]string{metrics.NodePoolLabel},
 	)
+	NodeClaimCondition = opmetrics.NewPrometheusGauge(
+		crmetrics.Registry,
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.NodePoolSubsystem,
+			Name:      "nodeclaim_condition",
+			Help:      "The number of nodeclaims owned by a nodepool broken down by status condition type and status. Labeled by nodepool, condition type, and condition status. Useful for tracking rollout progress, e.g. drift reconciliation via condition=\"Drifted\",status=\"True\".",
+		},
+		[]string{
+			metrics.NodePoolLabel,
+			conditionLabel,
+			conditionStatusLabel,
+		},
+	)
 )
 
 type Controller struct {
@@ -111,12 +131,16 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if !nodepoolutils.IsManaged(nodePool, c.cloudProvider) {
 		return reconcile.Result{}, nil
 	}
-	c.metricStore.Update(req.String(), c.buildMetrics(nodePool))
+	storeMetrics, err := c.buildMetrics(ctx, nodePool)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	c.metricStore.Update(req.String(), storeMetrics)
 	// periodically update our metrics per nodepool even if nothing has changed
 	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
-func (c *Controller) buildMetrics(nodePool *v1.NodePool) (res []*metrics.StoreMetric) {
+func (c *Controller) buildMetrics(ctx context.Context, nodePool *v1.NodePool) (res []*metrics.StoreMetric, err error) {
 	res = append(res, &metrics.StoreMetric{
 		GaugeMetric: ClusterCost,
 		Labels:      map[string]string{metrics.NodePoolLabel: nodePool.Name},
@@ -135,7 +159,47 @@ func (c *Controller) buildMetrics(nodePool *v1.NodePool) (res []*metrics.StoreMe
 			})
 		}
 	}
-	return res
+
+	conditionMetrics, err := c.buildNodeClaimConditionMetrics(ctx, nodePool)
+	if err != nil {
+		return nil, err
+	}
+	return append(res, conditionMetrics...), nil
+}
+
+// buildNodeClaimConditionMetrics emits a gauge per (condition type, condition status) counting the NodeClaims owned by
+// the NodePool in that state. This provides an aggregate, NodePool-level view of NodeClaim conditions (e.g. Drifted)
+// so that rollout progress can be tracked across the nodes a NodePool owns.
+func (c *Controller) buildNodeClaimConditionMetrics(ctx context.Context, nodePool *v1.NodePool) ([]*metrics.StoreMetric, error) {
+	nodeClaimList := &v1.NodeClaimList{}
+	if err := c.kubeClient.List(ctx, nodeClaimList, nodeclaimutils.ForNodePool(nodePool.Name)); err != nil {
+		return nil, err
+	}
+	// Count NodeClaims bucketed by condition type and status.
+	counts := map[conditionKey]int{}
+	for i := range nodeClaimList.Items {
+		for _, cond := range nodeClaimList.Items[i].Status.Conditions {
+			counts[conditionKey{condition: cond.Type, status: string(cond.Status)}]++
+		}
+	}
+	res := make([]*metrics.StoreMetric, 0, len(counts))
+	for key, count := range counts {
+		res = append(res, &metrics.StoreMetric{
+			GaugeMetric: NodeClaimCondition,
+			Labels: map[string]string{
+				metrics.NodePoolLabel: nodePool.Name,
+				conditionLabel:        key.condition,
+				conditionStatusLabel:  key.status,
+			},
+			Value: float64(count),
+		})
+	}
+	return res, nil
+}
+
+type conditionKey struct {
+	condition string
+	status    string
 }
 
 func getLimits(nodePool *v1.NodePool) corev1.ResourceList {

--- a/pkg/controllers/metrics/nodepool/suite_test.go
+++ b/pkg/controllers/metrics/nodepool/suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
@@ -132,8 +133,52 @@ var _ = Describe("Metrics", func() {
 			Expect(m.GetGauge().GetValue()).To(BeNumerically("~", v.AsApproximateFloat64()))
 		}
 	})
+	It("should update the nodeclaim condition metrics broken down by condition type and status", func() {
+		ExpectApplied(ctx, env.Client, nodePool)
+
+		// Two NodeClaims drifted, one not drifted.
+		nc1 := test.NodeClaim(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name}}})
+		nc2 := test.NodeClaim(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name}}})
+		nc3 := test.NodeClaim(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name}}})
+		nc1.StatusConditions().SetTrue(v1.ConditionTypeDrifted)
+		nc2.StatusConditions().SetTrue(v1.ConditionTypeDrifted)
+		ExpectApplied(ctx, env.Client, nc1, nc2, nc3)
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+
+		m, found := FindMetricWithLabelValues("karpenter_nodepools_nodeclaim_condition", map[string]string{
+			metrics.NodePoolLabel: nodePool.GetName(),
+			"condition":           v1.ConditionTypeDrifted,
+			"status":              string(metav1.ConditionTrue),
+		})
+		Expect(found).To(BeTrue())
+		Expect(m.GetGauge().GetValue()).To(BeNumerically("==", 2))
+	})
+	It("should remove a nodeclaim condition metric label set once no NodeClaims are in that state", func() {
+		ExpectApplied(ctx, env.Client, nodePool)
+
+		nc := test.NodeClaim(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name}}})
+		nc.StatusConditions().SetTrue(v1.ConditionTypeDrifted)
+		ExpectApplied(ctx, env.Client, nc)
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+
+		driftedLabels := map[string]string{
+			metrics.NodePoolLabel: nodePool.GetName(),
+			"condition":           v1.ConditionTypeDrifted,
+			"status":              string(metav1.ConditionTrue),
+		}
+		_, found := FindMetricWithLabelValues("karpenter_nodepools_nodeclaim_condition", driftedLabels)
+		Expect(found).To(BeTrue())
+
+		// Clearing the Drifted condition should remove the drifted=True label set on the next reconcile.
+		_ = nc.StatusConditions().Clear(v1.ConditionTypeDrifted)
+		ExpectApplied(ctx, env.Client, nc)
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+
+		_, found = FindMetricWithLabelValues("karpenter_nodepools_nodeclaim_condition", driftedLabels)
+		Expect(found).To(BeFalse())
+	})
 	It("should delete the nodepool state metrics on nodepool delete", func() {
-		expectedMetrics := []string{"karpenter_nodepools_limit", "karpenter_nodepools_usage"}
+		expectedMetrics := []string{"karpenter_nodepools_limit", "karpenter_nodepools_usage", "karpenter_nodepools_nodeclaim_condition"}
 		nodePool.Spec.Limits = v1.Limits{
 			corev1.ResourceCPU:              resource.MustParse("100"),
 			corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -145,6 +190,9 @@ var _ = Describe("Metrics", func() {
 			corev1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
 		}
 		ExpectApplied(ctx, env.Client, nodePool)
+		nc := test.NodeClaim(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name}}})
+		nc.StatusConditions().SetTrue(v1.ConditionTypeDrifted)
+		ExpectApplied(ctx, env.Client, nc)
 		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
 
 		for _, name := range expectedMetrics {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #3071

**Description**
Adds a new metric `karpenter_nodepools_nodeclaim_condition` which tracks the number of nodeclaims by condition and status for each nodepool. This enables tracking various states in nodepools, like rollout progress of drift for a mass-change (e.g AMI updates). 

**How was this change tested?**
`make presubmit` and running locally in our development clusters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
