### PR TITLE
perf: Improve `SimulateScheduling` performance by reusing `TopologyDomainGroup`s and `InstanceType`s

### DIFF
--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -156,10 +156,10 @@ func (c *consolidation) sortCandidates(_ context.Context, candidates []*Candidat
 // computeConsolidation computes a consolidation action to take
 //
 // nolint:gocyclo
-func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...*Candidate) (Command, error) {
+func (c *consolidation) computeConsolidation(ctx context.Context, schedulerFactory *provisioning.SchedulerFactory, candidates ...*Candidate) (Command, error) {
 	var err error
 	// Run scheduling simulation to compute consolidation option
-	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, c.clock, c.recorder, []pscheduling.Options{pscheduling.IsConsolidationSimulation}, candidates...)
+	results, err := SimulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, c.clock, c.recorder, schedulerFactory, candidates...)
 	if err != nil {
 		// if a candidate node is now deleting, just retry
 		if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/consolidation_dra_test.go
+++ b/pkg/controllers/disruption/consolidation_dra_test.go
@@ -71,7 +71,9 @@ var _ = Describe("Consolidation/DRA", func() {
 			Expect(err).To(Succeed())
 			return candidate
 		})
-		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, []pscheduling.Options{pscheduling.IsConsolidationSimulation}, candidates...)
+		schedulerFactory, err := disruption.NewSchedulerFactory(ctx, prov, pscheduling.IsConsolidationSimulation)
+		Expect(err).To(Succeed())
+		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, schedulerFactory, candidates...)
 		Expect(err).To(Succeed())
 		return results
 	}

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -73,6 +73,10 @@ func (d *Drift) ComputeCommands(ctx context.Context, disruptionBudgetMapping map
 	// Prioritize empty candidates since we want them to get priority over non-empty candidates if the budget is constrained.
 	// Disrupting empty candidates first also helps reduce the overall churn because if a non-empty candidate is disrupted first,
 	// the pods from that node can reschedule on the empty nodes and will need to move again when those nodes get disrupted.
+	schedulerFactory, err := NewSchedulerFactory(ctx, d.provisioner)
+	if err != nil {
+		return []Command{}, err
+	}
 	for _, candidate := range slices.Concat(emptyCandidates, nonEmptyCandidates) {
 		// If the disruption budget doesn't allow this candidate to be disrupted,
 		// continue to the next candidate. We don't need to decrement any budget
@@ -81,7 +85,7 @@ func (d *Drift) ComputeCommands(ctx context.Context, disruptionBudgetMapping map
 			continue
 		}
 		// Check if we need to create any NodeClaims.
-		results, err := SimulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, d.clock, d.recorder, nil, candidate)
+		results, err := SimulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, d.clock, d.recorder, schedulerFactory, candidate)
 		if err != nil {
 			// if a candidate is now deleting, just retry
 			if errors.Is(err, errCandidateDeleting) {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -49,9 +49,23 @@ import (
 
 var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 
+func NewSchedulerFactory(ctx context.Context, provisioner *provisioning.Provisioner, extraOpts ...scheduling.Options) (*provisioning.SchedulerFactory, error) {
+	var opts []scheduling.Options
+	if options.FromContext(ctx).PreferencePolicy == options.PreferencePolicyIgnore {
+		opts = append(opts, scheduling.IgnorePreferences)
+	}
+	opts = append(opts, scheduling.MinValuesPolicy(options.FromContext(ctx).MinValuesPolicy))
+	opts = append(opts, extraOpts...)
+	factory, err := provisioner.NewSchedulerFactory(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating scheduler factory, %w", err)
+	}
+	return factory, nil
+}
+
 //nolint:gocyclo
 func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *state.Cluster, provisioner *provisioning.Provisioner, clk clock.Clock, recorder events.Recorder,
-	schedulerOpts []scheduling.Options, candidates ...*Candidate,
+	schedulerFactory *provisioning.SchedulerFactory, candidates ...*Candidate,
 ) (scheduling.Results, error) {
 	candidateNames := sets.NewString(lo.Map(candidates, func(t *Candidate, i int) string { return t.Name() })...)
 	nodes := cluster.DeepCopyNodes()
@@ -101,21 +115,14 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	}
 	pods = append(pods, deletingNodePods...)
 
-	var opts []scheduling.Options
-	if options.FromContext(ctx).PreferencePolicy == options.PreferencePolicyIgnore {
-		opts = append(opts, scheduling.IgnorePreferences)
-	}
-	opts = append(opts, scheduling.MinValuesPolicy(options.FromContext(ctx).MinValuesPolicy))
-	opts = append(opts, schedulerOpts...)
 	// Both consolidation candidate pods and pods on already-deleting nodes are migrating off their current nodes, so
 	// the DRA allocator should treat the devices they hold as available for reallocation (and re-allocate their claims).
 	deletingPodUIDs := sets.New(lo.Map(append(candidatePods, deletingNodePods...), func(p *corev1.Pod, _ int) types.UID { return p.UID })...)
-	scheduler, err := provisioner.NewScheduler(
+	scheduler, err := schedulerFactory.NewScheduler(
 		log.IntoContext(ctx, operatorlogging.NopLogger),
 		pods,
 		stateNodes,
 		deletingPodUIDs,
-		opts...,
 	)
 	if err != nil {
 		return scheduling.Results{}, fmt.Errorf("creating scheduler, %w", err)

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	scheduler "sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
@@ -130,6 +131,10 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 	// duplicate emissions.
 	var lastRejectedCmd Command
 	var lastRejectedPerPool map[string]ScoreResult
+	schedulerFactory, err := NewSchedulerFactory(ctx, m.provisioner, pscheduling.IsConsolidationSimulation)
+	if err != nil {
+		return Command{}, nil, err
+	}
 	// Set a timeout
 	timeoutCtx, cancel := context.WithTimeout(ctx, MultiNodeConsolidationTimeoutDuration)
 	defer cancel()
@@ -138,7 +143,7 @@ func (m *MultiNodeConsolidation) firstNConsolidationOption(ctx context.Context, 
 		candidatesToConsolidate := candidates[0 : mid+1]
 
 		// Pass the timeout context to ensure sub-operations can be canceled
-		cmd, err := m.computeConsolidation(timeoutCtx, candidatesToConsolidate...)
+		cmd, err := m.computeConsolidation(timeoutCtx, schedulerFactory, candidatesToConsolidate...)
 		// context deadline exceeded will return to the top of the loop and either return nothing or the last saved command
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 )
 
 var SingleNodeConsolidationTimeoutDuration = 3 * time.Minute
@@ -64,6 +65,11 @@ func (s *SingleNodeConsolidation) ComputeCommands(ctx context.Context, disruptio
 
 	unseenNodePools := sets.New(lo.Map(candidates, func(c *Candidate, _ int) string { return c.NodePool.Name })...)
 
+	schedulerFactory, err := NewSchedulerFactory(ctx, s.provisioner, pscheduling.IsConsolidationSimulation)
+	if err != nil {
+		return []Command{}, err
+	}
+
 	for i, candidate := range candidates {
 		if s.clock.Now().After(timeout) {
 			ConsolidationTimeoutsTotal.Inc(map[string]string{ConsolidationTypeLabel: s.ConsolidationType()})
@@ -90,7 +96,7 @@ func (s *SingleNodeConsolidation) ComputeCommands(ctx context.Context, disruptio
 		}
 
 		// compute a possible consolidation option
-		cmd, err := s.computeConsolidation(ctx, candidate)
+		cmd, err := s.computeConsolidation(ctx, schedulerFactory, candidate)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "failed computing consolidation")
 			continue

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -252,7 +252,9 @@ var _ = Describe("Simulate Scheduling", func() {
 		candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, stateNode, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(Succeed())
 
-		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, nil, candidate)
+		schedulerFactory, err := disruption.NewSchedulerFactory(ctx, prov)
+		Expect(err).To(Succeed())
+		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, schedulerFactory, candidate)
 		Expect(err).To(Succeed())
 		Expect(results.PodErrors[pod]).To(BeNil())
 	})

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -299,7 +299,11 @@ func (v *validation) validateCommand(ctx context.Context, cmd Command, candidate
 	if len(candidates) == 0 {
 		return NewValidationError(fmt.Errorf("no candidates"))
 	}
-	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, v.clock, v.recorder, []scheduling.Options{scheduling.IsConsolidationSimulation}, candidates...)
+	schedulerFactory, err := NewSchedulerFactory(ctx, v.provisioner, scheduling.IsConsolidationSimulation)
+	if err != nil {
+		return err
+	}
+	results, err := SimulateScheduling(ctx, v.kubeClient, v.cluster, v.provisioner, v.clock, v.recorder, schedulerFactory, candidates...)
 	if err != nil {
 		return fmt.Errorf("simluating scheduling, %w", err)
 	}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -313,6 +313,8 @@ func (p *Provisioner) NewScheduler(
 		instanceTypes[np.Name] = its
 	}
 
+	inputs := scheduler.NewNodePoolInputs(nodePools, instanceTypes)
+
 	// Get volume topology requirements WITHOUT modifying pods.
 	// Volume requirements are passed separately and added to nodeRequirements only.
 	// Pods that fail volume topology lookup are excluded from scheduling.
@@ -330,7 +332,7 @@ func (p *Provisioner) NewScheduler(
 	scheduler.NewDefaultTopologySpreadInjector(p.kubeClient).Inject(ctx, pods)
 
 	// Calculate cluster topology, if a context error occurs, it is wrapped and returned
-	topology, err := scheduler.NewTopology(ctx, p.kubeClient, p.cluster, stateNodes, nodePools, instanceTypes, pods, opts...)
+	topology, err := scheduler.NewTopology(ctx, p.kubeClient, p.cluster, stateNodes, inputs, pods, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("tracking topology counts, %w", err)
 	}
@@ -356,7 +358,7 @@ func (p *Provisioner) NewScheduler(
 	}
 
 	// Pass volumeReqs to scheduler - added to nodeRequirements for NodeClaim zone selection
-	return scheduler.NewScheduler(ctx, p.kubeClient, nodePools, p.cluster, stateNodes, topology, instanceTypes, daemonSetPods, p.recorder, p.clock, volumeReqs, allocator, opts...), nil
+	return scheduler.NewScheduler(ctx, p.kubeClient, inputs, p.cluster, stateNodes, topology, daemonSetPods, p.recorder, p.clock, volumeReqs, allocator, opts...), nil
 }
 
 func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -261,59 +261,25 @@ func (p *Provisioner) consolidationWarnings(ctx context.Context, pods []*corev1.
 
 var ErrNodePoolsNotFound = errors.New("no nodepools found")
 
-//nolint:gocyclo
-func (p *Provisioner) NewScheduler(
-	ctx context.Context,
-	pods []*corev1.Pod,
-	stateNodes []*state.StateNode,
-	deletingPodUIDs sets.Set[types.UID],
-	opts ...scheduler.Options,
-) (*scheduler.Scheduler, error) {
-	nodePools, err := nodepoolutils.ListManaged(ctx, p.kubeClient, p.cloudProvider)
+// NewSchedulerFactory Calculates the NodePoolInputs once
+// and reuses it across all scheduling simulations within a single disruption iteration.
+type SchedulerFactory struct {
+	provisioner *Provisioner
+	inputs      *scheduler.NodePoolInputs
+	opts        []scheduler.Options
+}
+
+func (p *Provisioner) NewSchedulerFactory(ctx context.Context, opts ...scheduler.Options) (*SchedulerFactory, error) {
+	nodePools, instanceTypes, err := p.listNodePoolsAndInstanceTypes(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("listing nodepools, %w", err)
+		return nil, err
 	}
-	nodePools = lo.Filter(nodePools, func(np *v1.NodePool, _ int) bool {
-		if nodepoolutils.IsStatic(np) {
-			return false
-		}
-		if !np.StatusConditions().IsTrue(status.ConditionReady) {
-			log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Error(err, "ignoring nodepool, not ready")
-			return false
-		}
-		return np.DeletionTimestamp.IsZero()
-	})
-	if len(nodePools) == 0 {
-		return nil, ErrNodePoolsNotFound
-	}
-
-	// nodeTemplates generated from NodePools are ordered by weight
-	// since they are stored within a slice and scheduling
-	// will always attempt to schedule on the first nodeTemplate
-	nodepoolutils.OrderByWeight(nodePools)
-
-	instanceTypes := map[string][]*cloudprovider.InstanceType{}
-	for _, np := range nodePools {
-		its, err := p.cloudProvider.GetInstanceTypes(ctx, np)
-		if err != nil {
-			if cloudprovider.IsUnevaluatedNodePoolError(err) {
-				log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).V(1).Info("skipping, awaiting nodeoverlay evaluation")
-				continue
-			}
-			if errors.Is(err, context.DeadlineExceeded) {
-				return nil, fmt.Errorf("getting instance types, %w", err)
-			}
-			log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Error(err, "skipping, unable to resolve instance types")
-			continue
-		}
-		if len(its) == 0 {
-			log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Info("skipping, no resolved instance types found")
-			continue
-		}
-		instanceTypes[np.Name] = its
-	}
-
 	inputs := scheduler.NewNodePoolInputs(nodePools, instanceTypes)
+	return &SchedulerFactory{provisioner: p, inputs: inputs, opts: opts}, nil
+}
+
+func (f *SchedulerFactory) NewScheduler(ctx context.Context, pods []*corev1.Pod, stateNodes []*state.StateNode, deletingPodUIDs sets.Set[types.UID]) (*scheduler.Scheduler, error) {
+	p := f.provisioner
 
 	// Get volume topology requirements WITHOUT modifying pods.
 	// Volume requirements are passed separately and added to nodeRequirements only.
@@ -332,7 +298,7 @@ func (p *Provisioner) NewScheduler(
 	scheduler.NewDefaultTopologySpreadInjector(p.kubeClient).Inject(ctx, pods)
 
 	// Calculate cluster topology, if a context error occurs, it is wrapped and returned
-	topology, err := scheduler.NewTopology(ctx, p.kubeClient, p.cluster, stateNodes, inputs, pods, opts...)
+	topology, err := scheduler.NewTopology(ctx, p.kubeClient, p.cluster, stateNodes, f.inputs, pods, f.opts...)
 	if err != nil {
 		return nil, fmt.Errorf("tracking topology counts, %w", err)
 	}
@@ -354,11 +320,73 @@ func (p *Provisioner) NewScheduler(
 		if err != nil {
 			return nil, fmt.Errorf("gathering allocated devices, %w", err)
 		}
-		allocator = dynamicresources.NewAllocator(inClusterSlices, allocatedDevices, dynamicresources.BuildAttributeBindings(instanceTypes), p.kubeClient, deletingPodUIDs)
+		allocator = dynamicresources.NewAllocator(inClusterSlices, allocatedDevices, dynamicresources.BuildAttributeBindings(f.inputs.InstanceTypes), p.kubeClient, deletingPodUIDs)
 	}
 
 	// Pass volumeReqs to scheduler - added to nodeRequirements for NodeClaim zone selection
-	return scheduler.NewScheduler(ctx, p.kubeClient, inputs, p.cluster, stateNodes, topology, daemonSetPods, p.recorder, p.clock, volumeReqs, allocator, opts...), nil
+	return scheduler.NewScheduler(ctx, p.kubeClient, f.inputs, p.cluster, stateNodes, topology, daemonSetPods, p.recorder, p.clock, volumeReqs, allocator, f.opts...), nil
+}
+
+func (p *Provisioner) NewScheduler(
+	ctx context.Context,
+	pods []*corev1.Pod,
+	stateNodes []*state.StateNode,
+	deletingPodUIDs sets.Set[types.UID],
+	opts ...scheduler.Options,
+) (*scheduler.Scheduler, error) {
+	factory, err := p.NewSchedulerFactory(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return factory.NewScheduler(ctx, pods, stateNodes, deletingPodUIDs)
+}
+
+//nolint:gocyclo
+func (p *Provisioner) listNodePoolsAndInstanceTypes(ctx context.Context) ([]*v1.NodePool, map[string][]*cloudprovider.InstanceType, error) {
+	nodePools, err := nodepoolutils.ListManaged(ctx, p.kubeClient, p.cloudProvider)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing nodepools, %w", err)
+	}
+	nodePools = lo.Filter(nodePools, func(np *v1.NodePool, _ int) bool {
+		if nodepoolutils.IsStatic(np) {
+			return false
+		}
+		if !np.StatusConditions().IsTrue(status.ConditionReady) {
+			log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Error(err, "ignoring nodepool, not ready")
+			return false
+		}
+		return np.DeletionTimestamp.IsZero()
+	})
+	if len(nodePools) == 0 {
+		return nil, nil, ErrNodePoolsNotFound
+	}
+
+	// nodeTemplates generated from NodePools are ordered by weight
+	// since they are stored within a slice and scheduling
+	// will always attempt to schedule on the first nodeTemplate
+	nodepoolutils.OrderByWeight(nodePools)
+
+	instanceTypes := map[string][]*cloudprovider.InstanceType{}
+	for _, np := range nodePools {
+		its, err := p.cloudProvider.GetInstanceTypes(ctx, np)
+		if err != nil {
+			if cloudprovider.IsUnevaluatedNodePoolError(err) {
+				log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).V(1).Info("skipping, awaiting nodeoverlay evaluation")
+				continue
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				return nil, nil, fmt.Errorf("getting instance types, %w", err)
+			}
+			log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Error(err, "skipping, unable to resolve instance types")
+			continue
+		}
+		if len(its) == 0 {
+			log.FromContext(ctx).WithValues("NodePool", klog.KObj(np)).Info("skipping, no resolved instance types found")
+			continue
+		}
+		instanceTypes[np.Name] = its
+	}
+	return nodePools, instanceTypes, nil
 }
 
 func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -127,11 +127,10 @@ var IsConsolidationSimulation = func(opts *options) {
 func NewScheduler(
 	ctx context.Context,
 	kubeClient client.Client,
-	nodePools []*v1.NodePool,
+	inputs *NodePoolInputs,
 	cluster *state.Cluster,
 	stateNodes []*state.StateNode,
 	topology *Topology,
-	instanceTypes map[string][]*cloudprovider.InstanceType,
 	daemonSetPods []*corev1.Pod,
 	recorder events.Recorder,
 	clock clock.Clock,
@@ -144,7 +143,7 @@ func NewScheduler(
 	// if any of the nodePools add a taint with a prefer no schedule effect, we add a toleration for the taint
 	// during preference relaxation
 	toleratePreferNoSchedule := false
-	for _, np := range nodePools {
+	for _, np := range inputs.nodePools {
 		for _, taint := range np.Spec.Template.Spec.Taints {
 			if taint.Effect == corev1.TaintEffectPreferNoSchedule {
 				toleratePreferNoSchedule = true
@@ -153,10 +152,10 @@ func NewScheduler(
 	}
 	// Pre-filter instance types eligible for NodePools to reduce work done during scheduling loops for pods
 	// if no templates remain, we still want to build the scheduler so that Karpenter can ack pods which can schedule to existing and in-flight capacity
-	templates := lo.FilterMap(nodePools, func(np *v1.NodePool, _ int) (*NodeClaimTemplate, bool) {
+	templates := lo.FilterMap(inputs.nodePools, func(np *v1.NodePool, _ int) (*NodeClaimTemplate, bool) {
 		var err error
 		nct := NewNodeClaimTemplate(np)
-		nct.InstanceTypeOptions, _, err = filterInstanceTypesByRequirements(instanceTypes[np.Name], nct.Requirements, &corev1.Pod{}, corev1.ResourceList{}, []DaemonOverheadGroup{{InstanceTypes: instanceTypes[np.Name], HostPortUsage: scheduling.NewHostPortUsage()}}, corev1.ResourceList{}, minValuesPolicy == karpopts.MinValuesPolicyBestEffort)
+		nct.InstanceTypeOptions, _, err = filterInstanceTypesByRequirements(inputs.instanceTypes[np.Name], nct.Requirements, &corev1.Pod{}, corev1.ResourceList{}, []DaemonOverheadGroup{{InstanceTypes: inputs.instanceTypes[np.Name], HostPortUsage: scheduling.NewHostPortUsage()}}, corev1.ResourceList{}, minValuesPolicy == karpopts.MinValuesPolicyBestEffort)
 		if len(nct.InstanceTypeOptions) == 0 {
 			if instanceTypeFilterErr, ok := lo.ErrorsAs[InstanceTypeFilterError](err); ok && instanceTypeFilterErr.minValuesIncompatibleErr != nil {
 				recorder.Publish(NoCompatibleInstanceTypes(np, true))
@@ -180,22 +179,22 @@ func NewScheduler(
 		volumeReqsByPod:      volumeReqsByPod,          // Volume requirements per pod
 		recorder:             recorder,
 		preferences:          &Preferences{ToleratePreferNoSchedule: toleratePreferNoSchedule},
-		remainingResources: lo.SliceToMap(nodePools, func(np *v1.NodePool) (string, corev1.ResourceList) {
+		remainingResources: lo.SliceToMap(inputs.nodePools, func(np *v1.NodePool) (string, corev1.ResourceList) {
 			// The limits are copied so that scheduling never mutates the input
 			return np.Name, corev1.ResourceList(np.Spec.Limits).DeepCopy()
 		}),
 		clock:                   clock,
-		reservationManager:      NewReservationManager(instanceTypes),
+		reservationManager:      NewReservationManager(inputs.instanceTypes),
 		reservedOfferingMode:    option.Resolve(opts...).reservedOfferingMode,
 		preferencePolicy:        option.Resolve(opts...).preferencePolicy,
 		minValuesPolicy:         minValuesPolicy,
 		numConcurrentReconciles: lo.Ternary(option.Resolve(opts...).numConcurrentReconciles > 0, option.Resolve(opts...).numConcurrentReconciles, 1),
 		allocator:               allocator,
-		instanceTypes:           instanceTypes,
+		instanceTypes:           inputs.instanceTypes,
 		cachedResourceClaims:    map[types.NamespacedName]*resourcev1.ResourceClaim{},
 	}
 
-	npByName := lo.SliceToMap(nodePools, func(np *v1.NodePool) (string, *v1.NodePool) {
+	npByName := lo.SliceToMap(inputs.nodePools, func(np *v1.NodePool) (string, *v1.NodePool) {
 		return np.Name, np
 	})
 

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -181,7 +181,8 @@ func NewScheduler(
 		recorder:             recorder,
 		preferences:          &Preferences{ToleratePreferNoSchedule: toleratePreferNoSchedule},
 		remainingResources: lo.SliceToMap(nodePools, func(np *v1.NodePool) (string, corev1.ResourceList) {
-			return np.Name, corev1.ResourceList(np.Spec.Limits)
+			// The limits are copied so that scheduling never mutates the input
+			return np.Name, corev1.ResourceList(np.Spec.Limits).DeepCopy()
 		}),
 		clock:                   clock,
 		reservationManager:      NewReservationManager(instanceTypes),

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -155,7 +155,7 @@ func NewScheduler(
 	templates := lo.FilterMap(inputs.nodePools, func(np *v1.NodePool, _ int) (*NodeClaimTemplate, bool) {
 		var err error
 		nct := NewNodeClaimTemplate(np)
-		nct.InstanceTypeOptions, _, err = filterInstanceTypesByRequirements(inputs.instanceTypes[np.Name], nct.Requirements, &corev1.Pod{}, corev1.ResourceList{}, []DaemonOverheadGroup{{InstanceTypes: inputs.instanceTypes[np.Name], HostPortUsage: scheduling.NewHostPortUsage()}}, corev1.ResourceList{}, minValuesPolicy == karpopts.MinValuesPolicyBestEffort)
+		nct.InstanceTypeOptions, _, err = filterInstanceTypesByRequirements(inputs.InstanceTypes[np.Name], nct.Requirements, &corev1.Pod{}, corev1.ResourceList{}, []DaemonOverheadGroup{{InstanceTypes: inputs.InstanceTypes[np.Name], HostPortUsage: scheduling.NewHostPortUsage()}}, corev1.ResourceList{}, minValuesPolicy == karpopts.MinValuesPolicyBestEffort)
 		if len(nct.InstanceTypeOptions) == 0 {
 			if instanceTypeFilterErr, ok := lo.ErrorsAs[InstanceTypeFilterError](err); ok && instanceTypeFilterErr.minValuesIncompatibleErr != nil {
 				recorder.Publish(NoCompatibleInstanceTypes(np, true))
@@ -184,13 +184,13 @@ func NewScheduler(
 			return np.Name, corev1.ResourceList(np.Spec.Limits).DeepCopy()
 		}),
 		clock:                   clock,
-		reservationManager:      NewReservationManager(inputs.instanceTypes),
+		reservationManager:      NewReservationManager(inputs.InstanceTypes),
 		reservedOfferingMode:    option.Resolve(opts...).reservedOfferingMode,
 		preferencePolicy:        option.Resolve(opts...).preferencePolicy,
 		minValuesPolicy:         minValuesPolicy,
 		numConcurrentReconciles: lo.Ternary(option.Resolve(opts...).numConcurrentReconciles > 0, option.Resolve(opts...).numConcurrentReconciles, 1),
 		allocator:               allocator,
-		instanceTypes:           inputs.instanceTypes,
+		instanceTypes:           inputs.InstanceTypes,
 		cachedResourceClaims:    map[types.NamespacedName]*resourcev1.ResourceClaim{},
 	}
 

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -232,9 +232,10 @@ func setupScheduler(ctx context.Context, pods []*corev1.Pod, opts ...scheduling.
 	client := fakecr.NewFakeClient()
 	clock := &clock.RealClock{}
 	cluster = state.NewCluster(clock, client, cloudProvider)
-	topology, err := scheduling.NewTopology(ctx, client, cluster, nil, []*v1.NodePool{nodePool}, map[string][]*cloudprovider.InstanceType{
+	inputs := scheduling.NewNodePoolInputs([]*v1.NodePool{nodePool}, map[string][]*cloudprovider.InstanceType{
 		nodePool.Name: instanceTypes,
-	}, pods, opts...)
+	})
+	topology, err := scheduling.NewTopology(ctx, client, cluster, nil, inputs, pods, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating topology, %w", err)
 	}
@@ -242,11 +243,10 @@ func setupScheduler(ctx context.Context, pods []*corev1.Pod, opts ...scheduling.
 	return scheduling.NewScheduler(
 		ctx,
 		client,
-		[]*v1.NodePool{nodePool},
+		inputs,
 		cluster,
 		nil,
 		topology,
-		map[string][]*cloudprovider.InstanceType{nodePool.Name: instanceTypes},
 		nil,
 		events.NewRecorder(&record.FakeRecorder{}),
 		clock,

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -5492,11 +5492,11 @@ var _ = Context("Scheduling", func() {
 
 			// When IgnoreDRARequests = true (default): only appPod counts (1 CPU total)
 			ctx1 := options.ToContext(ctx, test.Options(test.OptionsFields{IgnoreDRARequests: new(true)}))
-			topology1, err := scheduling.NewTopology(ctx1, env.Client, cluster, nil, []*v1.NodePool{nodePool},
-				map[string][]*cloudprovider.InstanceType{nodePool.Name: cloudProvider.InstanceTypes}, []*corev1.Pod{appPod})
+			inputs := scheduling.NewNodePoolInputs([]*v1.NodePool{nodePool},
+				map[string][]*cloudprovider.InstanceType{nodePool.Name: cloudProvider.InstanceTypes})
+			topology1, err := scheduling.NewTopology(ctx1, env.Client, cluster, nil, inputs, []*corev1.Pod{appPod})
 			Expect(err).ToNot(HaveOccurred())
-			scheduler1 := scheduling.NewScheduler(ctx1, env.Client, []*v1.NodePool{nodePool}, cluster, nil, topology1,
-				map[string][]*cloudprovider.InstanceType{nodePool.Name: cloudProvider.InstanceTypes},
+			scheduler1 := scheduling.NewScheduler(ctx1, env.Client, inputs, cluster, nil, topology1,
 				[]*corev1.Pod{draDaemonPod}, events.NewRecorder(&record.FakeRecorder{}), env.Clock, nil, nil)
 			results1, err := scheduler1.Solve(ctx1, []*corev1.Pod{appPod})
 			Expect(err).ToNot(HaveOccurred())
@@ -5505,11 +5505,9 @@ var _ = Context("Scheduling", func() {
 
 			// When IgnoreDRARequests = false: both draDaemonPod + appPod count (3+1=4 CPU total)
 			ctx2 := options.ToContext(ctx, test.Options(test.OptionsFields{IgnoreDRARequests: new(false)}))
-			topology2, err := scheduling.NewTopology(ctx2, env.Client, cluster, nil, []*v1.NodePool{nodePool},
-				map[string][]*cloudprovider.InstanceType{nodePool.Name: cloudProvider.InstanceTypes}, []*corev1.Pod{appPod})
+			topology2, err := scheduling.NewTopology(ctx2, env.Client, cluster, nil, inputs, []*corev1.Pod{appPod})
 			Expect(err).ToNot(HaveOccurred())
-			scheduler2 := scheduling.NewScheduler(ctx2, env.Client, []*v1.NodePool{nodePool}, cluster, nil, topology2,
-				map[string][]*cloudprovider.InstanceType{nodePool.Name: cloudProvider.InstanceTypes},
+			scheduler2 := scheduling.NewScheduler(ctx2, env.Client, inputs, cluster, nil, topology2,
 				[]*corev1.Pod{draDaemonPod}, events.NewRecorder(&record.FakeRecorder{}), env.Clock, nil, nil)
 			results2, err := scheduler2.Solve(ctx2, []*corev1.Pod{appPod})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -67,14 +67,14 @@ type Topology struct {
 
 type NodePoolInputs struct {
 	nodePools     []*v1.NodePool
-	instanceTypes map[string][]*cloudprovider.InstanceType
+	InstanceTypes map[string][]*cloudprovider.InstanceType
 	domainGroups  map[string]TopologyDomainGroup
 }
 
 func NewNodePoolInputs(nodePools []*v1.NodePool, instanceTypes map[string][]*cloudprovider.InstanceType) *NodePoolInputs {
 	return &NodePoolInputs{
 		nodePools:     nodePools,
-		instanceTypes: instanceTypes,
+		InstanceTypes: instanceTypes,
 		domainGroups:  buildDomainGroups(nodePools, instanceTypes),
 	}
 }

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -65,13 +65,26 @@ type Topology struct {
 	stateNodes   []*state.StateNode
 }
 
+type NodePoolInputs struct {
+	nodePools     []*v1.NodePool
+	instanceTypes map[string][]*cloudprovider.InstanceType
+	domainGroups  map[string]TopologyDomainGroup
+}
+
+func NewNodePoolInputs(nodePools []*v1.NodePool, instanceTypes map[string][]*cloudprovider.InstanceType) *NodePoolInputs {
+	return &NodePoolInputs{
+		nodePools:     nodePools,
+		instanceTypes: instanceTypes,
+		domainGroups:  buildDomainGroups(nodePools, instanceTypes),
+	}
+}
+
 func NewTopology(
 	ctx context.Context,
 	kubeClient client.Client,
 	cluster *state.Cluster,
 	stateNodes []*state.StateNode,
-	nodePools []*v1.NodePool,
-	instanceTypes map[string][]*cloudprovider.InstanceType,
+	inputs *NodePoolInputs,
 	pods []*corev1.Pod,
 	opts ...Options,
 ) (*Topology, error) {
@@ -80,7 +93,7 @@ func NewTopology(
 		preferencePolicy:      option.Resolve(opts...).preferencePolicy,
 		cluster:               cluster,
 		stateNodes:            stateNodes,
-		domainGroups:          buildDomainGroups(nodePools, instanceTypes),
+		domainGroups:          inputs.domainGroups,
 		topologyGroups:        map[uint64]*TopologyGroup{},
 		inverseTopologyGroups: map[uint64]*TopologyGroup{},
 		excludedPods:          sets.New[string](),


### PR DESCRIPTION
**Description**

Consolidation generally performs multiple consolidation simulations per cycle. Most significantly `SingleNodeConsolidation` performs one simulation per node. In my production clusters a call to `SimulateScheduling` takes ~900ms, meaning that `SingleNodeConsolidation` needs 18 minutes to scan 1000 nodes (of course there is a timeout before that, but that's not the point).

Below is an example trace of a `SimulateScheduling` call:

<img width="2080" height="510" alt="image" src="https://github.com/user-attachments/assets/4da99dd8-1b04-4c56-936b-aad861e0877e" />

As you can see the scheduling simulation took 930ms, but very little of that computational cost belongs to the actual scheduling simulation. Most of it is the setup, which in principle could be done once and then reused across many simulations (with some challenges). In this PR I'm specifically tackling the `getInstanceTypes` (65ms) and `buildDomainGroups` (304ms) calls. The PR puts results of these two operations in a `ShedulerFactory` which then reuses the data across many `SimulateScheduling` within a single consolidation cycle.

This is an example `SimulateScheduling` trace after the change:

<img width="2087" height="435" alt="image" src="https://github.com/user-attachments/assets/84041530-1f94-4b9e-8550-8abcccfda80a" />

Both `getInstanceTypes` and `buildDomainGroups` are gone from the trace as they now happen outside of `SimulateScheduling`. The `SimulateScheduling` time is reduced from 930ms to 512ms. A 45% reduction.

I think there's more that could be done to reduce that time. But I'd prefere doing it in separate PRs rather than bloating this one.

Note on the test setup: 
I run a fork of karpenter 1.9.0 with extra tracing, metrics and other stuff. So I've done the changes and the assessment on a fork of 1.9.0, and then rebased onto `main`. I haven't seen any differences between the two versions that would meaningfully affect performance of `getInstanceTypes` or `buildDomainGroups`, which made me conclude that `main` needs these improvements as much as 1.9.0 does.

Behaviour changes:
While this PR is meant as a pure performance optimisation, it still leads to subtle behaviour changes:
* Previously `GetInstanceTypes` was called before each simulation, meaning that within a single consolidation cycle different instance types could have been used by different simulations. The call is now done once for each consolidation method so all simulation that consolidation does use the same instance types info even if it changes at the source while the consolidation cycle is in progress. I'd say that's better, but it is a potential behaviour change.
* aside from the validation delay and the `consolidateAfter`, karpenter's consolidation doesn't have an explicit pacing mechanism. Computational throughput is the effective consolidation pace regulator. Making the computation faster will make karpenter run more consolidations per unit of time under certain scenarios. This is the whole point of this change, but it may be seen as a regression in cluster stability.

**How was this change tested?**
* It passes existing unit tests
* I'm running a fork containing this change in production

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.