### PR TITLE
fix:  add nodepool label to cloud provider errors

### DIFF
--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -98,13 +98,14 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: "cloudprovider",
 			Name:      "errors_total",
-			Help:      "Total number of errors returned from CloudProvider calls.",
+			Help:      "Total number of errors returned from CloudProvider calls. Labeled by the controller, method name, provider, error type, and owning NodePool when available.",
 		},
 		[]opmetrics.Label{
 			metrics.Controller,
 			Method,
 			Provider,
 			Error,
+			metrics.NodePool,
 		},
 	)
 )
@@ -126,10 +127,11 @@ func Decorate(cloudProvider cloudprovider.CloudProvider) cloudprovider.CloudProv
 
 func (d *decorator) Create(ctx context.Context, nodeClaim *v1.NodeClaim) (*v1.NodeClaim, error) {
 	method := "Create"
+	nodePoolName := nodePoolNameForNodeClaim(nodeClaim)
 	defer metrics.Measure(MethodDuration, getLabelsMapForDuration(ctx, d, method))()
 	nodeClaim, err := d.CloudProvider.Create(ctx, nodeClaim)
 	if err != nil {
-		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, err))
+		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, nodePoolName, err))
 	}
 	return nodeClaim, err
 }
@@ -139,7 +141,7 @@ func (d *decorator) Delete(ctx context.Context, nodeClaim *v1.NodeClaim) error {
 	defer metrics.Measure(MethodDuration, getLabelsMapForDuration(ctx, d, method))()
 	err := d.CloudProvider.Delete(ctx, nodeClaim)
 	if err != nil {
-		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, err))
+		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, nodePoolNameForNodeClaim(nodeClaim), err))
 	}
 	return err
 }
@@ -149,7 +151,7 @@ func (d *decorator) Get(ctx context.Context, id string) (*v1.NodeClaim, error) {
 	defer metrics.Measure(MethodDuration, getLabelsMapForDuration(ctx, d, method))()
 	nodeClaim, err := d.CloudProvider.Get(ctx, id)
 	if err != nil {
-		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, err))
+		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, "", err))
 	}
 	return nodeClaim, err
 }
@@ -159,7 +161,7 @@ func (d *decorator) List(ctx context.Context) ([]*v1.NodeClaim, error) {
 	defer metrics.Measure(MethodDuration, getLabelsMapForDuration(ctx, d, method))()
 	nodeClaims, err := d.CloudProvider.List(ctx)
 	if err != nil {
-		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, err))
+		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, "", err))
 	}
 	return nodeClaims, err
 }
@@ -169,7 +171,7 @@ func (d *decorator) GetInstanceTypes(ctx context.Context, nodePool *v1.NodePool)
 	defer metrics.Measure(MethodDuration, getLabelsMapForDuration(ctx, d, method))()
 	instanceType, err := d.CloudProvider.GetInstanceTypes(ctx, nodePool)
 	if err != nil {
-		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, err))
+		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, nodePoolNameForNodePool(nodePool), err))
 	}
 	return instanceType, err
 }
@@ -179,7 +181,7 @@ func (d *decorator) IsDrifted(ctx context.Context, nodeClaim *v1.NodeClaim) (clo
 	defer metrics.Measure(MethodDuration, getLabelsMapForDuration(ctx, d, method))()
 	isDrifted, err := d.CloudProvider.IsDrifted(ctx, nodeClaim)
 	if err != nil {
-		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, err))
+		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, nodePoolNameForNodeClaim(nodeClaim), err))
 	}
 	return isDrifted, err
 }
@@ -194,19 +196,32 @@ func getLabelsMapForDuration(ctx context.Context, d *decorator, method string) m
 	}
 }
 
-// getLabelsMapForError is a convenience func that constructs a map[string]string
-// for a prometheus Label map used to compose a counter metric spec
-func getLabelsMapForError(ctx context.Context, d *decorator, method string, err error) map[string]string {
+// getLabelsMapForError builds labels for CloudProvider error metrics.
+func getLabelsMapForError(ctx context.Context, d *decorator, method, nodePoolName string, err error) map[string]string {
 	return map[string]string{
 		metrics.ControllerLabel: injection.GetControllerName(ctx),
 		metricLabelMethod:       method,
 		metricLabelProvider:     d.Name(),
 		metricLabelError:        GetErrorTypeLabelValue(err),
+		metrics.NodePoolLabel:    nodePoolName,
 	}
 }
 
-// GetErrorTypeLabelValue is a convenience func that returns
-// a string representation of well-known CloudProvider error types
+func nodePoolNameForNodeClaim(nodeClaim *v1.NodeClaim) string {
+	if nodeClaim == nil {
+		return ""
+	}
+	return nodeClaim.Labels[v1.NodePoolLabelKey]
+}
+
+func nodePoolNameForNodePool(nodePool *v1.NodePool) string {
+	if nodePool == nil {
+		return ""
+	}
+	return nodePool.Name
+}
+
+// GetErrorTypeLabelValue returns the label for a known CloudProvider error.
 func GetErrorTypeLabelValue(err error) string {
 	switch {
 	case cloudprovider.IsInsufficientCapacityError(err):

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -151,7 +151,7 @@ func (d *decorator) Get(ctx context.Context, id string) (*v1.NodeClaim, error) {
 	defer metrics.Measure(MethodDuration, getLabelsMapForDuration(ctx, d, method))()
 	nodeClaim, err := d.CloudProvider.Get(ctx, id)
 	if err != nil {
-		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, "", err))
+		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, nodePoolNameForNodeClaim(nodeClaim), err))
 	}
 	return nodeClaim, err
 }
@@ -161,6 +161,7 @@ func (d *decorator) List(ctx context.Context) ([]*v1.NodeClaim, error) {
 	defer metrics.Measure(MethodDuration, getLabelsMapForDuration(ctx, d, method))()
 	nodeClaims, err := d.CloudProvider.List(ctx)
 	if err != nil {
+		// List can cover multiple NodePools, so there is no single NodePool to label.
 		ErrorsTotal.Inc(getLabelsMapForError(ctx, d, method, "", err))
 	}
 	return nodeClaims, err

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -204,7 +204,7 @@ func getLabelsMapForError(ctx context.Context, d *decorator, method, nodePoolNam
 		metricLabelMethod:       method,
 		metricLabelProvider:     d.Name(),
 		metricLabelError:        GetErrorTypeLabelValue(err),
-		metrics.NodePoolLabel:    nodePoolName,
+		metrics.NodePoolLabel:   nodePoolName,
 	}
 }
 

--- a/pkg/cloudprovider/metrics/cloudprovider_internal_test.go
+++ b/pkg/cloudprovider/metrics/cloudprovider_internal_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	dto "github.com/prometheus/client_model/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+)
+
+var _ = Describe("CloudProvider error metric labels", func() {
+	BeforeEach(func() {
+		ErrorsTotal.Reset()
+	})
+	AfterEach(func() {
+		ErrorsTotal.Reset()
+	})
+
+	It("should expose the NodePool label", func() {
+		ctx := injection.WithControllerName(context.Background(), "provisioner")
+		providerErr := cloudprovider.NewInsufficientCapacityError(errors.New("not enough capacity"))
+		decorated := Decorate(&erroringCloudProvider{createErr: providerErr})
+		_, err := decorated.Create(ctx, &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{v1.NodePoolLabelKey: "default"},
+		}})
+		Expect(err).To(MatchError(providerErr))
+
+		metricFamilies, err := crmetrics.Registry.Gather()
+		Expect(err).ToNot(HaveOccurred())
+		metricFamily := findMetricFamily(metricFamilies, "karpenter_cloudprovider_errors_total")
+		Expect(metricFamily).ToNot(BeNil())
+		Expect(metricFamily.Metric).To(HaveLen(1))
+		Expect(metricFamily.Metric[0].GetCounter().GetValue()).To(Equal(float64(1)))
+		Expect(metricLabels(metricFamily.Metric[0])).To(Equal(map[string]string{
+			"controller": "provisioner",
+			"error":      "InsufficientCapacityError",
+			"method":     "Create",
+			"nodepool":   "default",
+			"provider":   "fake",
+		}))
+	})
+
+	It("should derive the NodePool from available CloudProvider arguments", func() {
+		Expect(nodePoolNameForNodeClaim(&v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{v1.NodePoolLabelKey: "nodeclaim-pool"},
+		}})).To(Equal("nodeclaim-pool"))
+		Expect(nodePoolNameForNodePool(&v1.NodePool{ObjectMeta: metav1.ObjectMeta{Name: "nodepool-argument"}})).To(Equal("nodepool-argument"))
+		Expect(nodePoolNameForNodeClaim(nil)).To(BeEmpty())
+		Expect(nodePoolNameForNodePool(nil)).To(BeEmpty())
+	})
+})
+
+type erroringCloudProvider struct {
+	cloudprovider.CloudProvider
+	createErr error
+}
+
+func (erroringCloudProvider) Name() string {
+	return "fake"
+}
+
+func (e erroringCloudProvider) Create(context.Context, *v1.NodeClaim) (*v1.NodeClaim, error) {
+	return nil, e.createErr
+}
+
+func findMetricFamily(metricFamilies []*dto.MetricFamily, name string) *dto.MetricFamily {
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() == name {
+			return metricFamily
+		}
+	}
+	return nil
+}
+
+func metricLabels(metric *dto.Metric) map[string]string {
+	labels := map[string]string{}
+	for _, label := range metric.Label {
+		labels[label.GetName()] = label.GetValue()
+	}
+	return labels
+}

--- a/pkg/cloudprovider/metrics/cloudprovider_internal_test.go
+++ b/pkg/cloudprovider/metrics/cloudprovider_internal_test.go
@@ -63,6 +63,32 @@ var _ = Describe("CloudProvider error metric labels", func() {
 		}))
 	})
 
+	It("should expose the NodePool returned with a Get error", func() {
+		ctx := injection.WithControllerName(context.Background(), "nodeclaim-lifecycle")
+		providerErr := errors.New("get failed")
+		decorated := Decorate(&erroringCloudProvider{
+			getNodeClaim: &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1.NodePoolLabelKey: "default"},
+			}},
+			getErr: providerErr,
+		})
+		_, err := decorated.Get(ctx, "nodeclaim-id")
+		Expect(err).To(MatchError(providerErr))
+
+		metricFamilies, err := crmetrics.Registry.Gather()
+		Expect(err).ToNot(HaveOccurred())
+		metricFamily := findMetricFamily(metricFamilies, "karpenter_cloudprovider_errors_total")
+		Expect(metricFamily).ToNot(BeNil())
+		Expect(metricFamily.Metric).To(HaveLen(1))
+		Expect(metricLabels(metricFamily.Metric[0])).To(Equal(map[string]string{
+			"controller": "nodeclaim-lifecycle",
+			"error":      "",
+			"method":     "Get",
+			"nodepool":   "default",
+			"provider":   "fake",
+		}))
+	})
+
 	It("should derive the NodePool from available CloudProvider arguments", func() {
 		Expect(nodePoolNameForNodeClaim(&v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{v1.NodePoolLabelKey: "nodeclaim-pool"},
@@ -75,7 +101,9 @@ var _ = Describe("CloudProvider error metric labels", func() {
 
 type erroringCloudProvider struct {
 	cloudprovider.CloudProvider
-	createErr error
+	createErr    error
+	getNodeClaim *v1.NodeClaim
+	getErr       error
 }
 
 func (erroringCloudProvider) Name() string {
@@ -84,6 +112,10 @@ func (erroringCloudProvider) Name() string {
 
 func (e erroringCloudProvider) Create(context.Context, *v1.NodeClaim) (*v1.NodeClaim, error) {
 	return nil, e.createErr
+}
+
+func (e erroringCloudProvider) Get(context.Context, string) (*v1.NodeClaim, error) {
+	return e.getNodeClaim, e.getErr
 }
 
 func findMetricFamily(metricFamilies []*dto.MetricFamily, name string) *dto.MetricFamily {


### PR DESCRIPTION
Fixes #3254

**Description**

This adds the `nodepool` label to `karpenter_cloudprovider_errors_total`.

When NodePool context is available, the metric reads it from the NodeClaim or NodePool passed to the CloudProvider call. For `Get` and `List`, the label stays empty because those calls do not identify a NodePool.

The change stays in Karpenter core, so provider implementations do not need to change.

**How was this change tested?**

- `go test ./pkg/cloudprovider/metrics`
- `go test -race ./pkg/cloudprovider/metrics`
- `go vet ./pkg/cloudprovider/metrics`
- `go test ./pkg/cloudprovider/...`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.