### PR TITLE
docs: Update RELEASE.md to include release cadence

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,13 @@ This repository is the home for both of the above components.
 
 The versioning strategy for this project is covered in detail in [the release type section of the compatibility documentation](https://karpenter.sh/docs/upgrading/compatibility/#release-types).
 
+## Release Cadence and Compatibility
+
+- `kubernetes-sigs/karpenter` does not follow a fixed release cadence. Individual providers (e.g. `karpenter-provider-aws`) may adhere to their own release schedules.
+- Minor version releases may include small breaking changes to the interfaces consumed by providers. Providers should expect to make adjustments when adopting a new minor version.
+- Customer-facing breaking changes are the responsibility of each provider to communicate to its users through that provider's release notes and upgrade guides.
+- Discussion of upcoming changes happens in the [Karpenter Working Group](https://github.com/kubernetes-sigs/karpenter#working-group-meetings).
+
 ## Releasing a New Version
 
 The following steps must be done by one of the [Karpenter Maintainers](https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-autoscaling/teams.yaml):


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Update RELEASE.md to include release cadence and other info.

This is following a kubernetes #karpenter slack channel discussion:

```
Question:
does kubernetes-sigs/karpenter have a release cadence to adhere to like k8s does?

also about how early are breaking changes in the next y release communicated?

Answer:
Hey contributor! I believe:

1. k-sigs/karpenter adheres to no general release cadence. (though I think provider-aws adheres to some CVE patching SLO)


2. You can assume some *small* provider breaking changes between k-sigs/karpenter releases (e.g. small interface changes).

3. It is responsibility of provider to announce any customer breaking changes

Come join us at [Karpenter WG](https://github.com/kubernetes-sigs/karpenter#working-group-meetings) if you have any further questions.
```

**How was this change tested?**

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
