### PR TITLE
ci: tailor kube-api-linter config for CRD-based APIs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,8 +29,44 @@ linters:
         type: "module"
         description: Kube API Linter lints Kube like APIs based on API conventions and best practices.
         settings:
-          linters: {}
-          lintersConfig: {}
+          # KAL's defaults target built-in/aggregated APIs. Karpenter's APIs are
+          # CRDs, so tailor the config accordingly (see openshift/api for reference).
+          linters:
+            disable:
+              - nonpointerstructs # Intended for native types, not CRD types.
+              - statusoptional # Legacy, not currently recommended.
+          lintersConfig:
+            conditions:
+              isFirstField: Warn
+              usePatchStrategy: Ignore # Patch strategy markers are required for in-tree API types, not CRDs.
+              useProtobuf: Ignore # CRDs are not serialized with protobuf.
+            # Use Warn rather than SuggestFix so that KAL reports issues without
+            # rewriting API types when running with `issues.fix: true`.
+            optionalfields:
+              pointers:
+                # Only require pointers when needed to distinguish the zero value
+                # from an omitted field.
+                preference: WhenRequired
+                policy: Warn
+              omitempty:
+                # Optional fields should be omitted from the serialized output
+                # unless they are non-zero.
+                policy: Warn
+              omitzero:
+                # Require omitzero on optional struct fields so they can be omitted
+                # correctly without needing pointers to structs.
+                policy: Warn
+            requiredfields:
+              pointers:
+                # Require pointers on required fields only when the zero value is a
+                # valid user choice with a semantic difference from being omitted.
+                policy: Warn
+              omitempty:
+                # Require omitempty on required fields so that not setting a value
+                # behaves the same between structured and unstructured clients.
+                policy: Warn
+              omitzero:
+                policy: Warn
     gocyclo:
       min-complexity: 11
     goheader:
@@ -81,6 +117,13 @@ linters:
       - path-except: pkg/apis/
         linters:
           - kubeapilinter
+      # These types are copied from the upstream cluster-autoscaler CapacityBuffer
+      # API and are kept in sync with upstream, so don't enforce field conventions
+      # that would change their Go types.
+      - path: pkg/apis/autoscaling/v1beta1/capacitybuffer\.go
+        linters:
+          - kubeapilinter
+        text: optionalfields
     paths:
       - tools
       - website
@@ -92,8 +135,6 @@ linters:
       - examples$
 issues:
   fix: true
-  fix-by-linter:
-    - kubeapilinter: false
 formatters:
   enable:
     - goimports


### PR DESCRIPTION
Fixes #3226

**Description**

Follow-up to #2618. As @JoelSpeed pointed out in https://github.com/kubernetes-sigs/karpenter/pull/2618#discussion_r3759217215, kube-api-linter's default configuration is tailored to APIs implemented as built-in or aggregated APIs, while Karpenter's APIs (`NodePool`, `NodeClaim`, ...) are CRDs. This PR fills in the previously empty `linters: {}` / `lintersConfig: {}` with a CRD-appropriate configuration, using the [openshift/api config](https://github.com/openshift/api/blob/master/.golangci.yaml) as a reference.

Reading through the change:

1. **`lintersConfig.conditions`** — `useProtobuf` and `usePatchStrategy` are set to `Ignore`. Their defaults (`SuggestFix`) would suggest adding protobuf tags and patch strategy markers to `Conditions` fields; the KAL docs note these are required for in-tree API types but not for CRDs.
2. **`linters.disable`** — `nonpointerstructs` (its docs state it is not intended for CRD types; `optionalfields`/`requiredfields` cover CRDs instead) and `statusoptional` (legacy, no longer recommended).
3. **`lintersConfig.optionalfields` / `requiredfields`** — pointer preference `WhenRequired` (pointers only where the zero value must be distinguished from omission, rather than the default `Always`) plus `omitempty`/`omitzero` enforcement, in line with current CRD guidance.
4. **Policies use `Warn` instead of `SuggestFix`** — #2618 added `issues.fix-by-linter` intending to keep KAL from auto-rewriting API types under `issues.fix: true`. That option doesn't actually exist in golangci-lint (`golangci-lint config verify` rejects it as an invalid property, and it is silently ignored at runtime), so this PR removes it and expresses the same intent through KAL's per-check `policy: Warn` knobs.
5. **Exclusion for `pkg/apis/autoscaling/v1beta1/capacitybuffer.go`** — these types are copied verbatim from the upstream cluster-autoscaler CapacityBuffer API ("Keep in sync with upstream as needed"), so `optionalfields` findings that would change their Go types (e.g. `*LocalObjectRef` → `LocalObjectRef` + `omitzero`) are excluded there, mirroring how openshift/api handles its copied provider types.

Deliberately out of scope (tracked in #3226): enabling CRD-relevant opt-in linters (`nobools`, `nomaps`, `maxlength`, `statussubresource`, ...) and revisiting the existing `//nolint:kubeapilinter` directives — those are better evaluated incrementally based on how many new findings they surface.

Note: KAL upstream is working on automatically applying CRD-appropriate defaults, so parts of this config may become unnecessary once that lands.

**How was this change tested?**

- `golangci-lint config verify` now passes (it fails on `main` due to the invalid `fix-by-linter` property).
- `go tool -modfile=go.tools.mod golangci-lint-kube-api-linter run` → `0 issues.` with no files modified.
- Verified the capacitybuffer exclusion is doing real work: running with the exclusion removed reports exactly 3 `optionalfields` findings in `capacitybuffer.go` (and with the previous `SuggestFix` defaults, `issues.fix: true` rewrote the field types — confirming the `Warn` policies are load-bearing too).

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
