### PR TITLE
feat: add cloud provider vended feature gates

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -104,8 +104,9 @@ type Operator struct {
 }
 
 type Options struct {
-	LeaderElectionLabels map[string]string
-	LeaderElectionConfig *rest.Config // Optional separate config for leader election
+	LeaderElectionLabels   map[string]string
+	LeaderElectionConfig   *rest.Config // Optional separate config for leader election
+	AdditionalFeatureGates map[string]bool
 }
 
 // Adds LeaderElectionLabels to the underlying manager's LeaderElectionOptions
@@ -122,6 +123,15 @@ func WithLeaderElectionConfig(config *rest.Config) option.Function[Options] {
 	}
 }
 
+// WithAdditionalFeatureGates registers cloudprovider-defined feature gates and their default values. They're parsed
+// from the same --feature-gates flag / FEATURE_GATES env var as the core gates, and are readable through
+// options.FromContext(ctx).FeatureGates.Additional[name]. Panics if a gate collides with a core gate name.
+func WithAdditionalFeatureGates(gates map[string]bool) option.Function[Options] {
+	return func(opts *Options) {
+		opts.AdditionalFeatureGates = lo.Assign(opts.AdditionalFeatureGates, gates)
+	}
+}
+
 // NewOperator instantiates a controller manager or panics
 func NewOperator(o ...option.Function[Options]) (context.Context, *Operator) {
 	opts := option.Resolve(o...)
@@ -130,6 +140,8 @@ func NewOperator(o ...option.Function[Options]) (context.Context, *Operator) {
 	ctx := context.Background()
 
 	// Options
+	// Register cloudprovider feature gates before parsing so they're picked up from --feature-gates
+	options.RegisterAdditionalFeatureGates(opts.AdditionalFeatureGates)
 	ctx = injection.WithOptionsOrDie(ctx, options.Injectables...)
 
 	// Make the Karpenter binary aware of the container memory limit

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -21,7 +21,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -49,6 +52,12 @@ var (
 	validPreferencePolicies = []PreferencePolicy{PreferencePolicyIgnore, PreferencePolicyRespect}
 
 	Injectables = []Injectable{&Options{}}
+
+	AdditionalFeatureGates = map[string]bool{}
+
+	// coreFeatureGateNames must list every bool field on FeatureGates. The "should reject every bool field on
+	// FeatureGates as a cloudprovider gate name" spec fails if it drifts.
+	coreFeatureGateNames = []string{"NodeRepair", "ReservedCapacity", "SpotToSpotConsolidation", "NodeOverlay", "StaticCapacity", "CapacityBuffer"}
 )
 
 type optionsKey struct{}
@@ -62,6 +71,7 @@ type FeatureGates struct {
 	NodeOverlay             bool
 	StaticCapacity          bool
 	CapacityBuffer          bool
+	Additional              map[string]bool
 }
 
 // Options contains all CLI flags / env vars for karpenter-core. It adheres to the options.Injectable interface.
@@ -131,7 +141,7 @@ func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.preferencePolicyRaw, "preference-policy", env.WithDefaultString("PREFERENCE_POLICY", string(PreferencePolicyRespect)), "How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'")
 	fs.StringVar(&o.minValuesPolicyRaw, "min-values-policy", env.WithDefaultString("MIN_VALUES_POLICY", string(MinValuesPolicyStrict)), "Min values policy for scheduling. Options include 'Strict' for existing behavior where min values are strictly enforced or 'BestEffort' where Karpenter relaxes min values when it isn't satisfied.")
 	fs.BoolVarWithEnv(&o.IgnoreDRARequests, "ignore-dra-requests", "IGNORE_DRA_REQUESTS", true, "When set, Karpenter will ignore pods' DRA requests during scheduling simulations. NOTE: This flag will be removed once formal DRA support is GA in Karpenter.")
-	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false,CapacityBuffer=false"), "Optional features can be enabled / disabled using feature gates. Current options are: NodeRepair, ReservedCapacity, SpotToSpotConsolidation, NodeOverlay, StaticCapacity, and CapacityBuffer.")
+	fs.StringVar(&o.FeatureGates.inputStr, "feature-gates", env.WithDefaultString("FEATURE_GATES", "NodeRepair=false,ReservedCapacity=true,SpotToSpotConsolidation=false,NodeOverlay=false,StaticCapacity=false,CapacityBuffer=false"), fmt.Sprintf("Optional features can be enabled / disabled using feature gates. Current options are: %s.", strings.Join(validFeatureGateNames(), ", ")))
 }
 
 func (o *Options) Parse(fs *FlagSet, args ...string) error {
@@ -175,7 +185,18 @@ func DefaultFeatureGates() FeatureGates {
 		NodeOverlay:             false,
 		StaticCapacity:          false,
 		CapacityBuffer:          false,
+		Additional:              maps.Clone(AdditionalFeatureGates),
 	}
+}
+
+// RegisterAdditionalFeatureGates adds cloudprovider-defined gates to AdditionalFeatureGates
+func RegisterAdditionalFeatureGates(gates map[string]bool) {
+	for name := range gates {
+		if slices.Contains(coreFeatureGateNames, name) {
+			panic(fmt.Sprintf("feature gate %q conflicts with a karpenter-core feature gate", name))
+		}
+	}
+	AdditionalFeatureGates = lo.Assign(AdditionalFeatureGates, gates)
 }
 
 func ParseFeatureGates(gateStr string) (FeatureGates, error) {
@@ -205,8 +226,17 @@ func ParseFeatureGates(gateStr string) (FeatureGates, error) {
 	if val, ok := gateMap["CapacityBuffer"]; ok {
 		gates.CapacityBuffer = val
 	}
+	for name := range gates.Additional {
+		if val, ok := gateMap[name]; ok {
+			gates.Additional[name] = val
+		}
+	}
 
 	return gates, nil
+}
+
+func validFeatureGateNames() []string {
+	return append(slices.Clone(coreFeatureGateNames), slices.Sorted(maps.Keys(AdditionalFeatureGates))...)
 }
 
 func ToContext(ctx context.Context, opts *Options) context.Context {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -55,9 +56,11 @@ var (
 
 	AdditionalFeatureGates = map[string]bool{}
 
-	// coreFeatureGateNames must list every bool field on FeatureGates. The "should reject every bool field on
-	// FeatureGates as a cloudprovider gate name" spec fails if it drifts.
-	coreFeatureGateNames = []string{"NodeRepair", "ReservedCapacity", "SpotToSpotConsolidation", "NodeOverlay", "StaticCapacity", "CapacityBuffer"}
+	// coreFeatureGateNames is every bool field on FeatureGates, so adding a core gate to the struct is enough to
+	// have it show up in --help and to be rejected as a cloudprovider gate name
+	coreFeatureGateNames = lo.FilterMap(slices.Collect(reflect.TypeFor[FeatureGates]().Fields()), func(f reflect.StructField, _ int) (string, bool) {
+		return f.Name, f.IsExported() && f.Type.Kind() == reflect.Bool
+	})
 )
 
 type optionsKey struct{}

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -132,15 +132,16 @@ var _ = Describe("Options", func() {
 			It("should panic when a cloudprovider gate collides with a core gate", func() {
 				Expect(func() { options.RegisterAdditionalFeatureGates(map[string]bool{"NodeRepair": true}) }).To(Panic())
 			})
-			// Guards against coreFeatureGateNames drifting as core gates are added to the FeatureGates struct. A
-			// missing name would let a cloudprovider silently shadow a core gate.
-			It("should reject every bool field on FeatureGates as a cloudprovider gate name", func() {
+			// Every core gate should be collision-checked and listed in --help without anyone maintaining a list of
+			// gate names by hand
+			It("should cover every bool field on FeatureGates", func() {
 				for field := range reflect.TypeFor[options.FeatureGates]().Fields() {
 					if !field.IsExported() || field.Type.Kind() != reflect.Bool {
 						continue
 					}
 					Expect(func() { options.RegisterAdditionalFeatureGates(map[string]bool{field.Name: true}) }).
-						To(Panic(), "core gate %s is missing from coreFeatureGateNames", field.Name)
+						To(Panic(), "core gate %s should collide with a cloudprovider gate of the same name", field.Name)
+					Expect(fs.Lookup("feature-gates").Usage).To(ContainSubstring(field.Name))
 				}
 			})
 		})

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -94,6 +94,56 @@ var _ = Describe("Options", func() {
 			Entry("with whitespace", "SpotToSpotConsolidation\t= false", false),
 			Entry("multiple values", "Hello=true,SpotToSpotConsolidation=false,World=true", false),
 		)
+
+		Context("Additional", func() {
+			BeforeEach(func() {
+				options.RegisterAdditionalFeatureGates(map[string]bool{"MyProviderGate": false, "MyEnabledGate": true})
+				// Re-add flags so the usage string picks up the registered gates
+				fs = &options.FlagSet{FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError)}
+				opts = &options.Options{}
+				opts.AddFlags(fs)
+			})
+			AfterEach(func() {
+				options.AdditionalFeatureGates = map[string]bool{}
+			})
+
+			It("should use the cloudprovider provided defaults when unset", func() {
+				Expect(opts.Parse(fs)).To(Succeed())
+				Expect(opts.FeatureGates.Additional).To(Equal(map[string]bool{"MyProviderGate": false, "MyEnabledGate": true}))
+			})
+			It("should parse cloudprovider gates alongside core gates", func() {
+				Expect(opts.Parse(fs, "--feature-gates", "NodeRepair=true,MyProviderGate=true,MyEnabledGate=false")).To(Succeed())
+				Expect(opts.FeatureGates.NodeRepair).To(BeTrue())
+				Expect(opts.FeatureGates.Additional).To(Equal(map[string]bool{"MyProviderGate": true, "MyEnabledGate": false}))
+			})
+			It("should not mutate the registered defaults when parsing", func() {
+				Expect(opts.Parse(fs, "--feature-gates", "MyProviderGate=true")).To(Succeed())
+				Expect(options.AdditionalFeatureGates).To(Equal(map[string]bool{"MyProviderGate": false, "MyEnabledGate": true}))
+			})
+			It("should include cloudprovider gates in the flag usage string", func() {
+				Expect(fs.Lookup("feature-gates").Usage).To(ContainSubstring("MyEnabledGate, MyProviderGate"))
+			})
+			// Unknown gates are tolerated for both core and cloudprovider gates, so a gate a cloudprovider hasn't
+			// registered is ignored rather than rejected
+			It("should ignore a gate that no cloudprovider registered", func() {
+				Expect(opts.Parse(fs, "--feature-gates", "MyProviderGaet=true")).To(Succeed())
+				Expect(opts.FeatureGates.Additional).To(Equal(map[string]bool{"MyProviderGate": false, "MyEnabledGate": true}))
+			})
+			It("should panic when a cloudprovider gate collides with a core gate", func() {
+				Expect(func() { options.RegisterAdditionalFeatureGates(map[string]bool{"NodeRepair": true}) }).To(Panic())
+			})
+			// Guards against coreFeatureGateNames drifting as core gates are added to the FeatureGates struct. A
+			// missing name would let a cloudprovider silently shadow a core gate.
+			It("should reject every bool field on FeatureGates as a cloudprovider gate name", func() {
+				for field := range reflect.TypeFor[options.FeatureGates]().Fields() {
+					if !field.IsExported() || field.Type.Kind() != reflect.Bool {
+						continue
+					}
+					Expect(func() { options.RegisterAdditionalFeatureGates(map[string]bool{field.Name: true}) }).
+						To(Panic(), "core gate %s is missing from coreFeatureGateNames", field.Name)
+				}
+			})
+		})
 	})
 
 	Context("Parse", func() {
@@ -411,5 +461,6 @@ func expectOptionsMatch(optsA, optsB *options.Options) {
 	Expect(optsA.FeatureGates.StaticCapacity).To(Equal(optsB.FeatureGates.StaticCapacity))
 	Expect(optsA.FeatureGates.CapacityBuffer).To(Equal(optsB.FeatureGates.CapacityBuffer))
 	Expect(optsA.FeatureGates.SpotToSpotConsolidation).To(Equal(optsB.FeatureGates.SpotToSpotConsolidation))
+	Expect(optsA.FeatureGates.Additional).To(Equal(optsB.FeatureGates.Additional))
 	Expect(optsA.IgnoreDRARequests).To(Equal(optsB.IgnoreDRARequests))
 }

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -59,6 +59,7 @@ type FeatureGates struct {
 	NodeOverlay             *bool
 	StaticCapacity          *bool
 	CapacityBuffer          *bool
+	Additional              map[string]bool
 }
 
 func Options(overrides ...OptionsFields) *options.Options {
@@ -96,6 +97,7 @@ func Options(overrides ...OptionsFields) *options.Options {
 			NodeOverlay:             lo.FromPtrOr(opts.FeatureGates.NodeOverlay, false),
 			StaticCapacity:          lo.FromPtrOr(opts.FeatureGates.StaticCapacity, false),
 			CapacityBuffer:          lo.FromPtrOr(opts.FeatureGates.CapacityBuffer, false),
+			Additional:              lo.Assign(options.AdditionalFeatureGates, opts.FeatureGates.Additional),
 		},
 	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

adds feature to allow cloud providers to inject cloud provider specific feature flags

usage something like

```
ctx, op := operator.NewOperator(coreoperator.NewOperator(
	coreoperator.WithAdditionalFeatureGates(map[string]bool{"MyCoolFeatureGate": false}),
))
```
and to use it in a provider
```
karpoptions.FromContext(ctx).FeatureGates.Additional["MyCoolFeatureGate"]
```

**How was this change tested?**

unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
