### PR TITLE
fix: use fully qualified attribute name in BuildAttributeBindings

### DIFF
--- a/pkg/cloudprovider/dynamicresources.go
+++ b/pkg/cloudprovider/dynamicresources.go
@@ -82,6 +82,9 @@ type AttributeBinding struct {
 	// Devices is the set of devices that share the attribute value. Must contain
 	// at least 2 devices; bindings with fewer are ignored.
 	Devices []DeviceID
-	// Attribute is the fully qualified attribute name that the devices share.
+	// Attribute is the attribute name that the devices share. As with ResourceSlice device
+	// attributes, a name without a domain prefix is assumed to be in the driver's domain, so
+	// a bare name is only valid when every bound device shares a driver; bindings that mix
+	// drivers under a bare name are ignored.
 	Attribute resourcev1.QualifiedName
 }

--- a/pkg/scheduling/dynamicresources/attributebindings.go
+++ b/pkg/scheduling/dynamicresources/attributebindings.go
@@ -18,6 +18,7 @@ package dynamicresources
 
 import (
 	"maps"
+	"strings"
 	"unique"
 
 	resourcev1 "k8s.io/api/resource/v1"
@@ -86,6 +87,25 @@ func (ab AttributeBindings) Bound(nodePool string, instanceType InstanceTypeID, 
 	return deviceBindings.Has(deviceB.DeviceID)
 }
 
+// canonicalAttributeName returns the fully qualified form of a binding's attribute name.
+// Claims always match on a fully qualified name, so a bare name declared by a cloud provider
+// is qualified with the bound devices' common driver. Following the same defaulting the DRA
+// API applies to bare ResourceSlice device attribute names, and the inverse of
+// LookupAttribute's fallback. Returns false when a bare name's binding spans drivers, since
+// there is no single domain to imply.
+func canonicalAttributeName(attribute resourcev1.QualifiedName, devices []cloudprovider.DeviceID) (resourcev1.QualifiedName, bool) {
+	if _, _, ok := strings.Cut(string(attribute), "/"); ok {
+		return attribute, true
+	}
+	driver := devices[0].Driver
+	for _, device := range devices[1:] {
+		if device.Driver != driver {
+			return "", false
+		}
+	}
+	return resourcev1.QualifiedName(driver.Value() + "/" + string(attribute)), true
+}
+
 // BuildAttributeBindings constructs the attribute binding graph from cloud provider instance type
 // metadata. It creates symmetric pairs for each declared binding and computes the transitive
 // closure per (attribute, nodePool, instanceType) triple.
@@ -99,10 +119,14 @@ func BuildAttributeBindings(instanceTypesByNodePool map[string][]*cloudprovider.
 				if len(itBinding.Devices) < 2 {
 					continue
 				}
-				bindingsForAttribute, ok := bindings[itBinding.Attribute]
+				attribute, ok := canonicalAttributeName(itBinding.Attribute, itBinding.Devices)
+				if !ok {
+					continue
+				}
+				bindingsForAttribute, ok := bindings[attribute]
 				if !ok {
 					bindingsForAttribute = make(map[string]map[InstanceTypeID]map[cloudprovider.DeviceID]sets.Set[cloudprovider.DeviceID])
-					bindings[itBinding.Attribute] = bindingsForAttribute
+					bindings[attribute] = bindingsForAttribute
 				}
 				bindingsForNodePool, ok := bindingsForAttribute[nodePool]
 				if !ok {

--- a/pkg/scheduling/dynamicresources/attributebindings_test.go
+++ b/pkg/scheduling/dynamicresources/attributebindings_test.go
@@ -228,6 +228,21 @@ var _ = Describe("AttributeBindings", func() {
 			Expect(ab.Bound("pool-b", it, attrZone, devB, devC)).To(BeTrue())
 			Expect(ab.Bound("pool-b", it, attrZone, devA, devB)).To(BeFalse())
 		})
+		It("qualifies a bare attribute name with the bound devices' driver", func() {
+			ab := dynamicresources.BuildAttributeBindings(map[string][]*cloudprovider.InstanceType{
+				"pool-a": {itType("gpu-xl", attrBinding("parentUUID", devA, devB))},
+			})
+			it := unique.Make("gpu-xl")
+			Expect(ab.Bound("pool-a", it, "driver.example.com/parentUUID", devA, devB)).To(BeTrue())
+			Expect(ab.HasBindings("pool-a", it, "driver.example.com/parentUUID", devA)).To(BeTrue())
+			Expect(ab.Bound("pool-a", it, "parentUUID", devA, devB)).To(BeFalse())
+		})
+		It("skips a bare attribute name when the binding spans drivers", func() {
+			ab := dynamicresources.BuildAttributeBindings(map[string][]*cloudprovider.InstanceType{
+				"pool-a": {itType("gpu-xl", attrBinding("parentUUID", devA, deviceID("other.example.com", "pool-a", "device-b")))},
+			})
+			Expect(ab).To(BeEmpty())
+		})
 		It("tracks the same attribute across multiple instance types in a pool independently", func() {
 			ab := dynamicresources.BuildAttributeBindings(map[string][]*cloudprovider.InstanceType{
 				"pool-a": {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

was looking at node overlay x dra and found that when karpenter builds attribute bindings and only the bare name is specified, it is stored without adding the driver

seems to be against what the DRA API does and the fact that claims are always matched on a fully qualified name

but unsure if it was intentional that bare names were going to be rejected as it didn't seem like there was any signaling for that

**How was this change tested?**

unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
