### PR TITLE
POC prefer m/r/x types if new pods have high memory requests

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -62,6 +62,7 @@ import (
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodepoolutils "sigs.k8s.io/karpenter/pkg/utils/nodepool"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+	"sigs.k8s.io/karpenter/pkg/utils/resources"
 )
 
 // LaunchOptions are the set of options that can be used to trigger certain
@@ -162,10 +163,75 @@ func (p *Provisioner) Reconcile(ctx context.Context) (result reconciler.Result, 
 	if len(results.NewNodeClaims) == 0 {
 		return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
 	}
+	p.forceMemoryTypesForMemoryPods(ctx, results.NewNodeClaims)
 	if _, err = p.CreateNodeClaims(ctx, results.NewNodeClaims, WithReason(metrics.ProvisionedReason), RecordPodNomination); err != nil {
 		return reconciler.Result{}, err
 	}
 	return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
+}
+
+// instance-type families ordered from most to least memory per cpu, with the requested memory:cpu ratio
+// (GB:core) at which their extra cost outweighs the cpu the next cheaper family would waste.
+// Break-even numbers are derived from on-demand us-east-1 pricing of the .xlarge sizes (Aug 2026):
+//
+//	c7g  4 vcpu /  8 GiB @ $0.1450/hr =>  2:1, $0.03625/vcpu-hr
+//	m7g  4 vcpu / 16 GiB @ $0.1632/hr =>  4:1, $0.04080/vcpu-hr
+//	r7g  4 vcpu / 32 GiB @ $0.2142/hr =>  8:1, $0.05355/vcpu-hr
+//	x8g  4 vcpu / 64 GiB @ $0.3908/hr => 16:1, $0.09770/vcpu-hr
+//
+// Note there is no x7g family, so x8g (Graviton4) is the memory heavy tier even though c/m/r are gen7 (Graviton3).
+var memoryHeavyFamilies = []struct {
+	prefix   string
+	minRatio float64
+}{
+	// break-even vs r7g: (0.0977/0.05355) * 8 =~ 14.6
+	{prefix: "x", minRatio: 14.6},
+	// break-even vs m7g: (0.05355/0.0408) * 4 =~ 5.25
+	{prefix: "r", minRatio: 5.25},
+	// break-even vs c7g: (0.0408/0.03625) * 2 =~ 2.25
+	{prefix: "m", minRatio: 2.25},
+}
+
+func (p *Provisioner) forceMemoryTypesForMemoryPods(ctx context.Context, nodeClaims []*scheduler.NodeClaim) {
+	for _, nc := range nodeClaims {
+		ratio, ok := memoryToCPURatio(nc.Pods)
+		if !ok {
+			continue
+		}
+		for _, family := range memoryHeavyFamilies {
+			// forcing makes sense ?
+			if ratio < family.minRatio {
+				continue
+			}
+
+			// forcing is possible and needed ?
+			matching, others := lo.FilterReject(nc.InstanceTypeOptions, func(it *cloudprovider.InstanceType, _ int) bool {
+				return strings.HasPrefix(it.Name, family.prefix)
+			})
+			if len(matching) == 0 || len(others) == 0 {
+				continue
+			}
+
+			// force!
+			log.FromContext(ctx).WithValues("ratio", ratio, "family", family.prefix).
+				V(1).Info("forcing instance-types with more memory per cpu because of high memory ratio")
+			nc.InstanceTypeOptions = matching
+			break
+		}
+	}
+}
+
+// memoryToCPURatio returns the requested memory (GB) per cpu (core), false when nothing requests cpu
+func memoryToCPURatio(pods []*corev1.Pod) (float64, bool) {
+	requests := resources.RequestsForPods(pods...)
+	requestedMemory := requests[corev1.ResourceMemory]
+	requestedCPU := requests[corev1.ResourceCPU]
+	if requestedCPU.IsZero() {
+		return 0, false
+	}
+	memoryGB := float64(requestedMemory.Value()) / (1024 * 1024 * 1024)
+	cpuCores := float64(requestedCPU.MilliValue()) / 1000.0
+	return memoryGB / cpuCores, true
 }
 
 // CreateNodeClaims launches nodes passed into the function in parallel. It returns a slice of the successfully created node


### PR DESCRIPTION
## Description
our nodepools ended up always spinning up m or c types (cheapest) since the pendings pods were never big enough to require r types (we run 8xl as the smallest ~30 cpus) so we ended up with lots of c/m-s but the actual pod requests were very memory heavy so we had to wait for consolidation which lead to more pod interruptions
(also tried changing batching settings, but even 1m/5m did not help)

## How was this change tested?
updated the nodepool and saw that we get a good mix of m and r on the first try now

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.