### PR TITLE
fix: keep DRA devices held by non-pod consumers when their pods delete

### DIFF
--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -70,6 +70,9 @@ type ContributionMetadata struct {
 	PodUIDs []types.UID
 	// ConsumedCapacity is the capacity this single claim consumes on the device.
 	ConsumedCapacity map[resourcev1.QualifiedName]resource.Quantity
+	// Releasable is false when the contributing claim has a non-pod consumer (or an empty ReservedFor), so its share
+	// must not be freed just because its pods are deleting.
+	Releasable bool
 }
 
 // Metadata contains supplementary information about an allocated device, derived from the ReservedFor status of all
@@ -290,6 +293,7 @@ func (c *Controller) computeDeviceMetadata(device cloudprovider.DeviceID) Device
 			meta.Contributions = append(meta.Contributions, ContributionMetadata{
 				PodUIDs:          claimMeta.PodUIDs,
 				ConsumedCapacity: contributions.ConsumedCapacity,
+				Releasable:       claimMeta.Releasable,
 			})
 		}
 	}

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -775,6 +775,39 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			})
 		})
 
+		It("copies each claim's releasability onto its contribution", func() {
+			// The pod-only device asserts Releasable=true, which guards against dropping the production copy since false
+			// is the zero value; the mixed pod/non-pod device asserts its contribution is not releasable.
+			podClaim := withReservedFor(
+				resourceClaim("pod-claim", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+					"memory": resource.MustParse("256Mi"),
+				})),
+				podRef("pod-a", "uid-a"),
+			)
+			mixedClaim := withReservedFor(
+				resourceClaim("mixed-claim", deviceResultWithCapacity("device-1", map[resourcev1.QualifiedName]resource.Quantity{
+					"memory": resource.MustParse("128Mi"),
+				})),
+				podRef("pod-b", "uid-b"),
+				nonPodRef(),
+			)
+			ExpectApplied(ctx, env.Client, podClaim, mixedClaim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(podClaim))
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(mixedClaim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+
+			podMeta := devices[deviceID("device-0")]
+			Expect(podMeta.Contributions).To(HaveLen(1))
+			Expect(podMeta.Contributions[0].Releasable).To(BeTrue())
+
+			mixedMeta := devices[deviceID("device-1")]
+			Expect(mixedMeta.Contributions).To(HaveLen(1))
+			Expect(mixedMeta.Contributions[0].Releasable).To(BeFalse())
+		})
+
 		It("aggregates consumed capacity across multiple claims referencing the same device", func() {
 			claimA := withReservedFor(
 				resourceClaim("claim-a", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{

--- a/pkg/controllers/provisioning/dra.go
+++ b/pkg/controllers/provisioning/dra.go
@@ -116,7 +116,8 @@ func (p *Provisioner) gatherAllocatedDevices(ctx context.Context, deletingPodUID
 
 // deviceReallocation classifies an already-allocated device for the allocator's seed set, given the set of deleting
 // pods. It returns whether the whole device is available for reallocation (freed), and for a surviving shared device
-// the consumed capacity that remains reserved. A surviving exclusive device returns freed=false with a nil map.
+// the consumed capacity that remains reserved, as a non-nil map that may be empty. A surviving exclusive device
+// returns freed=false with a nil map.
 func deviceReallocation(meta deviceallocation.DeviceMetadata, deletingPodUIDs sets.Set[types.UID]) (freed bool, consumed map[resourcev1.QualifiedName]resource.Quantity) {
 	// A device with no live consumers that every referencing claim considers releasable is available.
 	if meta.Releasable && len(meta.PodUIDs) == 0 {
@@ -128,15 +129,12 @@ func deviceReallocation(meta deviceallocation.DeviceMetadata, deletingPodUIDs se
 		return true, nil
 	}
 	if meta.Shared {
-		// Free just the deleting pods' share of the device's consumed capacity. The device as a whole survives the
-		// all-consumers-deleting check above (live pods remain), but each contribution whose pods are all deleting is
-		// migrating off and its capacity should be available for reallocation.
-		effective := effectiveConsumedCapacity(meta, deletingPodUIDs)
-		if len(effective) == 0 {
-			// Every dimension was freed (or there was no live consumption left); treat the device as available.
-			return true, nil
-		}
-		return false, effective
+		// The two checks above are the only proof that the whole device can be released; reaching here means a live pod
+		// or a non-pod consumer still holds it, so the device stays in the seed state. effectiveConsumedCapacity
+		// subtracts the deleting pods' share, and the remaining map may be empty when the surviving shares consume zero
+		// capacity. Keep it non-nil: its key records the device's shared occupancy, which the allocator charges against
+		// fixed pool counters regardless of the capacity value.
+		return false, effectiveConsumedCapacity(meta, deletingPodUIDs)
 	}
 	return false, nil
 }

--- a/pkg/controllers/provisioning/dra.go
+++ b/pkg/controllers/provisioning/dra.go
@@ -101,29 +101,44 @@ func (p *Provisioner) gatherAllocatedDevices(ctx context.Context, deletingPodUID
 		ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{},
 	}
 	for id, meta := range seq {
-		// A device with no live consumers that every referencing claim considers releasable is available.
-		if meta.Releasable && len(meta.PodUIDs) == 0 {
+		freed, consumed := deviceReallocation(meta, deletingPodUIDs)
+		if freed {
 			continue
 		}
-		// A device consumed only by deleting pods is available for reallocation.
-		if len(meta.PodUIDs) > 0 && allConsumersDeleting(meta.PodUIDs, deletingPodUIDs) {
-			continue
-		}
-		if meta.Shared {
-			// Free just the deleting pods' share of the device's consumed capacity. The device as a whole survives the
-			// all-consumers-deleting check above (live pods remain), but each contribution whose pods are all deleting
-			// is migrating off and its capacity should be available for reallocation.
-			effective := effectiveConsumedCapacity(meta, deletingPodUIDs)
-			if len(effective) == 0 {
-				// Every dimension was freed (or there was no live consumption left); treat the device as available.
-				continue
-			}
-			state.ConsumedCapacity[id] = effective
+		if consumed != nil {
+			state.ConsumedCapacity[id] = consumed
 			continue
 		}
 		state.ExclusiveDevices.Insert(id)
 	}
 	return state, nil
+}
+
+// deviceReallocation classifies an already-allocated device for the allocator's seed set, given the set of deleting
+// pods. It returns whether the whole device is available for reallocation (freed), and for a surviving shared device
+// the consumed capacity that remains reserved. A surviving exclusive device returns freed=false with a nil map.
+func deviceReallocation(meta deviceallocation.DeviceMetadata, deletingPodUIDs sets.Set[types.UID]) (freed bool, consumed map[resourcev1.QualifiedName]resource.Quantity) {
+	// A device with no live consumers that every referencing claim considers releasable is available.
+	if meta.Releasable && len(meta.PodUIDs) == 0 {
+		return true, nil
+	}
+	// A device consumed only by deleting pods is available for reallocation. A non-pod consumer keeps the device in
+	// use (Releasable is false), so it is not freed here even when every pod consumer is deleting.
+	if meta.Releasable && len(meta.PodUIDs) > 0 && allConsumersDeleting(meta.PodUIDs, deletingPodUIDs) {
+		return true, nil
+	}
+	if meta.Shared {
+		// Free just the deleting pods' share of the device's consumed capacity. The device as a whole survives the
+		// all-consumers-deleting check above (live pods remain), but each contribution whose pods are all deleting is
+		// migrating off and its capacity should be available for reallocation.
+		effective := effectiveConsumedCapacity(meta, deletingPodUIDs)
+		if len(effective) == 0 {
+			// Every dimension was freed (or there was no live consumption left); treat the device as available.
+			return true, nil
+		}
+		return false, effective
+	}
+	return false, nil
 }
 
 // effectiveConsumedCapacity computes a shared device's consumed capacity with the contributions of fully-deleting
@@ -136,9 +151,9 @@ func effectiveConsumedCapacity(meta deviceallocation.DeviceMetadata, deletingPod
 		effective[dim] = qty.DeepCopy()
 	}
 	for _, contribution := range meta.Contributions {
-		// A contribution reserved by no pods (e.g. a non-pod consumer) is never treated as deleting — only contributions
-		// whose entire pod set is being deleted are freed.
-		if len(contribution.PodUIDs) == 0 || !allConsumersDeleting(contribution.PodUIDs, deletingPodUIDs) {
+		// A contribution is freed only when its claim is releasable (no non-pod consumer) and its entire pod set is
+		// deleting. A claim reserved by no pods, or by a non-pod consumer alongside a deleting pod, keeps its share.
+		if !contribution.Releasable || len(contribution.PodUIDs) == 0 || !allConsumersDeleting(contribution.PodUIDs, deletingPodUIDs) {
 			continue
 		}
 		for dim, consumed := range contribution.ConsumedCapacity {

--- a/pkg/controllers/provisioning/dra_internal_test.go
+++ b/pkg/controllers/provisioning/dra_internal_test.go
@@ -89,7 +89,7 @@ var _ = Describe("DRA Provisioner Internals", func() {
 			for dim, qty := range capacity {
 				consumed[dim] = resource.MustParse(qty)
 			}
-			return deviceallocation.ContributionMetadata{PodUIDs: pods, ConsumedCapacity: consumed}
+			return deviceallocation.ContributionMetadata{PodUIDs: pods, ConsumedCapacity: consumed, Releasable: true}
 		}
 		// sharedMeta builds shared-device metadata whose aggregated ConsumedCapacity is the sum of its contributions.
 		sharedMeta := func(contributions ...deviceallocation.ContributionMetadata) deviceallocation.DeviceMetadata {
@@ -158,6 +158,84 @@ var _ = Describe("DRA Provisioner Internals", func() {
 			)
 			effective := effectiveConsumedCapacity(meta, sets.New[types.UID]("deleting-a"))
 			expectCapacity(effective, map[resourcev1.QualifiedName]string{"memory": "256Mi"})
+		})
+
+		It("should keep a non-releasable contribution's share even when its pod is deleting", func() {
+			// The claim is reserved by both a deleting pod and a non-pod consumer, so it is not releasable and its share
+			// must not be freed when the pod deletes.
+			c := contribution([]types.UID{"deleting-a"}, map[resourcev1.QualifiedName]string{"memory": "256Mi"})
+			c.Releasable = false
+			meta := sharedMeta(c)
+			effective := effectiveConsumedCapacity(meta, sets.New[types.UID]("deleting-a"))
+			expectCapacity(effective, map[resourcev1.QualifiedName]string{"memory": "256Mi"})
+		})
+	})
+
+	Describe("deviceReallocation", func() {
+		deleting := sets.New[types.UID]("deleting-a", "deleting-b")
+		shared := func(contributions ...deviceallocation.ContributionMetadata) deviceallocation.DeviceMetadata {
+			aggregate := map[resourcev1.QualifiedName]resource.Quantity{}
+			var podUIDs []types.UID
+			for _, c := range contributions {
+				podUIDs = append(podUIDs, c.PodUIDs...)
+				for dim, qty := range c.ConsumedCapacity {
+					cur := aggregate[dim]
+					cur.Add(qty)
+					aggregate[dim] = cur
+				}
+			}
+			return deviceallocation.DeviceMetadata{Releasable: true, Shared: true, PodUIDs: podUIDs, ConsumedCapacity: aggregate, Contributions: contributions}
+		}
+		share := func(pods []types.UID, memory string) deviceallocation.ContributionMetadata {
+			return deviceallocation.ContributionMetadata{
+				PodUIDs:          pods,
+				ConsumedCapacity: map[resourcev1.QualifiedName]resource.Quantity{"memory": resource.MustParse(memory)},
+				Releasable:       true,
+			}
+		}
+
+		It("frees a releasable device with no live consumers", func() {
+			freed, consumed := deviceReallocation(deviceallocation.DeviceMetadata{Releasable: true}, deleting)
+			Expect(freed).To(BeTrue())
+			Expect(consumed).To(BeNil())
+		})
+
+		It("frees a releasable device whose every pod consumer is deleting", func() {
+			meta := deviceallocation.DeviceMetadata{Releasable: true, PodUIDs: []types.UID{"deleting-a"}}
+			freed, consumed := deviceReallocation(meta, deleting)
+			Expect(freed).To(BeTrue())
+			Expect(consumed).To(BeNil())
+		})
+
+		It("keeps a device held by a non-pod consumer even when its pods are all deleting", func() {
+			// Releasable is false because a non-pod consumer still holds the device, so it must not be freed for
+			// reallocation even though every pod consumer is deleting.
+			meta := deviceallocation.DeviceMetadata{Releasable: false, PodUIDs: []types.UID{"deleting-a"}}
+			freed, consumed := deviceReallocation(meta, deleting)
+			Expect(freed).To(BeFalse())
+			Expect(consumed).To(BeNil())
+		})
+
+		It("keeps an exclusive device with a live consumer", func() {
+			meta := deviceallocation.DeviceMetadata{Releasable: true, PodUIDs: []types.UID{"live-a"}}
+			freed, consumed := deviceReallocation(meta, deleting)
+			Expect(freed).To(BeFalse())
+			Expect(consumed).To(BeNil())
+		})
+
+		It("returns the surviving share of a shared device mixing live and deleting claims", func() {
+			meta := shared(share([]types.UID{"live-a"}, "256Mi"), share([]types.UID{"deleting-b"}, "128Mi"))
+			freed, consumed := deviceReallocation(meta, deleting)
+			Expect(freed).To(BeFalse())
+			Expect(consumed).To(HaveLen(1))
+			Expect(consumed["memory"].Equal(resource.MustParse("256Mi"))).To(BeTrue())
+		})
+
+		It("frees a shared device whose every consumer is deleting", func() {
+			meta := shared(share([]types.UID{"deleting-a"}, "256Mi"))
+			freed, consumed := deviceReallocation(meta, deleting)
+			Expect(freed).To(BeTrue())
+			Expect(consumed).To(BeNil())
 		})
 	})
 })

--- a/pkg/controllers/provisioning/dra_internal_test.go
+++ b/pkg/controllers/provisioning/dra_internal_test.go
@@ -176,15 +176,18 @@ var _ = Describe("DRA Provisioner Internals", func() {
 		shared := func(contributions ...deviceallocation.ContributionMetadata) deviceallocation.DeviceMetadata {
 			aggregate := map[resourcev1.QualifiedName]resource.Quantity{}
 			var podUIDs []types.UID
+			releasable := true
 			for _, c := range contributions {
 				podUIDs = append(podUIDs, c.PodUIDs...)
+				releasable = releasable && c.Releasable
 				for dim, qty := range c.ConsumedCapacity {
 					cur := aggregate[dim]
 					cur.Add(qty)
 					aggregate[dim] = cur
 				}
 			}
-			return deviceallocation.DeviceMetadata{Releasable: true, Shared: true, PodUIDs: podUIDs, ConsumedCapacity: aggregate, Contributions: contributions}
+			// Mirror computeDeviceMetadata: the device is releasable only if every contributing claim is.
+			return deviceallocation.DeviceMetadata{Releasable: releasable, Shared: true, PodUIDs: podUIDs, ConsumedCapacity: aggregate, Contributions: contributions}
 		}
 		share := func(pods []types.UID, memory string) deviceallocation.ContributionMetadata {
 			return deviceallocation.ContributionMetadata{
@@ -236,6 +239,29 @@ var _ = Describe("DRA Provisioner Internals", func() {
 			freed, consumed := deviceReallocation(meta, deleting)
 			Expect(freed).To(BeTrue())
 			Expect(consumed).To(BeNil())
+		})
+
+		It("keeps a shared device when a live pod holds a zero-capacity share", func() {
+			// Subtracting the deleting claim's share empties the effective map, but the live pod still holds a
+			// zero-capacity share, so the device must stay in the seed state rather than be freed. An empty effective
+			// map is not proof that the last share is gone.
+			meta := shared(share([]types.UID{"deleting-a"}, "256Mi"), share([]types.UID{"live-b"}, "0"))
+			freed, consumed := deviceReallocation(meta, deleting)
+			Expect(freed).To(BeFalse())
+			Expect(consumed).ToNot(BeNil())
+			Expect(consumed).To(BeEmpty())
+		})
+
+		It("keeps a shared device when a non-releasable zero-capacity share survives", func() {
+			// A non-pod consumer holds a zero-capacity share alongside a deleting pod's positive share. Subtracting the
+			// deleting share empties the map, but the non-pod share still occupies the device.
+			nonPodShare := share(nil, "0")
+			nonPodShare.Releasable = false
+			meta := shared(share([]types.UID{"deleting-a"}, "256Mi"), nonPodShare)
+			freed, consumed := deviceReallocation(meta, deleting)
+			Expect(freed).To(BeFalse())
+			Expect(consumed).ToNot(BeNil())
+			Expect(consumed).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
Karpenter's provisioning loop reconstructs the set of already-allocated DRA devices before each scheduling simulation, and filters out the ones whose consumers are all going away so their capacity can be reused. That filter treated "every pod consumer is deleting" as "the device is free", but a ResourceClaim can also be reserved by a non-pod consumer, and those are invisible to the deleting-pod check.

## The problem

`gatherAllocatedDevices` freed a device as soon as `allConsumersDeleting` returned true for its pod UIDs. The device metadata already carries a `Releasable` flag that is false when any referencing claim has a non-pod consumer (or an empty `ReservedFor`), and the sibling "no live consumers" shortcut right above it already respects that flag. The all-consumers-deleting shortcut did not.

So a device reserved by both a deleting pod and a non-pod consumer, or a shared device split across a deleting-pod claim and a separate non-pod claim, was handed back to the allocator as free while something still held it. The scheduling simulation would then see it as available and could allocate it a second time.

## The fix

Two changes, both mirroring the guard that was already present for the no-live-consumers case:

- Gate the all-consumers-deleting shortcut with `meta.Releasable`, so a device still held by a non-pod consumer is never freed through the deleting-pod path.
- Carry each claim's `Releasable` onto its `ContributionMetadata`, and skip subtracting a non-releasable contribution's share in `effectiveConsumedCapacity`. This covers the shared-device case where a single claim mixes a deleting pod with a non-pod consumer, so its share stays reserved even though the pod is gone.

The per-device classification that `gatherAllocatedDevices` runs is pulled out into a small pure helper, `deviceReallocation`, so the reallocation decision (free, keep as exclusive, or keep with the remaining shared capacity) can be unit-tested without standing up the whole controller.

## Testing

Added unit tests for both paths, each confirmed to fail before the change and pass after: a non-releasable contribution keeps its share in `effectiveConsumedCapacity`, and `deviceReallocation` keeps a device held by a non-pod consumer even when its pods are all deleting, alongside the freed, exclusive, and shared-partial branches. The full `provisioning` and `deviceallocation` suites pass.

## Scope

This addresses the non-pod-consumer release path described in #3212. The other half of that issue, that `Shared` is derived from the presence of `ConsumedCapacity` rather than from the claim's `ShareID`, is a separate and more structural change that I have left out of this PR.
