### PR TITLE
fix: Filter out incompatible Offerings in EstimatedSavings()

### DIFF
--- a/pkg/controllers/disruption/balanced_scoring_test.go
+++ b/pkg/controllers/disruption/balanced_scoring_test.go
@@ -33,6 +33,8 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
@@ -467,6 +469,68 @@ var _ = Describe("Balanced Scoring", func() {
 			Entry("zero savings", 0.0, 10.0, 0.0, false, false),
 			Entry("negative savings", -5.0, 10.0, 0.0, false, false),
 		)
+
+		It("should REJECT a move when EstimatedSavings excludes spot offerings for an on-demand-only NodePool", func() {
+			// Numbers such that if a spot price were to leak into an on-demand-only NodePool it would flip the 0.5 gate
+			// from reject -> approve.
+			np := makeBalancedNodePool("pool-onDemand-only", nil)
+			sourceIT := fake.NewInstanceType("source-type",
+				fake.WithOfferings(cloudprovider.Offering{
+					Available: true,
+					Price:     0.50,
+					Requirements: scheduling.NewLabelRequirements(map[string]string{
+						v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+						corev1.LabelTopologyZone: "test-zone-1",
+					}),
+				}),
+			)
+			candidate := makeCandidate("source-node", np, sourceIT, []*corev1.Pod{
+				makePod("p1", ""), makePod("p2", ""), makePod("p3", ""),
+			})
+			destIT := fake.NewInstanceType("dest-type",
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available: true,
+						Price:     0.10,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  v1.CapacityTypeSpot,
+							corev1.LabelTopologyZone: "test-zone-1",
+						}),
+					},
+					cloudprovider.Offering{
+						Available: true,
+						Price:     0.40,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+							corev1.LabelTopologyZone: "test-zone-1",
+						}),
+					},
+				),
+			)
+			cmd := Command{
+				Candidates:   []*Candidate{candidate},
+				Replacements: []*Replacement{{}},
+				Results: pscheduling.Results{
+					NewNodeClaims: []*pscheduling.NodeClaim{
+						{
+							NodeClaimTemplate: pscheduling.NodeClaimTemplate{
+								InstanceTypeOptions: []*cloudprovider.InstanceType{destIT},
+								Requirements: scheduling.NewRequirements(
+									scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, v1.CapacityTypeOnDemand),
+								),
+							},
+						},
+					},
+				},
+			}
+			poolTotals := NodePoolTotals{TotalCost: 1.0, TotalDisruptionCost: 10.0}
+
+			savings := cmd.EstimatedSavings()
+			result := ScoreMove(savings, ComputeMoveDisruptionCost(cmd.Candidates), poolTotals, v1.BalancedK)
+
+			Expect(savings).To(BeNumerically("~", 0.10, 0.001))
+			Expect(result.Approved()).To(BeFalse())
+		})
 	})
 
 	Describe("ShouldDisrupt", func() {

--- a/pkg/controllers/disruption/consolidation_logging_test.go
+++ b/pkg/controllers/disruption/consolidation_logging_test.go
@@ -25,10 +25,12 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
+	pkgscheduling "sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/test"
 )
 
@@ -150,6 +152,201 @@ func TestGetCommandEstimatedSavings_MultipleReplacements(t *testing.T) {
 	// Use tolerance for floating point comparison
 	if diff := savings - expectedSavings; diff < -floatComparisonDelta || diff > floatComparisonDelta {
 		t.Errorf("Command.EstimatedSavings() = %v, want %v (verifying multi-NodeClaim cost summing)", savings, expectedSavings)
+	}
+}
+
+func TestGetCommandEstimatedSavings_OnDemandOnlyNodePool(t *testing.T) {
+	// This test verifies that EstimatedSavings only considers offerings that are valid for the NodePool under
+	// consideration (e.g. on-demand-only NodePool)
+	candidate := mockCandidate("node-1")
+	candidate.instanceType = fake.NewInstanceType("source-type",
+		fake.WithOfferings(cloudprovider.Offering{
+			Available: true,
+			Price:     0.50,
+			Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+				corev1.LabelTopologyZone: "us-west-2a",
+			}),
+		}),
+	)
+	candidate.Price = 0.50
+
+	destType := fake.NewInstanceType("dest-type",
+		fake.WithOfferings(
+			cloudprovider.Offering{
+				Available: true,
+				Price:     0.10,
+				Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+					v1.CapacityTypeLabelKey:  v1.CapacityTypeSpot,
+					corev1.LabelTopologyZone: "us-west-2a",
+				}),
+			},
+			cloudprovider.Offering{
+				Available: true,
+				Price:     0.40,
+				Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+					v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+					corev1.LabelTopologyZone: "us-west-2a",
+				}),
+			},
+		),
+	)
+
+	nodeClaimReqs := pkgscheduling.NewRequirements(
+		pkgscheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, v1.CapacityTypeOnDemand),
+	)
+
+	cmd := Command{
+		Candidates:   []*Candidate{candidate},
+		Replacements: []*Replacement{{}},
+		Results: scheduling.Results{
+			NewNodeClaims: []*scheduling.NodeClaim{
+				{
+					NodeClaimTemplate: scheduling.NodeClaimTemplate{
+						InstanceTypeOptions: []*cloudprovider.InstanceType{destType},
+						Requirements:        nodeClaimReqs,
+					},
+				},
+			},
+		},
+	}
+
+	// Expected: sourcePrice (0.50) - destPrice (0.40, the on-demand offering) = 0.10
+	// Without filtering: 0.50 - 0.10 = 0.40 (bug: spot price used as dest price)
+	savings := cmd.EstimatedSavings()
+	expectedSavings := 0.10
+
+	if diff := savings - expectedSavings; diff < -floatComparisonDelta || diff > floatComparisonDelta {
+		t.Errorf("Command.EstimatedSavings() = %v, want %v", savings, expectedSavings)
+	}
+}
+
+func TestGetCommandEstimatedSavings_ZoneRequirement(t *testing.T) {
+	// Verifies EstimatedSavings filters AZ requirements properly
+	candidate := mockCandidate("node-1")
+	candidate.instanceType = fake.NewInstanceType("source-type",
+		fake.WithOfferings(cloudprovider.Offering{
+			Available: true,
+			Price:     0.50,
+			Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+				corev1.LabelTopologyZone: "us-west-2a",
+			}),
+		}),
+	)
+	candidate.Price = 0.50
+
+	destType := fake.NewInstanceType("dest-type",
+		fake.WithOfferings(
+			cloudprovider.Offering{
+				Available: true,
+				Price:     0.05,
+				Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+					v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+					corev1.LabelTopologyZone: "us-west-2b",
+				}),
+			},
+			cloudprovider.Offering{
+				Available: true,
+				Price:     0.45,
+				Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+					v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+					corev1.LabelTopologyZone: "us-west-2a",
+				}),
+			},
+		),
+	)
+
+	nodeClaimReqs := pkgscheduling.NewRequirements(
+		pkgscheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
+	)
+
+	cmd := Command{
+		Candidates:   []*Candidate{candidate},
+		Replacements: []*Replacement{{}},
+		Results: scheduling.Results{
+			NewNodeClaims: []*scheduling.NodeClaim{
+				{
+					NodeClaimTemplate: scheduling.NodeClaimTemplate{
+						InstanceTypeOptions: []*cloudprovider.InstanceType{destType},
+						Requirements:        nodeClaimReqs,
+					},
+				},
+			},
+		},
+	}
+
+	// Expected: sourcePrice (0.50) - destPrice (0.45, us-west-2a) = 0.05
+	// The us-west-2b offering (0.05) must be excluded because the NodePool requires us-west-2a.
+	savings := cmd.EstimatedSavings()
+	expectedSavings := 0.05
+
+	if diff := savings - expectedSavings; diff < -floatComparisonDelta || diff > floatComparisonDelta {
+		t.Errorf("Command.EstimatedSavings() = %v, want %v (compatible filter must apply to non-capacity-type requirements)", savings, expectedSavings)
+	}
+}
+
+func TestGetCommandEstimatedSavings_NoCapacityTypeRestriction(t *testing.T) {
+	// Negative control such that we consider all offerings for NodePool with no capacity-type restriction
+	candidate := mockCandidate("node-1")
+	candidate.instanceType = fake.NewInstanceType("source-type",
+		fake.WithOfferings(cloudprovider.Offering{
+			Available: true,
+			Price:     0.50,
+			Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+				corev1.LabelTopologyZone: "us-west-2a",
+			}),
+		}),
+	)
+	candidate.Price = 0.50
+
+	destType := fake.NewInstanceType("dest-type",
+		fake.WithOfferings(
+			cloudprovider.Offering{
+				Available: true,
+				Price:     0.10,
+				Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+					v1.CapacityTypeLabelKey:  v1.CapacityTypeSpot,
+					corev1.LabelTopologyZone: "us-west-2a",
+				}),
+			},
+			cloudprovider.Offering{
+				Available: true,
+				Price:     0.40,
+				Requirements: pkgscheduling.NewLabelRequirements(map[string]string{
+					v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+					corev1.LabelTopologyZone: "us-west-2a",
+				}),
+			},
+		),
+	)
+
+	nodeClaimReqs := pkgscheduling.NewRequirements(
+		pkgscheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, v1.CapacityTypeOnDemand, v1.CapacityTypeSpot),
+	)
+
+	cmd := Command{
+		Candidates:   []*Candidate{candidate},
+		Replacements: []*Replacement{{}},
+		Results: scheduling.Results{
+			NewNodeClaims: []*scheduling.NodeClaim{
+				{
+					NodeClaimTemplate: scheduling.NodeClaimTemplate{
+						InstanceTypeOptions: []*cloudprovider.InstanceType{destType},
+						Requirements:        nodeClaimReqs,
+					},
+				},
+			},
+		},
+	}
+
+	// Expected: sourcePrice (0.50) - destPrice (0.10, spot is legal) = 0.40
+	savings := cmd.EstimatedSavings()
+	expectedSavings := 0.40
+
+	if diff := savings - expectedSavings; diff < -floatComparisonDelta || diff > floatComparisonDelta {
+		t.Errorf("Command.EstimatedSavings() = %v, want %v (fix must not exclude legal offerings)", savings, expectedSavings)
 	}
 }
 

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -357,7 +357,10 @@ func (c Command) SourceCost() float64 {
 }
 
 // EstimatedSavings returns the estimated cost savings from this consolidation.
-// Returns 0.0 when pricing cannot be determined.
+// Unknown prices degrade silently: an unpriceable source node carries Price 0
+// (see resolveNodePrice) and deflates savings, while a replacement with no
+// available compatible offering contributes 0 to destination cost and inflates
+// them.
 func (c Command) EstimatedSavings() float64 {
 	sourcePrice := c.SourceCost()
 
@@ -367,11 +370,12 @@ func (c Command) EstimatedSavings() float64 {
 	}
 
 	// For replace consolidation, sum destination costs from all replacement NodeClaims.
-	// Filter to available offerings so ICE'd zones don't produce an optimistic estimate.
 	destPrice := 0.0
 	for _, nodeClaim := range c.Results.NewNodeClaims {
 		if len(nodeClaim.InstanceTypeOptions) > 0 {
-			available := nodeClaim.InstanceTypeOptions[0].Offerings.Available()
+			available := nodeClaim.InstanceTypeOptions[0].Offerings.
+				Available().                       // Filter to available offerings so ICE'd zones don't produce an optimistic estimate.
+				Compatible(nodeClaim.Requirements) // Filter to only consider allowed offerings
 			if len(available) > 0 {
 				destPrice += available.Cheapest().Price
 			}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Bug: Karpenter with NodePools that set `consolidationPolicy=balanced` AND `capacityType=onDemand` is overly approving of consolidation moves. 

Root cause: Karpenter is always considering spot instance prices for consolidation moves instead of restricting itself to just onDemand prices. This is because `EstimatedSavings()` in the disruption loop doesn't filter out incompatible NodeClaims. 

Thankfully Karpenter will eventually filter out spot instances and never make a move if new instance isn't cheaper due to safeguards in the rest of the consolidation loop.

Explained another way:

An `InstanceType` (e.g. `m6i.xlarge`) is not a single price it's a type
with a list of `Offerings`. One offering per (capacity-type, zone) combo:

```yaml
m6i.xlarge:
  offerings:
    - {capacity-type: on-demand, zone: us-west-2a, price: $0.192, available: true}
    - {capacity-type: on-demand, zone: us-west-2b, price: $0.192, available: true}
    - {capacity-type: spot,      zone: us-west-2a, price: $0.065, available: true}
    - {capacity-type: spot,      zone: us-west-2b, price: $0.070, available: true}
    ...
```

The simulated scheduler picks which types are candidates by asking "does at least one
offering match the pool's requirements?" It hands the whole type with
all its offerings to downstream code. Downstream is expected to filter
offerings itself when it does per-offering math (like "what's the cheapest
one I'd actually launch?"). However, `EstimatedSavings` in the disruption loop forgets to do that
filter. 

This `EstimatedSavings()` value feeds `ScoreMove()` in
`balanced.go`, so the Balanced consolidation score gate over-approves
moves. In my observations this made a `m7i.xlarge → m6i.xlarge` swap
scores above the 0.5 threshold when the true list-price would have
kept them below. (See manual testing)

Fix: `Compatible(nodeClaim.requirements)` filters offerings whose Requirements don't intersect the
NodePool's Requirements. (e.g. filters out spot offerings for capacity-type=on-demand NodePools) 

**How was this change tested?**
- Much Manual testing: See [karpenter experiments](https://github.com/AndrewSirenko/karpenter-experiments/tree/main/estimated-savings-balanced). Reproduction steps provided.
- New unit test
- TODO: What should an integration/e2e test for this look like? Run real scheduler + disruption controller against a fake API server & fake cloud provider? To prove full: NodePool spec → scheduler → NodeClaim.Requirements → EstimatedSavings? 

**AI Disclosure**

I used an LLM to parallel program with me. This included:
- First draft of code changes (edited by me)
- Helping me setup the manual tests and producing summaries

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.