### PR TITLE
chore: default consolidateAfter instead of requiring it

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -143,11 +143,12 @@ spec:
                         - message: '''schedule'' must be set with ''duration'''
                           rule: self.all(x, has(x.schedule) == has(x.duration))
                     consolidateAfter:
+                      default: 0s
                       description: |-
                         ConsolidateAfter is the duration the controller will wait
                         before attempting to terminate nodes that are underutilized.
                         Refer to ConsolidationPolicy for how underutilization is considered.
-                        When replicas is set, ConsolidateAfter is simply ignored
+                        When replicas is set, ConsolidateAfter is simply ignored.
                       pattern: ^(([0-9]+(s|m|h))+|Never)$
                       type: string
                     consolidationPolicy:
@@ -162,8 +163,6 @@ spec:
                         - WhenEmptyOrUnderutilized
                         - Balanced
                       type: string
-                  required:
-                    - consolidateAfter
                   type: object
                 limits:
                   additionalProperties:

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -143,11 +143,12 @@ spec:
                         - message: '''schedule'' must be set with ''duration'''
                           rule: self.all(x, has(x.schedule) == has(x.duration))
                     consolidateAfter:
+                      default: 0s
                       description: |-
                         ConsolidateAfter is the duration the controller will wait
                         before attempting to terminate nodes that are underutilized.
                         Refer to ConsolidationPolicy for how underutilization is considered.
-                        When replicas is set, ConsolidateAfter is simply ignored
+                        When replicas is set, ConsolidateAfter is simply ignored.
                       pattern: ^(([0-9]+(s|m|h))+|Never)$
                       type: string
                     consolidationPolicy:
@@ -162,8 +163,6 @@ spec:
                         - WhenEmptyOrUnderutilized
                         - Balanced
                       type: string
-                  required:
-                    - consolidateAfter
                   type: object
                 limits:
                   additionalProperties:

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -85,12 +85,13 @@ type Disruption struct {
 	// ConsolidateAfter is the duration the controller will wait
 	// before attempting to terminate nodes that are underutilized.
 	// Refer to ConsolidationPolicy for how underutilization is considered.
-	// When replicas is set, ConsolidateAfter is simply ignored
+	// When replicas is set, ConsolidateAfter is simply ignored.
+	// +kubebuilder:default:="0s"
 	// +kubebuilder:validation:Pattern=`^(([0-9]+(s|m|h))+|Never)$`
 	// +kubebuilder:validation:Type="string"
 	// +kubebuilder:validation:Schemaless
-	// +required
-	ConsolidateAfter NillableDuration `json:"consolidateAfter"`
+	// +optional
+	ConsolidateAfter NillableDuration `json:"consolidateAfter,omitempty"`
 	//nolint:kubeapilinter
 	// ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
 	// algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified.

--- a/pkg/apis/v1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1/nodepool_validation_cel_test.go
@@ -145,6 +145,18 @@ var _ = Describe("CEL/Validation", func() {
 			nodePool.Spec.Disruption.ConsolidationPolicy = ConsolidationPolicyWhenEmpty
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 		})
+		It("should default consolidateAfter to '0s' when omitted on a dynamic NodePool", func() {
+			u := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodePool))
+			unstructured.RemoveNestedField(u, "spec", "disruption", "consolidateAfter")
+			obj := &unstructured.Unstructured{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj))
+
+			Expect(env.Client.Create(ctx, obj)).To(Succeed())
+			value, ok, err := unstructured.NestedString(obj.Object, "spec", "disruption", "consolidateAfter")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(value).To(Equal("0s"))
+		})
 		DescribeTable("should succeed on a valid consolidationPolicy", func(value string) {
 			raw := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodePool))
 			lo.Must0(unstructured.SetNestedField(raw, value, "spec", "disruption", "consolidationPolicy"))
@@ -890,6 +902,16 @@ var _ = Describe("CEL/Validation", func() {
 				np.Spec.Template.Spec.TerminationGracePeriod = &metav1.Duration{Duration: time.Second * 300}
 			}),
 		)
+
+		It("should succeed when consolidateAfter is omitted on a static NodePool", func() {
+			u := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(nodePool))
+			lo.Must0(unstructured.SetNestedField(u, int64(3), "spec", "replicas"))
+			unstructured.RemoveNestedField(u, "spec", "disruption", "consolidateAfter")
+			obj := &unstructured.Unstructured{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj))
+
+			Expect(env.Client.Create(ctx, obj)).To(Succeed())
+		})
 
 		Context("Update Scenarios", func() {
 			It("should succeed when increasing replicas in a NodePool", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Theres a default for `consolidateAfter` when the disruption struct is not specified - https://github.com/ryan-mist/karpenter/blob/70506bda53b48a3f9d29f12280da751519556dae/pkg/apis/crds/karpenter.sh_nodepools.yaml#L73

However, there is no default when this struct is half-specified

e.g with
```
 disruption:
    consolidationPolicy: WhenEmptyOrUnderutilized
```

This PR makes it so `consolidateAfter` is not required, and adds a default to `consolidateAfter` when disruption is specified

**How was this change tested?**
* unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
