### PR TITLE
fix(kwok): set simulated node capacity from instance type, not pod requests

### DIFF
--- a/kwok/cloudprovider/cloudprovider.go
+++ b/kwok/cloudprovider/cloudprovider.go
@@ -226,9 +226,11 @@ func (c CloudProvider) toNode(nodeClaim *v1.NodeClaim) (*corev1.Node, error) {
 		},
 		Status: corev1.NodeStatus{
 			// KWOK nodes don't support overriding Karpenter's WellKnownResources,
-			// so we only apply resource requests, since NodeOverlay will not apply.
+			// so we only apply resource requests for overriding, since NodeOverlay will not apply.
 			// If this changes in the future, we'll need to update capacity and allocatable values for KWOK nodes.
-			Capacity:    nodeClaim.Spec.Resources.Requests,
+			// The instance type's actual capacity/allocatable still takes precedence for well-known resources so
+			// that a NodeClaim that never registers is still counted accurately against NodePool limits.
+			Capacity:    lo.Assign(nodeClaim.Spec.Resources.Requests, instanceType.Capacity),
 			Allocatable: lo.Assign(nodeClaim.Spec.Resources.Requests, instanceType.Allocatable()),
 			Phase:       corev1.NodePending,
 		},

--- a/kwok/cloudprovider/cloudprovider_test.go
+++ b/kwok/cloudprovider/cloudprovider_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kwok
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/test"
+)
+
+// A NodeClaim that never registers keeps whatever Status.Capacity toNode() gave it for its
+// whole lifetime, since no kubelet ever corrects it. If that capacity only reflects the pod
+// requests that triggered the NodeClaim rather than the selected instance type's real capacity,
+// NodePool.Status.Resources and the scheduler's remaining-limits tracking both under-count the
+// NodeClaim, letting Karpenter create far more NodeClaims than spec.limits should allow.
+// https://github.com/kubernetes-sigs/karpenter/issues/2854
+var _ = Describe("toNode", func() {
+	It("should set node capacity from the selected instance type, not just the pod-derived resource requests", func() {
+		instanceType := fake.NewInstanceType("big-instance-type", fake.WithResources(corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("32"),
+			corev1.ResourceMemory: resource.MustParse("128Gi"),
+			corev1.ResourcePods:   resource.MustParse("100"),
+		}))
+		cp := CloudProvider{instanceTypes: []*cloudprovider.InstanceType{instanceType}}
+
+		nodeClaim := test.NodeClaim(v1.NodeClaim{
+			Spec: v1.NodeClaimSpec{
+				Requirements: []v1.NodeSelectorRequirementWithMinValues{
+					{
+						Key:      corev1.LabelInstanceTypeStable,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{instanceType.Name},
+					},
+				},
+				Resources: v1.ResourceRequirements{
+					// Mimics a single small pod's request, which is what the NodeClaim
+					// controller sizes Spec.Resources.Requests to.
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("0.6"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+		})
+
+		node, err := cp.toNode(nodeClaim)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(node.Status.Capacity.Cpu().Value()).To(BeEquivalentTo(32))
+		expectedMemory := resource.MustParse("128Gi")
+		Expect(node.Status.Capacity.Memory().Value()).To(BeEquivalentTo(expectedMemory.Value()))
+	})
+})

--- a/kwok/cloudprovider/suite_test.go
+++ b/kwok/cloudprovider/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kwok
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCloudProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CloudProvider")
+}


### PR DESCRIPTION
Motivation:
The kwok reference cloud provider's toNode() sets a simulated Node's
Status.Capacity to the sum of pod requests that sized the NodeClaim,
instead of the selected instance type's real capacity. Status.Allocatable
already correctly merges in the instance type's real values, but Capacity
does not.

CloudProvider.Create() returns this Capacity value synchronously as
NodeClaim.Status.Capacity, before the simulated Node is actually created.
If node registration is blocked or never completes, no kubelet ever
corrects this value, so it is permanently under-reported. NodePool
resource usage (pkg/controllers/state/cluster.go) and the scheduler's
remaining-limits tracking (pkg/controllers/provisioning/scheduling/scheduler.go)
both read this stale Capacity for any node that has not yet initialized,
so a stuck NodeClaim is under-counted against NodePool spec.limits by the
difference between its pod requests and the real instance type capacity.
This matches the mechanism a reporter on the linked issue diagnosed from
their own kwok-based reproduction, using a NodePool CPU limit.

This only affects the kwok reference/test cloud provider (kwok/cloudprovider),
which is not used by any production cloud provider implementation; behavior
of real cloud providers (AWS, Azure, GCP, etc., which live in separate repos)
is unaffected.

Approach:
Merge instanceType.Capacity into the simulated Node's Status.Capacity,
mirroring how Status.Allocatable already merges in
instanceType.Allocatable(). Pod-request-derived values still apply for
any custom/extended resource not present on the instance type.

Validation:
Added kwok/cloudprovider/cloudprovider_test.go, which builds a NodeClaim
sized by a single small pod request (0.6 CPU / 256Mi) against a fake
32 CPU / 128Gi instance type and asserts the resulting simulated node's
Status.Capacity reflects the instance type, not the pod request.

Ran `go test ./kwok/...`, which passes with the fix. Reverting only the
fix (keeping the new test) reproduces the reported failure mode: the test
fails with Capacity reporting ~1 CPU (the rounded 0.6 CPU pod request)
instead of the instance type's 32 CPU.

Also ran `go build ./...`, `go vet ./kwok/...`, and `gofmt -l` on the
changed files; all clean.

Not run: the full e2e regression suite (test/suites/regression) against a
live kwok cluster, since this fix targets the isolated capacity
calculation that is the root cause, and CONTRIBUTING.md only requires
that tests cover behavior changes for this class of fix.

Report: https://github.com/kubernetes-sigs/karpenter/issues/2854
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #2854

```release-note
fix(kwok): set simulated node capacity from instance type, not pod requests
```