### PR TITLE
fix: heal stranded unlaunched nodeclaim entries in cluster state

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -60,6 +60,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
+	statenodeclaimgc "sigs.k8s.io/karpenter/pkg/controllers/state/nodeclaimgc"
 	staticdeprovisioning "sigs.k8s.io/karpenter/pkg/controllers/static/deprovisioning"
 	staticprovisioning "sigs.k8s.io/karpenter/pkg/controllers/static/provisioning"
 	"sigs.k8s.io/karpenter/pkg/events"
@@ -114,6 +115,7 @@ func NewControllers(
 		informer.NewNodePoolController(kubeClient, cloudProvider, cluster, clusterCost),
 		informer.NewNodeClaimController(kubeClient, cloudProvider, cluster, clusterCost),
 		informer.NewPricingController(kubeClient, cloudProvider, clusterCost),
+		statenodeclaimgc.NewController(kubeClient, cluster),
 		termination.NewController(clock, kubeClient, cloudProvider, terminator.NewTerminator(clock, kubeClient, evictionQueue, recorder), recorder),
 		nodepoolreadiness.NewController(clock, kubeClient, cloudProvider),
 		nodepoolregistrationhealth.NewController(clock, kubeClient, cloudProvider, npState),

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -447,6 +447,14 @@ func (c *Cluster) NodeClaimExists(nodeClaimName string) bool {
 	return ok
 }
 
+func (c *Cluster) UnlaunchedNodeClaimExists(nodeClaimName string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	providerID, ok := c.nodeClaimNameToProviderID[nodeClaimName]
+	return ok && providerID == ""
+}
+
 // AckPods marks the pod as acknowledged for scheduling from the provisioner. This is only done once per-pod.
 func (c *Cluster) AckPods(pods ...*corev1.Pod) {
 	now := c.clock.Now()

--- a/pkg/controllers/state/nodeclaimgc/controller.go
+++ b/pkg/controllers/state/nodeclaimgc/controller.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeclaimgc
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+)
+
+// gracePeriod is how long after a NodeClaim is created we wait before verifying it still exists. It only needs to
+// comfortably exceed the worst-case delay for the provisioner's post-create seed to land
+const gracePeriod = 15 * time.Second
+
+type Controller struct {
+	kubeClient client.Client
+	cluster    *state.Cluster
+}
+
+func NewController(kubeClient client.Client, cluster *state.Cluster) *Controller {
+	return &Controller{
+		kubeClient: kubeClient,
+		cluster:    cluster,
+	}
+}
+
+func (c *Controller) Name() string {
+	return "state.nodeclaimgc"
+}
+
+// Garbage collects unlaunched NodeClaim entries from cluster state that no longer exist on the API
+// server, so a create/delete race in the seed window can't hold Synced() false indefinitely as seen
+// in https://github.com/kubernetes-sigs/karpenter/issues/3176.
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	ctx = injection.WithControllerName(ctx, c.Name())
+
+	// This runs a grace period after the NodeClaim was created, so the seed has landed. If the NodeClaim still
+	// exists or there is no entry in nodeClaimNameToProviderID (cluster state), there's nothing to heal.
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: req.Name}, &v1.NodeClaim{}); err != nil {
+		if !errors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		if c.cluster.UnlaunchedNodeClaimExists(req.Name) {
+			log.FromContext(ctx).WithValues("NodeClaim", klog.KRef("", req.Name)).Info("garbage collecting stale unlaunched nodeclaim from cluster state")
+			c.cluster.DeleteNodeClaim(req.Name)
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		Watches(&v1.NodeClaim{}, handler.Funcs{
+			CreateFunc: func(_ context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{Name: e.Object.GetName()}}, gracePeriod)
+			},
+		}).
+		Complete(c)
+}

--- a/pkg/controllers/state/nodeclaimgc/controller.go
+++ b/pkg/controllers/state/nodeclaimgc/controller.go
@@ -70,7 +70,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, err
 		}
 		if c.cluster.UnlaunchedNodeClaimExists(req.Name) {
-			log.FromContext(ctx).WithValues("NodeClaim", klog.KRef("", req.Name)).Info("garbage collecting stale unlaunched nodeclaim from cluster state")
+			log.FromContext(ctx).WithValues("NodeClaim", klog.KRef("", req.Name)).V(1).Info("garbage collecting stale unlaunched nodeclaim from cluster state")
 			c.cluster.DeleteNodeClaim(req.Name)
 		}
 	}

--- a/pkg/controllers/state/nodeclaimgc/suite_test.go
+++ b/pkg/controllers/state/nodeclaimgc/suite_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeclaimgc_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/karpenter/pkg/apis"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
+	nodeclaimgc "sigs.k8s.io/karpenter/pkg/controllers/state/nodeclaimgc"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/state/cost"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var (
+	ctx                 context.Context
+	env                 *test.Environment
+	cluster             *state.Cluster
+	clusterCost         *cost.ClusterCost
+	cloudProvider       *fake.CloudProvider
+	gcController        *nodeclaimgc.Controller
+	nodeClaimController *informer.NodeClaimController
+)
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controllers/State/NodeClaimGC")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
+	ctx = options.ToContext(ctx, test.Options())
+	cloudProvider = fake.NewCloudProvider()
+	cluster = state.NewCluster(env.Clock, env.Client, cloudProvider)
+	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)
+	gcController = nodeclaimgc.NewController(env.Client, cluster)
+	nodeClaimController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+	cluster.Reset()
+	cloudProvider.Reset()
+})
+
+func request(name string) reconcile.Request {
+	return reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}
+}
+
+var _ = Describe("NodeClaim Cluster State GC", func() {
+	It("should heal the wedge caused by a seed landing after the informer's delete cleanup", func() {
+		// The informer observes the NotFound and cleans up first (a no-op against empty state),
+		// then the provisioner's seed lands and strands name -> "". Synced() is now stuck false
+		// until state.nodeclaimgc reconciles.
+		nodeClaim := test.NodeClaim()
+		nodeClaim.Status.ProviderID = ""
+
+		// Informer delete cleanup runs first against a NodeClaim that doesn't exist -> no-op.
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		// The provisioner's post-create seed lands afterwards, stranding the ghost entry.
+		cluster.UpdateNodeClaim(nodeClaim)
+		Expect(cluster.Synced(ctx)).To(BeFalse())
+
+		// A later re-check of the NodeClaim (still gone) heals it.
+		ExpectReconciled(ctx, gcController, request(nodeClaim.Name))
+		Expect(cluster.NodeClaimExists(nodeClaim.Name)).To(BeFalse())
+		Expect(cluster.Synced(ctx)).To(BeTrue())
+	})
+	It("should not evict an unlaunched NodeClaim that still exists after the grace period", func() {
+		// A NodeClaim that is genuinely still launching (empty providerID) must keep Synced() false and must not be
+		// evicted. Any later deletion lands after the seed, so the informer's normal cleanup handles it.
+		nodeClaim := test.NodeClaim()
+		nodeClaim.Status.ProviderID = ""
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		cluster.UpdateNodeClaim(nodeClaim)
+
+		Expect(cluster.UnlaunchedNodeClaimExists(nodeClaim.Name)).To(BeTrue())
+		Expect(cluster.Synced(ctx)).To(BeFalse())
+
+		ExpectReconciled(ctx, gcController, request(nodeClaim.Name))
+
+		Expect(cluster.UnlaunchedNodeClaimExists(nodeClaim.Name)).To(BeTrue())
+		Expect(cluster.Synced(ctx)).To(BeFalse())
+	})
+	It("should not evict a launched entry even if its NodeClaim no longer exists", func() {
+		// Launched entries (non-empty providerID) never hold Synced() false and are owned by the informer, not this
+		// controller. Even with the NodeClaim is gone from cache, the controller must leave them untouched.
+		nodeClaim := test.NodeClaim()
+		nodeClaim.Status.ProviderID = test.RandomProviderID()
+		cluster.UpdateNodeClaim(nodeClaim)
+
+		Expect(cluster.NodeClaimExists(nodeClaim.Name)).To(BeTrue())
+
+		ExpectReconciled(ctx, gcController, request(nodeClaim.Name))
+
+		Expect(cluster.NodeClaimExists(nodeClaim.Name)).To(BeTrue())
+	})
+	It("should be a no-op when the entry was already cleaned up", func() {
+		nodeClaim := test.NodeClaim()
+		nodeClaim.Status.ProviderID = ""
+		cluster.UpdateNodeClaim(nodeClaim)
+		cluster.DeleteNodeClaim(nodeClaim.Name)
+
+		Expect(cluster.NodeClaimExists(nodeClaim.Name)).To(BeFalse())
+
+		ExpectReconciled(ctx, gcController, request(nodeClaim.Name))
+
+		Expect(cluster.NodeClaimExists(nodeClaim.Name)).To(BeFalse())
+		Expect(cluster.Synced(ctx)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #3176

**Description**
Adds a controller to clear deleted, unlaunched, NodeClaims from `nodeClaimNameToProviderID` after a grace period. 

This heals a rare race condition in which the removal of a NodeClaim from `nodeClaimNameToProviderID`, which occurs due to NodeClaim deletion, happens before the NodeClaim is added to `nodeClaimNameToProviderID` in the synchronous `provisioner.Create` path. When this race occurs, NodeClaims are stranded in `nodeClaimNameToProviderID` and cluster state becomes unsynced until controller restart

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
