### PR TITLE
fix: delete pod unbound time metrics when a pod leaves Pending unscheduled

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -393,8 +393,12 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 		c.unscheduledPods.Insert(key)
 		return
 	}
-	if c.unscheduledPods.Has(key) && ok && cond.Status == corev1.ConditionTrue {
-		// Delete the unbound metric since the pod is now bound
+	if c.unscheduledPods.Has(key) {
+		// The pod has left Pending, so the unbound metrics no longer describe it.
+		// Delete them regardless of the PodScheduled condition: a pod can leave
+		// Pending while PodScheduled is still False, and these metrics would
+		// otherwise keep reporting stale values until the pod is deleted from the
+		// cluster entirely.
 		PodUnboundTimeSeconds.Delete(map[string]string{
 			podName:      pod.Name,
 			podNamespace: pod.Namespace,
@@ -404,9 +408,13 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 			podNamespace: pod.Namespace,
 		})
 
-		PodBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(pod.CreationTimestamp.Time).Seconds(), nil)
-		if !schedulableTime.IsZero() {
-			PodProvisioningBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), nil)
+		// The bound durations are only meaningful when the pod actually reached
+		// PodScheduled=True, so they stay gated on the condition.
+		if ok && cond.Status == corev1.ConditionTrue {
+			PodBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(pod.CreationTimestamp.Time).Seconds(), nil)
+			if !schedulableTime.IsZero() {
+				PodProvisioningBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), nil)
+			}
 		}
 		c.unscheduledPods.Delete(key)
 	}

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -206,6 +206,45 @@ var _ = Describe("Pod Metrics", func() {
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_bound_duration_seconds", map[string]string{})
 		Expect(found).To(BeTrue())
 	})
+	It("should delete the pod unbound time metrics when the pod leaves Pending without PodScheduled=True", func() {
+		p := test.Pod()
+		p.Status.Phase = corev1.PodPending
+
+		env.Clock.Step(1 * time.Hour)
+		cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {p}}, map[string][]*corev1.Pod{"nc1": {p}})
+
+		// Pending with PodScheduled=False, so the unbound metrics are emitted.
+		p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodScheduled, Status: corev1.ConditionFalse, LastTransitionTime: metav1.Now()}}
+		ExpectApplied(ctx, env.Client, p)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
+		_, found := FindMetricWithLabelValues("karpenter_pods_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeTrue())
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeTrue())
+
+		// The pod leaves Pending while PodScheduled is still False. The unbound
+		// metrics no longer describe the pod and must not be left behind.
+		p.Status.Phase = corev1.PodFailed
+		ExpectApplied(ctx, env.Client, p)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
+
+		_, found = FindMetricWithLabelValues("karpenter_pods_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeFalse())
+		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_unbound_time_seconds", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		})
+		Expect(found).To(BeFalse())
+	})
 	It("should update the pod startup and unstarted time metrics", func() {
 		p := test.Pod()
 		p.Status.Phase = corev1.PodPending


### PR DESCRIPTION
**Fixes #3153**

**Description**

`recordPodBoundMetric` deletes the unbound gauges only when the pod has left `Pending` **and** `PodScheduled` is `True`:

```go
if c.unscheduledPods.Has(key) && ok && cond.Status == corev1.ConditionTrue {
    PodUnboundTimeSeconds.Delete(...)
    PodProvisioningUnboundTimeSeconds.Delete(...)
    ...
}
```

A pod can leave `Pending` while `PodScheduled` is still `False` — the same race documented in #3120, where kubelet's status patch and the scheduler's condition update interleave. In that case the `Pending` branch above returns early no longer, and this branch never fires, so neither gauge is ever deleted. `unscheduledPods` is only cleared here or in the top-level `NotFound` handler, so `karpenter_pods_unbound_time_seconds` and `karpenter_pods_provisioning_unbound_time_seconds` keep reporting stale values for that pod until it is removed from the cluster entirely.

This deletes the unbound gauges whenever a tracked pod is no longer `Pending`, regardless of the condition — the same "delete idempotently once the metric no longer applies" shape used by `recordPodSchedulingUndecidedMetric` after #3120. The `PodBoundDurationSeconds` and `PodProvisioningBoundDurationSeconds` histograms remain gated on `PodScheduled=True`, since a duration-to-bound is only meaningful if the pod actually bound.

**How was this change tested?**

Added a spec to `pkg/controllers/metrics/pod`: a pod is observed `Pending` with `PodScheduled=False` (both gauges present), then moves to `Failed` while the condition stays `False`. The gauges must be gone.

Against the previous behaviour that spec fails, since the gauges are still registered:

```
[FAILED] Expected
to be false
Ran 14 of 14 Specs — 13 Passed | 1 Failed
```

With the fix all 14 specs pass. Run with `KUBEBUILDER_ASSETS` from `setup-envtest`.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, fix, and test were verified against the source and run against the existing suite before submitting.