### PR TITLE
feat: support DRA admin access in the device allocator

### DIFF
--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -160,6 +160,12 @@ func (c *Controller) reconcileClaim(ctx context.Context, nn types.NamespacedName
 	contributions := make(map[cloudprovider.DeviceID]DeviceContribution, len(claim.Status.Allocation.Devices.Results))
 	for i := range claim.Status.Allocation.Devices.Results {
 		result := &claim.Status.Allocation.Devices.Results[i]
+		// Admin-access allocations bind for privileged monitoring only; they don't consume
+		// the device and must not mark it allocated, so other claims (and Karpenter's
+		// scheduling simulation) still treat it as available (KEP-5018).
+		if lo.FromPtr(result.AdminAccess) {
+			continue
+		}
 		deviceID := cloudprovider.DeviceID{
 			Driver: unique.Make(result.Driver),
 			Pool:   unique.Make(result.Pool),

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,6 +137,15 @@ func deviceResult(device string) resourcev1.DeviceRequestAllocationResult {
 		Pool:    "pool-a",
 		Device:  device,
 	}
+}
+
+// deviceResultAdmin builds an allocation result marked adminAccess, which binds for monitoring only
+// and must not be tracked as consuming the device (KEP-5018).
+func deviceResultAdmin(device string) resourcev1.DeviceRequestAllocationResult {
+	r := deviceResult(device)
+	adminAccess := true
+	r.AdminAccess = &adminAccess
+	return r
 }
 
 // deviceID constructs a cloudprovider.DeviceID using interned handles, matching the controller's representation.
@@ -260,6 +270,41 @@ var _ = Describe("DeviceAllocation Controller", func() {
 
 			_, err := controller.AllocatedDevices(cancelCtx)
 			Expect(err).To(Equal(context.Canceled))
+		})
+	})
+
+	Describe("Admin access (KEP-5018)", func() {
+		BeforeEach(func() {
+			// The apiserver rejects adminAccess allocations unless the namespace carries the label.
+			ns := &corev1.Namespace{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: "default"}, ns)).To(Succeed())
+			if ns.Labels == nil {
+				ns.Labels = map[string]string{}
+			}
+			ns.Labels["resource.kubernetes.io/admin-access"] = "true"
+			Expect(env.Client.Update(ctx, ns)).To(Succeed())
+			triggerHydration()
+		})
+		It("does not track a device allocated only for admin access", func() {
+			claim := resourceClaim("admin-claim", deviceResultAdmin("device-0"))
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(collectDevices(seq)).To(BeEmpty())
+		})
+		It("tracks non-admin devices while ignoring admin-access results in the same claim", func() {
+			claim := resourceClaim("mixed-claim",
+				deviceResult("device-0"),
+				deviceResultAdmin("device-1"),
+			)
+			ExpectApplied(ctx, env.Client, claim)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(collectDevices(seq)).To(Equal(expectedDevices(deviceID("device-0"))))
 		})
 	})
 

--- a/pkg/controllers/provisioning/dra_test.go
+++ b/pkg/controllers/provisioning/dra_test.go
@@ -674,6 +674,66 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 		})
 	})
 
+	Context("Admin access against existing nodes (Y)", func() {
+		// The apiserver rejects adminAccess claims unless the namespace carries the allowlist label.
+		BeforeEach(func() {
+			ns := &corev1.Namespace{}
+			Expect(env.Client.Get(ctx, client.ObjectKey{Name: "default"}, ns)).To(Succeed())
+			if ns.Labels == nil {
+				ns.Labels = map[string]string{}
+			}
+			ns.Labels["resource.kubernetes.io/admin-access"] = "true"
+			Expect(env.Client.Update(ctx, ns)).To(Succeed())
+		})
+
+		// heldDeviceNode creates an initialized gpu-it node publishing one in-cluster device that is already held by a
+		// live pod, so the device is tracked as allocated. Returns the node.
+		heldDeviceNode := func() *corev1.Node {
+			GinkgoHelper()
+			node := existingNode("gpu-it", true, corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("4Gi"), corev1.ResourcePods: resource.MustParse("10"),
+			})
+			ExpectApplied(ctx, env.Client, nodeLocalSlice(node, gpuDriver, "incluster-gpu-0"))
+			livePod := test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Name: "live-pod"}})
+			ExpectApplied(ctx, env.Client, livePod)
+			ExpectApplied(ctx, env.Client, allocatedClusterWideClaim("held-claim",
+				test.NodeLocalPoolName(gpuDriver, node.Name), gpuDriver, "incluster-gpu-0", podConsumer(livePod)))
+			return node
+		}
+
+		It("should bind an admin-access claim to a held device on an existing node without launching a new node (Y1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			node := heldDeviceNode()
+
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("admin-claim", test.AdminExactDeviceRequest("req", "gpu", 1)))
+			pod := draPod("gpu", "admin-claim")
+			provisionDRA(pod)
+
+			// Admin access binds to the already-held in-cluster device, so the pod fits the existing node and no new
+			// NodeClaim is provisioned — the core ask of the issue.
+			scheduled := ExpectScheduled(ctx, env.Client, pod)
+			Expect(scheduled.Name).To(Equal(node.Name))
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+
+		It("should launch a new node for a normal claim when the existing node's only device is held (Y2)", func() {
+			// Same setup as Y1 but with a normal (non-admin) claim: the held device is unavailable, so Karpenter must
+			// provision a new node. This is the contrast that proves admin access changed the outcome.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			node := heldDeviceNode()
+
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("normal-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+			pod := draPod("gpu", "normal-claim")
+			provisionDRA(pod)
+
+			scheduled := ExpectScheduled(ctx, env.Client, pod)
+			Expect(scheduled.Name).ToNot(Equal(node.Name))
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		})
+	})
+
 	Context("Topology propagation from node-local devices (D)", func() {
 		It("should tighten a new NodeClaim to the zone of a zoned in-cluster device (D1)", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}

--- a/pkg/scheduling/dynamicresources/allocator.go
+++ b/pkg/scheduling/dynamicresources/allocator.go
@@ -560,6 +560,9 @@ type deviceAllocationMetadata struct {
 	deviceWithID     DeviceWithID
 	consumedCapacity map[resourcev1.QualifiedName]resource.Quantity
 	requestName      RequestName
+	// adminAccess marks an allocation that binds for privileged monitoring without
+	// consuming the device (KEP-5018). Excluded from the committed device set.
+	adminAccess bool
 }
 
 // allocate runs a per-instance-type DFS over in-cluster and template devices.
@@ -633,10 +636,14 @@ func (a *allocator) allocate(instanceTypes []InstanceTypeID) (*AllocationResult,
 			a.allocatingCapacity = nil
 			a.templateAllocatingCapacity = nil
 
-			deviceIDsByIT[itID] = make([]DeviceID, len(a.allocatedDevicesMetadata))
+			deviceIDsByIT[itID] = make([]DeviceID, 0, len(a.allocatedDevicesMetadata))
 			itReqs := scheduling.NewRequirements()
-			for di, da := range a.allocatedDevicesMetadata {
-				deviceIDsByIT[itID][di] = da.deviceWithID.ID
+			for _, da := range a.allocatedDevicesMetadata {
+				// Admin-access devices are part of the solution but don't consume the device,
+				// so they're excluded from the set the tracker commits as allocated (KEP-5018).
+				if !da.adminAccess {
+					deviceIDsByIT[itID] = append(deviceIDsByIT[itID], da.deviceWithID.ID)
+				}
 				meta := claimAllocMeta[da.claimIndex]
 				// Update the contributed requirements for the device, each devices contributed requirements are intersected to
 				// find the contributed requirements for the instance type.
@@ -853,15 +860,22 @@ func (a *allocator) tryDevice(
 	deviceID := dw.ID
 
 	// 1. Availability check — multi-alloc devices use capacity as the gatekeeper;
-	//    exclusive devices use binary allocation tracking.
+	//    exclusive devices use binary allocation tracking. Admin-access requests bypass
+	//    both: they may bind to already-allocated devices and don't consume capacity
+	//    (KEP-5018). The in-DFS dedupe still applies so a request gets distinct devices.
 	var consumed map[resourcev1.QualifiedName]resource.Quantity
-	if dw.AllowMultipleAllocations {
+	switch {
+	case rd.AdminAccess:
+		if a.allocatedDevices.Has(deviceID) {
+			return false
+		}
+	case dw.AllowMultipleAllocations:
 		var ok bool
 		consumed, ok = a.checkCapacity(dw.Device, deviceID, rd)
 		if !ok {
 			return false
 		}
-	} else {
+	default:
 		if a.allocationTracker.IsAllocated(deviceID, a.nodeClaim, a.itID) {
 			return false
 		}
@@ -870,8 +884,9 @@ func (a *allocator) tryDevice(
 		}
 	}
 
-	// 2. Counter verification — check shared counter budgets.
-	if len(dw.ConsumesCounters) > 0 {
+	// 2. Counter verification — check shared counter budgets. Admin-access requests
+	//    ignore resource allocations, so counters are neither checked nor consumed.
+	if !rd.AdminAccess && len(dw.ConsumesCounters) > 0 {
 		poolKey := PoolKey{Driver: deviceID.Driver, Pool: deviceID.Pool}
 		var remainingCounterSets map[string]map[string]resourcev1.Counter
 		if deviceID.Template {
@@ -943,17 +958,22 @@ func (a *allocator) tryDevice(
 		deviceWithID:     dw,
 		consumedCapacity: consumed,
 		requestName:      rd.Name,
+		adminAccess:      rd.AdminAccess,
 	})
-	if dw.AllowMultipleAllocations {
-		// Ensures a multi-allocatable device has a allocating capacity map, even if it has no capacity dimensions.
-		// This is needed so that Commit() can identify multi-alloc devices via capacityConsumptionByIT presence.
-		allocatingCapacityMap := lo.Ternary(deviceID.Template, a.templateAllocatingCapacity, a.allocatingCapacity)
-		if allocatingCapacityMap[deviceID] == nil {
-			allocatingCapacityMap[deviceID] = make(map[resourcev1.QualifiedName]resource.Quantity)
+	// Admin-access allocations don't consume the device, so skip all capacity/counter
+	// bookkeeping (KEP-5018).
+	if !rd.AdminAccess {
+		if dw.AllowMultipleAllocations {
+			// Ensures a multi-allocatable device has a allocating capacity map, even if it has no capacity dimensions.
+			// This is needed so that Commit() can identify multi-alloc devices via capacityConsumptionByIT presence.
+			allocatingCapacityMap := lo.Ternary(deviceID.Template, a.templateAllocatingCapacity, a.allocatingCapacity)
+			if allocatingCapacityMap[deviceID] == nil {
+				allocatingCapacityMap[deviceID] = make(map[resourcev1.QualifiedName]resource.Quantity)
+			}
 		}
+		a.deductAllocatingCapacity(consumed, deviceID, deviceID.Template)
+		a.deductAllocatingCounters(dw.Device, PoolKey{Driver: deviceID.Driver, Pool: deviceID.Pool}, deviceID.Template)
 	}
-	a.deductAllocatingCapacity(consumed, deviceID, deviceID.Template)
-	a.deductAllocatingCounters(dw.Device, PoolKey{Driver: deviceID.Driver, Pool: deviceID.Pool}, deviceID.Template)
 
 	// Recurse.
 	if a.dfs(claimIdx, reqIdx, subReqIdx, slotIdx+1) {
@@ -962,8 +982,10 @@ func (a *allocator) tryDevice(
 
 	// Backtrack — undo in reverse order of application: capacity, counters, allocation, then
 	// requirements/pools, then constraints.
-	a.restoreAllocatingCapacity(consumed, deviceID, deviceID.Template)
-	a.restoreAllocatingCounters(dw.Device, PoolKey{Driver: deviceID.Driver, Pool: deviceID.Pool}, deviceID.Template)
+	if !rd.AdminAccess {
+		a.restoreAllocatingCapacity(consumed, deviceID, deviceID.Template)
+		a.restoreAllocatingCounters(dw.Device, PoolKey{Driver: deviceID.Driver, Pool: deviceID.Pool}, deviceID.Template)
+	}
 	a.allocatedDevicesMetadata = a.allocatedDevicesMetadata[:len(a.allocatedDevicesMetadata)-1]
 	a.allocatedDevices.Delete(deviceID)
 

--- a/pkg/scheduling/dynamicresources/allocator_test.go
+++ b/pkg/scheduling/dynamicresources/allocator_test.go
@@ -205,6 +205,13 @@ func exactRequest(name, className string, count int64) resourcev1.DeviceRequest 
 	}
 }
 
+//nolint:unparam
+func exactAdminRequest(name, className string, count int64) resourcev1.DeviceRequest {
+	req := exactRequest(name, className, count)
+	req.Exactly.AdminAccess = lo.ToPtr(true)
+	return req
+}
+
 func exactRequestWithSelector(name, className string, count int64, expr string) resourcev1.DeviceRequest {
 	return resourcev1.DeviceRequest{
 		Name: name,
@@ -2822,6 +2829,191 @@ var _ = Describe("Allocator", func() {
 			claim2 := makeClaim("c2", exactRequest("req-1", "gpu", 2))
 			_, err = alloc.Allocate(ctx, ncB, []*resourcev1.ResourceClaim{claim2})
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Admin access (KEP-5018)", func() {
+		var inClusterSlices []dynamicresources.ResourceSlice
+
+		BeforeEach(func() {
+			inClusterSlices = []dynamicresources.ResourceSlice{
+				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
+					withGeneration(1, 1), withAPIDevices("gpu-0")),
+			}
+		})
+
+		It("should bind an admin-access request to an already-allocated device", func() {
+			// The single device is preallocated on the API server. A normal request would fail,
+			// but an admin-access request must still bind to it.
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
+				ExclusiveDevices: sets.New(deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID),
+			}, nil, env.Client, nil)
+
+			nc := makeNodeClaim("it-1")
+			normal := makeClaim("c-normal", exactRequest("req-1", "gpu", 1))
+			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{normal})
+			Expect(err).To(HaveOccurred())
+
+			admin := makeClaim("c-admin", exactAdminRequest("req-1", "gpu", 1))
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{admin})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+		})
+
+		It("should not consume the device, leaving it available for a normal claim after commit", func() {
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
+				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
+			}, nil, env.Client, nil)
+
+			// An admin-access allocation is committed for one NodeClaim.
+			ncA := makeNodeClaimWithID("nc-a", "it-1")
+			admin := makeClaim("c-admin", exactAdminRequest("req-1", "gpu", 1))
+			resultA, err := alloc.Allocate(ctx, ncA, []*resourcev1.ResourceClaim{admin})
+			Expect(err).ToNot(HaveOccurred())
+			resultA.Allocation.Commit(ctx)
+
+			// A different NodeClaim's normal claim must still be able to allocate the same device,
+			// since admin access didn't consume it.
+			ncB := makeNodeClaimWithID("nc-b", "it-1")
+			normal := makeClaim("c-normal", exactRequest("req-1", "gpu", 1))
+			resultB, err := alloc.Allocate(ctx, ncB, []*resourcev1.ResourceClaim{normal})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resultB).ToNot(BeNil())
+		})
+
+		It("should bind to a device allocated inflight by another NodeClaim in the same loop", func() {
+			// Distinct from the preallocated case: the device becomes allocated via Commit,
+			// exercising the IsAllocated (inflight) path that admin access must also bypass.
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
+				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
+			}, nil, env.Client, nil)
+
+			ncA := makeNodeClaimWithID("nc-a", "it-1")
+			normal := makeClaim("c-normal", exactRequest("req-1", "gpu", 1))
+			resultA, err := alloc.Allocate(ctx, ncA, []*resourcev1.ResourceClaim{normal})
+			Expect(err).ToNot(HaveOccurred())
+			resultA.Allocation.Commit(ctx)
+
+			ncB := makeNodeClaimWithID("nc-b", "it-1")
+			admin := makeClaim("c-admin", exactAdminRequest("req-1", "gpu", 1))
+			resultB, err := alloc.Allocate(ctx, ncB, []*resourcev1.ResourceClaim{admin})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resultB).ToNot(BeNil())
+		})
+
+		It("should still require distinct devices for a multi-count admin request", func() {
+			// Only one physical device exists; the in-DFS dedupe must still prevent an admin
+			// request from satisfying count=2 by reusing the same device.
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
+				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
+			}, nil, env.Client, nil)
+
+			nc := makeNodeClaim("it-1")
+			admin := makeClaim("c-admin", exactAdminRequest("req-1", "gpu", 2))
+			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{admin})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should still enforce selectors for an admin request", func() {
+			// Admin access bypasses allocation state, not device matching: a selector that
+			// matches no device must still fail.
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
+				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
+			}, nil, env.Client, nil)
+
+			nc := makeNodeClaim("it-1")
+			req := exactRequestWithSelector("req-1", "gpu", 1, `device.driver == "nonexistent.example.com"`)
+			req.Exactly.AdminAccess = lo.ToPtr(true)
+			admin := makeClaim("c-admin", req)
+			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{admin})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should ignore exhausted counter budgets for an admin request", func() {
+			// Budget fits one device; a normal count=2 request fails but an admin one succeeds.
+			counterSlices := []dynamicresources.ResourceSlice{
+				makeAPISlice("s-counters", "gpu.example.com", "pool-a",
+					withSharedCounters(counterSet("gpu-slices", map[string]resource.Quantity{
+						"memory": resource.MustParse("40Gi"),
+					})),
+					withGeneration(1, 2),
+				),
+				makeAPISlice("s-devices", "gpu.example.com", "pool-a", withAllNodes(),
+					withGeneration(1, 2),
+					withDevicesConsumingCounters(
+						deviceConsumingCounter("gpu-0", "gpu-slices", map[string]resource.Quantity{"memory": resource.MustParse("40Gi")}),
+						deviceConsumingCounter("gpu-1", "gpu-slices", map[string]resource.Quantity{"memory": resource.MustParse("40Gi")}),
+					),
+				),
+			}
+			alloc = dynamicresources.NewAllocator(counterSlices, dynamicresources.AllocatedDeviceState{
+				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
+			}, nil, env.Client, nil)
+			nc := makeNodeClaim("it-1")
+
+			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{makeClaim("c-normal", exactRequest("req-1", "gpu", 2))})
+			Expect(err).To(HaveOccurred())
+
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{makeClaim("c-admin", exactAdminRequest("req-1", "gpu", 2))})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+		})
+
+		It("should ignore exhausted multi-alloc capacity for an admin request", func() {
+			multiAllocSlices := []dynamicresources.ResourceSlice{
+				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
+					withGeneration(1, 1),
+					func(s *resourcev1.ResourceSlice) {
+						s.Spec.Devices = append(s.Spec.Devices, resourcev1.Device{
+							Name:                     "gpu-0",
+							AllowMultipleAllocations: ptr.To(true),
+							Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+								"gpu.example.com/vram": {Value: resource.MustParse("80Gi")},
+							},
+						})
+					},
+				),
+			}
+			// gpu-0 has only 10Gi free; a normal 16Gi request fails, an admin one ignores capacity.
+			alloc = dynamicresources.NewAllocator(multiAllocSlices, dynamicresources.AllocatedDeviceState{
+				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
+				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
+					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {
+						"gpu.example.com/vram": resource.MustParse("70Gi"),
+					},
+				},
+			}, nil, env.Client, nil)
+			nc := makeNodeClaim("it-1")
+			capReq := map[resourcev1.QualifiedName]resource.Quantity{"gpu.example.com/vram": resource.MustParse("16Gi")}
+
+			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{makeClaim("c-normal", exactRequestWithCapacity("req-1", "gpu", 1, capReq))})
+			Expect(err).To(HaveOccurred())
+
+			adminReq := exactRequestWithCapacity("req-1", "gpu", 1, capReq)
+			adminReq.Exactly.AdminAccess = lo.ToPtr(true)
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{makeClaim("c-admin", adminReq)})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+		})
+
+		It("should allocate a claim mixing a normal and an admin request", func() {
+			twoDeviceSlices := []dynamicresources.ResourceSlice{
+				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
+					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1")),
+			}
+			// gpu-0 is already allocated: the normal request must take gpu-1, while the admin
+			// request may bind the allocated gpu-0.
+			alloc = dynamicresources.NewAllocator(twoDeviceSlices, dynamicresources.AllocatedDeviceState{
+				ExclusiveDevices: sets.New(deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID),
+			}, nil, env.Client, nil)
+			nc := makeNodeClaim("it-1")
+			claim := makeClaim("c-mixed",
+				exactRequest("req-normal", "gpu", 1),
+				exactAdminRequest("req-admin", "gpu", 1),
+			)
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
 		})
 	})
 

--- a/pkg/scheduling/dynamicresources/request.go
+++ b/pkg/scheduling/dynamicresources/request.go
@@ -39,6 +39,7 @@ type deviceRequestAccessor interface {
 	AllocationMode() resourcev1.DeviceAllocationMode
 	Count() int64
 	Capacity() *resourcev1.CapacityRequirements
+	AdminAccess() bool
 }
 
 type exactRequestAccessor struct {
@@ -60,6 +61,9 @@ func (a exactRequestAccessor) Count() int64 {
 func (a exactRequestAccessor) Capacity() *resourcev1.CapacityRequirements {
 	return a.req.Capacity
 }
+func (a exactRequestAccessor) AdminAccess() bool {
+	return lo.FromPtr(a.req.AdminAccess)
+}
 
 type subRequestAccessor struct {
 	sub *resourcev1.DeviceSubRequest
@@ -79,6 +83,12 @@ func (a subRequestAccessor) Count() int64 {
 }
 func (a subRequestAccessor) Capacity() *resourcev1.CapacityRequirements {
 	return a.sub.Capacity
+}
+
+// AdminAccess is always false for FirstAvailable sub-requests: the DRA API only
+// exposes adminAccess on top-level (Exactly) requests.
+func (a subRequestAccessor) AdminAccess() bool {
+	return false
 }
 
 // RequestData holds the parsed and validated metadata for a single device request.
@@ -113,6 +123,10 @@ type RequestData struct {
 	// CapacityRequests contains the per-dimension capacity requirements from
 	// ExactDeviceRequest.Capacity.Requests. nil when no capacity is requested.
 	CapacityRequests map[resourcev1.QualifiedName]resource.Quantity
+	// AdminAccess indicates the request is for privileged administrative access
+	// (KEP-5018). Admin-access requests may bind to already-allocated devices and
+	// don't consume the device. Only set for Exactly requests.
+	AdminAccess bool
 }
 
 // ClaimData holds the parsed constraints and requests for a single ResourceClaim.
@@ -344,6 +358,7 @@ func buildRequestData(
 		Selectors:      selectors,
 		NumDevices:     int(req.Count()),
 		AllocationMode: resourcev1.DeviceAllocationModeExactCount,
+		AdminAccess:    req.AdminAccess(),
 	}
 
 	if req.Capacity() != nil {

--- a/pkg/test/dra.go
+++ b/pkg/test/dra.go
@@ -123,6 +123,15 @@ func ExactDeviceRequestWithCapacity(name, className string, count int64, capacit
 	return req
 }
 
+// AdminExactDeviceRequest builds an ExactCount DeviceRequest with adminAccess enabled (KEP-5018). Admin-access
+// requests may bind to already-allocated devices and do not consume them. The containing namespace must carry the
+// resource.kubernetes.io/admin-access label or the apiserver rejects the claim.
+func AdminExactDeviceRequest(name, className string, count int64) resourcev1.DeviceRequest {
+	req := ExactDeviceRequest(name, className, count)
+	req.Exactly.AdminAccess = lo.ToPtr(true)
+	return req
+}
+
 // AllDeviceRequest builds a DeviceRequest in "All" allocation mode for the given class.
 func AllDeviceRequest(name, className string) resourcev1.DeviceRequest {
 	return resourcev1.DeviceRequest{


### PR DESCRIPTION
Fixes #3230

**Description**

Admin-access `ResourceClaim` requests (KEP-5018) can bind to devices that are already allocated and do not consume them. This wires that behavior into the device allocator:

- Admin-access requests treat already-allocated devices as eligible placement options, instead of skipping them.
- Admin-access allocations no longer count as consuming a device, so other claims can still use it.
- Existing admin-access allocations read from the cluster are ignored the same way.

As a result, Karpenter does not provision extra nodes for admin-access pods that fit hardware already in use.

**How was this change tested?**

- Allocator unit tests: bind to allocated devices, ignore counters and capacity, and keep device distinctness and selector matching.
- deviceallocation controller unit tests: skip admin-access results.
- Provisioning integration tests: an admin-access pod binds to a held device on an existing node with no new `NodeClaim`, while an equivalent normal claim launches one.
- `go test ./pkg/scheduling/dynamicresources/... ./pkg/controllers/dynamicresources/... ./pkg/controllers/provisioning/...` on envtest 1.35. Pre-existing Consumable Capacity failures are unrelated; they need the `DRAConsumableCapacity` apiserver feature gate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
