### PR TITLE
chore(breaking): set the queue_failures_total consolidation_type label to the command's consolidation type instead of its decision string

### DIFF
--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -166,7 +166,7 @@ func (q *Queue) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconci
 		DisruptionQueueFailuresTotal.Add(float64(len(failedLaunches)), map[string]string{
 			decisionLabel:          string(cmd.Decision()),
 			metrics.ReasonLabel:    strings.ToLower(string(cmd.Reason())),
-			ConsolidationTypeLabel: string(cmd.Decision()),
+			ConsolidationTypeLabel: cmd.ConsolidationType(),
 		})
 		stateNodes := lo.Map(cmd.Candidates, func(c *Candidate, _ int) *state.StateNode { return c.StateNode })
 		multiErr := multierr.Combine(err, state.RequireNoScheduleTaint(ctx, q.kubeClient, false, stateNodes...))

--- a/pkg/controllers/disruption/queue_test.go
+++ b/pkg/controllers/disruption/queue_test.go
@@ -206,6 +206,43 @@ var _ = Describe("Queue", func() {
 			node1 = ExpectNodeExists(ctx, env.Client, node1.Name)
 			Expect(node1.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
 		})
+		It("should emit the consolidation type in the failures metric when a command fails", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node1}, []*v1.NodeClaim{nodeClaim1})
+			stateNode := ExpectStateNodeExistsForNodeClaim(cluster, nodeClaim1)
+
+			nct := scheduling.NewNodeClaimTemplate(nodePool)
+			nct.InstanceTypeOptions = append([]*cloudprovider.InstanceType{}, cloudProvider.InstanceTypes...)
+			replacements := []*disruption.Replacement{
+				{
+					NodeClaim: &scheduling.NodeClaim{NodeClaimTemplate: *nct},
+				},
+			}
+
+			// A single-node consolidation command's Decision() is "replace" (it has both
+			// candidates and replacements) while its ConsolidationType() is "single". The
+			// failures metric must report the consolidation type, not the decision.
+			c := disruption.MakeConsolidation(env.Clock, cluster, env.Client, prov, cloudProvider, recorder, queue)
+			cmd := &disruption.Command{
+				Method:            disruption.NewSingleNodeConsolidation(c),
+				CreationTimestamp: env.Clock.Now(),
+				ID:                uuid.New(),
+				Results:           scheduling.Results{},
+				Candidates:        []*disruption.Candidate{{StateNode: stateNode, NodePool: nodePool}},
+				Replacements:      replacements,
+			}
+			Expect(cmd.Decision()).To(Equal(disruption.ReplaceDecision))
+			Expect(cmd.ConsolidationType()).To(Equal(disruption.SingleNodeConsolidationType))
+			Expect(queue.StartCommand(ctx, cmd)).To(BeNil())
+
+			// Step the clock to trigger the timeout so the command fails.
+			env.Clock.Step(11 * time.Minute)
+			ExpectObjectReconciled(ctx, env.Client, queue, stateNode.NodeClaim)
+
+			ExpectMetricCounterValue(disruption.DisruptionQueueFailuresTotal, 1, map[string]string{
+				disruption.ConsolidationTypeLabel: disruption.SingleNodeConsolidationType,
+			})
+		})
 		It("should fully handle a command when replacements are initialized", func() {
 			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool)
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node1}, []*v1.NodeClaim{nodeClaim1})

--- a/pkg/controllers/disruption/queue_test.go
+++ b/pkg/controllers/disruption/queue_test.go
@@ -235,6 +235,9 @@ var _ = Describe("Queue", func() {
 			Expect(cmd.ConsolidationType()).To(Equal(disruption.SingleNodeConsolidationType))
 			Expect(queue.StartCommand(ctx, cmd)).To(BeNil())
 
+			// This metric isn't reset between specs, so clear it to isolate this failure.
+			disruption.DisruptionQueueFailuresTotal.Reset()
+
 			// Step the clock to trigger the timeout so the command fails.
 			env.Clock.Step(11 * time.Minute)
 			ExpectObjectReconciled(ctx, env.Client, queue, stateNode.NodeClaim)


### PR DESCRIPTION


DisruptionQueueFailuresTotal.Add set ConsolidationTypeLabel to string(cmd.Decision()), emitting decision values (replace/delete/no-op) into consolidation_type — outside the label's value set {multi,single,empty} and duplicating the adjacent decision label. Use cmd.ConsolidationType(), matching the other emitters. This changes the emitted label values for karpenter_voluntary_disruption_queue_failures_total (breaking for dashboards grouping by consolidation_type).

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
