### PR TITLE
chore: consolidateAfter shouldn't be required on static NodePools

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -147,7 +147,7 @@ spec:
                         ConsolidateAfter is the duration the controller will wait
                         before attempting to terminate nodes that are underutilized.
                         Refer to ConsolidationPolicy for how underutilization is considered.
-                        When replicas is set, ConsolidateAfter is simply ignored
+                        Required unless replicas is set, in which case it is simply ignored.
                       pattern: ^(([0-9]+(s|m|h))+|Never)$
                       type: string
                     consolidationPolicy:
@@ -162,8 +162,6 @@ spec:
                         - WhenEmptyOrUnderutilized
                         - Balanced
                       type: string
-                  required:
-                    - consolidateAfter
                   type: object
                 limits:
                   additionalProperties:
@@ -465,6 +463,8 @@ spec:
                   rule: '!has(self.replicas) || (!has(self.limits) || size(self.limits) == 0 || (size(self.limits) == 1 && ''nodes'' in self.limits))'
                 - message: '''weight'' is not supported on static NodePools'
                   rule: '!has(self.replicas) || !has(self.weight)'
+                - message: disruption.consolidateAfter is required on dynamic NodePools
+                  rule: has(self.replicas) || has(self.disruption.consolidateAfter)
             status:
               description: NodePoolStatus defines the observed state of NodePool
               properties:

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -147,7 +147,7 @@ spec:
                         ConsolidateAfter is the duration the controller will wait
                         before attempting to terminate nodes that are underutilized.
                         Refer to ConsolidationPolicy for how underutilization is considered.
-                        When replicas is set, ConsolidateAfter is simply ignored
+                        Required unless replicas is set, in which case it is simply ignored.
                       pattern: ^(([0-9]+(s|m|h))+|Never)$
                       type: string
                     consolidationPolicy:
@@ -162,8 +162,6 @@ spec:
                         - WhenEmptyOrUnderutilized
                         - Balanced
                       type: string
-                  required:
-                    - consolidateAfter
                   type: object
                 limits:
                   additionalProperties:
@@ -463,6 +461,8 @@ spec:
                   rule: '!has(self.replicas) || (!has(self.limits) || size(self.limits) == 0 || (size(self.limits) == 1 && ''nodes'' in self.limits))'
                 - message: '''weight'' is not supported on static NodePools'
                   rule: '!has(self.replicas) || !has(self.weight)'
+                - message: disruption.consolidateAfter is required on dynamic NodePools
+                  rule: has(self.replicas) || has(self.disruption.consolidateAfter)
             status:
               description: NodePoolStatus defines the observed state of NodePool
               properties:

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -39,6 +39,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="has(self.replicas) == has(oldSelf.replicas)",message="Cannot transition NodePool between static (replicas set) and dynamic (replicas unset) provisioning modes"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || (!has(self.limits) || size(self.limits) == 0 || (size(self.limits) == 1 && 'nodes' in self.limits))",message="only 'limits.nodes' is supported on static NodePools"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || !has(self.weight)",message="'weight' is not supported on static NodePools"
+// +kubebuilder:validation:XValidation:rule="has(self.replicas) || has(self.disruption.consolidateAfter)",message="disruption.consolidateAfter is required on dynamic NodePools"
 type NodePoolSpec struct {
 	//nolint:kubeapilinter
 	// Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
@@ -85,12 +86,12 @@ type Disruption struct {
 	// ConsolidateAfter is the duration the controller will wait
 	// before attempting to terminate nodes that are underutilized.
 	// Refer to ConsolidationPolicy for how underutilization is considered.
-	// When replicas is set, ConsolidateAfter is simply ignored
+	// Required unless replicas is set, in which case it is simply ignored.
 	// +kubebuilder:validation:Pattern=`^(([0-9]+(s|m|h))+|Never)$`
 	// +kubebuilder:validation:Type="string"
 	// +kubebuilder:validation:Schemaless
-	// +required
-	ConsolidateAfter NillableDuration `json:"consolidateAfter"`
+	// +optional
+	ConsolidateAfter NillableDuration `json:"consolidateAfter,omitempty"`
 	//nolint:kubeapilinter
 	// ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
 	// algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified.

--- a/pkg/apis/v1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1/nodepool_validation_cel_test.go
@@ -145,6 +145,14 @@ var _ = Describe("CEL/Validation", func() {
 			nodePool.Spec.Disruption.ConsolidationPolicy = ConsolidationPolicyWhenEmpty
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 		})
+		It("should fail when consolidateAfter is omitted on a dynamic NodePool", func() {
+			u := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodePool))
+			unstructured.RemoveNestedField(u, "spec", "disruption", "consolidateAfter")
+			obj := &unstructured.Unstructured{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj))
+
+			Expect(env.Client.Create(ctx, obj)).ToNot(Succeed())
+		})
 		DescribeTable("should succeed on a valid consolidationPolicy", func(value string) {
 			raw := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodePool))
 			lo.Must0(unstructured.SetNestedField(raw, value, "spec", "disruption", "consolidationPolicy"))
@@ -890,6 +898,16 @@ var _ = Describe("CEL/Validation", func() {
 				np.Spec.Template.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
 			}),
 		)
+
+		It("should succeed when consolidateAfter is omitted on a static NodePool", func() {
+			u := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodePool))
+			lo.Must0(unstructured.SetNestedField(u, int64(3), "spec", "replicas"))
+			unstructured.RemoveNestedField(u, "spec", "disruption", "consolidateAfter")
+			obj := &unstructured.Unstructured{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj))
+
+			Expect(env.Client.Create(ctx, obj)).To(Succeed())
+		})
 
 		Context("Update Scenarios", func() {
 			It("should succeed when increasing replicas in a NodePool", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
* `consolidateAfter` is marked as required, but is ignored in static NodePools. This field should be optional, and only required in dynamic nodepools

**How was this change tested?**
* unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
