### PR TITLE
fix: revoke voluntary disruption when a blocking pod lands on a candidate

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -101,7 +101,7 @@ func NewControllers(
 	virtualPodCache := virtualpods.NewVirtualPodCache(kubeClient)
 	p := provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster, clock, deviceAllocationController, virtualPodCache)
 	evictionQueue := terminator.NewQueue(kubeClient, recorder)
-	disruptionQueue := disruption.NewQueue(kubeClient, recorder, cluster, clock, p)
+	disruptionQueue := disruption.NewQueue(kubeClient, mgr.GetAPIReader(), recorder, cluster, clock, p)
 	npState := nodepoolhealth.NewState()
 	clusterCost := cost.NewClusterCost(ctx, cloudProvider, kubeClient)
 	controllers := []controller.Controller{

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -3103,7 +3103,7 @@ var _ = Describe("Consolidation", func() {
 				ExpectReconcileSucceeded(ctx, nodeClaimStateController, client.ObjectKeyFromObject(nc))
 			}
 			// Reset the disruption controller so consolidation methods are not cached as consolidated
-			*queue = lo.FromPtr(disruption.NewQueue(env.Client, recorder, cluster, env.Clock, prov))
+			*queue = lo.FromPtr(disruption.NewQueue(env.Client, env.Client, recorder, cluster, env.Clock, prov))
 			disruptionController = disruption.NewController(env.Clock, env.Client, prov, cloudProvider, recorder, cluster, queue, clusterCost,
 				disruption.WithMethods(NewMethodsWithNopValidator()...))
 			ExpectSingletonReconciled(ctx, disruptionController)

--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -56,6 +56,8 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
+	podutils "sigs.k8s.io/karpenter/pkg/utils/pod"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
 
@@ -97,14 +99,18 @@ type Queue struct {
 	ProviderIDToCommand map[string]*Command // providerID -> command, maps a candidate to its command
 	source              chan event.TypedGenericEvent[*v1.NodeClaim]
 	kubeClient          client.Client
-	recorder            events.Recorder
-	cluster             *state.Cluster
-	clock               clock.Clock
-	provisioner         *provisioning.Provisioner
+	// apiReader reads directly from the apiserver, bypassing the informer cache. It's used to
+	// confirm a candidate is still disruptable at the point of no return, where a stale cache
+	// would cost us the workload.
+	apiReader   client.Reader
+	recorder    events.Recorder
+	cluster     *state.Cluster
+	clock       clock.Clock
+	provisioner *provisioning.Provisioner
 }
 
 // NewQueue creates a queue that will asynchronously orchestrate disruption commands
-func NewQueue(kubeClient client.Client, recorder events.Recorder, cluster *state.Cluster, clock clock.Clock,
+func NewQueue(kubeClient client.Client, apiReader client.Reader, recorder events.Recorder, cluster *state.Cluster, clock clock.Clock,
 	provisioner *provisioning.Provisioner,
 ) *Queue {
 	queue := &Queue{
@@ -113,6 +119,7 @@ func NewQueue(kubeClient client.Client, recorder events.Recorder, cluster *state
 		source:              make(chan event.TypedGenericEvent[*v1.NodeClaim], 10000),
 		ProviderIDToCommand: map[string]*Command{},
 		kubeClient:          kubeClient,
+		apiReader:           apiReader,
 		recorder:            recorder,
 		cluster:             cluster,
 		clock:               clock,
@@ -227,6 +234,18 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 		return fmt.Errorf("waiting for replacement initialization, %w", err)
 	}
 
+	// Deleting the NodeClaim is the point of no return: a deletionTimestamp can't be cleared, and
+	// the termination controller only drains once it's set. Confirm the candidates are still
+	// disruptable while we can still walk the command back.
+	if err := q.ensureCandidatesDisruptable(ctx, cmd); err != nil {
+		if state.IgnorePodBlockEvictionError(err) == nil {
+			// The decision is no longer valid. Give up on the command so its candidates get
+			// un-tainted, rather than committing them to termination.
+			return NewUnrecoverableError(err)
+		}
+		return err
+	}
+
 	// All replacements have been provisioned.
 	// All we need to do now is get a successful delete call for each node claim,
 	// then the termination controller will handle the eventual deletion of the nodes.
@@ -249,6 +268,48 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 	})
 	// If there were any deletion failures, we should requeue.
 	// In the case where we requeue, but the timeout for the command is reached, we'll mark this as a failure.
+	return multierr.Combine(errs...)
+}
+
+// ensureCandidatesDisruptable re-reads the pods bound to each candidate straight from the
+// apiserver and returns a PodBlockEvictionError if any of them blocks eviction.
+//
+// The decision to disrupt was taken against cluster state that can go stale: LastPodEventTime
+// keeps a NodeClaim's Consolidatable condition current, and both it and the pod informer stop
+// tracking reality when the apiserver sheds writes (ResourceExhausted), so a node can be picked
+// as empty while pods are landing on it. The disrupted taint is already in place by the time we
+// get here, which is what makes this read conclusive rather than another race: nothing new can
+// be scheduled to the candidate, so whatever the apiserver returns now is the final set of pods.
+//
+// This only applies to graceful disruption. Eventual disruption deliberately proceeds through
+// blocking pods once a NodeClaim's TerminationGracePeriod is set.
+func (q *Queue) ensureCandidatesDisruptable(ctx context.Context, cmd *Command) error {
+	if cmd.Class() != GracefulDisruptionClass {
+		return nil
+	}
+	errs := make([]error, len(cmd.Candidates))
+	workqueue.ParallelizeUntil(ctx, len(cmd.Candidates), len(cmd.Candidates), func(i int) {
+		if cmd.Candidates[i].Node == nil {
+			return
+		}
+		pods, err := nodeutils.GetPods(ctx, q.apiReader, cmd.Candidates[i].Node.Name)
+		if err != nil {
+			errs[i] = fmt.Errorf("listing pods, %w", err)
+			return
+		}
+		for _, p := range pods {
+			// Mirrors StateNode.ValidatePodsDisruptable: only actively running pods hold up
+			// disruption with the do-not-disrupt annotation.
+			if !podutils.IsDisruptable(p, q.clock, q.recorder) {
+				err := serrors.Wrap(
+					fmt.Errorf(`pod scheduled after the disruption decision has a "karpenter.sh/do-not-disrupt" annotation`),
+					"Pod", klog.KObj(p))
+				q.recorder.Publish(disruptionevents.Blocked(cmd.Candidates[i].Node, cmd.Candidates[i].NodeClaim, pretty.Sentence(err.Error()))...)
+				errs[i] = state.NewPodBlockEvictionError(err)
+				return
+			}
+		}
+	})
 	return multierr.Combine(errs...)
 }
 

--- a/pkg/controllers/disruption/queue_test.go
+++ b/pkg/controllers/disruption/queue_test.go
@@ -206,6 +206,56 @@ var _ = Describe("Queue", func() {
 			node1 = ExpectNodeExists(ctx, env.Client, node1.Name)
 			Expect(node1.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
 		})
+		It("should untaint nodes and abandon the command when a do-not-disrupt pod lands on a candidate", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node1}, []*v1.NodeClaim{nodeClaim1})
+			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
+
+			cmd := &disruption.Command{
+				Method:            disruption.NewEmptiness(disruption.MakeConsolidation(env.Clock, cluster, env.Client, prov, cloudProvider, recorder, queue)),
+				CreationTimestamp: env.Clock.Now(),
+				ID:                uuid.New(),
+				Results:           scheduling.Results{},
+				Candidates:        []*disruption.Candidate{{StateNode: stateNode, NodePool: nodePool}},
+			}
+			Expect(queue.StartCommand(ctx, cmd)).To(BeNil())
+			node1 = ExpectNodeExists(ctx, env.Client, node1.Name)
+			Expect(node1.Spec.Taints).To(ContainElement(v1.DisruptedNoScheduleTaint))
+
+			// The node was empty when the command was computed. A pod that blocks eviction lands on
+			// it before we delete the NodeClaim, which our cluster state hasn't caught up with.
+			pod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1.DoNotDisruptAnnotationKey: "true"}},
+			})
+			ExpectApplied(ctx, env.Client, pod)
+			ExpectManualBinding(ctx, env.Client, pod, node1)
+
+			ExpectObjectReconciled(ctx, env.Client, queue, stateNode.NodeClaim)
+
+			// The command is walked back rather than committed: the taint is removed and the
+			// NodeClaim is left alone, so the pod runs to completion.
+			node1 = ExpectNodeExists(ctx, env.Client, node1.Name)
+			Expect(node1.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
+			ExpectExists(ctx, env.Client, nodeClaim1)
+			Expect(nodeClaim1.DeletionTimestamp.IsZero()).To(BeTrue())
+		})
+		It("should delete the candidate when no pod blocks eviction", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node1}, []*v1.NodeClaim{nodeClaim1})
+			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
+
+			cmd := &disruption.Command{
+				Method:            disruption.NewEmptiness(disruption.MakeConsolidation(env.Clock, cluster, env.Client, prov, cloudProvider, recorder, queue)),
+				CreationTimestamp: env.Clock.Now(),
+				ID:                uuid.New(),
+				Results:           scheduling.Results{},
+				Candidates:        []*disruption.Candidate{{StateNode: stateNode, NodePool: nodePool}},
+			}
+			Expect(queue.StartCommand(ctx, cmd)).To(BeNil())
+
+			ExpectObjectReconciled(ctx, env.Client, queue, stateNode.NodeClaim)
+			ExpectNotFound(ctx, env.Client, nodeClaim1)
+		})
 		It("should fully handle a command when replacements are initialized", func() {
 			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool)
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node1}, []*v1.NodeClaim{nodeClaim1})
@@ -419,7 +469,7 @@ var _ = Describe("Queue", func() {
 		Context("CalculateRetryDuration", func() {
 			DescribeTable("should calculate correct timeout based on queue length",
 				func(numCommands int, expectedDuration time.Duration) {
-					q := disruption.NewQueue(env.Client, recorder, cluster, env.Clock, prov)
+					q := disruption.NewQueue(env.Client, env.Client, recorder, cluster, env.Clock, prov)
 					q.Lock()
 					for i := range numCommands {
 						q.ProviderIDToCommand[strconv.Itoa(i)] = &disruption.Command{}

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -105,7 +105,7 @@ var _ = BeforeSuite(func() {
 	recorder = test.NewEventRecorder()
 	draController = deviceallocation.NewController(env.Client)
 	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, env.Clock, draController, virtualpods.NewVirtualPodCache(env.Client))
-	queue = disruption.NewQueue(env.Client, recorder, cluster, env.Clock, prov)
+	queue = disruption.NewQueue(env.Client, env.Client, recorder, cluster, env.Clock, prov)
 })
 
 var _ = AfterSuite(func() {
@@ -130,7 +130,7 @@ var _ = BeforeEach(func() {
 	disruptionController = disruption.NewController(env.Clock, env.Client, prov, cloudProvider, recorder, cluster, queue, clusterCost, disruption.WithMethods(NewMethodsWithNopValidator()...))
 	env.Clock.SetTime(time.Now())
 	cluster.Reset()
-	*queue = lo.FromPtr(disruption.NewQueue(env.Client, recorder, cluster, env.Clock, prov))
+	*queue = lo.FromPtr(disruption.NewQueue(env.Client, env.Client, recorder, cluster, env.Clock, prov))
 	cluster.MarkUnconsolidated()
 
 	// Reset Feature Flags to test defaults
@@ -473,7 +473,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		defer hangCreateClient.Stop()
 
 		p := provisioning.NewProvisioner(hangCreateClient, recorder, cloudProvider, cluster, env.Clock, deviceallocation.NewController(hangCreateClient), virtualpods.NewVirtualPodCache(hangCreateClient))
-		q := disruption.NewQueue(hangCreateClient, recorder, cluster, env.Clock, p)
+		q := disruption.NewQueue(hangCreateClient, env.Client, recorder, cluster, env.Clock, p)
 		dc := disruption.NewController(env.Clock, hangCreateClient, p, cloudProvider, recorder, cluster, q, clusterCost)
 
 		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -106,7 +106,7 @@ func IgnoreDuplicateNodeClaimError(err error) error {
 // GetPods grabs all pods that are currently bound to the passed node names.
 // Empty node names are skipped so callers operating on un-registered NodeClaims
 // don't accidentally match unscheduled pods via the "spec.nodeName" field selector.
-func GetPods(ctx context.Context, kubeClient client.Client, nodeNames ...string) ([]*corev1.Pod, error) {
+func GetPods(ctx context.Context, kubeClient client.Reader, nodeNames ...string) ([]*corev1.Pod, error) {
 	var pods []*corev1.Pod
 	for _, nodeName := range nodeNames {
 		if nodeName == "" {


### PR DESCRIPTION
Fixes #3185

**Description**

A graceful disruption command is decided against cluster state that can go stale. `LastPodEventTime` is what keeps a NodeClaim's `Consolidatable` condition current, and both it and the pod informer stop tracking reality when the apiserver sheds writes — in the incident behind the linked issue, `nodeclaim.podevents`, `nodeclaim.disruption` and the taint write were all failing with `etcdserver: throttle: too many requests` for ~57s, so a node was selected as `Empty` while 8 pods with `karpenter.sh/do-not-disrupt` were landing on it.

Deleting the NodeClaim is the point of no return: a `deletionTimestamp` can't be cleared, and `node/termination` only calls `finalize` once it's set, so from that moment the drain can only keep retrying evictions it will never win (`FailedDraining … N pods are waiting to be evicted`, until the node goes away and the pods die un-evicted).

This re-reads the candidate's pods **directly from the apiserver** immediately before that delete, and gives up the command if any pod blocks eviction — the existing failure path in `Queue.Reconcile` then un-taints the candidates and clears the disruption condition, so the pods run to completion and the node is reused.

Two properties worth calling out:

- The check runs **after** the `karpenter.sh/disrupted` taint is applied, which is what makes it conclusive rather than another race: nothing new can schedule to the candidate, so the pods the apiserver returns are the final set.
- Eventual disruption is exempt (`cmd.Class() != GracefulDisruptionClass` returns early), since it deliberately proceeds through blocking pods once a NodeClaim has a `TerminationGracePeriod`.

Cost is one uncached pod LIST per graceful disruption command, on the path that already does per-candidate writes.

Notes for reviewers:

- `NewQueue` takes an additional `client.Reader`, wired from `mgr.GetAPIReader()` in `NewControllers`. This is a signature change for anyone constructing the queue directly. Happy to hide it behind an `option.Function` instead if you'd prefer, though a nil reader would silently disable the check.
- `nodeutils.GetPods` is widened from `client.Client` to `client.Reader`. `client.Client` satisfies `client.Reader`, so existing callers are unaffected.
- Only the do-not-disrupt annotation is checked, not PDBs. Extending it to `pdb.Limits` would need the limits rebuilt at this point; happy to add if you want parity with `ValidatePodsDisruptable`.
- This does not cover a binding the scheduler had already decided before the taint became visible. That needs drain decoupled from NodeClaim deletion, which is a design change rather than a patch.

**How was this change tested?**

`make test` scope for the affected packages, with envtest:

- `pkg/controllers/disruption` (316 specs), `pkg/utils/node`, `pkg/controllers/node/termination`, `pkg/controllers/node/termination/terminator` — all passing.
- Two new specs in `queue_test.go`: one asserts the taint is removed and the NodeClaim is left alone when a do-not-disrupt pod is bound to a candidate after `StartCommand`; the other asserts an Empty command still deletes the NodeClaim when nothing blocks eviction.
- Verified the first spec fails without the fix (stubbing out the new check makes it fail on the taint assertion).
- `go build ./...`, `go vet ./pkg/controllers/disruption/...` and `gofmt` are clean. I could not run `golangci-lint` locally — the repo config requires the `kubeapilinter` plugin from your toolchain build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
