### PR TITLE
fix: adding dynamic resources field to nodeoverlay apply

### DIFF
--- a/pkg/controllers/nodeoverlay/store.go
+++ b/pkg/controllers/nodeoverlay/store.go
@@ -130,6 +130,7 @@ func (s *internalInstanceTypeStore) apply(nodePoolName string, it *cloudprovider
 		Requirements:           it.Requirements,           // Shared - never modified
 		Overhead:               it.Overhead,               // Shared - never modified
 		VolumeAttachmentLimits: it.VolumeAttachmentLimits, // Shared - never modified
+		DynamicResources:       it.DynamicResources,       // Shared - never modified
 		Capacity:               it.Capacity,
 	}
 

--- a/pkg/controllers/nodeoverlay/store_test.go
+++ b/pkg/controllers/nodeoverlay/store_test.go
@@ -220,6 +220,33 @@ var _ = Describe("Store Apply Correctness", func() {
 		})
 	})
 
+	Context("with DRA templates", func() {
+		It("should carry over DynamicResources when overlays are applied", func() {
+			instanceType := fake.GPUInstanceType("m5.large", 2)
+
+			store := newInternalInstanceTypeStore()
+			store.evaluatedNodePools.Insert("default")
+			store.updates = map[string]map[string]*instanceTypeUpdate{
+				"default": {
+					instanceType.Name: &instanceTypeUpdate{
+						Price: map[string]*priceUpdate{
+							instanceType.Offerings[0].Requirements.String(): {OverlayUpdate: new("+0.01"), lowestWeight: new(int32(10))},
+						},
+						Capacity: &capacityUpdate{
+							OverlayUpdate: corev1.ResourceList{
+								"hugepages-2Mi": resource.MustParse("100Mi"),
+							},
+						},
+					},
+				},
+			}
+
+			result := store.apply("default", instanceType)
+
+			Expect(result.DynamicResources).To(Equal(instanceType.DynamicResources), "expected DynamicResources to be carried over")
+		})
+	})
+
 	Context("with capacity overlay", func() {
 		It("should correctly apply capacity overlay", func() {
 			originalMemory := resource.MustParse("8Gi")


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

internalInstanceTypeStore.apply builds a new cloudprovider.InstanceType and does not copy DynamicResources, so any instance type matched by a price or capacity overlay silently loses its provider-supplied templates

was looking at node overlay x dra and found this

**How was this change tested?**

unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
