### PR TITLE
chore(breaking): standardize the reason metric label to lowercase values

### DIFF
--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package disruption_test
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -78,7 +79,7 @@ var _ = Describe("Drift", func() {
 	Context("Metrics", func() {
 		It("should correctly report eligible drifted nodes", func() {
 			eligibleNodesLabels := map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			}
 			pod := test.Pod(test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{
@@ -149,11 +150,11 @@ var _ = Describe("Drift", func() {
 
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 3, map[string]string{
 				metrics.NodePoolLabel: nodePool.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 			ExpectMetricGaugeValue(disruption.NodePoolNodesConsumingBudgets, 0, map[string]string{
 				metrics.NodePoolLabel: nodePool.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 		It("should disrupt 3 nodes, taking into account commands in progress", func() {
@@ -310,7 +311,7 @@ var _ = Describe("Drift", func() {
 			for _, np := range nps {
 				ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 1, map[string]string{
 					metrics.NodePoolLabel: np.Name,
-					metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+					metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 				})
 			}
 
@@ -323,16 +324,16 @@ var _ = Describe("Drift", func() {
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(20))
 			// These nodes will disrupt because of Drift instead of Emptiness because they are not marked consolidatable
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 10, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 			for _, np := range nps {
 				ExpectMetricCounterValue(disruption.NodepoolDecisionsPerformed, 1, map[string]string{
 					metrics.NodePoolLabel: np.Name,
-					metrics.ReasonLabel:   "drifted",
+					metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 				})
 				ExpectMetricGaugeValue(disruption.NodePoolNodesConsumingBudgets, 0, map[string]string{
 					metrics.NodePoolLabel: nodePool.Name,
-					metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+					metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 				})
 			}
 		})
@@ -824,7 +825,7 @@ var _ = Describe("Drift", func() {
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 			ExpectNotFound(ctx, env.Client, nodeClaim, node)
 			ExpectMetricGaugeValue(disruption.EligibleNodes, 1, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 		It("should drift empty nodes before non-empty nodes", func() {
@@ -890,10 +891,10 @@ var _ = Describe("Drift", func() {
 			ExpectExists(ctx, env.Client, node)
 			ExpectNotFound(ctx, env.Client, nodeClaim2, node2)
 			ExpectMetricGaugeValue(disruption.EligibleNodes, 2, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 1, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 		It("should delete drifted nodes when they are empty and consolidatable", func() {
@@ -914,7 +915,7 @@ var _ = Describe("Drift", func() {
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 			ExpectNotFound(ctx, env.Client, nodeClaim, node)
 			ExpectMetricGaugeValue(disruption.EligibleNodes, 1, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 		It("should untaint nodes when drift replacement fails", func() {

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -300,10 +300,10 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 		allowedDisruptions := nodePool.MustGetAllowedDisruptions(clk, numNodes[nodePool.Name], reason)
 		disruptionBudgetMapping[nodePool.Name] = lo.Max([]int{allowedDisruptions - disrupting[nodePool.Name], 0})
 		NodePoolAllowedDisruptions.Set(float64(allowedDisruptions), map[string]string{
-			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: strings.ToLower(string(reason)),
 		})
 		NodePoolNodesConsumingBudgets.Set(float64(disrupting[nodePool.Name]), map[string]string{
-			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: strings.ToLower(string(reason)),
 		})
 		if numNodes[nodePool.Name] != 0 && allowedDisruptions == 0 {
 			recorder.Publish(disruptionevents.NodePoolBlockedForDisruptionReason(nodePool, reason))

--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -165,7 +165,7 @@ func (q *Queue) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconci
 		})
 		DisruptionQueueFailuresTotal.Add(float64(len(failedLaunches)), map[string]string{
 			decisionLabel:          string(cmd.Decision()),
-			metrics.ReasonLabel:    pretty.ToSnakeCase(string(cmd.Reason())),
+			metrics.ReasonLabel:    strings.ToLower(string(cmd.Reason())),
 			ConsolidationTypeLabel: string(cmd.Decision()),
 		})
 		stateNodes := lo.Map(cmd.Candidates, func(c *Candidate, _ int) *state.StateNode { return c.StateNode })
@@ -246,7 +246,7 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 			consolidationPolicy = pretty.ToSnakeCase(string(cmd.Candidates[i].NodePool.Spec.Disruption.ConsolidationPolicy))
 		}
 		labels := map[string]string{
-			metrics.ReasonLabel:              pretty.ToSnakeCase(string(cmd.Reason())),
+			metrics.ReasonLabel:              strings.ToLower(string(cmd.Reason())),
 			metrics.NodePoolLabel:            cmd.Candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel:        cmd.Candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
 			metrics.ConsolidationPolicyLabel: consolidationPolicy,

--- a/pkg/controllers/disruption/staticdrift_test.go
+++ b/pkg/controllers/disruption/staticdrift_test.go
@@ -18,6 +18,7 @@ package disruption_test
 
 import (
 	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -115,7 +116,7 @@ var _ = Describe("StaticDrift", func() {
 			// Should only allow 2 nodes to be disrupted because of budget
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 2, map[string]string{
 				metrics.NodePoolLabel: nodePool.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 
 			// Verify StateNodePool Has been updated
@@ -137,7 +138,7 @@ var _ = Describe("StaticDrift", func() {
 
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(numNodes))
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 2, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 		It("should respect disruption budgets (Nodes Percentage) for static drift", func() {
@@ -174,7 +175,7 @@ var _ = Describe("StaticDrift", func() {
 			// Should only allow 1 nodes to be disrupted because of budget
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 1, map[string]string{
 				metrics.NodePoolLabel: nodePool.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 
 			// Verify StateNodePool Has been updated
@@ -197,7 +198,7 @@ var _ = Describe("StaticDrift", func() {
 
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(numNodes))
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 1, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 		It("should respect budgets for multiple static nodepools", func() {
@@ -309,15 +310,15 @@ var _ = Describe("StaticDrift", func() {
 
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 1, map[string]string{
 				metrics.NodePoolLabel: nodePool1.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 2, map[string]string{
 				metrics.NodePoolLabel: nodePool2.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 2, map[string]string{
 				metrics.NodePoolLabel: nodePool3.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 
 			// Verify StateNodePool Has been updated
@@ -355,7 +356,7 @@ var _ = Describe("StaticDrift", func() {
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(len(allNodes)))
 
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 5, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 	})
@@ -435,7 +436,7 @@ var _ = Describe("StaticDrift", func() {
 
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 2, map[string]string{
 				metrics.NodePoolLabel: nodePool.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 
 			// Verify StateNodePool Has been updated
@@ -457,7 +458,7 @@ var _ = Describe("StaticDrift", func() {
 
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(2))
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 2, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 		It("should drift partially when we can acquire some limits", func() {
@@ -493,7 +494,7 @@ var _ = Describe("StaticDrift", func() {
 
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 5, map[string]string{
 				metrics.NodePoolLabel: nodePool.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 
 			// Verify StateNodePool Has been updated
@@ -515,7 +516,7 @@ var _ = Describe("StaticDrift", func() {
 
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(5))
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 2, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 		It("should keep drifting partially when we can acquire some limits for each reconcile", func() {
@@ -571,7 +572,7 @@ var _ = Describe("StaticDrift", func() {
 
 				Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(5))
 				ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, float64(i+1), map[string]string{
-					metrics.ReasonLabel: "drifted",
+					metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 				})
 			}
 		})
@@ -662,7 +663,7 @@ var _ = Describe("StaticDrift", func() {
 
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(1))
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 1, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 	})
@@ -778,15 +779,15 @@ var _ = Describe("StaticDrift", func() {
 
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 2, map[string]string{
 				metrics.NodePoolLabel: nodePool1.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 2, map[string]string{
 				metrics.NodePoolLabel: nodePool2.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 			ExpectMetricGaugeValue(disruption.NodePoolAllowedDisruptions, 2, map[string]string{
 				metrics.NodePoolLabel: nodePool3.Name,
-				metrics.ReasonLabel:   string(v1.DisruptionReasonDrifted),
+				metrics.ReasonLabel:   strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 
 			// Execute commands, should drift 4 nodes total
@@ -818,7 +819,7 @@ var _ = Describe("StaticDrift", func() {
 			Expect(len(ExpectNodeClaims(ctx, env.Client))).To(Equal(len(allNodes)))
 
 			ExpectMetricCounterValue(disruption.DecisionsPerformedTotal, 4, map[string]string{
-				metrics.ReasonLabel: "drifted",
+				metrics.ReasonLabel: strings.ToLower(string(v1.DisruptionReasonDrifted)),
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

The reason dimension is emitted three different ways across disruption metrics — raw TitleCase (Underutilized) in the NodePool budget gauges, pretty.ToSnakeCase in the queue metrics, and strings.ToLower elsewhere. This unifies them all to strings.ToLower so reason has one consistent, documentable value set.

Breaking change: karpenter_nodepool_allowed_disruptions and karpenter_nodepool_nodes_consuming_budgets now emit lowercase reason values (underutilized vs Underutilized). The other emissions already lowercased their single-word values, so those are unchanged; the ToSnakeCase→ToLower swap is output-preserving for the current single-word reasons.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
