### PR TITLE
fix: add consolidation triggers for expired node nominations and consolidatable status changes

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -298,7 +298,7 @@ func (c *Cluster) NominateNodeForPod(ctx context.Context, providerID string) {
 	if n, ok := c.nodes[providerID]; ok {
 		n.Nominate(ctx, c.clock) // extends nomination window if already nominated
 		c.clusterStateMu.Lock()
-		if n.nominatedUntil.Time.After(c.latestNominationExpiry) {
+		if n.nominatedUntil.After(c.latestNominationExpiry) {
 			c.latestNominationExpiry = n.nominatedUntil.Time
 		}
 		c.clusterStateMu.Unlock()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -80,6 +80,10 @@ type Cluster struct {
 	// the state, interested disruption methods can check to see if this has changed to
 	// optimize and not try to disrupt if nothing about the cluster has changed.
 	clusterState time.Time
+	// Nominated nodes are excluded from disruption, but nomination expiry is a passive
+	// clock check that produces no state update. Track the latest expiry so that
+	// ConsolidationState can mark the cluster unconsolidated once it lapses.
+	latestNominationExpiry time.Time
 
 	unsyncedTimeMu      sync.Mutex
 	unsyncedStartTime   time.Time
@@ -293,6 +297,11 @@ func (c *Cluster) NominateNodeForPod(ctx context.Context, providerID string) {
 
 	if n, ok := c.nodes[providerID]; ok {
 		n.Nominate(ctx, c.clock) // extends nomination window if already nominated
+		c.clusterStateMu.Lock()
+		if n.nominatedUntil.Time.After(c.latestNominationExpiry) {
+			c.latestNominationExpiry = n.nominatedUntil.Time
+		}
+		c.clusterStateMu.Unlock()
 	}
 }
 
@@ -612,7 +621,14 @@ func (c *Cluster) MarkUnconsolidated() time.Time {
 func (c *Cluster) ConsolidationState() time.Time {
 	c.clusterStateMu.RLock()
 	state := c.clusterState
+	nominationExpiry := c.latestNominationExpiry
 	c.clusterStateMu.RUnlock()
+
+	// A nomination that expired after the last state change frees a node up for
+	// disruption, so treat the expiry as a state change.
+	if nominationExpiry.After(state) && !c.clock.Now().Before(nominationExpiry) {
+		return c.MarkUnconsolidated()
+	}
 
 	// time.Time uses a monotonic clock for these comparisons
 	if c.clock.Since(state) < time.Minute*5 {
@@ -638,6 +654,7 @@ func (c *Cluster) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.clusterState = time.Time{}
+	c.latestNominationExpiry = time.Time{}
 	c.unsyncedStartTime = time.Time{}
 	c.lastUnsyncedLogTime = time.Time{}
 	c.hasSynced.Store(false)

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -969,6 +969,10 @@ func (c *Cluster) triggerConsolidationOnChange(old, new *StateNode) {
 		c.MarkUnconsolidated()
 		return
 	}
+	if old.Consolidatable() != new.Consolidatable() {
+		c.MarkUnconsolidated()
+		return
+	}
 }
 
 // HasSynced returns whether the cluster state has been synchronized at least once.

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -356,6 +356,11 @@ func (in *StateNode) Initialized() bool {
 	return true
 }
 
+// Consolidatable reports whether the disruption controllers would treat this node as a consolidation candidate.
+func (in *StateNode) Consolidatable() bool {
+	return in.NodeClaim != nil && in.NodeClaim.StatusConditions().Get(v1.ConditionTypeConsolidatable).IsTrue()
+}
+
 func (in *StateNode) Capacity() corev1.ResourceList {
 	if !in.Initialized() && in.NodeClaim != nil {
 		// Override any zero quantity values in the node status

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1748,6 +1748,31 @@ var _ = Describe("Consolidated State", func() {
 		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
 		Expect(cluster.ConsolidationState()).ToNot(Equal(state))
 	})
+	It("should cause consolidation state to change when a NodeClaim's Consolidatable condition changes", func() {
+		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey:            nodePool.Name,
+					corev1.LabelInstanceTypeStable: cloudProvider.InstanceTypes[0].Name,
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClaim, node)
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+
+		env.Clock.Step(time.Minute)
+		state := cluster.ConsolidationState()
+
+		// An update with no relevant change shouldn't invalidate
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		Expect(cluster.ConsolidationState()).To(Equal(state))
+
+		nodeClaim.StatusConditions().SetTrue(v1.ConditionTypeConsolidatable)
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		Expect(cluster.ConsolidationState()).ToNot(Equal(state))
+	})
 })
 
 var _ = Describe("Data Races", func() {

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1773,6 +1773,32 @@ var _ = Describe("Consolidated State", func() {
 		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 		Expect(cluster.ConsolidationState()).ToNot(Equal(state))
 	})
+	It("should cause consolidation state to change when a node's nomination expires", func() {
+		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey:            nodePool.Name,
+					corev1.LabelInstanceTypeStable: cloudProvider.InstanceTypes[0].Name,
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClaim, node)
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+
+		env.Clock.Step(time.Minute)
+		state := cluster.ConsolidationState()
+
+		cluster.NominateNodeForPod(ctx, node.Spec.ProviderID)
+		Expect(cluster.ConsolidationState()).To(Equal(state))
+
+		// Nomination window is 20s; expiry should invalidate exactly once
+		env.Clock.Step(time.Second * 21)
+		Expect(ExpectStateNodeExists(cluster, node).Nominated(env.Clock)).To(BeFalse())
+		newState := cluster.ConsolidationState()
+		Expect(newState).ToNot(Equal(state))
+		Expect(cluster.ConsolidationState()).To(Equal(newState))
+	})
 })
 
 var _ = Describe("Data Races", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change introduces two new triggers for state changes that should have triggered consolidation. Before this change, the hardcoded 5 minute run would mask over missing these state changes. That behavior caused delays in consolidation actions. 

The two addition triggers are:
 - A node is marked as` Consolidatable` or not `Consolidatable`
 - A nominated node expires

Both of these triggers changes the node state such that consolidation needs to be reevaluated. 

**How was this change tested?**

- Added suite tests
- Tested on the Oxide Karpenter provider. The situation that led me to investigate was a prepared demo of consolidation. When I scaled up an inflate deployment in two batches, resulting in two nodes. I expected them to consolidate immediately since I had `consolidateAfter: 0s`. However, I observed that I was hitting the 5m reevaluation period instead of it triggering on state changes. After this change,  I observe consolidation kicking in a little bit after the second node is goes `ready`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
