### PR TITLE
chore(controllers): standardize Name() to a string literal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,22 @@ A file for [guiding coding agents](https://agents.md/).
 - KWOK reference provider (local dev): `kwok/`
 - E2E suites: `test/suites/`
 
+## Controllers
+
+- Every controller (a type implementing `controller.Controller`, i.e. with a
+  `Register(ctx, manager) error` method and registered in
+  `pkg/controllers/controllers.go`) exposes its name via:
+
+  ```go
+  func (c *Controller) Name() string { return "<literal>" }
+  ```
+
+  Use a plain string literal — not a `Sprintf`, a concatenation, or a struct
+  field. The literal must match the name passed to `.Named(...)` during
+  registration. Controller names are used only for the `controller` dimension
+  on metrics and for logging, so a literal is sufficient and keeps the full set
+  of names scrapeable directly from source.
+
 ## Issue and PR Guidelines
 
 - Never create an issue.

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -117,6 +117,10 @@ func NewController(kubeClient client.Client) *Controller {
 	}
 }
 
+func (c *Controller) Name() string {
+	return "dynamicresources.deviceallocation"
+}
+
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	c.Hydrate(ctx)
 


### PR DESCRIPTION


<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add the missing Name() method to the dynamicresources/deviceallocation controller so every controller exposes its name as a plain string literal, matching the name it registers with via .Named(). Document the convention in AGENTS.md.

Controller names feed only the metrics controller dimension and logging, so a literal is sufficient and keeps the full set of names scrapeable from source.

**How was this change tested?**

make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
