### PR TITLE
fix: fail closed on invalid consumed-capacity in the DRA device-allocation controller

### DIFF
--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -161,7 +161,13 @@ func (c *Controller) reconcileClaim(ctx context.Context, nn types.NamespacedName
 			Pool:   unique.Make(result.Pool),
 			Device: unique.Make(result.Device),
 		}
-		contributions[deviceID] = DeviceContribution{ConsumedCapacity: result.ConsumedCapacity}
+		// Sum this result's consumed capacity into the device's contribution rather than overwriting it. A
+		// multi-allocatable device can appear in more than one result of the same claim as distinct shares
+		// that differ only by ShareID, which is not part of deviceID, so they collapse to the same key here.
+		// addCapacity also drops any negative per-dimension value before it is aggregated across claims. See #3209.
+		contributions[deviceID] = DeviceContribution{
+			ConsumedCapacity: addCapacity(contributions[deviceID].ConsumedCapacity, result.ConsumedCapacity),
+		}
 	}
 
 	devicesToRemove := make(sets.Set[cloudprovider.DeviceID])
@@ -314,11 +320,20 @@ func deviceIDToString(d cloudprovider.DeviceID, _ int) string {
 	return d.String()
 }
 
+// addCapacity sums src into dest and returns the result, allocating dest lazily on the first kept entry. A
+// negative quantity is dropped rather than folded in: consumed capacity is never negative, and a negative
+// value ingested from a ResourceClaim status (which the API server does not yet validate,
+// kubernetes/kubernetes#140563) could otherwise offset a positive contribution from another claim or share
+// and under-count a shared device, over-admitting it. Leaving dest nil when nothing is kept means a device
+// with no positive consumed capacity is not treated as shared. See #3209.
 func addCapacity(dest, src map[resourcev1.QualifiedName]resource.Quantity) map[resourcev1.QualifiedName]resource.Quantity {
-	if dest == nil {
-		dest = make(map[resourcev1.QualifiedName]resource.Quantity, len(src))
-	}
 	for name, quantity := range src {
+		if quantity.Sign() < 0 {
+			continue
+		}
+		if dest == nil {
+			dest = make(map[resourcev1.QualifiedName]resource.Quantity, len(src))
+		}
 		current := dest[name]
 		current.Add(quantity)
 		dest[name] = current

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -99,7 +99,9 @@ type DeviceMetadata struct {
 	Contributions []ContributionMetadata
 	// InvalidConsumedCapacity is true when any claim referencing this device reported a negative
 	// consumed-capacity value. The device's accounting cannot be trusted, so it must not be allocated on
-	// either the exclusive or the allow-multiple path until the invalid state clears. See #3209.
+	// either the exclusive or the allow-multiple path until the invalid state clears. While it is set,
+	// ConsumedCapacity and Contributions hold only the results that were well-formed, so neither is the
+	// device's total and neither may be used to decide a fit. See #3209.
 	InvalidConsumedCapacity bool
 }
 
@@ -360,7 +362,7 @@ func addCapacity(dest, src map[resourcev1.QualifiedName]resource.Quantity) map[r
 }
 
 // hasNegativeCapacity reports whether any per-dimension quantity is negative. Consumed capacity is never
-// negative, so a negative value makes the whole physical-device contribution invalid, not just that one
+// negative, so a negative value makes the whole DRA-device contribution invalid, not just that one
 // dimension; the caller fails the device closed rather than keeping the other dimensions. See #3209.
 func hasNegativeCapacity(capacity map[resourcev1.QualifiedName]resource.Quantity) bool {
 	for _, quantity := range capacity {

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -152,6 +152,33 @@ func (c *Controller) Hydrate(ctx context.Context) {
 	})
 }
 
+// contributionsForResults folds a claim's allocation results into per-device contributions. Results that
+// share a device (distinct shares differing only by ShareID, which is not part of deviceID) have their
+// consumed capacity summed. A result with a negative per-dimension value is invalid input (a driver bug or
+// a corrupt status the API server does not yet validate, kubernetes/kubernetes#140563); it flags the DRA
+// device (the (driver, pool, device) key, which may be one partition of a physical device) as invalid
+// rather than being dropped, since a dropped negative reads as zero usage and fails open on an
+// allow-multiple device. Pure so the folding rules can be unit-tested with constructed results. See #3209.
+func contributionsForResults(results []resourcev1.DeviceRequestAllocationResult) map[cloudprovider.DeviceID]DeviceContribution {
+	contributions := make(map[cloudprovider.DeviceID]DeviceContribution, len(results))
+	for i := range results {
+		result := &results[i]
+		deviceID := cloudprovider.DeviceID{
+			Driver: unique.Make(result.Driver),
+			Pool:   unique.Make(result.Pool),
+			Device: unique.Make(result.Device),
+		}
+		contribution := contributions[deviceID]
+		if hasNegativeCapacity(result.ConsumedCapacity) {
+			contribution.InvalidConsumedCapacity = true
+		} else {
+			contribution.ConsumedCapacity = addCapacity(contribution.ConsumedCapacity, result.ConsumedCapacity)
+		}
+		contributions[deviceID] = contribution
+	}
+	return contributions
+}
+
 //nolint:gocyclo
 func (c *Controller) reconcileClaim(ctx context.Context, nn types.NamespacedName, claim *resourcev1.ResourceClaim) {
 	if claim.Status.Allocation == nil || len(claim.Status.Allocation.Devices.Results) == 0 {
@@ -161,29 +188,7 @@ func (c *Controller) reconcileClaim(ctx context.Context, nn types.NamespacedName
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	contributions := make(map[cloudprovider.DeviceID]DeviceContribution, len(claim.Status.Allocation.Devices.Results))
-	for i := range claim.Status.Allocation.Devices.Results {
-		result := &claim.Status.Allocation.Devices.Results[i]
-		deviceID := cloudprovider.DeviceID{
-			Driver: unique.Make(result.Driver),
-			Pool:   unique.Make(result.Pool),
-			Device: unique.Make(result.Device),
-		}
-		// Sum this result's consumed capacity into the device's contribution rather than overwriting it. A
-		// multi-allocatable device can appear in more than one result of the same claim as distinct shares
-		// that differ only by ShareID, which is not part of deviceID, so they collapse to the same key here.
-		// A negative per-dimension value is invalid input (a driver bug or a corrupt status the API server
-		// does not yet validate, kubernetes/kubernetes#140563). Flag the whole physical device rather than
-		// dropping the value: a dropped negative reads as zero usage, which fails open on an allow-multiple
-		// device. See #3209.
-		contribution := contributions[deviceID]
-		if hasNegativeCapacity(result.ConsumedCapacity) {
-			contribution.InvalidConsumedCapacity = true
-		} else {
-			contribution.ConsumedCapacity = addCapacity(contribution.ConsumedCapacity, result.ConsumedCapacity)
-		}
-		contributions[deviceID] = contribution
-	}
+	contributions := contributionsForResults(claim.Status.Allocation.Devices.Results)
 
 	devicesToRemove := make(sets.Set[cloudprovider.DeviceID])
 	for device := range c.claimMetadata[nn].Contributions {

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -53,6 +53,10 @@ type DeviceContribution struct {
 	// ConsumedCapacity is the capacity this claim consumes on the device.
 	// nil for exclusive allocations.
 	ConsumedCapacity map[resourcev1.QualifiedName]resource.Quantity
+	// InvalidConsumedCapacity is true when any result contributing to this device reported a negative
+	// consumed-capacity value. Such a device is untrustworthy and must fail closed rather than be
+	// aggregated. See #3209.
+	InvalidConsumedCapacity bool
 }
 
 type ClaimMetadata struct {
@@ -93,6 +97,10 @@ type DeviceMetadata struct {
 	// is the per-claim view that ConsumedCapacity aggregates; consumers that need to attribute capacity to specific
 	// pods (e.g. to release only a deleting pod's share) use this instead of the aggregate.
 	Contributions []ContributionMetadata
+	// InvalidConsumedCapacity is true when any claim referencing this device reported a negative
+	// consumed-capacity value. The device's accounting cannot be trusted, so it must not be allocated on
+	// either the exclusive or the allow-multiple path until the invalid state clears. See #3209.
+	InvalidConsumedCapacity bool
 }
 
 type Controller struct {
@@ -164,10 +172,17 @@ func (c *Controller) reconcileClaim(ctx context.Context, nn types.NamespacedName
 		// Sum this result's consumed capacity into the device's contribution rather than overwriting it. A
 		// multi-allocatable device can appear in more than one result of the same claim as distinct shares
 		// that differ only by ShareID, which is not part of deviceID, so they collapse to the same key here.
-		// addCapacity also drops any negative per-dimension value before it is aggregated across claims. See #3209.
-		contributions[deviceID] = DeviceContribution{
-			ConsumedCapacity: addCapacity(contributions[deviceID].ConsumedCapacity, result.ConsumedCapacity),
+		// A negative per-dimension value is invalid input (a driver bug or a corrupt status the API server
+		// does not yet validate, kubernetes/kubernetes#140563). Flag the whole physical device rather than
+		// dropping the value: a dropped negative reads as zero usage, which fails open on an allow-multiple
+		// device. See #3209.
+		contribution := contributions[deviceID]
+		if hasNegativeCapacity(result.ConsumedCapacity) {
+			contribution.InvalidConsumedCapacity = true
+		} else {
+			contribution.ConsumedCapacity = addCapacity(contribution.ConsumedCapacity, result.ConsumedCapacity)
 		}
+		contributions[deviceID] = contribution
 	}
 
 	devicesToRemove := make(sets.Set[cloudprovider.DeviceID])
@@ -290,6 +305,9 @@ func (c *Controller) computeDeviceMetadata(device cloudprovider.DeviceID) Device
 		meta.PodUIDs = append(meta.PodUIDs, claimMeta.PodUIDs...)
 
 		contributions := claimMeta.Contributions[device]
+		if contributions.InvalidConsumedCapacity {
+			meta.InvalidConsumedCapacity = true
+		}
 		if contributions.ConsumedCapacity != nil {
 			meta.Shared = true
 			meta.ConsumedCapacity = addCapacity(meta.ConsumedCapacity, contributions.ConsumedCapacity)
@@ -320,17 +338,12 @@ func deviceIDToString(d cloudprovider.DeviceID, _ int) string {
 	return d.String()
 }
 
-// addCapacity sums src into dest and returns the result, allocating dest lazily on the first kept entry. A
-// negative quantity is dropped rather than folded in: consumed capacity is never negative, and a negative
-// value ingested from a ResourceClaim status (which the API server does not yet validate,
-// kubernetes/kubernetes#140563) could otherwise offset a positive contribution from another claim or share
-// and under-count a shared device, over-admitting it. Leaving dest nil when nothing is kept means a device
-// with no positive consumed capacity is not treated as shared. See #3209.
+// addCapacity sums src into dest and returns the result, allocating dest lazily on the first entry. Callers
+// must reject a source containing a negative value (see hasNegativeCapacity) before summing it: addCapacity
+// itself is a plain sum and does not sanitize, so a negative here would offset a positive contribution from
+// another claim or share and under-count a shared device.
 func addCapacity(dest, src map[resourcev1.QualifiedName]resource.Quantity) map[resourcev1.QualifiedName]resource.Quantity {
 	for name, quantity := range src {
-		if quantity.Sign() < 0 {
-			continue
-		}
 		if dest == nil {
 			dest = make(map[resourcev1.QualifiedName]resource.Quantity, len(src))
 		}
@@ -339,4 +352,16 @@ func addCapacity(dest, src map[resourcev1.QualifiedName]resource.Quantity) map[r
 		dest[name] = current
 	}
 	return dest
+}
+
+// hasNegativeCapacity reports whether any per-dimension quantity is negative. Consumed capacity is never
+// negative, so a negative value makes the whole physical-device contribution invalid, not just that one
+// dimension; the caller fails the device closed rather than keeping the other dimensions. See #3209.
+func hasNegativeCapacity(capacity map[resourcev1.QualifiedName]resource.Quantity) bool {
+	for _, quantity := range capacity {
+		if quantity.Sign() < 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controllers/dynamicresources/deviceallocation/negative_capacity_internal_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/negative_capacity_internal_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceallocation
+
+import (
+	"testing"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// TestHasNegativeCapacity is an internal unit test (no envtest) for the sign scan that flags an invalid
+// consumed-capacity contribution. A negative in any dimension invalidates the whole contribution so the
+// device fails closed, rather than keeping the other dimensions (which would read as zero usage). See #3209.
+func TestHasNegativeCapacity(t *testing.T) {
+	cases := []struct {
+		name string
+		cap  map[resourcev1.QualifiedName]resource.Quantity
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", map[resourcev1.QualifiedName]resource.Quantity{}, false},
+		{"positive", map[resourcev1.QualifiedName]resource.Quantity{"memory": resource.MustParse("256Mi")}, false},
+		{"zero is not negative", map[resourcev1.QualifiedName]resource.Quantity{"memory": resource.MustParse("0")}, false},
+		{"negative", map[resourcev1.QualifiedName]resource.Quantity{"memory": resource.MustParse("-1")}, true},
+		{"negative among positive dimensions", map[resourcev1.QualifiedName]resource.Quantity{
+			"memory":      resource.MustParse("-128Mi"),
+			"connections": resource.MustParse("3"),
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasNegativeCapacity(tc.cap); got != tc.want {
+				t.Fatalf("hasNegativeCapacity(%v) = %v, want %v", tc.cap, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/dynamicresources/deviceallocation/negative_capacity_internal_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/negative_capacity_internal_test.go
@@ -80,6 +80,12 @@ func TestContributionsForResults(t *testing.T) {
 			t.Fatal("want InvalidConsumedCapacity=true even with a valid sibling result on the same device")
 		}
 	})
+	t.Run("a valid result after an invalid one does not clear the flag", func(t *testing.T) {
+		got := contributionsForResults([]resourcev1.DeviceRequestAllocationResult{result("d0", neg), result("d0", pos2)})
+		if !got[id("d0")].InvalidConsumedCapacity {
+			t.Fatal("want InvalidConsumedCapacity=true when the invalid result comes first")
+		}
+	})
 	t.Run("distinct shares of the same device are summed", func(t *testing.T) {
 		got := contributionsForResults([]resourcev1.DeviceRequestAllocationResult{result("d0", pos2), result("d0", pos3)})
 		c := got[id("d0")]

--- a/pkg/controllers/dynamicresources/deviceallocation/negative_capacity_internal_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/negative_capacity_internal_test.go
@@ -18,9 +18,12 @@ package deviceallocation
 
 import (
 	"testing"
+	"unique"
 
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 )
 
 // TestHasNegativeCapacity is an internal unit test (no envtest) for the sign scan that flags an invalid
@@ -49,4 +52,54 @@ func TestHasNegativeCapacity(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestContributionsForResults exercises the ingestion folding rules directly with constructed results, so
+// the negative-handling and share-aggregation behavior is covered without relying on the API server
+// accepting a negative ConsumedCapacity (kubernetes/kubernetes#140563 may reject it in a future envtest).
+func TestContributionsForResults(t *testing.T) {
+	id := func(device string) cloudprovider.DeviceID {
+		return cloudprovider.DeviceID{Driver: unique.Make("driver"), Pool: unique.Make("pool"), Device: unique.Make(device)}
+	}
+	result := func(device string, cap map[resourcev1.QualifiedName]resource.Quantity) resourcev1.DeviceRequestAllocationResult {
+		return resourcev1.DeviceRequestAllocationResult{Driver: "driver", Pool: "pool", Device: device, Request: "req", ConsumedCapacity: cap}
+	}
+	neg := map[resourcev1.QualifiedName]resource.Quantity{"memory": resource.MustParse("-1")}
+	pos2 := map[resourcev1.QualifiedName]resource.Quantity{"memory": resource.MustParse("2")}
+	pos3 := map[resourcev1.QualifiedName]resource.Quantity{"memory": resource.MustParse("3")}
+
+	t.Run("a negative result flags the device invalid", func(t *testing.T) {
+		got := contributionsForResults([]resourcev1.DeviceRequestAllocationResult{result("d0", neg)})
+		if !got[id("d0")].InvalidConsumedCapacity {
+			t.Fatal("want InvalidConsumedCapacity=true")
+		}
+	})
+	t.Run("a valid sibling result does not clear the invalid flag", func(t *testing.T) {
+		got := contributionsForResults([]resourcev1.DeviceRequestAllocationResult{result("d0", pos2), result("d0", neg)})
+		if !got[id("d0")].InvalidConsumedCapacity {
+			t.Fatal("want InvalidConsumedCapacity=true even with a valid sibling result on the same device")
+		}
+	})
+	t.Run("distinct shares of the same device are summed", func(t *testing.T) {
+		got := contributionsForResults([]resourcev1.DeviceRequestAllocationResult{result("d0", pos2), result("d0", pos3)})
+		c := got[id("d0")]
+		if c.InvalidConsumedCapacity {
+			t.Fatal("want InvalidConsumedCapacity=false")
+		}
+		if q := c.ConsumedCapacity["memory"]; q.Cmp(resource.MustParse("5")) != 0 {
+			t.Fatalf("want summed memory=5, got %s", q.String())
+		}
+	})
+	t.Run("only the malformed device is flagged", func(t *testing.T) {
+		got := contributionsForResults([]resourcev1.DeviceRequestAllocationResult{result("d0", neg), result("d1", pos2)})
+		if !got[id("d0")].InvalidConsumedCapacity {
+			t.Fatal("d0 should be invalid")
+		}
+		if got[id("d1")].InvalidConsumedCapacity {
+			t.Fatal("d1 should not be invalid")
+		}
+		if q := got[id("d1")].ConsumedCapacity["memory"]; q.Cmp(resource.MustParse("2")) != 0 {
+			t.Fatalf("d1 memory want 2, got %s", q.String())
+		}
+	})
 }

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -892,6 +892,42 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			})
 		})
 
+		It("clears the invalid flag once the offending claim is gone", func() {
+			// The flag is recomputed from the claims that currently reference the device, not latched on it. When
+			// the claim carrying the negative goes away the device is allocatable again, with the capacity the
+			// surviving claim still holds.
+			claimA := withReservedFor(
+				resourceClaim("claim-a", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+					"memory": resource.MustParse("256Mi"),
+				})),
+				podRef("pod-a", "uid-a"),
+			)
+			claimB := withReservedFor(
+				resourceClaim("claim-b", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+					"memory": resource.MustParse("-128Mi"),
+				})),
+				podRef("pod-b", "uid-b"),
+			)
+			ExpectApplied(ctx, env.Client, claimA, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(collectDevices(seq)[deviceID("device-0")].InvalidConsumedCapacity).To(BeTrue())
+
+			ExpectDeleted(ctx, env.Client, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			seq, err = controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			meta := collectDevices(seq)[deviceID("device-0")]
+			Expect(meta.InvalidConsumedCapacity).To(BeFalse())
+			expectCapacity(meta.ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
+				"memory": resource.MustParse("256Mi"),
+			})
+		})
+
 		It("surfaces per-claim contributions paired with their reserving pods", func() {
 			claimA := withReservedFor(
 				resourceClaim("claim-a", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -807,11 +807,11 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			})
 		})
 
-		It("drops a negative consumed-capacity contribution rather than offsetting a positive one from another claim", func() {
-			// claim-b reports a negative memory contribution. Consumed capacity is never negative, and the API
-			// server does not yet reject it (kubernetes/kubernetes#140563), so it must not offset claim-a's
-			// positive memory contribution during aggregation and under-count the shared device. claim-b's valid
-			// positive connections contribution is still counted.
+		It("flags a device with a negative consumed-capacity contribution as invalid and excludes that whole claim", func() {
+			// claim-b reports a negative memory contribution. Consumed capacity is never negative, so the whole
+			// claim-b contribution is untrustworthy: it is excluded from the aggregate (its positive connections
+			// too) and the device is flagged invalid so it fails closed at allocation. Dropping only the negative
+			// dimension would read as zero usage and fail open on an allow-multiple device. See #3209.
 			claimA := withReservedFor(
 				resourceClaim("claim-a", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
 					"memory":      resource.MustParse("256Mi"),
@@ -835,13 +835,14 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			devices := collectDevices(seq)
 			meta := devices[deviceID("device-0")]
 			Expect(meta.Shared).To(BeTrue())
-			// memory is claim-a's 256Mi alone; claim-b's -128Mi is dropped, not subtracted (would be 128Mi before
-			// the fix). connections sums both positive contributions.
+			// claim-b's negative invalidates the device: it fails closed at allocation regardless of the aggregate.
+			Expect(meta.InvalidConsumedCapacity).To(BeTrue())
+			// Only claim-a's valid contribution is aggregated; claim-b's connections=3 is not partially kept.
 			expectCapacity(meta.ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
 				"memory":      resource.MustParse("256Mi"),
-				"connections": resource.MustParse("4"),
+				"connections": resource.MustParse("1"),
 			})
-			// The per-claim breakdown is sanitized too: claim-b contributes only its positive connections.
+			// claim-b contributes nothing to the per-claim breakdown; its whole contribution is excluded.
 			contributionForPod := func(uid types.UID) deviceallocation.ContributionMetadata {
 				for _, c := range meta.Contributions {
 					for _, podUID := range c.PodUIDs {
@@ -852,9 +853,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				}
 				return deviceallocation.ContributionMetadata{}
 			}
-			expectCapacity(contributionForPod("uid-b").ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
-				"connections": resource.MustParse("3"),
-			})
+			Expect(contributionForPod("uid-b").ConsumedCapacity).To(BeNil())
 		})
 
 		It("sums multiple shares of the same device within a claim rather than overwriting", func() {

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -807,6 +807,84 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			})
 		})
 
+		It("drops a negative consumed-capacity contribution rather than offsetting a positive one from another claim", func() {
+			// claim-b reports a negative memory contribution. Consumed capacity is never negative, and the API
+			// server does not yet reject it (kubernetes/kubernetes#140563), so it must not offset claim-a's
+			// positive memory contribution during aggregation and under-count the shared device. claim-b's valid
+			// positive connections contribution is still counted.
+			claimA := withReservedFor(
+				resourceClaim("claim-a", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+					"memory":      resource.MustParse("256Mi"),
+					"connections": resource.MustParse("1"),
+				})),
+				podRef("pod-a", "uid-a"),
+			)
+			claimB := withReservedFor(
+				resourceClaim("claim-b", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+					"memory":      resource.MustParse("-128Mi"),
+					"connections": resource.MustParse("3"),
+				})),
+				podRef("pod-b", "uid-b"),
+			)
+			ExpectApplied(ctx, env.Client, claimA, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			meta := devices[deviceID("device-0")]
+			Expect(meta.Shared).To(BeTrue())
+			// memory is claim-a's 256Mi alone; claim-b's -128Mi is dropped, not subtracted (would be 128Mi before
+			// the fix). connections sums both positive contributions.
+			expectCapacity(meta.ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
+				"memory":      resource.MustParse("256Mi"),
+				"connections": resource.MustParse("4"),
+			})
+			// The per-claim breakdown is sanitized too: claim-b contributes only its positive connections.
+			contributionForPod := func(uid types.UID) deviceallocation.ContributionMetadata {
+				for _, c := range meta.Contributions {
+					for _, podUID := range c.PodUIDs {
+						if podUID == uid {
+							return c
+						}
+					}
+				}
+				return deviceallocation.ContributionMetadata{}
+			}
+			expectCapacity(contributionForPod("uid-b").ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
+				"connections": resource.MustParse("3"),
+			})
+		})
+
+		It("sums multiple shares of the same device within a claim rather than overwriting", func() {
+			// A multi-allocatable device can be allocated more than once to the same claim as distinct shares that
+			// differ only by ShareID. deviceID ignores ShareID, so the shares collapse to one key; their consumed
+			// capacity must be summed, not overwritten by the last share.
+			shareA, shareB := types.UID("11111111-1111-1111-1111-111111111111"), types.UID("22222222-2222-2222-2222-222222222222")
+			resultA := deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+				"memory": resource.MustParse("256Mi"),
+			})
+			resultA.ShareID = &shareA
+			resultB := deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+				"memory": resource.MustParse("128Mi"),
+			})
+			resultB.ShareID = &shareB
+			claim := withReservedFor(resourceClaim("claim-a", resultA, resultB), podRef("pod-a", "uid-a"))
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			meta := devices[deviceID("device-0")]
+			Expect(meta.Shared).To(BeTrue())
+			// Both shares are summed: 256Mi + 128Mi. Before the fix the second share overwrote the first (128Mi).
+			expectCapacity(meta.ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
+				"memory": resource.MustParse("384Mi"),
+			})
+		})
+
 		It("surfaces per-claim contributions paired with their reserving pods", func() {
 			claimA := withReservedFor(
 				resourceClaim("claim-a", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -807,7 +807,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			})
 		})
 
-		It("flags a device with a negative consumed-capacity contribution as invalid and excludes that whole claim", func() {
+		It("flags a device as invalid when a claim reports a negative consumed-capacity contribution", func() {
 			// claim-b reports a negative memory contribution. Consumed capacity is never negative, so the whole
 			// claim-b contribution is untrustworthy: it is excluded from the aggregate (its positive connections
 			// too) and the device is flagged invalid so it fails closed at allocation. Dropping only the negative
@@ -880,6 +880,14 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			Expect(meta.Shared).To(BeTrue())
 			// Both shares are summed: 256Mi + 128Mi. Before the fix the second share overwrote the first (128Mi).
 			expectCapacity(meta.ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
+				"memory": resource.MustParse("384Mi"),
+			})
+			// The summed capacity is attributed to the single referencing claim's contribution (paired with its
+			// reserving pod), not just the device aggregate. effectiveConsumedCapacity subtracts this per-claim
+			// contribution, so it must carry the full 384Mi for the whole share to be released when pod-a deletes.
+			Expect(meta.Contributions).To(HaveLen(1))
+			Expect(meta.Contributions[0].PodUIDs).To(ConsistOf(types.UID("uid-a")))
+			expectCapacity(meta.Contributions[0].ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
 				"memory": resource.MustParse("384Mi"),
 			})
 		})

--- a/pkg/controllers/provisioning/dra.go
+++ b/pkg/controllers/provisioning/dra.go
@@ -99,8 +99,16 @@ func (p *Provisioner) gatherAllocatedDevices(ctx context.Context, deletingPodUID
 	state := dynamicresources.AllocatedDeviceState{
 		ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
 		ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{},
+		BlockedDevices:   sets.New[cloudprovider.DeviceID](),
 	}
 	for id, meta := range seq {
+		// A device with invalid consumed-capacity accounting (e.g. a negative value in a claim status) is
+		// blocked on every allocation path until the invalid state clears. This must come first: dropping the
+		// value instead would read as zero usage and fail open on an allow-multiple device. See #3209.
+		if meta.InvalidConsumedCapacity {
+			state.BlockedDevices.Insert(id)
+			continue
+		}
 		// A device with no live consumers that every referencing claim considers releasable is available.
 		if meta.Releasable && len(meta.PodUIDs) == 0 {
 			continue

--- a/pkg/controllers/provisioning/dra_internal_test.go
+++ b/pkg/controllers/provisioning/dra_internal_test.go
@@ -151,6 +151,16 @@ var _ = Describe("DRA Provisioner Internals", func() {
 			Expect(effective).To(BeEmpty())
 		})
 
+		It("should release the whole aggregated share of a single multi-share claim when its pod deletes", func() {
+			// One claim holding two shares of a device, summed by the controller into a single 384Mi
+			// contribution. When its pod deletes, the full 384Mi must be freed, not just one share's worth.
+			meta := sharedMeta(
+				contribution([]types.UID{"deleting-a"}, map[resourcev1.QualifiedName]string{"memory": "384Mi"}),
+			)
+			effective := effectiveConsumedCapacity(meta, sets.New[types.UID]("deleting-a"))
+			Expect(effective).To(BeEmpty())
+		})
+
 		It("should retain a contribution that mixes deleting and live pods", func() {
 			// A single claim reserved by both a deleting and a live pod is not fully deleting, so its capacity stays.
 			meta := sharedMeta(

--- a/pkg/scheduling/dynamicresources/allocationtracker.go
+++ b/pkg/scheduling/dynamicresources/allocationtracker.go
@@ -36,6 +36,10 @@ type AllocationTracker struct {
 	// after set during Allocator construction.
 	PreallocatedDevices sets.Set[DeviceID]
 
+	// BlockedDevices represents devices whose consumed-capacity accounting is invalid and must not be allocated on any
+	// path. Immutable after construction.
+	BlockedDevices sets.Set[DeviceID]
+
 	// PreallocatedConsumedCapacity holds the aggregated consumed capacity for multi-allocatable devices
 	// from existing cluster allocations. Multi-allocatable devices appear here instead of PreallocatedDevices.
 	// Immutable after construction. Map: deviceID → dimensionName → consumed quantity.
@@ -96,8 +100,13 @@ func NewAllocationTracker(allocatedState AllocatedDeviceState) *AllocationTracke
 	for id, capacity := range allocatedState.ConsumedCapacity {
 		preallocatedCapacity[DeviceID{DeviceID: id}] = capacity
 	}
+	blockedDevices := make(sets.Set[DeviceID], len(allocatedState.BlockedDevices))
+	for id := range allocatedState.BlockedDevices {
+		blockedDevices.Insert(DeviceID{DeviceID: id})
+	}
 	return &AllocationTracker{
 		PreallocatedDevices:                   preallocatedDevices,
+		BlockedDevices:                        blockedDevices,
 		PreallocatedConsumedCapacity:          preallocatedCapacity,
 		InflightClusterAllocations:            make(map[DeviceID]*InflightAllocationMetadata),
 		InflightClusterAllocationsByNodeClaim: make(map[NodeClaimID]map[InstanceTypeID]sets.Set[DeviceID]),

--- a/pkg/scheduling/dynamicresources/allocator.go
+++ b/pkg/scheduling/dynamicresources/allocator.go
@@ -147,6 +147,10 @@ type AllocatedDeviceState struct {
 	ExclusiveDevices sets.Set[cloudprovider.DeviceID]
 	// ConsumedCapacity maps multi-allocatable devices to their aggregated consumed capacity.
 	ConsumedCapacity map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity
+	// BlockedDevices contains devices whose consumed-capacity accounting is invalid (e.g. a negative
+	// ConsumedCapacity in a ResourceClaim status). They must not be allocated on either the exclusive or the
+	// allow-multiple path until the invalid state clears.
+	BlockedDevices sets.Set[cloudprovider.DeviceID]
 }
 
 // NewAllocator constructs an Allocator for a single scheduling loop.
@@ -851,6 +855,12 @@ func (a *allocator) tryDevice(
 	dw DeviceWithID,
 ) bool {
 	deviceID := dw.ID
+
+	// 0. A device with invalid consumed-capacity accounting fails closed on every path. The allow-multiple
+	//    branch below does not consult IsAllocated, so this cannot rely on the exclusive-device set. See #3209.
+	if a.allocationTracker.BlockedDevices.Has(deviceID) {
+		return false
+	}
 
 	// 1. Availability check — multi-alloc devices use capacity as the gatekeeper;
 	//    exclusive devices use binary allocation tracking.

--- a/pkg/scheduling/dynamicresources/allocator_test.go
+++ b/pkg/scheduling/dynamicresources/allocator_test.go
@@ -878,20 +878,27 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
+			newNodeClaim := func() dynamicresources.NodeClaim {
+				return &fakeNodeClaim{
+					id:             unique.Make("test-nc"),
+					nodePoolID:     unique.Make("test-np"),
+					requirements:   scheduling.NewRequirements(scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a")),
+					instanceTypes:  []dynamicresources.InstanceTypeID{unique.Make("it-1")},
+					resourceSlices: make(map[dynamicresources.InstanceTypeID][]dynamicresources.ResourceSlice),
+				}
+			}
+			// With nothing blocked gpu-0 takes the whole budget, which pins the rejection below on the block
+			// rather than on a slice, claim, or selector that never matched to begin with.
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{}, nil, env.Client, nil)
+			result, err := alloc.Allocate(ctx, newNodeClaim(), []*resourcev1.ResourceClaim{makeClaim("c1", exactRequest("req-1", "gpu", 1))})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+
 			blocked := sets.New[cloudprovider.DeviceID](
 				deviceID("gpu.example.com", "pool-a", "gpu-offnode").DeviceID,
 			)
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{BlockedDevices: blocked}, nil, env.Client, nil)
-
-			nc := &fakeNodeClaim{
-				id:             unique.Make("test-nc"),
-				nodePoolID:     unique.Make("test-np"),
-				requirements:   scheduling.NewRequirements(scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a")),
-				instanceTypes:  []dynamicresources.InstanceTypeID{unique.Make("it-1")},
-				resourceSlices: make(map[dynamicresources.InstanceTypeID][]dynamicresources.ResourceSlice),
-			}
-			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
-			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			_, err = alloc.Allocate(ctx, newNodeClaim(), []*resourcev1.ResourceClaim{makeClaim("c1", exactRequest("req-1", "gpu", 1))})
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -957,6 +964,59 @@ var _ = Describe("Allocator", func() {
 				))
 			}),
 		)
+	})
+
+	Describe("Blocked devices", func() {
+		It("should reject a blocked exclusive device that is otherwise free", func() {
+			// The device is the only candidate and consumes no shared counters, so nothing but the block can
+			// reject it. Without the check ahead of the allocation-mode branch this allocation succeeds. See #3209.
+			inClusterSlices := []dynamicresources.ResourceSlice{
+				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withGeneration(1, 1), withAPIDevices("gpu-0")),
+			}
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{}, nil, env.Client, nil)
+			result, err := alloc.Allocate(ctx, makeNodeClaim("it-1"), []*resourcev1.ResourceClaim{makeClaim("c1", exactRequest("req-1", "gpu", 1))})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+
+			blocked := sets.New[cloudprovider.DeviceID](deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{BlockedDevices: blocked}, nil, env.Client, nil)
+			_, err = alloc.Allocate(ctx, makeNodeClaim("it-1"), []*resourcev1.ResourceClaim{makeClaim("c1", exactRequest("req-1", "gpu", 1))})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject a blocked allow-multiple device that still has free capacity", func() {
+			// The allow-multiple branch gates on capacity instead of the exclusive-device set, so a block it does
+			// not see reads as the full 80Gi still free. The unblocked run pins that the request itself fits.
+			// See #3209.
+			inClusterSlices := []dynamicresources.ResourceSlice{
+				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
+					withGeneration(1, 1),
+					func(s *resourcev1.ResourceSlice) {
+						s.Spec.Devices = append(s.Spec.Devices, resourcev1.Device{
+							Name:                     "gpu-0",
+							AllowMultipleAllocations: ptr.To(true),
+							Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+								"gpu.example.com/vram": {Value: resource.MustParse("80Gi")},
+							},
+						})
+					},
+				),
+			}
+			newClaim := func() *resourcev1.ResourceClaim {
+				return makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
+					"gpu.example.com/vram": resource.MustParse("16Gi"),
+				}))
+			}
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{}, nil, env.Client, nil)
+			result, err := alloc.Allocate(ctx, makeNodeClaim("it-1"), []*resourcev1.ResourceClaim{newClaim()})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+
+			blocked := sets.New[cloudprovider.DeviceID](deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{BlockedDevices: blocked}, nil, env.Client, nil)
+			_, err = alloc.Allocate(ctx, makeNodeClaim("it-1"), []*resourcev1.ResourceClaim{newClaim()})
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Describe("SharedCounters — zero capacity edge cases", func() {

--- a/pkg/scheduling/dynamicresources/allocator_test.go
+++ b/pkg/scheduling/dynamicresources/allocator_test.go
@@ -853,6 +853,48 @@ var _ = Describe("Allocator", func() {
 			Expect(result).ToNot(BeNil())
 		})
 
+		It("should deduct a blocked NonTargetingDevice's counters from the budget", func() {
+			// Same shape as the preallocated-NonTargetingDevices case above, but gpu-offnode is blocked rather
+			// than preallocated, and the budget is 40Gi. gpu-offnode reserves all of it, so the candidate gpu-0
+			// (40Gi) is rejected: a blocked device still occupies its shared counters even off the target topology.
+			inClusterSlices := []dynamicresources.ResourceSlice{
+				makeAPISlice("s-counters", "gpu.example.com", "pool-a",
+					withSharedCounters(counterSet("gpu-slices", map[string]resource.Quantity{
+						"memory": resource.MustParse("40Gi"),
+					})),
+					withGeneration(1, 3),
+				),
+				makeAPISlice("s-devices", "gpu.example.com", "pool-a", withAllNodes(),
+					withGeneration(1, 3),
+					withDevicesConsumingCounters(
+						deviceConsumingCounter("gpu-0", "gpu-slices", map[string]resource.Quantity{"memory": resource.MustParse("40Gi")}),
+					),
+				),
+				makeAPISlice("s-offnode", "gpu.example.com", "pool-a",
+					withZoneSelector("eu-west-1a"),
+					withGeneration(1, 3),
+					withDevicesConsumingCounters(
+						deviceConsumingCounter("gpu-offnode", "gpu-slices", map[string]resource.Quantity{"memory": resource.MustParse("40Gi")}),
+					),
+				),
+			}
+			blocked := sets.New[cloudprovider.DeviceID](
+				deviceID("gpu.example.com", "pool-a", "gpu-offnode").DeviceID,
+			)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{BlockedDevices: blocked}, nil, env.Client, nil)
+
+			nc := &fakeNodeClaim{
+				id:             unique.Make("test-nc"),
+				nodePoolID:     unique.Make("test-np"),
+				requirements:   scheduling.NewRequirements(scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a")),
+				instanceTypes:  []dynamicresources.InstanceTypeID{unique.Make("it-1")},
+				resourceSlices: make(map[dynamicresources.InstanceTypeID][]dynamicresources.ResourceSlice),
+			}
+			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
+			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).To(HaveOccurred())
+		})
+
 		DescribeTable("should reject allocation when device references invalid counters",
 			func(setup func() dynamicresources.NodeClaim) {
 				nc := setup()

--- a/pkg/scheduling/dynamicresources/partitionable_devices.go
+++ b/pkg/scheduling/dynamicresources/partitionable_devices.go
@@ -204,9 +204,20 @@ func addDeltaToRemaining(remaining map[PoolKey]map[string]map[string]resourcev1.
 	}
 }
 
+// hasPersistedCounterOccupancy reports whether a device already holds a fixed shared-counter footprint
+// that must be reserved before any new allocation in the pool. This covers a dedicated preallocation
+// (PreallocatedDevices), an allow-multiple preallocation (PreallocatedConsumedCapacity), and a blocked
+// device whose consumed-capacity accounting is invalid: the device cannot be allocated, but it still
+// occupies the pool counters its ConsumesCounters reserve, so those must not be handed to another device.
+func (at *AllocationTracker) hasPersistedCounterOccupancy(id DeviceID) bool {
+	return at.PreallocatedDevices.Has(id) ||
+		at.BlockedDevices.Has(id) ||
+		lo.HasKey(at.PreallocatedConsumedCapacity, id)
+}
+
 // InitRemainingCounters initializes the remaining counter budget for a pool. Called lazily on first
 // access for each pool during allocation. The initial value is the pool's total counter budget
-// minus consumption from preallocated devices.
+// minus consumption from devices that already occupy a shared-counter footprint.
 func (at *AllocationTracker) InitRemainingCounters(pool *Pool) {
 	if _, ok := at.RemainingCounters[pool.Key]; ok {
 		return
@@ -221,17 +232,17 @@ func (at *AllocationTracker) InitRemainingCounters(pool *Pool) {
 			remainingCounterSets[counterSetName][counterName] = resourcev1.Counter{Value: counter.Value.DeepCopy()}
 		}
 	}
-	// Deduct consumption from preallocated devices.
+	// Deduct consumption from devices that already occupy a shared-counter footprint (preallocated,
+	// allow-multiple, or blocked). A blocked device cannot be allocated, but its counters stay reserved
+	// so they are not handed to another device in the same pool.
 	for i := range pool.Devices {
-		if !at.PreallocatedDevices.Has(pool.Devices[i].ID) &&
-			!lo.HasKey(at.PreallocatedConsumedCapacity, pool.Devices[i].ID) {
+		if !at.hasPersistedCounterOccupancy(pool.Devices[i].ID) {
 			continue
 		}
 		deductFromCounters(remainingCounterSets, pool.Devices[i].Device)
 	}
 	for i := range pool.NonTargetingDevices {
-		if !at.PreallocatedDevices.Has(pool.NonTargetingDevices[i].ID) &&
-			!lo.HasKey(at.PreallocatedConsumedCapacity, pool.NonTargetingDevices[i].ID) {
+		if !at.hasPersistedCounterOccupancy(pool.NonTargetingDevices[i].ID) {
 			continue
 		}
 		deductFromCounters(remainingCounterSets, pool.NonTargetingDevices[i].Device)


### PR DESCRIPTION
Fixes #3209

### Description

The device-allocation controller (`pkg/controllers/dynamicresources/deviceallocation/controller.go`) folds each `ResourceClaim`'s per-device `ConsumedCapacity` into a shared device's running total, which the provisioning simulation reads to decide whether a new claim still fits. Two problems in that accounting let it mis-count a shared device and admit a claim that does not fit.

1. **A negative contribution is invalid input, and silently dropping it fails open.** `ConsumedCapacity` is never negative, but the API server does not yet reject a negative value (kubernetes/kubernetes#140563), so a driver bug or a corrupt status can still produce one. An earlier revision of this PR dropped the negative dimension. That reads the device as zero usage, and `gatherAllocatedDevices` then routes a zero-consumption device to `ExclusiveDevices` — but `tryDevice` skips the exclusive-allocation check on the `AllowMultipleAllocations` path, so the device is still offered at full capacity. Dropping the value fails open, which is exactly the over-admission #3209 describes.

2. **Distinct shares of one device within a claim overwrote each other.** A multi-allocatable device can appear in several results of the same claim as separate shares that differ only by `ShareID`. The controller keys a device by `(Driver, Pool, Device)` with no `ShareID`, so those shares collapse to one key and the ingestion assignment kept only the last, discarding the earlier shares' consumption.

### Fix

A negative in any dimension now marks the **whole DRA device** (the `(driver, pool, device)` key, which may be one partition of a physical device) invalid (`InvalidConsumedCapacity`), carried through `DeviceMetadata` into a new `BlockedDevices` set that `tryDevice` rejects **before** both the allow-multiple and the exclusive branch. The device fails closed on every allocation path and recovers on its own once the allocation is cleared or the claim disappears (a populated `status.allocation` is immutable, so recovery is the claim being cleared or deleted, not edited in place). A blocked device still reserves its pool `ConsumesCounters` in `InitRemainingCounters`, so the counters it holds are not handed to another device in the same pool. A negative in one dimension invalidates that whole contribution rather than keeping the others, since a status reporting one impossible value is not trustworthy for the rest. `addCapacity` is a plain sum again (both callers reject a negative source first), and ingestion sums a device's results instead of replacing them, so distinct `ShareID` shares of one device are no longer lost.

### Test

- `flags a device as invalid when a claim reports a negative consumed-capacity contribution` applies two claims sharing a device, one reporting a negative memory contribution, and asserts the device is flagged invalid.
- `sums multiple shares of the same device within a claim rather than overwriting` applies one claim holding two shares of a device (distinct `ShareID`), asserts their consumed capacity is summed, and that the sum is attributed to the single claim's per-pod contribution so `effectiveConsumedCapacity` releases the whole share when the pod deletes (checked directly in the provisioning internal test).
- an allocator regression rejects a candidate whose pool `ConsumesCounters` are held by a blocked device, so a blocked device's counters are not made available to another device.
- `should reject a blocked exclusive device that is otherwise free` and `should reject a blocked allow-multiple device that still has free capacity` make the blocked device the only candidate with no shared counters, so nothing but the gate can reject it. Removing the `BlockedDevices` check from `tryDevice` leaves `pkg/scheduling/dynamicresources`, `pkg/controllers/dynamicresources` and `pkg/controllers/provisioning` green without them, and fails exactly these two with them. Each runs the same fixture unblocked first, so a slice or claim that never matched cannot pass for the wrong reason; the counter regression carries the same control.
- `clears the invalid flag once the offending claim is gone` deletes the claim carrying the negative and asserts the device is allocatable again with the surviving claim's capacity, since the flag is recomputed from the current claims rather than latched.
- `TestContributionsForResults` and `TestHasNegativeCapacity` are env-free unit tests over the ingestion folding and the sign scan (negative flags the device, a valid sibling does not clear the flag, distinct shares sum, only the malformed device is flagged), so they do not depend on the API server accepting a negative status.

The envtest-backed cases run in CI (they need `KUBEBUILDER_ASSETS`); the unit test runs anywhere.

### Note for reviewers

The guard sits at the controller's ingestion boundary, where `ConsumedCapacity` is copied from a `ResourceClaim` status the API server does not validate for sign. It fails closed rather than dropping the value, because a shared device dropped to zero is still admitted through `tryDevice`'s allow-multiple path — treating an untrusted negative as "no usage" is the unsafe direction for a scheduling simulation. The block is per-DRA-device (the `(driver, pool, device)` key) and self-clears, so a transient bad status quarantines just that device until the allocation is cleared or the claim disappears. The counter regression exercises the non-targeting device loop directly; the shared `hasPersistedCounterOccupancy` predicate keeps the targeting loop in step, so both loops are covered by the one helper rather than two separate tests. Happy to adjust the naming (`InvalidConsumedCapacity` / `BlockedDevices`) if you would prefer different terms.

### Related follow-ups

Two neighbouring problems are tracked separately rather than folded in here, since both change the shared-allocation identity model and the release rules:

- #3212 — the whole-device deleting shortcut can release a device a non-pod consumer still holds, and shared state is derived from `ConsumedCapacity != nil` instead of `ShareID != nil`. #3215 is open for the non-pod half.
- #3213 — allocator availability misses cross-mode allocations, and a persisted shared device's fixed counter footprint is charged twice.


