### PR TITLE
chore: add dynamic_resources dimensions on pod metrics

### DIFF
--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -54,6 +54,7 @@ const (
 	podScheduled        = "scheduled"
 	podReady            = "ready"
 	managed             = "managed"
+	podDynamicResources = "dynamic_resources"
 )
 
 // Pod metric dimensions. zone, nodepool, and capacity_type reuse the shared
@@ -68,6 +69,7 @@ var (
 	podScheduledLabel        = opmetrics.Label{Name: podScheduled, Help: "Whether the pod has been scheduled to a node.", Values: metrics.BoolValues}
 	podReadyLabel            = opmetrics.Label{Name: podReady, Help: "Whether the pod is ready.", Values: metrics.BoolValues}
 	managedLabel             = opmetrics.Label{Name: managed, Help: "Whether the pod is bound to a Karpenter-managed node.", Values: metrics.BoolValues}
+	podDynamicResourcesLabel = opmetrics.Label{Name: podDynamicResources, Help: "Whether the pod has DRA (dynamic resource allocation) requirements.", Values: metrics.BoolValues}
 	podPhaseLabel            = opmetrics.Label{
 		Name: podPhase,
 		Help: "The pod's lifecycle phase.",
@@ -122,7 +124,7 @@ var (
 			Help:      "The time from pod creation until the pod is bound.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]opmetrics.Label{},
+		[]opmetrics.Label{podDynamicResourcesLabel},
 	)
 	PodUnboundTimeSeconds = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -132,7 +134,7 @@ var (
 			Name:      "unbound_time_seconds",
 			Help:      "The time from pod creation until the pod is bound.",
 		},
-		[]opmetrics.Label{podNameLabel, podNamespaceLabel},
+		[]opmetrics.Label{podNameLabel, podNamespaceLabel, podDynamicResourcesLabel},
 	)
 	// Stage: alpha
 	PodProvisioningBoundDurationSeconds = opmetrics.NewPrometheusHistogram(
@@ -144,7 +146,7 @@ var (
 			Help:      "The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]opmetrics.Label{},
+		[]opmetrics.Label{podDynamicResourcesLabel},
 	)
 	// Stage: alpha
 	PodProvisioningUnboundTimeSeconds = opmetrics.NewPrometheusGauge(
@@ -155,7 +157,7 @@ var (
 			Name:      "provisioning_unbound_time_seconds",
 			Help:      "The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 		},
-		[]opmetrics.Label{podNameLabel, podNamespaceLabel},
+		[]opmetrics.Label{podNameLabel, podNamespaceLabel, podDynamicResourcesLabel},
 	)
 	// Stage: alpha
 	PodProvisioningStartupDurationSeconds = opmetrics.NewPrometheusHistogram(
@@ -251,11 +253,11 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			})
 			c.unscheduledPods.Delete(req.String())
 			// Delete the unbound metric since the pod is deleted
-			PodUnboundTimeSeconds.Delete(map[string]string{
+			PodUnboundTimeSeconds.DeletePartialMatch(map[string]string{
 				podName:      req.Name,
 				podNamespace: req.Namespace,
 			})
-			PodProvisioningUnboundTimeSeconds.Delete(map[string]string{
+			PodProvisioningUnboundTimeSeconds.DeletePartialMatch(map[string]string{
 				podName:      req.Name,
 				podNamespace: req.Namespace,
 			})
@@ -391,6 +393,7 @@ func (c *Controller) recordPodStartupMetric(pod *corev1.Pod, schedulableTime tim
 }
 func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.Time) {
 	key := client.ObjectKeyFromObject(pod).String()
+	dynamicResources := strconv.FormatBool(podutils.HasDRARequirements(pod))
 	cond, ok := lo.Find(pod.Status.Conditions, func(c corev1.PodCondition) bool {
 		return c.Type == corev1.PodScheduled
 	})
@@ -398,17 +401,19 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 		if !ok || cond.Status != corev1.ConditionTrue {
 			// If the podScheduled condition does not exist, or it exists and is not set to true, we emit pod_current_unbound_time_seconds metric.
 			PodUnboundTimeSeconds.Set(time.Since(pod.CreationTimestamp.Time).Seconds(), map[string]string{
-				podName:      pod.Name,
-				podNamespace: pod.Namespace,
+				podName:             pod.Name,
+				podNamespace:        pod.Namespace,
+				podDynamicResources: dynamicResources,
 			})
 			if !schedulableTime.IsZero() {
 				PodProvisioningUnboundTimeSeconds.Set(time.Since(schedulableTime).Seconds(), map[string]string{
-					podName:      pod.Name,
-					podNamespace: pod.Namespace,
+					podName:             pod.Name,
+					podNamespace:        pod.Namespace,
+					podDynamicResources: dynamicResources,
 				})
 			} else {
 				// Idempotently delete the unbound_time_seconds metric if the schedulable time is zero
-				PodProvisioningUnboundTimeSeconds.Delete(map[string]string{
+				PodProvisioningUnboundTimeSeconds.DeletePartialMatch(map[string]string{
 					podName:      pod.Name,
 					podNamespace: pod.Namespace,
 				})
@@ -419,18 +424,22 @@ func (c *Controller) recordPodBoundMetric(pod *corev1.Pod, schedulableTime time.
 	}
 	if c.unscheduledPods.Has(key) && ok && cond.Status == corev1.ConditionTrue {
 		// Delete the unbound metric since the pod is now bound
-		PodUnboundTimeSeconds.Delete(map[string]string{
+		PodUnboundTimeSeconds.DeletePartialMatch(map[string]string{
 			podName:      pod.Name,
 			podNamespace: pod.Namespace,
 		})
-		PodProvisioningUnboundTimeSeconds.Delete(map[string]string{
+		PodProvisioningUnboundTimeSeconds.DeletePartialMatch(map[string]string{
 			podName:      pod.Name,
 			podNamespace: pod.Namespace,
 		})
 
-		PodBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(pod.CreationTimestamp.Time).Seconds(), nil)
+		PodBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(pod.CreationTimestamp.Time).Seconds(), map[string]string{
+			podDynamicResources: dynamicResources,
+		})
 		if !schedulableTime.IsZero() {
-			PodProvisioningBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), nil)
+			PodProvisioningBoundDurationSeconds.Observe(cond.LastTransitionTime.Sub(schedulableTime).Seconds(), map[string]string{
+				podDynamicResources: dynamicResources,
+			})
 		}
 		c.unscheduledPods.Delete(key)
 	}

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -208,6 +208,9 @@ var _ = Describe("Pod Metrics", func() {
 	})
 	DescribeTable("should label the pod binding metrics with dynamic_resources",
 		func(pod *corev1.Pod, expected string) {
+			if expected == "true" && env.Version.Minor() < 34 {
+				Skip("DRA is only available in K8s versions >= 1.34.x")
+			}
 			pod.Status.Phase = corev1.PodPending
 
 			env.Clock.Step(1 * time.Hour)

--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -206,6 +206,47 @@ var _ = Describe("Pod Metrics", func() {
 		_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_bound_duration_seconds", map[string]string{})
 		Expect(found).To(BeTrue())
 	})
+	DescribeTable("should label the pod binding metrics with dynamic_resources",
+		func(pod *corev1.Pod, expected string) {
+			pod.Status.Phase = corev1.PodPending
+
+			env.Clock.Step(1 * time.Hour)
+			cluster.MarkPodSchedulingDecisions(ctx, map[*corev1.Pod]error{}, map[string][]*corev1.Pod{"n1": {pod}}, map[string][]*corev1.Pod{"nc1": {pod}})
+
+			// PodScheduled condition does not exist yet, so the unbound metrics are emitted labeled by dynamic_resources.
+			ExpectApplied(ctx, env.Client, pod)
+			ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(pod))
+			_, found := FindMetricWithLabelValues("karpenter_pods_unbound_time_seconds", map[string]string{
+				"name":              pod.GetName(),
+				"namespace":         pod.GetNamespace(),
+				"dynamic_resources": expected,
+			})
+			Expect(found).To(BeTrue())
+			_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_unbound_time_seconds", map[string]string{
+				"name":              pod.GetName(),
+				"namespace":         pod.GetNamespace(),
+				"dynamic_resources": expected,
+			})
+			Expect(found).To(BeTrue())
+
+			// Pod becomes scheduled and running, firing the bound duration metrics labeled by dynamic_resources.
+			pod.Status.Phase = corev1.PodRunning
+			pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodScheduled, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()}}
+			ExpectApplied(ctx, env.Client, pod)
+			ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(pod))
+			_, found = FindMetricWithLabelValues("karpenter_pods_bound_duration_seconds", map[string]string{
+				"dynamic_resources": expected,
+			})
+			Expect(found).To(BeTrue())
+			_, found = FindMetricWithLabelValues("karpenter_pods_provisioning_bound_duration_seconds", map[string]string{
+				"dynamic_resources": expected,
+			})
+			Expect(found).To(BeTrue())
+		},
+		Entry("when the pod does not request dynamic resources", test.Pod(), "false"),
+		Entry("when the pod requests dynamic resources via a pod-level resource claim",
+			test.Pod(test.PodOptions{ResourceClaims: []corev1.PodResourceClaim{test.PodResourceClaimReference("gpu", "gpu-claim")}}), "true"),
+	)
 	It("should update the pod startup and unstarted time metrics", func() {
 		p := test.Pod()
 		p.Status.Phase = corev1.PodPending


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
* adds `dynamic_resources` dimensions to pod binding and provisioning metrics

**How was this change tested?**
* unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
