### PR TITLE
feat: configurable multi-node max candidates

### DIFF
--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	scheduler "sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
@@ -76,9 +77,7 @@ func (m *MultiNodeConsolidation) ComputeCommands(ctx context.Context, disruption
 		disruptionBudgetMapping[candidate.NodePool.Name]--
 	}
 
-	// Only consider a maximum batch of 100 NodeClaims to save on computation.
-	// This could be further configurable in the future.
-	maxParallel := lo.Clamp(len(disruptableCandidates), 0, 100)
+	maxParallel := lo.Clamp(len(disruptableCandidates), 0, options.FromContext(ctx).MultiNodeConsolidationMaxCandidates)
 
 	cmd, perPoolResults, err := m.firstNConsolidationOption(ctx, disruptableCandidates, maxParallel)
 	if err != nil {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -66,30 +66,31 @@ type FeatureGates struct {
 
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
 type Options struct {
-	ServiceName                      string
-	MetricsPort                      int
-	HealthProbePort                  int
-	KubeClientQPS                    int
-	KubeClientBurst                  int
-	EnableProfiling                  bool
-	DisableControllerWarmup          bool
-	DisableLeaderElection            bool
-	DisableClusterStateObservability bool
-	LeaderElectionName               string
-	LeaderElectionNamespace          string
-	MemoryLimit                      int64
-	CPURequests                      int64
-	LogLevel                         string
-	LogOutputPaths                   string
-	LogErrorOutputPaths              string
-	BatchMaxDuration                 time.Duration
-	BatchIdleDuration                time.Duration
-	preferencePolicyRaw              string
-	PreferencePolicy                 PreferencePolicy
-	minValuesPolicyRaw               string
-	MinValuesPolicy                  MinValuesPolicy
-	IgnoreDRARequests                bool // NOTE: This flag will be removed once formal DRA support is GA in Karpenter.
-	FeatureGates                     FeatureGates
+	ServiceName                         string
+	MetricsPort                         int
+	HealthProbePort                     int
+	KubeClientQPS                       int
+	KubeClientBurst                     int
+	EnableProfiling                     bool
+	DisableControllerWarmup             bool
+	DisableLeaderElection               bool
+	DisableClusterStateObservability    bool
+	LeaderElectionName                  string
+	LeaderElectionNamespace             string
+	MemoryLimit                         int64
+	CPURequests                         int64
+	LogLevel                            string
+	LogOutputPaths                      string
+	LogErrorOutputPaths                 string
+	BatchMaxDuration                    time.Duration
+	BatchIdleDuration                   time.Duration
+	preferencePolicyRaw                 string
+	PreferencePolicy                    PreferencePolicy
+	minValuesPolicyRaw                  string
+	MinValuesPolicy                     MinValuesPolicy
+	IgnoreDRARequests                   bool // NOTE: This flag will be removed once formal DRA support is GA in Karpenter.
+	MultiNodeConsolidationMaxCandidates int
+	FeatureGates                        FeatureGates
 }
 
 type FlagSet struct {
@@ -131,6 +132,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")
+	fs.IntVar(&o.MultiNodeConsolidationMaxCandidates, "multi-node-consolidation-max-candidates", env.WithDefaultInt("MULTI_NODE_CONSOLIDATION_MAX_CANDIDATES", 100), "The maximum number of candidates to consider in a multi-node consolidation pass.")
 	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false,CapacityBuffer=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, StaticCapacity, and CapacityBuffer.")
 }
 

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -65,6 +65,7 @@ var _ = Describe("Options", func() {
 		"PREFERENCE_POLICY",
 		"MIN_VALUES_POLICY",
 		"FEATURE_GATES",
+		"MULTI_NODE_CONSOLIDATION_MAX_CANDIDATES",
 	}
 
 	BeforeEach(func() {
@@ -412,4 +413,5 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.FeatureGates.CapacityBuffer).To(Equal(optsB.FeatureGates.CapacityBuffer))
 	Expect(optsA.FeatureGates.SpotToSpotConsolidation).To(Equal(optsB.FeatureGates.SpotToSpotConsolidation))
 	Expect(optsA.IgnoreDRARequests).To(Equal(optsB.IgnoreDRARequests))
+	Expect(optsA.MultiNodeConsolidationMaxCandidates).To(Equal(optsB.MultiNodeConsolidationMaxCandidates))
 }

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -28,28 +28,29 @@ import (
 
 type OptionsFields struct {
 	// Vendor Neutral
-	ServiceName                      *string
-	MetricsPort                      *int
-	HealthProbePort                  *int
-	KubeClientQPS                    *int
-	KubeClientBurst                  *int
-	EnableProfiling                  *bool
-	DisableControllerWarmup          *bool
-	DisableLeaderElection            *bool
-	DisableClusterStateObservability *bool
-	LeaderElectionName               *string
-	LeaderElectionNamespace          *string
-	MemoryLimit                      *int64
-	CPURequests                      *int64
-	LogLevel                         *string
-	LogOutputPaths                   *string
-	LogErrorOutputPaths              *string
-	PreferencePolicy                 *options.PreferencePolicy
-	MinValuesPolicy                  *options.MinValuesPolicy
-	BatchMaxDuration                 *time.Duration
-	BatchIdleDuration                *time.Duration
-	IgnoreDRARequests                *bool
-	FeatureGates                     FeatureGates
+	ServiceName                         *string
+	MetricsPort                         *int
+	HealthProbePort                     *int
+	KubeClientQPS                       *int
+	KubeClientBurst                     *int
+	EnableProfiling                     *bool
+	DisableControllerWarmup             *bool
+	DisableLeaderElection               *bool
+	DisableClusterStateObservability    *bool
+	LeaderElectionName                  *string
+	LeaderElectionNamespace             *string
+	MemoryLimit                         *int64
+	CPURequests                         *int64
+	LogLevel                            *string
+	LogOutputPaths                      *string
+	LogErrorOutputPaths                 *string
+	PreferencePolicy                    *options.PreferencePolicy
+	MinValuesPolicy                     *options.MinValuesPolicy
+	BatchMaxDuration                    *time.Duration
+	BatchIdleDuration                   *time.Duration
+	IgnoreDRARequests                   *bool
+	MultiNodeConsolidationMaxCandidates *int
+	FeatureGates                        FeatureGates
 }
 
 type FeatureGates struct {
@@ -70,25 +71,26 @@ func Options(overrides ...OptionsFields) *options.Options {
 	}
 
 	return &options.Options{
-		ServiceName:                      lo.FromPtrOr(opts.ServiceName, ""),
-		MetricsPort:                      lo.FromPtrOr(opts.MetricsPort, 8080),
-		HealthProbePort:                  lo.FromPtrOr(opts.HealthProbePort, 8081),
-		KubeClientQPS:                    lo.FromPtrOr(opts.KubeClientQPS, 200),
-		KubeClientBurst:                  lo.FromPtrOr(opts.KubeClientBurst, 300),
-		EnableProfiling:                  lo.FromPtrOr(opts.EnableProfiling, false),
-		DisableControllerWarmup:          lo.FromPtrOr(opts.DisableControllerWarmup, true),
-		DisableLeaderElection:            lo.FromPtrOr(opts.DisableLeaderElection, false),
-		DisableClusterStateObservability: lo.FromPtrOr(opts.DisableClusterStateObservability, false),
-		MemoryLimit:                      lo.FromPtrOr(opts.MemoryLimit, -1),
-		CPURequests:                      lo.FromPtrOr(opts.CPURequests, 5000), // use 5 threads to enforce parallelism
-		LogLevel:                         lo.FromPtrOr(opts.LogLevel, ""),
-		LogOutputPaths:                   lo.FromPtrOr(opts.LogOutputPaths, "stdout"),
-		LogErrorOutputPaths:              lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),
-		BatchMaxDuration:                 lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
-		BatchIdleDuration:                lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
-		PreferencePolicy:                 lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
-		MinValuesPolicy:                  lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
-		IgnoreDRARequests:                lo.FromPtrOr(opts.IgnoreDRARequests, true),
+		ServiceName:                         lo.FromPtrOr(opts.ServiceName, ""),
+		MetricsPort:                         lo.FromPtrOr(opts.MetricsPort, 8080),
+		HealthProbePort:                     lo.FromPtrOr(opts.HealthProbePort, 8081),
+		KubeClientQPS:                       lo.FromPtrOr(opts.KubeClientQPS, 200),
+		KubeClientBurst:                     lo.FromPtrOr(opts.KubeClientBurst, 300),
+		EnableProfiling:                     lo.FromPtrOr(opts.EnableProfiling, false),
+		DisableControllerWarmup:             lo.FromPtrOr(opts.DisableControllerWarmup, true),
+		DisableLeaderElection:               lo.FromPtrOr(opts.DisableLeaderElection, false),
+		DisableClusterStateObservability:    lo.FromPtrOr(opts.DisableClusterStateObservability, false),
+		MemoryLimit:                         lo.FromPtrOr(opts.MemoryLimit, -1),
+		CPURequests:                         lo.FromPtrOr(opts.CPURequests, 5000), // use 5 threads to enforce parallelism
+		LogLevel:                            lo.FromPtrOr(opts.LogLevel, ""),
+		LogOutputPaths:                      lo.FromPtrOr(opts.LogOutputPaths, "stdout"),
+		LogErrorOutputPaths:                 lo.FromPtrOr(opts.LogErrorOutputPaths, "stderr"),
+		BatchMaxDuration:                    lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
+		BatchIdleDuration:                   lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
+		PreferencePolicy:                    lo.FromPtrOr(opts.PreferencePolicy, options.PreferencePolicyRespect),
+		MinValuesPolicy:                     lo.FromPtrOr(opts.MinValuesPolicy, options.MinValuesPolicyStrict),
+		IgnoreDRARequests:                   lo.FromPtrOr(opts.IgnoreDRARequests, true),
+		MultiNodeConsolidationMaxCandidates: lo.FromPtrOr(opts.MultiNodeConsolidationMaxCandidates, 100),
 		FeatureGates: options.FeatureGates{
 			NodeRepair:              lo.FromPtrOr(opts.FeatureGates.NodeRepair, false),
 			ReservedCapacity:        lo.FromPtrOr(opts.FeatureGates.ReservedCapacity, true),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes: https://github.com/kubernetes-sigs/karpenter/issues/3186

**Description**

This maks the [multi-node max consolidation candidates](https://github.com/kubernetes-sigs/karpenter/blob/main/pkg/controllers/disruption/multinodeconsolidation.go#L81) value configurable

**How was this change tested?**

We've been running this in production. It's simple enough that I don't think it warrants unit or integration testing but LMK if there's something that should be done.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
