### PR TITLE
chore: improve controller error context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,10 @@ A file for [guiding coding agents](https://agents.md/).
 - Never create an issue.
 - Never create a PR.
 - Never create or reply to comments.
+
+## Error Handling
+
+- Use `serrors` everywhere, and only use standard structured keys already
+  established in the repository.
+- For Kubernetes resources, use Kind keys such as `Node`, `NodeClaim`, and
+  `NodePool` with `klog.KObj` or `klog.KRef`.

--- a/pkg/cloudprovider/overlay/cloudprovider.go
+++ b/pkg/cloudprovider/overlay/cloudprovider.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/awslabs/operatorpkg/serrors"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -43,7 +45,7 @@ func Decorate(cloudProvider cloudprovider.CloudProvider, kubeClient client.Clien
 func (d *decorator) GetInstanceTypes(ctx context.Context, nodePool *v1.NodePool) ([]*cloudprovider.InstanceType, error) {
 	its, err := d.CloudProvider.GetInstanceTypes(ctx, nodePool)
 	if err != nil {
-		return []*cloudprovider.InstanceType{}, err
+		return []*cloudprovider.InstanceType{}, serrors.Wrap(fmt.Errorf("getting cloud provider instance types, %w", err), "NodePool", klog.KObj(nodePool))
 	}
 	if options.FromContext(ctx).FeatureGates.NodeOverlay {
 		its, err = d.store.ApplyAll(nodePool.Name, its)

--- a/pkg/cloudprovider/overlay/suite_test.go
+++ b/pkg/cloudprovider/overlay/suite_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package overlay_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/overlay"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+)
+
+type erroringCloudProvider struct {
+	*fake.CloudProvider
+	err error
+}
+
+func (e *erroringCloudProvider) GetInstanceTypes(context.Context, *v1.NodePool) ([]*cloudprovider.InstanceType, error) {
+	return nil, e.err
+}
+
+func TestOverlay(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CloudProvider Overlay Suite")
+}
+
+var _ = Describe("CloudProvider Overlay", func() {
+	It("should add NodePool context to cloud provider errors", func() {
+		providerErr := errors.New("provider unavailable")
+		nodePool := &v1.NodePool{}
+		nodePool.Name = "default"
+		decorated := overlay.Decorate(&erroringCloudProvider{
+			CloudProvider: fake.NewCloudProvider(),
+			err:           providerErr,
+		}, nil, nil)
+
+		_, err := decorated.GetInstanceTypes(options.ToContext(context.Background(), &options.Options{}), nodePool)
+		Expect(err).To(MatchError(fmt.Sprintf("getting cloud provider instance types, %s (NodePool=%s)", providerErr, nodePool.Name)))
+		Expect(errors.Is(err, providerErr)).To(BeTrue())
+	})
+	It("should add empty NodePool context when the NodePool is nil", func() {
+		providerErr := errors.New("provider unavailable")
+		decorated := overlay.Decorate(&erroringCloudProvider{
+			CloudProvider: fake.NewCloudProvider(),
+			err:           providerErr,
+		}, nil, nil)
+
+		_, err := decorated.GetInstanceTypes(options.ToContext(context.Background(), &options.Options{}), nil)
+		Expect(err).To(MatchError(fmt.Sprintf("getting cloud provider instance types, %s (NodePool=)", providerErr)))
+		Expect(errors.Is(err, providerErr)).To(BeTrue())
+	})
+})

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -240,7 +240,7 @@ func filterOutSameInstanceType(replacement *Replacement, consolidate []*Candidat
 	var err error
 	replacement.NodeClaim, err = replacement.RemoveInstanceTypeOptionsByPriceAndMinValues(replacement.Requirements, maxPrice)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("filtering instance types by price, %w", err)
 	}
 	return replacement, nil
 }

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -951,7 +951,8 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s) (Node=%s)`, client.ObjectKeyFromObject(pod), node.Name)))
+		Expect(state.IsPodBlockEvictionError(err)).To(BeTrue())
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
 	It("should not consider candidates that have do-not-disrupt mirror pods scheduled", func() {
@@ -989,7 +990,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s) (Node=%s)`, client.ObjectKeyFromObject(pod), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
 	It("should not consider candidates that have do-not-disrupt daemonset pods scheduled", func() {
@@ -1028,7 +1029,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s) (Node=%s)`, client.ObjectKeyFromObject(pod), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
 	It("should consider candidates that have do-not-disrupt pods scheduled with a terminationGracePeriod set for eventual disruption", func() {
@@ -1118,7 +1119,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s) (Node=%s)`, client.ObjectKeyFromObject(pod), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
 	It("should not consider candidates that have PDB-blocked pods scheduled with a terminationGracePeriod set for graceful disruption", func() {
@@ -1154,7 +1155,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err = disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pdb prevents pod evictions (PodDisruptionBudget=[%s]) (Node=%s)`, client.ObjectKeyFromObject(budget), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget)))).To(BeTrue())
 	})
 	It("should not consider candidates that have do-not-disrupt pods scheduled without a terminationGracePeriod set for eventual disruption", func() {
@@ -1182,7 +1183,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.EventualDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s) (Node=%s)`, client.ObjectKeyFromObject(pod), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
 	It("should not consider candidates that have PDB-blocked pods scheduled without a terminationGracePeriod set for eventual disruption", func() {
@@ -1217,7 +1218,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err = disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.EventualDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pdb prevents pod evictions (PodDisruptionBudget=[%s]) (Node=%s)`, client.ObjectKeyFromObject(budget), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget)))).To(BeTrue())
 	})
 	It("should consider candidates that have do-not-disrupt terminating pods", func() {
@@ -1308,7 +1309,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(`disruption is blocked through the "karpenter.sh/do-not-disrupt" annotation`))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating node for disruption, disruption is blocked through the "karpenter.sh/do-not-disrupt" annotation (Node=%s)`, node.Name)))
 		Expect(recorder.DetectedEvent(`Disruption is blocked through the "karpenter.sh/do-not-disrupt" annotation`)).To(BeTrue())
 	})
 	It("should not consider candidates that have multiple PDBs on the same pod", func() {
@@ -1394,7 +1395,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err = disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pdb prevents pod evictions (PodDisruptionBudget=[%s]) (Node=%s)`, client.ObjectKeyFromObject(budget), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget)))).To(BeTrue())
 	})
 	It("should not consider candidates that have fully blocking PDBs on daemonset pods", func() {
@@ -1441,7 +1442,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err = disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pdb prevents pod evictions (PodDisruptionBudget=[%s]) (Node=%s)`, client.ObjectKeyFromObject(budget), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget)))).To(BeTrue())
 	})
 	It("should consider candidates that have fully blocking PDBs on mirror pods", func() {
@@ -1518,7 +1519,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err = disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s) (Node=%s)`, client.ObjectKeyFromObject(pod), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pod has "karpenter.sh/do-not-disrupt" annotation (Pod=%s)`, client.ObjectKeyFromObject(pod)))).To(BeTrue())
 	})
 	It("should not consider candidates that have fully blocking PDBs without a terminationGracePeriod set for graceful disruption", func() {
@@ -1552,7 +1553,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err = disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(fmt.Sprintf(`pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget))))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating pod disruption, pdb prevents pod evictions (PodDisruptionBudget=[%s]) (Node=%s)`, client.ObjectKeyFromObject(budget), node.Name)))
 		Expect(recorder.DetectedEvent(fmt.Sprintf(`Pdb prevents pod evictions (PodDisruptionBudget=[%s])`, client.ObjectKeyFromObject(budget)))).To(BeTrue())
 	})
 	It("should consider candidates that have fully blocking PDBs on terminal pods", func() {
@@ -1654,7 +1655,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("node isn't managed by karpenter"))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating node for disruption, node isn't managed by karpenter (Node=%s)`, node.Name)))
 	})
 	It("should not consider candidate that has just a NodeClaim representation", func() {
 		nodeClaim, _ := test.NodeClaimAndNode(v1.NodeClaim{
@@ -1673,7 +1674,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("nodeclaim does not have an associated node"))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating node for disruption, nodeclaim does not have an associated node (NodeClaim=%s)`, nodeClaim.Name)))
 	})
 	It("should not consider candidates that are nominated", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
@@ -1693,7 +1694,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("node is nominated for a pending pod"))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating node for disruption, node is nominated for a pending pod (Node=%s)`, node.Name)))
 		Expect(recorder.DetectedEvent("Node is nominated for a pending pod")).To(BeTrue())
 	})
 	It("should not consider candidates that are deleting", func() {
@@ -1716,7 +1717,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("node is deleting or marked for deletion"))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating node for disruption, node is deleting or marked for deletion (Node=%s)`, node.Name)))
 	})
 	It("should not consider candidates that are MarkedForDeletion", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
@@ -1737,7 +1738,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("node is deleting or marked for deletion"))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating node for disruption, node is deleting or marked for deletion (Node=%s)`, node.Name)))
 	})
 	It("should not consider candidates that aren't yet initialized", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
@@ -1757,7 +1758,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("node isn't initialized"))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating node for disruption, node isn't initialized (NodeClaim=%s)`, nodeClaim.Name)))
 	})
 	It("should not consider candidates that are not owned by a NodePool (no karpenter.sh/nodepool label)", func() {
 		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
@@ -1775,7 +1776,7 @@ var _ = Describe("Candidate Filtering", func() {
 		Expect(cluster.DeepCopyNodes()).To(HaveLen(1))
 		_, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, cluster.DeepCopyNodes()[0], pdbLimits, nodePoolMap, nodePoolInstanceTypeMap, queue, disruption.GracefulDisruptionClass)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(`node doesn't have required label (label=karpenter.sh/nodepool)`))
+		Expect(err.Error()).To(Equal(fmt.Sprintf(`validating node for disruption, node doesn't have required label (label=karpenter.sh/nodepool) (Node=%s)`, node.Name)))
 		Expect(recorder.DetectedEvent(`Node doesn't have required label (label=karpenter.sh/nodepool)`)).To(BeTrue())
 	})
 	It("should not consider candidates that are have a non-existent NodePool", func() {

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -172,7 +172,11 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 		if node.NodeClaim != nil {
 			recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, pretty.Sentence(err.Error()))...)
 		}
-		return nil, err
+		err = fmt.Errorf("validating node for disruption, %w", err)
+		if node.Node == nil || !node.Registered() {
+			return nil, serrors.Wrap(err, "NodeClaim", klog.KObj(node.NodeClaim))
+		}
+		return nil, serrors.Wrap(err, "Node", klog.KObj(node.Node))
 	}
 	// We know that the node will have the label key because of the node.IsDisruptable check above
 	nodePoolName := node.Labels()[v1.NodePoolLabelKey]
@@ -193,7 +197,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 		eventualDisruptionCandidate := node.NodeClaim.Spec.TerminationGracePeriod != nil && disruptionClass == EventualDisruptionClass
 		if lo.Ternary(eventualDisruptionCandidate, state.IgnorePodBlockEvictionError(err), err) != nil {
 			recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, pretty.Sentence(err.Error()))...)
-			return nil, err
+			return nil, serrors.Wrap(fmt.Errorf("validating pod disruption, %w", err), "Node", klog.KObj(node.Node))
 		}
 	}
 	reschedulable := lo.Filter(pods, func(p *corev1.Pod, _ int) bool { return pod.IsReschedulable(p) })

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -206,15 +206,15 @@ func (c *ConsolidationValidator) isValid(ctx context.Context, cmd Command, valid
 	}
 	validatedCandidates, err := c.validateCandidates(ctx, cmd.Candidates...)
 	if err != nil {
-		return err
+		return fmt.Errorf("validating candidates, %w", err)
 	}
 	if err := c.validateCommand(ctx, cmd, validatedCandidates); err != nil {
-		return err
+		return fmt.Errorf("validating command, %w", err)
 	}
 	// Revalidate candidates after validating the command. This mitigates the chance of a race condition outlined in
 	// the following GitHub issue: https://github.com/kubernetes-sigs/karpenter/issues/1167.
 	if _, err = c.validateCandidates(ctx, validatedCandidates...); err != nil {
-		return err
+		return fmt.Errorf("revalidating candidates, %w", err)
 	}
 	return nil
 }

--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/awslabs/operatorpkg/serrors"
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -96,7 +98,7 @@ func (d *Drift) isDrifted(ctx context.Context, nodePool *v1.NodePool, nodeClaim 
 		// Include instance type checking separate from the other two to reduce the amount of times we grab the instance types.
 		its, err := d.cloudProvider.GetInstanceTypes(ctx, nodePool)
 		if err != nil {
-			return "", err
+			return "", serrors.Wrap(fmt.Errorf("checking instance type drift, %w", err), "NodeClaim", klog.KObj(nodeClaim))
 		}
 		if reason := instanceTypeNotFound(its, nodeClaim); reason != "" {
 			return reason, nil
@@ -108,7 +110,7 @@ func (d *Drift) isDrifted(ctx context.Context, nodePool *v1.NodePool, nodeClaim 
 	// Then check if it's drifted from the cloud provider side.
 	driftedReason, err := d.cloudProvider.IsDrifted(ctx, nodeClaim)
 	if err != nil {
-		return "", err
+		return "", serrors.Wrap(fmt.Errorf("checking cloud provider drift, %w", err), "NodeClaim", klog.KObj(nodeClaim))
 	}
 	return driftedReason, nil
 }

--- a/pkg/controllers/nodeclaim/disruption/drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/drift_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package disruption_test
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"slices"
 	"time"
 
@@ -29,12 +32,22 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	cloudprovideroverlay "sigs.k8s.io/karpenter/pkg/cloudprovider/overlay"
 	"sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/disruption"
 	"sigs.k8s.io/karpenter/pkg/controllers/nodepool/hash"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
+
+type erroringCloudProvider struct {
+	cloudprovider.CloudProvider
+	err error
+}
+
+func (e *erroringCloudProvider) IsDrifted(context.Context, *v1.NodeClaim) (cloudprovider.DriftReason, error) {
+	return "", e.err
+}
 
 var _ = Describe("Drift", func() {
 	var nodePool *v1.NodePool
@@ -91,6 +104,38 @@ var _ = Describe("Drift", func() {
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeDrifted).IsTrue()).To(BeTrue())
+	})
+	It("should add resource context to instance type errors", func() {
+		providerErr := errors.New("provider unavailable")
+		cp.ErrorsForNodePool[nodePool.Name] = providerErr
+		controller := disruption.NewController(env.Clock, env.Client, cloudprovideroverlay.Decorate(cp, nil, nil))
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		env.Clock.Step(time.Hour * 2)
+
+		_, err := controller.Reconcile(ctx, nodeClaim)
+		Expect(err).To(MatchError(fmt.Sprintf(
+			"getting drift, checking instance type drift, getting cloud provider instance types, %s (NodePool=%s) (NodeClaim=%s)",
+			providerErr,
+			nodePool.Name,
+			nodeClaim.Name,
+		)))
+		Expect(errors.Is(err, providerErr)).To(BeTrue())
+	})
+	It("should add NodeClaim context to drift errors", func() {
+		providerErr := errors.New("provider unavailable")
+		controller := disruption.NewController(env.Clock, env.Client, &erroringCloudProvider{
+			CloudProvider: cp,
+			err:           providerErr,
+		})
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+
+		_, err := controller.Reconcile(ctx, nodeClaim)
+		Expect(err).To(MatchError(fmt.Sprintf(
+			"getting drift, checking cloud provider drift, %s (NodeClaim=%s)",
+			providerErr,
+			nodeClaim.Name,
+		)))
+		Expect(errors.Is(err, providerErr)).To(BeTrue())
 	})
 	It("should detect stale instance type drift if the instance type doesn't exist", func() {
 		cp.InstanceTypes = nil

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -18,16 +18,17 @@ package lifecycle
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/awslabs/operatorpkg/object"
+	"github.com/awslabs/operatorpkg/serrors"
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/errors"
-
-	"k8s.io/apimachinery/pkg/types"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"k8s.io/utils/clock"
@@ -118,7 +119,7 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 	if nodePoolName != "" {
 		nodePool := &v1.NodePool{}
 		if err := l.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
-			return err
+			return serrors.Wrap(fmt.Errorf("getting nodepool, %w", err), "NodePool", klog.KRef("", nodePoolName))
 		}
 		if _, found := lo.Find(nodeClaim.GetOwnerReferences(), func(o metav1.OwnerReference) bool {
 			return o.Kind == object.GVK(nodePool).Kind && o.UID == nodePool.UID
@@ -138,7 +139,7 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 			// can cause races due to the fact that it fully replaces the list on a change
 			// Here, we are updating the status condition list
 			if err := l.kubeClient.Status().Patch(ctx, nodePool, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
-				return err
+				return serrors.Wrap(fmt.Errorf("patching nodepool status, %w", err), "NodePool", klog.KObj(nodePool))
 			}
 		}
 		l.npState.Update(nodePool.UID, false)
@@ -148,7 +149,7 @@ func (l *Liveness) updateNodePoolRegistrationHealth(ctx context.Context, nodeCla
 
 func (l *Liveness) deleteNodeClaimForTimeout(ctx context.Context, timeout time.Duration, reason string, nodeClaim *v1.NodeClaim) error {
 	if err := l.kubeClient.Delete(ctx, nodeClaim); err != nil {
-		return err
+		return serrors.Wrap(fmt.Errorf("deleting nodeclaim for timeout, %w", err), "NodeClaim", klog.KObj(nodeClaim))
 	}
 	log.FromContext(ctx).V(1).WithValues("timeout", timeout, "reason", reason).Info("terminating due to timeout")
 	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{

--- a/pkg/controllers/nodeclaim/lifecycle/registration.go
+++ b/pkg/controllers/nodeclaim/lifecycle/registration.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/operatorpkg/object"
+	"github.com/awslabs/operatorpkg/serrors"
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
@@ -181,7 +182,7 @@ func (r *Registration) updateNodePoolRegistrationHealth(ctx context.Context, nod
 	if nodePoolName != "" {
 		nodePool := &v1.NodePool{}
 		if err := r.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
-			return err
+			return serrors.Wrap(fmt.Errorf("getting nodepool, %w", err), "NodePool", klog.KRef("", nodePoolName))
 		}
 		if _, found := lo.Find(nodeClaim.GetOwnerReferences(), func(o metav1.OwnerReference) bool {
 			return o.Kind == object.GVK(nodePool).Kind && o.UID == nodePool.UID
@@ -194,7 +195,7 @@ func (r *Registration) updateNodePoolRegistrationHealth(ctx context.Context, nod
 			// can cause races due to the fact that it fully replaces the list on a change
 			// Here, we are updating the status condition list
 			if err := r.kubeClient.Status().Patch(ctx, nodePool, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
-				return err
+				return serrors.Wrap(fmt.Errorf("patching nodepool status, %w", err), "NodePool", klog.KObj(nodePool))
 			}
 		}
 		r.npState.Update(nodePool.UID, true)

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -244,7 +244,7 @@ func (in *StateNode) ValidateNodeDisruptable(clk clock.Clock) error {
 func (in *StateNode) ValidatePodsDisruptable(ctx context.Context, kubeClient client.Client, pdbs pdb.Limits, clk clock.Clock, recorder events.Recorder) ([]*corev1.Pod, error) {
 	pods, err := in.Pods(ctx, kubeClient)
 	if err != nil {
-		return nil, fmt.Errorf("getting pods from node, %w", err)
+		return nil, err
 	}
 	for _, po := range pods {
 		// We only consider pods that are actively running for "karpenter.sh/do-not-disrupt"

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -114,7 +114,7 @@ func GetPods(ctx context.Context, kubeClient client.Client, nodeNames ...string)
 		}
 		var podList corev1.PodList
 		if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
-			return nil, fmt.Errorf("listing pods, %w", err)
+			return nil, serrors.Wrap(fmt.Errorf("listing pods, %w", err), "Node", klog.KRef("", nodeName))
 		}
 		for i := range podList.Items {
 			pods = append(pods, &podList.Items[i])
@@ -173,7 +173,7 @@ func GetCurrentlyReschedulablePods(ctx context.Context, kubeClient client.Client
 	nodeNames := lo.Map(nodes, func(n *corev1.Node, _ int) string { return n.Name })
 	pods, err := GetPods(ctx, kubeClient, nodeNames...)
 	if err != nil {
-		return nil, fmt.Errorf("listing pods, %w", err)
+		return nil, err
 	}
 
 	pdbs, err := pdb.NewLimits(ctx, kubeClient)

--- a/pkg/utils/node/suite_test.go
+++ b/pkg/utils/node/suite_test.go
@@ -18,12 +18,15 @@ package node_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -38,6 +41,15 @@ var (
 	ctx context.Context
 	env *test.Environment
 )
+
+type listErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c *listErrorClient) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return c.err
+}
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -93,6 +105,19 @@ var _ = Describe("NodeUtils", func() {
 		nodeClaims, err := nodeutils.GetNodeClaims(ctx, env.Client, testNode)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeClaims).To(HaveLen(0))
+	})
+	It("should add node context to pod listing errors", func() {
+		node := test.Node()
+		listErr := errors.New("api unavailable")
+		kubeClient := &listErrorClient{Client: env.Client, err: listErr}
+
+		_, err := nodeutils.GetPods(ctx, kubeClient, node.Name)
+		Expect(err).To(MatchError(fmt.Sprintf("listing pods, %s (Node=%s)", listErr, node.Name)))
+		Expect(errors.Is(err, listErr)).To(BeTrue())
+
+		_, err = nodeutils.GetCurrentlyReschedulablePods(ctx, kubeClient, env.Clock, test.NewEventRecorder(), node)
+		Expect(err).To(MatchError(fmt.Sprintf("listing pods, %s (Node=%s)", listErr, node.Name)))
+		Expect(errors.Is(err, listErr)).To(BeTrue())
 	})
 	Context("ReschedulablePods", func() {
 		It("should return no pods for an empty node name", func() {


### PR DESCRIPTION
Addresses [#2630](https://github.com/kubernetes-sigs/karpenter/issues/2630).

**Description**
Adds actionable context to controller errors while preserving error chains with `%w`.

This revives and updates the approach from [#2631](https://github.com/kubernetes-sigs/karpenter/pull/2631), incorporating its review feedback by avoiding redundant wrappers and placing shared pod-listing context at the lowest useful layer.

I’d like to do a follow up by distinguishing expected candidate rejections, such as PDB blocks, from operational errors, such as API failures while listing pods, so `GetCandidatesWithTotals` can surface actionable failures instead of silently discarding them. Left it out of scope for this change.

**How was this change tested?**
- `make verify`
- Some lcoal KWOK testing. A temporary wrapper injected an `IsDrifted` failure:
```
{"level":"ERROR","time":"2026-08-
  28T20:57:08.566Z","logger":"controller","caller":"controller/
  controller.go:494","message":"Reconciler
  error","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":
  "NodeClaim","NodeClaim":{"name":"runtime-error-demo"},"namespace":"","name":"runtime-error-
  demo","reconcileID":"77effb61-a36d-451d-b770-c63680233251","NodeClaim":{"name":"runtime-
  error-demo"},"error":"getting drift, checking cloud provider drift, injected cloud provider
  drift failure (NodeClaim=runtime-error-demo)"}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. LLMs assisted me but the contribution is mine.
