### PR TITLE
feat(metrics): add consolidation_policy and termination_mode labels to disruption metrics

### DIFF
--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -56,6 +56,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
+	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
 
@@ -239,10 +240,17 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 			return
 		}
 		q.recorder.Publish(disruptionevents.Terminating(cmd.Candidates[i].Node, cmd.Candidates[i].NodeClaim, string(cmd.Reason()))...)
+		// Drift also flows through this queue, so only report a policy for consolidation.
+		consolidationPolicy := ""
+		if cmd.ConsolidationType() != "" {
+			consolidationPolicy = pretty.ToSnakeCase(string(cmd.Candidates[i].NodePool.Spec.Disruption.ConsolidationPolicy))
+		}
 		labels := map[string]string{
-			metrics.ReasonLabel:       pretty.ToSnakeCase(string(cmd.Reason())),
-			metrics.NodePoolLabel:     cmd.Candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
-			metrics.CapacityTypeLabel: cmd.Candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
+			metrics.ReasonLabel:              pretty.ToSnakeCase(string(cmd.Reason())),
+			metrics.NodePoolLabel:            cmd.Candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
+			metrics.CapacityTypeLabel:        cmd.Candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
+			metrics.ConsolidationPolicyLabel: consolidationPolicy,
+			metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(cmd.Candidates[i].NodeClaim),
 		}
 		metrics.NodeClaimsDisruptedTotal.Inc(labels)
 		metrics.PodsDisruptionInitiatedTotal.Add(float64(len(cmd.Candidates[i].reschedulablePods)), labels)

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -40,14 +40,15 @@ import (
 	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 	disruptionutils "sigs.k8s.io/karpenter/pkg/utils/disruption"
 	"sigs.k8s.io/karpenter/pkg/utils/pdb"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 )
 
 const (
-	GracefulDisruptionClass = "graceful" // graceful disruption always respects blocking pod PDBs and the do-not-disrupt annotation
-	EventualDisruptionClass = "eventual" // eventual disruption is bounded by a NodePool's TerminationGracePeriod, regardless of blocking pod PDBs and the do-not-disrupt annotation
+	GracefulDisruptionClass = metrics.TerminationModeGraceful // graceful disruption always respects blocking pod PDBs and the do-not-disrupt annotation
+	EventualDisruptionClass = metrics.TerminationModeEventual // eventual disruption is bounded by a NodePool's TerminationGracePeriod, regardless of blocking pod PDBs and the do-not-disrupt annotation
 )
 
 type MethodOptions struct {

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
+	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
 
@@ -172,9 +173,11 @@ func (c *Controller) deleteNodeClaim(ctx context.Context, nodeClaim *v1.NodeClai
 	// The deletion timestamp has successfully been set for the Node, update relevant metrics.
 	log.FromContext(ctx).Info("deleting unhealthy node")
 	labels := map[string]string{
-		metrics.ReasonLabel:       metrics.UnhealthyReason,
-		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],
-		metrics.CapacityTypeLabel: node.Labels[v1.CapacityTypeLabelKey],
+		metrics.ReasonLabel:              metrics.UnhealthyReason,
+		metrics.NodePoolLabel:            node.Labels[v1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel:        node.Labels[v1.CapacityTypeLabelKey],
+		metrics.ConsolidationPolicyLabel: "",
+		metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
 	}
 	metrics.NodeClaimsDisruptedTotal.Inc(labels)
 	// Pods on the node have not yet started draining at this point — list captures

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -397,8 +397,10 @@ var _ = Describe("Node Health", func() {
 			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
 
 			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
-				metrics.ReasonLabel:   metrics.UnhealthyReason,
-				metrics.NodePoolLabel: nodePool.Name,
+				metrics.ReasonLabel:              metrics.UnhealthyReason,
+				metrics.NodePoolLabel:            nodePool.Name,
+				metrics.ConsolidationPolicyLabel: "",
+				metrics.TerminationModeLabel:     metrics.TerminationModeGraceful,
 			})
 			ExpectMetricCounterValue(health.NodeClaimsUnhealthyDisruptedTotal, 1, map[string]string{
 				health.Condition:      pretty.ToSnakeCase(string(cloudProvider.RepairPolicies()[0].ConditionType)),

--- a/pkg/controllers/nodeclaim/expiration/controller.go
+++ b/pkg/controllers/nodeclaim/expiration/controller.go
@@ -85,9 +85,11 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 	// 4. The deletion timestamp has successfully been set for the NodeClaim, update relevant metrics.
 	log.FromContext(ctx).V(1).Info("deleting expired nodeclaim")
 	labels := map[string]string{
-		metrics.ReasonLabel:       strings.ToLower(metrics.ExpiredReason),
-		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
-		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
+		metrics.ReasonLabel:              strings.ToLower(metrics.ExpiredReason),
+		metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
+		metrics.ConsolidationPolicyLabel: "",
+		metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
 	}
 	metrics.NodeClaimsDisruptedTotal.Inc(labels)
 	// Pods that haven't started draining yet still appear bound to the node, so the

--- a/pkg/controllers/nodeclaim/expiration/suite_test.go
+++ b/pkg/controllers/nodeclaim/expiration/suite_test.go
@@ -97,8 +97,10 @@ var _ = Describe("Expiration", func() {
 			ExpectNotFound(ctx, env.Client, nodeClaim)
 
 			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
-				metrics.ReasonLabel:   metrics.ExpiredReason,
-				metrics.NodePoolLabel: nodePool.Name,
+				metrics.ReasonLabel:              metrics.ExpiredReason,
+				metrics.NodePoolLabel:            nodePool.Name,
+				metrics.ConsolidationPolicyLabel: "",
+				metrics.TerminationModeLabel:     metrics.TerminationModeGraceful,
 			})
 		})
 		It("should fire a karpenter_nodeclaims_disrupted_total metric when expired", func() {
@@ -111,8 +113,10 @@ var _ = Describe("Expiration", func() {
 
 			ExpectNotFound(ctx, env.Client, nodeClaim)
 			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
-				metrics.ReasonLabel:   metrics.ExpiredReason,
-				metrics.NodePoolLabel: nodePool.Name,
+				metrics.ReasonLabel:              metrics.ExpiredReason,
+				metrics.NodePoolLabel:            nodePool.Name,
+				metrics.ConsolidationPolicyLabel: "",
+				metrics.TerminationModeLabel:     metrics.TerminationModeGraceful,
 			})
 		})
 		It("should fire karpenter_pods_disruption_initiated_total by the count of reschedulable pods on the node when expired", func() {
@@ -141,12 +145,16 @@ var _ = Describe("Expiration", func() {
 
 			ExpectNotFound(ctx, env.Client, nodeClaim)
 			ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
-				metrics.ReasonLabel:   metrics.ExpiredReason,
-				metrics.NodePoolLabel: nodePool.Name,
+				metrics.ReasonLabel:              metrics.ExpiredReason,
+				metrics.NodePoolLabel:            nodePool.Name,
+				metrics.ConsolidationPolicyLabel: "",
+				metrics.TerminationModeLabel:     metrics.TerminationModeGraceful,
 			})
 			ExpectMetricCounterValue(metrics.PodsDisruptionInitiatedTotal, 2, map[string]string{
-				metrics.ReasonLabel:   metrics.ExpiredReason,
-				metrics.NodePoolLabel: nodePool.Name,
+				metrics.ReasonLabel:              metrics.ExpiredReason,
+				metrics.NodePoolLabel:            nodePool.Name,
+				metrics.ConsolidationPolicyLabel: "",
+				metrics.TerminationModeLabel:     metrics.TerminationModeGraceful,
 			})
 		})
 	})
@@ -219,13 +227,17 @@ var _ = Describe("Expiration", func() {
 		ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
 		ExpectExists(ctx, env.Client, nodeClaim)
 		ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
-			metrics.ReasonLabel:   metrics.ExpiredReason,
-			metrics.NodePoolLabel: nodePool.Name,
+			metrics.ReasonLabel:              metrics.ExpiredReason,
+			metrics.NodePoolLabel:            nodePool.Name,
+			metrics.ConsolidationPolicyLabel: "",
+			metrics.TerminationModeLabel:     metrics.TerminationModeGraceful,
 		})
 		ExpectObjectReconciled(ctx, env.Client, expirationController, nodeClaim)
 		ExpectMetricCounterValue(metrics.NodeClaimsDisruptedTotal, 1, map[string]string{
-			metrics.ReasonLabel:   metrics.ExpiredReason,
-			metrics.NodePoolLabel: nodePool.Name,
+			metrics.ReasonLabel:              metrics.ExpiredReason,
+			metrics.NodePoolLabel:            nodePool.Name,
+			metrics.ConsolidationPolicyLabel: "",
+			metrics.TerminationModeLabel:     metrics.TerminationModeGraceful,
 		})
 	})
 })

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -110,9 +110,11 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 			"provider-id", nodeClaims[i].Status.ProviderID,
 		).V(1).Info("garbage collecting nodeclaim with no cloudprovider representation")
 		labels := map[string]string{
-			metrics.ReasonLabel:       "garbage_collected",
-			metrics.NodePoolLabel:     nodeClaims[i].Labels[v1.NodePoolLabelKey],
-			metrics.CapacityTypeLabel: nodeClaims[i].Labels[v1.CapacityTypeLabelKey],
+			metrics.ReasonLabel:              "garbage_collected",
+			metrics.NodePoolLabel:            nodeClaims[i].Labels[v1.NodePoolLabelKey],
+			metrics.CapacityTypeLabel:        nodeClaims[i].Labels[v1.CapacityTypeLabelKey],
+			metrics.ConsolidationPolicyLabel: "",
+			metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaims[i]),
 		}
 		metrics.NodeClaimsDisruptedTotal.Inc(labels)
 		// GC runs when the cloudprovider node is gone or NotReady; pod records may

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
+	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
 type Launch struct {
@@ -90,9 +91,11 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 				return nil, client.IgnoreNotFound(err)
 			}
 			metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-				metrics.ReasonLabel:       "insufficient_capacity",
-				metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
-				metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
+				metrics.ReasonLabel:              "insufficient_capacity",
+				metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
+				metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
+				metrics.ConsolidationPolicyLabel: "",
+				metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
 			})
 			return nil, nil
 		case cloudprovider.IsNodeClassNotReadyError(err):
@@ -101,9 +104,11 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 				return nil, client.IgnoreNotFound(err)
 			}
 			metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-				metrics.ReasonLabel:       "nodeclass_not_ready",
-				metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
-				metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
+				metrics.ReasonLabel:              "nodeclass_not_ready",
+				metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
+				metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
+				metrics.ConsolidationPolicyLabel: "",
+				metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
 			})
 			return nil, nil
 		default:

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -37,6 +37,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
+	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
 type Liveness struct {
@@ -151,9 +152,11 @@ func (l *Liveness) deleteNodeClaimForTimeout(ctx context.Context, timeout time.D
 	}
 	log.FromContext(ctx).V(1).WithValues("timeout", timeout, "reason", reason).Info("terminating due to timeout")
 	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-		metrics.ReasonLabel:       reason,
-		metrics.NodePoolLabel:     nodeClaim.Labels[v1.NodePoolLabelKey],
-		metrics.CapacityTypeLabel: nodeClaim.Labels[v1.CapacityTypeLabelKey],
+		metrics.ReasonLabel:              reason,
+		metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
+		metrics.ConsolidationPolicyLabel: "",
+		metrics.TerminationModeLabel:     nodeclaimutils.DisruptionTerminationMode(nodeClaim),
 	})
 	return nil
 }

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -26,17 +26,25 @@ const (
 	// Common namespace for application metrics.
 	Namespace = "karpenter"
 
-	NodePoolLabel         = "nodepool"
-	ReasonLabel           = "reason"
-	ResourceTypeLabel     = "resource_type"
-	CapacityTypeLabel     = "capacity_type"
-	ZoneLabel             = "zone"
-	MinValuesRelaxedLabel = "min_values_relaxed"
+	NodePoolLabel            = "nodepool"
+	ReasonLabel              = "reason"
+	ResourceTypeLabel        = "resource_type"
+	CapacityTypeLabel        = "capacity_type"
+	ZoneLabel                = "zone"
+	MinValuesRelaxedLabel    = "min_values_relaxed"
+	ConsolidationPolicyLabel = "consolidation_policy"
+	TerminationModeLabel     = "termination_mode"
 
 	// Reasons for CREATE/DELETE shared metrics
 	ProvisionedReason = "provisioned"
 	ExpiredReason     = "expired"
 	UnhealthyReason   = "unhealthy"
+
+	// termination_mode label values. Graceful and Eventual are also the canonical
+	// values for the disruption Graceful/Eventual classes in the disruption controller.
+	TerminationModeGraceful = "graceful"
+	TerminationModeEventual = "eventual"
+	TerminationModeForceful = "forceful"
 )
 
 // DurationBuckets returns a []float64 of default threshold values for duration histograms.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -64,12 +64,14 @@ var (
 			Namespace: Namespace,
 			Subsystem: NodeClaimSubsystem,
 			Name:      "disrupted_total",
-			Help:      "Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted and the owning nodepool.",
+			Help:      "Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted, the owning nodepool, the capacity type, the consolidation policy, and the termination mode.",
 		},
 		[]string{
 			ReasonLabel,
 			NodePoolLabel,
 			CapacityTypeLabel,
+			ConsolidationPolicyLabel,
+			TerminationModeLabel,
 		},
 	)
 	PodsDisruptionInitiatedTotal = opmetrics.NewPrometheusCounter(
@@ -78,12 +80,14 @@ var (
 			Namespace: Namespace,
 			Subsystem: PodSubsystem,
 			Name:      "disruption_initiated_total",
-			Help:      "Number of pod disruptions initiated in total by Karpenter, incremented by the reschedulable pod count whenever the underlying nodeclaim is disrupted. Labeled by reason the nodeclaim was disrupted, the owning nodepool, and the capacity type. Pods owned by DaemonSets and mirror pods are excluded.",
+			Help:      "Number of pod disruptions initiated in total by Karpenter, incremented by the reschedulable pod count whenever the underlying nodeclaim is disrupted. Labeled by reason the nodeclaim was disrupted, the owning nodepool, the capacity type, the consolidation policy, and the termination mode. Pods owned by DaemonSets and mirror pods are excluded.",
 		},
 		[]string{
 			ReasonLabel,
 			NodePoolLabel,
 			CapacityTypeLabel,
+			ConsolidationPolicyLabel,
+			TerminationModeLabel,
 		},
 	)
 	NodesCreatedTotal = opmetrics.NewPrometheusCounter(

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -35,12 +35,25 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
 func IsManaged(nodeClaim *v1.NodeClaim, cp cloudprovider.CloudProvider) bool {
 	return lo.ContainsBy(cp.GetSupportedNodeClasses(), func(nodeClass status.Object) bool {
 		return object.GVK(nodeClass).GroupKind() == nodeClaim.Spec.NodeClassRef.GroupKind()
 	})
+}
+
+// DisruptionTerminationMode returns the termination_mode metric label value for a
+// disrupted NodeClaim, derived from its terminationGracePeriod.
+func DisruptionTerminationMode(nodeClaim *v1.NodeClaim) string {
+	if nodeClaim == nil || nodeClaim.Spec.TerminationGracePeriod == nil {
+		return metrics.TerminationModeGraceful
+	}
+	if nodeClaim.Spec.TerminationGracePeriod.Duration <= 0 {
+		return metrics.TerminationModeForceful
+	}
+	return metrics.TerminationModeEventual
 }
 
 // IsManagedPredicateFuncs is used to filter controller-runtime NodeClaim watches to NodeClaims managed by the given cloudprovider.


### PR DESCRIPTION



<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Adds two labels to karpenter_nodeclaims_disrupted_total and karpenter_pods_disruption_initiated_total so disruption can be compared across consolidation policies -- e.g. to show that Balanced consolidation disrupts fewer pods than WhenEmptyOrUnderutilized.

- consolidation_policy: the owning nodepool's consolidationPolicy for consolidation-driven disruptions (gated on Command.ConsolidationType), or "none" for non-consolidation disruptions (drift, expiration, health, GC, launch failures).
- termination_mode: derived from the nodeclaim's terminationGracePeriod (TGP): graceful (no TGP), eventual (TGP > 0), or forceful (TGP == 0). Values align with the existing GracefulDisruptionClass/EventualDisruptionClass vocabulary.

A DisruptionTerminationMode helper in pkg/utils/nodeclaim centralizes the TGP classification. All NodeClaimsDisruptedTotal/PodsDisruptionInitiatedTotal increment sites are updated to populate both labels.

**How was this change tested?**

make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
