### PR TITLE
feat(metrics): document metric dimensions with built-in help and values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,24 @@ A file for [guiding coding agents](https://agents.md/).
   on metrics and for logging, so a literal is sufficient and keeps the full set
   of names scrapeable directly from source.
 
+## Metric Labels
+
+Metric dimensions and their values are documented in code as
+`metrics.Label{Name, Help, Values}` / `metrics.Value{Name, Help}`; the provider's
+docs generator turns them into per-dimension help and value tables.
+
+- Describe every dimension with a `Label`; never pass a bare string literal as a
+  metric's label name.
+- Reuse an existing `Label` when one already fits; reference its `.Name` rather
+  than redeclaring the dimension.
+- Define a `Label` in the most generic package that fits — shared dimensions in
+  `pkg/metrics`, operator-agnostic ones upstream in operatorpkg — and only
+  co-locate it in its owning package when an import cycle prevents centralizing.
+- Enumerate a dimension's stable values as `metrics.Value`s, listing the
+  well-known ones even when the set is not exhaustive. A value's `Name` comes from
+  a const, never a magic string; a value that exists only as a metric value should
+  be a first-class `metrics.Value` var that its emission site references by `.Name`.
+
 ## Issue and PR Guidelines
 
 - Never create an issue.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.6
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/awslabs/operatorpkg v0.0.0-20260708223819-4da4c353c5fa
+	github.com/awslabs/operatorpkg v0.0.0-20260828233137-b2a3ac602e40
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/awslabs/operatorpkg v0.0.0-20260708223819-4da4c353c5fa h1:SM2D/TaMO79MaSpBvRLm2Ed/SKbGCxuckRJBDDCGUck=
-github.com/awslabs/operatorpkg v0.0.0-20260708223819-4da4c353c5fa/go.mod h1:G/D6aERpu0RWYGZC8wrAfrtEI6nWHAQIkXmTGnNn2jM=
+github.com/awslabs/operatorpkg v0.0.0-20260828233137-b2a3ac602e40 h1:yUuD77hLNH4Wh1d8L7zaBVvdNyZGo8/TkEwzHbQNwtw=
+github.com/awslabs/operatorpkg v0.0.0-20260828233137-b2a3ac602e40/go.mod h1:G/D6aERpu0RWYGZC8wrAfrtEI6nWHAQIkXmTGnNn2jM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -30,16 +30,47 @@ import (
 )
 
 const (
-	metricLabelController = "controller"
-	metricLabelMethod     = "method"
-	metricLabelProvider   = "provider"
-	metricLabelError      = "error"
+	metricLabelMethod   = "method"
+	metricLabelProvider = "provider"
+	metricLabelError    = "error"
 	// MetricLabelErrorDefaultVal is the default string value that represents "error type unknown"
 	MetricLabelErrorDefaultVal = ""
-	// Well-known metricLabelError values
-	NodeClaimNotFoundError    = "NodeClaimNotFoundError"
-	NodeClassNotReadyError    = "NodeClassNotReadyError"
-	InsufficientCapacityError = "InsufficientCapacityError"
+)
+
+// Well-known `error` dimension values. These are metric-only values, so they are
+// first-class opmetrics.Value vars: the value string and its documentation live in
+// one place and callers refer to it by .Name.
+var (
+	NodeClaimNotFoundError = opmetrics.Value{
+		Name: "NodeClaimNotFoundError",
+		Help: "The NodeClaim's backing instance was not found.",
+	}
+	NodeClassNotReadyError = opmetrics.Value{
+		Name: "NodeClassNotReadyError",
+		Help: "The referenced NodeClass is not yet ready.",
+	}
+	InsufficientCapacityError = opmetrics.Value{
+		Name: "InsufficientCapacityError",
+		Help: "The cloud provider had insufficient capacity to fulfill the request.",
+	}
+)
+
+// Package-local metric dimensions for the CloudProvider metrics. The controller
+// dimension reuses the shared metrics.Controller description.
+var (
+	Method = opmetrics.Label{
+		Name: metricLabelMethod,
+		Help: "The CloudProvider interface method that was called, e.g. `Create`, `Delete`, `Get`, `List`, `GetInstanceTypes`, `IsDrifted`.",
+	}
+	Provider = opmetrics.Label{
+		Name: metricLabelProvider,
+		Help: "The name of the cloud provider implementation.",
+	}
+	Error = opmetrics.Label{
+		Name:   metricLabelError,
+		Help:   "The category of error returned by the CloudProvider call.",
+		Values: []opmetrics.Value{NodeClaimNotFoundError, NodeClassNotReadyError, InsufficientCapacityError},
+	}
 )
 
 // decorator implements CloudProvider
@@ -53,10 +84,10 @@ var MethodDuration = opmetrics.NewPrometheusHistogram(
 		Name:      "duration_seconds",
 		Help:      "Duration of cloud provider method calls. Labeled by the controller, method name and provider.",
 	},
-	[]string{
-		metricLabelController,
-		metricLabelMethod,
-		metricLabelProvider,
+	[]opmetrics.Label{
+		metrics.Controller,
+		Method,
+		Provider,
 	},
 )
 
@@ -69,11 +100,11 @@ var (
 			Name:      "errors_total",
 			Help:      "Total number of errors returned from CloudProvider calls.",
 		},
-		[]string{
-			metricLabelController,
-			metricLabelMethod,
-			metricLabelProvider,
-			metricLabelError,
+		[]opmetrics.Label{
+			metrics.Controller,
+			Method,
+			Provider,
+			Error,
 		},
 	)
 )
@@ -157,9 +188,9 @@ func (d *decorator) IsDrifted(ctx context.Context, nodeClaim *v1.NodeClaim) (clo
 // for a prometheus Label map used to compose a duration metric spec
 func getLabelsMapForDuration(ctx context.Context, d *decorator, method string) map[string]string {
 	return map[string]string{
-		metricLabelController: injection.GetControllerName(ctx),
-		metricLabelMethod:     method,
-		metricLabelProvider:   d.Name(),
+		metrics.ControllerLabel: injection.GetControllerName(ctx),
+		metricLabelMethod:       method,
+		metricLabelProvider:     d.Name(),
 	}
 }
 
@@ -167,10 +198,10 @@ func getLabelsMapForDuration(ctx context.Context, d *decorator, method string) m
 // for a prometheus Label map used to compose a counter metric spec
 func getLabelsMapForError(ctx context.Context, d *decorator, method string, err error) map[string]string {
 	return map[string]string{
-		metricLabelController: injection.GetControllerName(ctx),
-		metricLabelMethod:     method,
-		metricLabelProvider:   d.Name(),
-		metricLabelError:      GetErrorTypeLabelValue(err),
+		metrics.ControllerLabel: injection.GetControllerName(ctx),
+		metricLabelMethod:       method,
+		metricLabelProvider:     d.Name(),
+		metricLabelError:        GetErrorTypeLabelValue(err),
 	}
 }
 
@@ -179,11 +210,11 @@ func getLabelsMapForError(ctx context.Context, d *decorator, method string, err 
 func GetErrorTypeLabelValue(err error) string {
 	switch {
 	case cloudprovider.IsInsufficientCapacityError(err):
-		return InsufficientCapacityError
+		return InsufficientCapacityError.Name
 	case cloudprovider.IsNodeClaimNotFoundError(err):
-		return NodeClaimNotFoundError
+		return NodeClaimNotFoundError.Name
 	case cloudprovider.IsNodeClassNotReadyError(err):
-		return NodeClassNotReadyError
+		return NodeClassNotReadyError.Name
 	default:
 		return MetricLabelErrorDefaultVal
 	}

--- a/pkg/cloudprovider/metrics/cloudprovider_test.go
+++ b/pkg/cloudprovider/metrics/cloudprovider_test.go
@@ -35,13 +35,13 @@ var _ = Describe("Cloudprovider", func() {
 	Describe("CloudProvider nodeclaim errors via GetErrorTypeLabelValue()", func() {
 		Context("when the error is known", func() {
 			It("nodeclaim not found should be recognized", func() {
-				Expect(metrics.GetErrorTypeLabelValue(nodeClaimNotFoundErr)).To(Equal(metrics.NodeClaimNotFoundError))
+				Expect(metrics.GetErrorTypeLabelValue(nodeClaimNotFoundErr)).To(Equal(metrics.NodeClaimNotFoundError.Name))
 			})
 			It("insufficient capacity should be recognized", func() {
-				Expect(metrics.GetErrorTypeLabelValue(insufficientCapacityErr)).To(Equal(metrics.InsufficientCapacityError))
+				Expect(metrics.GetErrorTypeLabelValue(insufficientCapacityErr)).To(Equal(metrics.InsufficientCapacityError.Name))
 			})
 			It("nodeclass not ready should be recognized", func() {
-				Expect(metrics.GetErrorTypeLabelValue(nodeClassNotReadyErr)).To(Equal(metrics.NodeClassNotReadyError))
+				Expect(metrics.GetErrorTypeLabelValue(nodeClassNotReadyErr)).To(Equal(metrics.NodeClassNotReadyError.Name))
 			})
 		})
 		Context("when the error is unknown", func() {

--- a/pkg/controllers/disruption/balanced.go
+++ b/pkg/controllers/disruption/balanced.go
@@ -26,6 +26,7 @@ import (
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/state/cost"
 )
 
@@ -228,14 +229,14 @@ func (e *balancedEvaluator) ApproveCommand(ctx context.Context, cmd Command) (bo
 		policy := string(candidate.NodePool.Spec.Disruption.ConsolidationPolicy)
 		result, scored := perPool[poolName]
 
-		decisionLabel := "approved"
+		moveDecision := string(ApprovedDecision)
 		if scored && !result.Approved() {
-			decisionLabel = "rejected"
+			moveDecision = string(RejectedDecision)
 		}
-		ConsolidationMovesTotal.Inc(map[string]string{"decision": decisionLabel, "nodepool": poolName, "policy": policy})
+		ConsolidationMovesTotal.Inc(map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, policyLabel: policy})
 
 		if scored {
-			ConsolidationScoreHistogram.Observe(result.Score(), map[string]string{"decision": decisionLabel, "nodepool": poolName, "policy": policy})
+			ConsolidationScoreHistogram.Observe(result.Score(), map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, policyLabel: policy})
 			if result.Approved() {
 				e.recorder.Publish(disruptionevents.ConsolidationApproved(
 					candidate.Node, candidate.NodeClaim,
@@ -252,25 +253,25 @@ func (e *balancedEvaluator) ApproveCommand(ctx context.Context, cmd Command) (bo
 func (e *balancedEvaluator) EmitMultiNodeEvents(ctx context.Context, cmd Command, perPoolResults map[string]ScoreResult, approved bool) {
 	byPool := lo.GroupBy(cmd.Candidates, func(c *Candidate) string { return c.NodePool.Name })
 
-	moveDecision := "approved"
+	moveDecision := string(ApprovedDecision)
 	if !approved {
-		moveDecision = "rejected"
+		moveDecision = string(RejectedDecision)
 	}
 
 	for poolName, poolCandidates := range byPool {
 		nodePool := poolCandidates[0].NodePool
 		policy := string(nodePool.Spec.Disruption.ConsolidationPolicy)
-		ConsolidationMovesTotal.Inc(map[string]string{"decision": moveDecision, "nodepool": poolName, "policy": policy})
+		ConsolidationMovesTotal.Inc(map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, policyLabel: policy})
 
 		result, scored := perPoolResults[poolName]
 		if !scored {
 			continue
 		}
-		poolDecision := "approved"
+		poolDecision := string(ApprovedDecision)
 		if !result.Approved() {
-			poolDecision = "rejected"
+			poolDecision = string(RejectedDecision)
 		}
-		ConsolidationScoreHistogram.Observe(result.Score(), map[string]string{"decision": poolDecision, "nodepool": poolName, "policy": policy})
+		ConsolidationScoreHistogram.Observe(result.Score(), map[string]string{decisionLabel: poolDecision, metrics.NodePoolLabel: poolName, policyLabel: policy})
 
 		if result.Approved() {
 			e.recorder.Publish(disruptionevents.ConsolidationApprovedMultiNode(

--- a/pkg/controllers/disruption/emptiness.go
+++ b/pkg/controllers/disruption/emptiness.go
@@ -118,5 +118,5 @@ func (e *Emptiness) Class() string {
 }
 
 func (e *Emptiness) ConsolidationType() string {
-	return "empty"
+	return EmptyConsolidationType.Name
 }

--- a/pkg/controllers/disruption/metrics.go
+++ b/pkg/controllers/disruption/metrics.go
@@ -32,9 +32,66 @@ const (
 	policyLabel                  = "policy"
 )
 
+var (
+	MultiNodeConsolidationType = opmetrics.Value{
+		Name: "multi",
+		Help: "Consolidation that considers removing multiple nodes at once.",
+	}
+	SingleNodeConsolidationType = opmetrics.Value{
+		Name: "single",
+		Help: "Consolidation that considers removing a single node.",
+	}
+	EmptyConsolidationType = opmetrics.Value{
+		Name: "empty",
+		Help: "Consolidation that removes empty nodes.",
+	}
+)
+
+var (
+	ConsolidationType = opmetrics.Label{
+		Name:   ConsolidationTypeLabel,
+		Help:   "The consolidation algorithm that produced the decision.",
+		Values: []opmetrics.Value{MultiNodeConsolidationType, SingleNodeConsolidationType, EmptyConsolidationType},
+	}
+	DecisionDim = opmetrics.Label{
+		Name: decisionLabel,
+		Help: "The disruption decision taken for the candidate(s).",
+		Values: []opmetrics.Value{
+			{
+				Name: string(NoOpDecision),
+				Help: "No disruption action was taken.",
+			},
+			{
+				Name: string(ReplaceDecision),
+				Help: "The candidate(s) were replaced with more efficient capacity.",
+			},
+			{
+				Name: string(DeleteDecision),
+				Help: "The candidate(s) were deleted without replacement.",
+			},
+			{
+				Name: string(ApprovedDecision),
+				Help: "The disruption decision was approved for execution.",
+			},
+			{
+				Name: string(RejectedDecision),
+				Help: "The disruption decision was rejected before execution.",
+			},
+		},
+	}
+	Policy = opmetrics.Label{
+		Name: policyLabel,
+		Help: "The NodePool consolidation policy in effect for the move.",
+	}
+)
+
 func init() {
-	ConsolidationTimeoutsTotal.Add(0, map[string]string{ConsolidationTypeLabel: MultiNodeConsolidationType})
-	ConsolidationTimeoutsTotal.Add(0, map[string]string{ConsolidationTypeLabel: SingleNodeConsolidationType})
+	// Initialize the consolidation_type series that can time out to 0. Only the
+	// multi- and single-node algorithms run a bounded search that can hit a timeout;
+	// empty-node consolidation does not, so it is not pre-initialized here.
+	for _, ct := range []opmetrics.Value{MultiNodeConsolidationType, SingleNodeConsolidationType} {
+		ConsolidationTimeoutsTotal.Add(0, map[string]string{ConsolidationTypeLabel: ct.Name})
+	}
 }
 
 var (
@@ -47,7 +104,7 @@ var (
 			Help:      "Duration of the disruption decision evaluation process in seconds. Labeled by method and consolidation type.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]string{metrics.ReasonLabel, ConsolidationTypeLabel},
+		[]opmetrics.Label{metrics.DisruptionReason, ConsolidationType},
 	)
 	DecisionsPerformedTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
@@ -57,7 +114,7 @@ var (
 			Name:      "decisions_total",
 			Help:      "Number of disruption decisions performed. Labeled by disruption decision, reason, and consolidation type.",
 		},
-		[]string{decisionLabel, metrics.ReasonLabel, ConsolidationTypeLabel},
+		[]opmetrics.Label{DecisionDim, metrics.DisruptionReason, ConsolidationType},
 	)
 	NodepoolDecisionsPerformed = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
@@ -67,7 +124,7 @@ var (
 			Name:      "decisions_by_nodepool_total",
 			Help:      "Number of disruption decisions performed by nodepool. Labeled by nodepool name, disruption decision, reason, and consolidation type.",
 		},
-		[]string{metrics.NodePoolLabel, decisionLabel, metrics.ReasonLabel, ConsolidationTypeLabel},
+		[]opmetrics.Label{metrics.NodePool, DecisionDim, metrics.DisruptionReason, ConsolidationType},
 	)
 	EligibleNodes = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -77,7 +134,7 @@ var (
 			Name:      "eligible_nodes",
 			Help:      "Number of nodes eligible for disruption by Karpenter. Labeled by disruption reason.",
 		},
-		[]string{metrics.ReasonLabel},
+		[]opmetrics.Label{metrics.DisruptionReason},
 	)
 	ConsolidationTimeoutsTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
@@ -87,7 +144,7 @@ var (
 			Name:      "consolidation_timeouts_total",
 			Help:      "Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.",
 		},
-		[]string{ConsolidationTypeLabel},
+		[]opmetrics.Label{ConsolidationType},
 	)
 	FailedValidationsTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
@@ -97,7 +154,7 @@ var (
 			Name:      "failed_validations_total",
 			Help:      "Number of candidates that were selected for disruption but failed validation. Labeled by consolidation type.",
 		},
-		[]string{ConsolidationTypeLabel},
+		[]opmetrics.Label{ConsolidationType},
 	)
 	NodePoolAllowedDisruptions = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -107,7 +164,7 @@ var (
 			Name:      "allowed_disruptions",
 			Help:      "The number of nodes for a given NodePool that can be concurrently disrupting at a point in time. Labeled by NodePool. Note that allowed disruptions can change very rapidly, as new nodes may be created and others may be deleted at any point.",
 		},
-		[]string{metrics.NodePoolLabel, metrics.ReasonLabel},
+		[]opmetrics.Label{metrics.NodePool, metrics.DisruptionReason},
 	)
 	NodePoolNodesConsumingBudgets = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -117,7 +174,7 @@ var (
 			Name:      "nodes_consuming_budgets",
 			Help:      "The number of nodes consuming the budget of a nodepool at a point in time. Labeled by NodePool.",
 		},
-		[]string{metrics.NodePoolLabel, metrics.ReasonLabel},
+		[]opmetrics.Label{metrics.NodePool, metrics.DisruptionReason},
 	)
 	DisruptionQueueFailuresTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
@@ -127,7 +184,7 @@ var (
 			Name:      "queue_failures_total",
 			Help:      "The number of times that an enqueued disruption decision failed. Labeled by disruption method.",
 		},
-		[]string{decisionLabel, metrics.ReasonLabel, ConsolidationTypeLabel},
+		[]opmetrics.Label{DecisionDim, metrics.DisruptionReason, ConsolidationType},
 	)
 	ConsolidationScoreHistogram = opmetrics.NewPrometheusHistogram(
 		crmetrics.Registry,
@@ -137,7 +194,7 @@ var (
 			Help:      "Score of balanced consolidation moves. Labeled by decision, NodePool, and policy.",
 			Buckets:   []float64{0.1, 0.25, 0.33, 0.5, 1.0, 2.0, 5.0, 10.0},
 		},
-		[]string{decisionLabel, metrics.NodePoolLabel, policyLabel},
+		[]opmetrics.Label{DecisionDim, metrics.NodePool, Policy},
 	)
 	ConsolidationMovesTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
@@ -146,6 +203,6 @@ var (
 			Name:      "consolidation_moves_total",
 			Help:      "Number of balanced consolidation moves. Labeled by decision, NodePool, and policy.",
 		},
-		[]string{decisionLabel, metrics.NodePoolLabel, policyLabel},
+		[]opmetrics.Label{DecisionDim, metrics.NodePool, Policy},
 	)
 )

--- a/pkg/controllers/disruption/multinodeconsolidation.go
+++ b/pkg/controllers/disruption/multinodeconsolidation.go
@@ -33,7 +33,6 @@ import (
 )
 
 const MultiNodeConsolidationTimeoutDuration = 1 * time.Minute
-const MultiNodeConsolidationType = "multi"
 
 type MultiNodeConsolidation struct {
 	consolidation
@@ -254,5 +253,5 @@ func (m *MultiNodeConsolidation) Class() string {
 }
 
 func (m *MultiNodeConsolidation) ConsolidationType() string {
-	return MultiNodeConsolidationType
+	return MultiNodeConsolidationType.Name
 }

--- a/pkg/controllers/disruption/queue_test.go
+++ b/pkg/controllers/disruption/queue_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Queue", func() {
 				Replacements:      replacements,
 			}
 			Expect(cmd.Decision()).To(Equal(disruption.ReplaceDecision))
-			Expect(cmd.ConsolidationType()).To(Equal(disruption.SingleNodeConsolidationType))
+			Expect(cmd.ConsolidationType()).To(Equal(disruption.SingleNodeConsolidationType.Name))
 			Expect(queue.StartCommand(ctx, cmd)).To(BeNil())
 
 			// This metric isn't reset between specs, so clear it to isolate this failure.
@@ -243,7 +243,7 @@ var _ = Describe("Queue", func() {
 			ExpectObjectReconciled(ctx, env.Client, queue, stateNode.NodeClaim)
 
 			ExpectMetricCounterValue(disruption.DisruptionQueueFailuresTotal, 1, map[string]string{
-				disruption.ConsolidationTypeLabel: disruption.SingleNodeConsolidationType,
+				disruption.ConsolidationTypeLabel: disruption.SingleNodeConsolidationType.Name,
 			})
 		})
 		It("should fully handle a command when replacements are initialized", func() {

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -32,8 +32,6 @@ import (
 
 var SingleNodeConsolidationTimeoutDuration = 3 * time.Minute
 
-const SingleNodeConsolidationType = "single"
-
 // SingleNodeConsolidation evaluates one node at a time for consolidation.
 type SingleNodeConsolidation struct {
 	consolidation
@@ -134,7 +132,7 @@ func (s *SingleNodeConsolidation) Class() string {
 }
 
 func (s *SingleNodeConsolidation) ConsolidationType() string {
-	return SingleNodeConsolidationType
+	return SingleNodeConsolidationType.Name
 }
 
 // SortCandidates applies the consolidation sort, then interweaves by NodePool.

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -257,6 +257,11 @@ var (
 	NoOpDecision    Decision = "no-op"
 	ReplaceDecision Decision = "replace"
 	DeleteDecision  Decision = "delete"
+	// ApprovedDecision and RejectedDecision are the decision label values emitted
+	// by the Balanced consolidation move metrics (consolidation_moves_total and
+	// consolidation_score).
+	ApprovedDecision Decision = "approved"
+	RejectedDecision Decision = "rejected"
 )
 
 func (c Command) Decision() Decision {

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -48,6 +48,15 @@ const (
 	managed   = "managed"
 )
 
+// Fixed node metric dimensions. The remaining dimensions are the cloud
+// provider's well-known labels, which are self-describing and wrapped without
+// help text (see nodeLabelNames).
+var (
+	nodeNameLabel  = opmetrics.Label{Name: nodeName, Help: "The name of the node."}
+	nodePhaseLabel = opmetrics.Label{Name: nodePhase, Help: "The node's lifecycle phase, e.g. `Pending`, `Running`."}
+	managedLabel   = opmetrics.Label{Name: managed, Help: "Whether the node is managed by Karpenter.", Values: metrics.BoolValues}
+)
+
 var (
 	Allocatable         opmetrics.GaugeMetric
 	TotalPodRequests    opmetrics.GaugeMetric
@@ -140,25 +149,28 @@ func initializeMetrics() {
 			Name:      "utilization_percent",
 			Help:      "Utilization of allocatable resources by pod requests",
 		},
-		[]string{metrics.ResourceTypeLabel},
+		[]opmetrics.Label{metrics.ResourceType},
 	)
 }
 
-func nodeLabelNamesWithResourceType() []string {
+func nodeLabelNamesWithResourceType() []opmetrics.Label {
 	return append(
 		nodeLabelNames(),
-		metrics.ResourceTypeLabel,
+		metrics.ResourceType,
 	)
 }
 
-func nodeLabelNames() []string {
+func nodeLabelNames() []opmetrics.Label {
 	return append(
 		// WellKnownLabels includes the nodepool label, so we don't need to add it as its own item here.
 		// If we do, prometheus will panic since there would be duplicate labels.
-		sets.New(lo.Values(getWellKnownLabels())...).UnsortedList(),
-		nodeName,
-		nodePhase,
-		managed,
+		// The well-known labels are self-describing, so they are wrapped without help text.
+		lo.Map(sets.New(lo.Values(getWellKnownLabels())...).UnsortedList(), func(l string, _ int) opmetrics.Label {
+			return opmetrics.Label{Name: l}
+		}),
+		nodeNameLabel,
+		nodePhaseLabel,
+		managedLabel,
 	)
 }
 

--- a/pkg/controllers/metrics/nodepool/controller.go
+++ b/pkg/controllers/metrics/nodepool/controller.go
@@ -50,9 +50,9 @@ var (
 			Name:      "limit",
 			Help:      "Limits specified on the nodepool that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.",
 		},
-		[]string{
-			metrics.ResourceTypeLabel,
-			metrics.NodePoolLabel,
+		[]opmetrics.Label{
+			metrics.ResourceType,
+			metrics.NodePool,
 		},
 	)
 	Usage = opmetrics.NewPrometheusGauge(
@@ -63,9 +63,9 @@ var (
 			Name:      "usage",
 			Help:      "The amount of resources that have been provisioned for a nodepool. Labeled by nodepool name and resource type.",
 		},
-		[]string{
-			metrics.ResourceTypeLabel,
-			metrics.NodePoolLabel,
+		[]opmetrics.Label{
+			metrics.ResourceType,
+			metrics.NodePool,
 		},
 	)
 	ClusterCost = opmetrics.NewPrometheusGauge(
@@ -76,7 +76,7 @@ var (
 			Name:      "cost_total",
 			Help:      "Total cost of the nodepool from Karpenter's perspective. Units are determined by the cloud provider. Not an authoritative source for billing. Includes modifications due to NodeOverlays",
 		},
-		[]string{metrics.NodePoolLabel},
+		[]opmetrics.Label{metrics.NodePool},
 	)
 )
 

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -48,13 +48,37 @@ const (
 	podNamespace        = "namespace"
 	ownerSelfLink       = "owner"
 	podHostName         = "node"
-	podHostZone         = "zone"
 	podHostArchitecture = "arch"
 	podHostInstanceType = "instance_type"
 	podPhase            = "phase"
 	podScheduled        = "scheduled"
 	podReady            = "ready"
 	managed             = "managed"
+)
+
+// Pod metric dimensions. zone, nodepool, and capacity_type reuse the shared
+// dimensions from pkg/metrics.
+var (
+	podNameLabel             = opmetrics.Label{Name: podName, Help: "The name of the pod."}
+	podNamespaceLabel        = opmetrics.Label{Name: podNamespace, Help: "The namespace of the pod."}
+	ownerLabel               = opmetrics.Label{Name: ownerSelfLink, Help: "The owning workload of the pod, formatted as `<kind>/<name>`."}
+	podHostNameLabel         = opmetrics.Label{Name: podHostName, Help: "The name of the node the pod is bound to."}
+	podHostArchitectureLabel = opmetrics.Label{Name: podHostArchitecture, Help: "The CPU architecture of the node the pod is bound to."}
+	podHostInstanceTypeLabel = opmetrics.Label{Name: podHostInstanceType, Help: "The instance type of the node the pod is bound to."}
+	podScheduledLabel        = opmetrics.Label{Name: podScheduled, Help: "Whether the pod has been scheduled to a node.", Values: metrics.BoolValues}
+	podReadyLabel            = opmetrics.Label{Name: podReady, Help: "Whether the pod is ready.", Values: metrics.BoolValues}
+	managedLabel             = opmetrics.Label{Name: managed, Help: "Whether the pod is bound to a Karpenter-managed node.", Values: metrics.BoolValues}
+	podPhaseLabel            = opmetrics.Label{
+		Name: podPhase,
+		Help: "The pod's lifecycle phase.",
+		Values: []opmetrics.Value{
+			{Name: string(corev1.PodPending), Help: "The pod has been accepted but not all containers are running."},
+			{Name: string(corev1.PodRunning), Help: "The pod is bound to a node and all containers are running."},
+			{Name: string(corev1.PodSucceeded), Help: "All containers terminated successfully."},
+			{Name: string(corev1.PodFailed), Help: "All containers terminated and at least one failed."},
+			{Name: string(corev1.PodUnknown), Help: "The pod's state could not be obtained."},
+		},
+	}
 )
 
 var (
@@ -64,7 +88,7 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: metrics.PodSubsystem,
 			Name:      "state",
-			Help:      "Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, nodepool name, zone, architecture, capacity type, instance type, pod phase, and pod readiness.",
+			Help:      "Pod state is the current state of pods. This metric can be used several ways as it is labeled by the pod name, namespace, owner, node, whether the pod is scheduled, nodepool name, zone, architecture, capacity type, instance type, pod phase, pod readiness, and whether the node is Karpenter-managed.",
 		},
 		labelNames(),
 	)
@@ -77,7 +101,7 @@ var (
 			Help:       "The time from pod creation until the pod is running.",
 			Objectives: metrics.SummaryObjectives(),
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 	PodUnstartedTimeSeconds = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -87,7 +111,7 @@ var (
 			Name:      "unstarted_time_seconds",
 			Help:      "The time from pod creation until the pod is running.",
 		},
-		[]string{podName, podNamespace},
+		[]opmetrics.Label{podNameLabel, podNamespaceLabel},
 	)
 	PodBoundDurationSeconds = opmetrics.NewPrometheusHistogram(
 		crmetrics.Registry,
@@ -98,7 +122,7 @@ var (
 			Help:      "The time from pod creation until the pod is bound.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 	PodUnboundTimeSeconds = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -108,7 +132,7 @@ var (
 			Name:      "unbound_time_seconds",
 			Help:      "The time from pod creation until the pod is bound.",
 		},
-		[]string{podName, podNamespace},
+		[]opmetrics.Label{podNameLabel, podNamespaceLabel},
 	)
 	// Stage: alpha
 	PodProvisioningBoundDurationSeconds = opmetrics.NewPrometheusHistogram(
@@ -120,7 +144,7 @@ var (
 			Help:      "The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 	// Stage: alpha
 	PodProvisioningUnboundTimeSeconds = opmetrics.NewPrometheusGauge(
@@ -131,7 +155,7 @@ var (
 			Name:      "provisioning_unbound_time_seconds",
 			Help:      "The time from when Karpenter first thinks the pod can schedule until it binds. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 		},
-		[]string{podName, podNamespace},
+		[]opmetrics.Label{podNameLabel, podNamespaceLabel},
 	)
 	// Stage: alpha
 	PodProvisioningStartupDurationSeconds = opmetrics.NewPrometheusHistogram(
@@ -143,7 +167,7 @@ var (
 			Help:      "The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 	// Stage: alpha
 	PodProvisioningUnstartedTimeSeconds = opmetrics.NewPrometheusGauge(
@@ -154,7 +178,7 @@ var (
 			Name:      "provisioning_unstarted_time_seconds",
 			Help:      "The time from when Karpenter first thinks the pod can schedule until the pod is running. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 		},
-		[]string{podName, podNamespace},
+		[]opmetrics.Label{podNameLabel, podNamespaceLabel},
 	)
 	// Stage: alpha
 	PodSchedulingUndecidedTimeSeconds = opmetrics.NewPrometheusGauge(
@@ -165,7 +189,7 @@ var (
 			Name:      "provisioning_scheduling_undecided_time_seconds",
 			Help:      "The time from when Karpenter has seen a pod without making a scheduling decision for the pod. Note: this calculated from a point in memory, not by the pod creation timestamp.",
 		},
-		[]string{podName, podNamespace},
+		[]opmetrics.Label{podNameLabel, podNamespaceLabel},
 	)
 )
 
@@ -179,21 +203,21 @@ type Controller struct {
 	unscheduledPods sets.Set[string]
 }
 
-func labelNames() []string {
-	return []string{
-		podName,
-		podNamespace,
-		ownerSelfLink,
-		podHostName,
-		podScheduled,
-		metrics.NodePoolLabel,
-		podHostZone,
-		podHostArchitecture,
-		metrics.CapacityTypeLabel,
-		podHostInstanceType,
-		podPhase,
-		podReady,
-		managed,
+func labelNames() []opmetrics.Label {
+	return []opmetrics.Label{
+		podNameLabel,
+		podNamespaceLabel,
+		ownerLabel,
+		podHostNameLabel,
+		podScheduledLabel,
+		metrics.NodePool,
+		metrics.Zone,
+		podHostArchitectureLabel,
+		metrics.CapacityType,
+		podHostInstanceTypeLabel,
+		podPhaseLabel,
+		podReadyLabel,
+		managedLabel,
 	}
 }
 
@@ -440,7 +464,7 @@ func (c *Controller) makeLabels(ctx context.Context, pod *corev1.Pod) (prometheu
 			return nil, err
 		}
 	}
-	metricLabels[podHostZone] = node.Labels[corev1.LabelTopologyZone]
+	metricLabels[metrics.ZoneLabel] = node.Labels[corev1.LabelTopologyZone]
 	metricLabels[podHostArchitecture] = node.Labels[corev1.LabelArchStable]
 	metricLabels[metrics.CapacityTypeLabel] = node.Labels[v1.CapacityTypeLabelKey]
 	metricLabels[podHostInstanceType] = node.Labels[corev1.LabelInstanceTypeStable]

--- a/pkg/controllers/node/health/controller.go
+++ b/pkg/controllers/node/health/controller.go
@@ -188,10 +188,10 @@ func (c *Controller) deleteNodeClaim(ctx context.Context, nodeClaim *v1.NodeClai
 	}
 	metrics.PodsDisruptionInitiatedTotal.Add(float64(len(reschedulablePods)), labels)
 	NodeClaimsUnhealthyDisruptedTotal.Inc(map[string]string{
-		Condition:                 pretty.ToSnakeCase(string(unhealthyNodeCondition.Type)),
+		ConditionLabel:            pretty.ToSnakeCase(string(unhealthyNodeCondition.Type)),
 		metrics.NodePoolLabel:     node.Labels[v1.NodePoolLabelKey],
 		metrics.CapacityTypeLabel: node.Labels[v1.CapacityTypeLabelKey],
-		ImageID:                   nodeClaim.Status.ImageID,
+		ImageIDLabel:              nodeClaim.Status.ImageID,
 	})
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/node/health/metrics.go
+++ b/pkg/controllers/node/health/metrics.go
@@ -25,8 +25,20 @@ import (
 )
 
 const (
-	ImageID   = "image_id"
-	Condition = "condition"
+	ImageIDLabel   = "image_id"
+	ConditionLabel = "condition"
+)
+
+// Metric dimensions specific to node health / repair.
+var (
+	Condition = opmetrics.Label{
+		Name: ConditionLabel,
+		Help: "The node status condition type that failed the repair health check and triggered disruption.",
+	}
+	ImageID = opmetrics.Label{
+		Name: ImageIDLabel,
+		Help: "The image ID of the node that was disrupted.",
+	}
 )
 
 var NodeClaimsUnhealthyDisruptedTotal = opmetrics.NewPrometheusCounter(
@@ -35,12 +47,12 @@ var NodeClaimsUnhealthyDisruptedTotal = opmetrics.NewPrometheusCounter(
 		Namespace: metrics.Namespace,
 		Subsystem: metrics.NodeClaimSubsystem,
 		Name:      "unhealthy_disrupted_total",
-		Help:      "Number of unhealthy nodeclaims disrupted in total by Karpenter. Labeled by condition on the node was disrupted, the owning nodepool, and the image ID.",
+		Help:      "Number of unhealthy nodeclaims disrupted in total by Karpenter. Labeled by the condition the node was disrupted on, the owning nodepool, the capacity type, and the image ID.",
 	},
-	[]string{
+	[]opmetrics.Label{
 		Condition,
-		metrics.NodePoolLabel,
-		metrics.CapacityTypeLabel,
+		metrics.NodePool,
+		metrics.CapacityType,
 		ImageID,
 	},
 )

--- a/pkg/controllers/node/health/suite_test.go
+++ b/pkg/controllers/node/health/suite_test.go
@@ -403,7 +403,7 @@ var _ = Describe("Node Health", func() {
 				metrics.TerminationModeLabel:     metrics.TerminationModeGraceful,
 			})
 			ExpectMetricCounterValue(health.NodeClaimsUnhealthyDisruptedTotal, 1, map[string]string{
-				health.Condition:      pretty.ToSnakeCase(string(cloudProvider.RepairPolicies()[0].ConditionType)),
+				health.ConditionLabel: pretty.ToSnakeCase(string(cloudProvider.RepairPolicies()[0].ConditionType)),
 				metrics.NodePoolLabel: nodePool.Name,
 			})
 		})

--- a/pkg/controllers/node/termination/metrics.go
+++ b/pkg/controllers/node/termination/metrics.go
@@ -38,7 +38,7 @@ var (
 			Help:       "The time taken between a node's deletion request and the removal of its finalizer",
 			Objectives: metrics.SummaryObjectives(),
 		},
-		[]string{metrics.NodePoolLabel},
+		[]opmetrics.Label{metrics.NodePool},
 	)
 	NodesDrainedTotal = opmetrics.NewPrometheusCounter(
 		crmetrics.Registry,
@@ -48,7 +48,7 @@ var (
 			Name:      "drained_total",
 			Help:      "The total number of nodes drained by Karpenter",
 		},
-		[]string{metrics.NodePoolLabel},
+		[]opmetrics.Label{metrics.NodePool},
 	)
 	NodeLifetimeDurationSeconds = opmetrics.NewPrometheusHistogram(
 		crmetrics.Registry,
@@ -84,6 +84,6 @@ var (
 				(dayDuration * 30).Seconds(),
 			},
 		},
-		[]string{metrics.NodePoolLabel},
+		[]opmetrics.Label{metrics.NodePool},
 	)
 )

--- a/pkg/controllers/node/termination/terminator/eviction.go
+++ b/pkg/controllers/node/termination/terminator/eviction.go
@@ -47,6 +47,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	terminatorevents "sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator/events"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
@@ -284,7 +285,7 @@ func (q *Queue) evict(ctx context.Context, pod *corev1.Pod) (reconcile.Result, e
 	PodsEvictionRequestsTotal.Inc(map[string]string{CodeLabel: "200"})
 	reason := evictionReason(ctx, pod, q.kubeClient)
 	q.recorder.Publish(terminatorevents.EvictPod(pod, reason))
-	PodsDrainedTotal.Inc(map[string]string{ReasonLabel: reason})
+	PodsDrainedTotal.Inc(map[string]string{metrics.ReasonLabel: reason})
 	q.complete(pod)
 	return reconcile.Result{}, nil
 }
@@ -318,7 +319,7 @@ func (q *Queue) forceDelete(ctx context.Context, pod *corev1.Pod, nodeTerminatio
 		"delete.gracePeriodSeconds", lo.FromPtr(gracePeriodSeconds),
 		"nodeclaim.terminationTime", lo.FromPtr(nodeTerminationTime),
 	).V(1).Info("deleting pod")
-	PodsDrainedTotal.Inc(map[string]string{ReasonLabel: evictionReason(ctx, pod, q.kubeClient)})
+	PodsDrainedTotal.Inc(map[string]string{metrics.ReasonLabel: evictionReason(ctx, pod, q.kubeClient)})
 	q.complete(pod)
 	return reconcile.Result{}, nil
 }
@@ -344,5 +345,5 @@ func evictionReason(ctx context.Context, pod *corev1.Pod, kubeClient client.Clie
 	if cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeDisruptionReason); cond.IsTrue() {
 		return cond.Reason
 	}
-	return "Forceful Termination"
+	return ForcefulTerminationReason
 }

--- a/pkg/controllers/node/termination/terminator/metrics.go
+++ b/pkg/controllers/node/termination/terminator/metrics.go
@@ -27,9 +27,29 @@ import (
 const (
 	// CodeLabel for eviction request
 	CodeLabel = "code"
-	// ReasonLabel for pod draining
-	ReasonLabel = "reason"
+	// ForcefulTerminationReason is the drain `reason` value emitted when a pod is
+	// force-deleted (the node's terminationGracePeriod elapsed) rather than
+	// drained under a disruption reason.
+	ForcefulTerminationReason = "Forceful Termination"
 )
+
+// Code describes the code dimension emitted by the pod eviction metric.
+var Code = opmetrics.Label{
+	Name: CodeLabel,
+	Help: "The HTTP response code returned by the Kubernetes eviction API (https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/) for the eviction request.",
+}
+
+// DrainReason describes the reason dimension emitted by the pod drain metric.
+// The emitted value is the owning NodeClaim's ConditionTypeDisruptionReason
+// condition reason when set (a voluntary-disruption reason), or
+// ForcefulTerminationReason otherwise. That condition reason is currently
+// emitted verbatim (PascalCase) rather than in the lowercase form the other
+// reason dimensions use, so the value set is left unenumerated until the reason
+// casing is standardized (see the reason-standardization follow-up).
+var DrainReason = opmetrics.Label{
+	Name: metrics.ReasonLabel,
+	Help: "Why the pod was drained: the owning NodeClaim's disruption reason, or forceful termination.",
+}
 
 var PodsEvictionRequestsTotal = opmetrics.NewPrometheusCounter(
 	crmetrics.Registry,
@@ -39,7 +59,7 @@ var PodsEvictionRequestsTotal = opmetrics.NewPrometheusCounter(
 		Name:      "eviction_requests_total",
 		Help:      "The total number of pod eviction requests made by Karpenter, labeled by response code",
 	},
-	[]string{CodeLabel},
+	[]opmetrics.Label{Code},
 )
 
 var PodsDrainedTotal = opmetrics.NewPrometheusCounter(
@@ -50,5 +70,5 @@ var PodsDrainedTotal = opmetrics.NewPrometheusCounter(
 		Name:      "drained_total",
 		Help:      "The total number of pods drained during node termination by Karpenter, labeled by reason",
 	},
-	[]string{ReasonLabel},
+	[]opmetrics.Label{DrainReason},
 )

--- a/pkg/controllers/node/termination/terminator/suite_test.go
+++ b/pkg/controllers/node/termination/terminator/suite_test.go
@@ -35,6 +35,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
@@ -184,7 +185,7 @@ var _ = Describe("Eviction/Queue", func() {
 			ExpectApplied(ctx, env.Client, pod, node)
 			queue.Add(nil, pod)
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
-			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: ""})
+			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{metrics.ReasonLabel: ""})
 			ExpectMetricCounterValue(terminator.PodsEvictionRequestsTotal, 1, map[string]string{terminator.CodeLabel: "200"})
 			Expect(recorder.Calls(events.Evicted)).To(Equal(1))
 		})
@@ -210,7 +211,7 @@ var _ = Describe("Eviction/Queue", func() {
 			queue.Add(nil, pod)
 			ExpectObjectReconciled(ctx, env.Client, queue, pod)
 
-			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: "SpotInterruption"})
+			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{metrics.ReasonLabel: "SpotInterruption"})
 			ExpectMetricCounterValue(terminator.PodsEvictionRequestsTotal, 1, map[string]string{terminator.CodeLabel: "200"})
 			Expect(recorder.Calls(events.Evicted)).To(Equal(1))
 		})
@@ -230,7 +231,7 @@ var _ = Describe("Eviction/Queue", func() {
 			pod = ExpectExists(ctx, env.Client, pod)
 			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 			Expect(recorder.Calls(events.Disrupted)).To(Equal(1))
-			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: ""})
+			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{metrics.ReasonLabel: ""})
 			// The queue entry is cleared once the force-delete succeeds.
 			Expect(queue.Has(pod)).To(BeFalse())
 		})
@@ -249,7 +250,7 @@ var _ = Describe("Eviction/Queue", func() {
 			pod = ExpectExists(ctx, env.Client, pod)
 			Expect(pod.DeletionTimestamp.IsZero()).To(BeFalse())
 			Expect(recorder.Calls(events.Disrupted)).To(Equal(1))
-			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{terminator.ReasonLabel: ""})
+			ExpectMetricCounterValue(terminator.PodsDrainedTotal, 1, map[string]string{metrics.ReasonLabel: ""})
 		})
 		It("should keep the earlier deadline when Add is called again with a looser one", func() {
 			// Once a pod has a force-delete deadline, a later Add must not push it out — otherwise

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -110,7 +110,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 			"provider-id", nodeClaims[i].Status.ProviderID,
 		).V(1).Info("garbage collecting nodeclaim with no cloudprovider representation")
 		labels := map[string]string{
-			metrics.ReasonLabel:              "garbage_collected",
+			metrics.ReasonLabel:              metrics.GarbageCollectedReason,
 			metrics.NodePoolLabel:            nodeClaims[i].Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel:        nodeClaims[i].Labels[v1.CapacityTypeLabelKey],
 			metrics.ConsolidationPolicyLabel: "",

--- a/pkg/controllers/nodeclaim/lifecycle/launch.go
+++ b/pkg/controllers/nodeclaim/lifecycle/launch.go
@@ -91,7 +91,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 				return nil, client.IgnoreNotFound(err)
 			}
 			metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-				metrics.ReasonLabel:              "insufficient_capacity",
+				metrics.ReasonLabel:              metrics.InsufficientCapacityReason,
 				metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
 				metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
 				metrics.ConsolidationPolicyLabel: "",
@@ -104,7 +104,7 @@ func (l *Launch) launchNodeClaim(ctx context.Context, nodeClaim *v1.NodeClaim) (
 				return nil, client.IgnoreNotFound(err)
 			}
 			metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
-				metrics.ReasonLabel:              "nodeclass_not_ready",
+				metrics.ReasonLabel:              metrics.NodeClassNotReadyReason,
 				metrics.NodePoolLabel:            nodeClaim.Labels[v1.NodePoolLabelKey],
 				metrics.CapacityTypeLabel:        nodeClaim.Labels[v1.CapacityTypeLabelKey],
 				metrics.ConsolidationPolicyLabel: "",

--- a/pkg/controllers/nodeclaim/lifecycle/liveness.go
+++ b/pkg/controllers/nodeclaim/lifecycle/liveness.go
@@ -51,9 +51,10 @@ type Liveness struct {
 // If we don't see the node within this time, then we should delete the NodeClaim and try again
 
 const (
-	registrationTimeout       = time.Minute * 15
-	registrationTimeoutReason = "registration_timeout"
-	launchTimeoutReason       = "launch_timeout"
+	registrationTimeout = time.Minute * 15
+	// Sourced from pkg/metrics so the documented reason values stay in one place.
+	registrationTimeoutReason = metrics.RegistrationTimeoutReason
+	launchTimeoutReason       = metrics.LaunchTimeoutReason
 )
 
 // LaunchTimeout is a heuristic time that we expect to be able to launch within

--- a/pkg/controllers/nodeclaim/lifecycle/metrics.go
+++ b/pkg/controllers/nodeclaim/lifecycle/metrics.go
@@ -33,7 +33,7 @@ var InstanceTerminationDurationSeconds = opmetrics.NewPrometheusHistogram(
 		Help:      "Duration of CloudProvider Instance termination in seconds.",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 11), //The threshold values generated here are 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024
 	},
-	[]string{metrics.NodePoolLabel},
+	[]opmetrics.Label{metrics.NodePool},
 )
 
 var NodeClaimTerminationDurationSeconds = opmetrics.NewPrometheusHistogram(
@@ -44,5 +44,5 @@ var NodeClaimTerminationDurationSeconds = opmetrics.NewPrometheusHistogram(
 		Name:      "termination_duration_seconds",
 		Help:      "Duration of NodeClaim termination in seconds.",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 12)}, //The threshold values generated here are 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024. 2048
-	[]string{metrics.NodePoolLabel},
+	[]opmetrics.Label{metrics.NodePool},
 )

--- a/pkg/controllers/provisioning/scheduling/metrics.go
+++ b/pkg/controllers/provisioning/scheduling/metrics.go
@@ -25,10 +25,19 @@ import (
 )
 
 const (
-	ControllerLabel    = "controller"
+	// ControllerLabel is an alias for the shared controller dimension. Its
+	// canonical description (help text) lives on metrics.Controller.
+	ControllerLabel    = metrics.ControllerLabel
 	schedulingIDLabel  = "scheduling_id"
 	schedulerSubsystem = "scheduler"
 )
+
+// SchedulingID describes the scheduling_id dimension. It is co-located here
+// because its value is a package-local runtime UUID.
+var SchedulingID = opmetrics.Label{
+	Name: schedulingIDLabel,
+	Help: "A unique identifier for a scheduling simulation run.",
+}
 
 var (
 	DurationSeconds = opmetrics.NewPrometheusHistogram(
@@ -40,8 +49,8 @@ var (
 			Help:      "Duration of scheduling simulations used for deprovisioning and provisioning in seconds.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]string{
-			ControllerLabel,
+		[]opmetrics.Label{
+			metrics.Controller,
 		},
 	)
 	QueueDepth = opmetrics.NewPrometheusGauge(
@@ -52,9 +61,9 @@ var (
 			Name:      "queue_depth",
 			Help:      "The number of pods currently waiting to be scheduled.",
 		},
-		[]string{
-			ControllerLabel,
-			schedulingIDLabel,
+		[]opmetrics.Label{
+			metrics.Controller,
+			SchedulingID,
 		},
 	)
 	UnfinishedWorkSeconds = opmetrics.NewPrometheusGauge(
@@ -65,9 +74,9 @@ var (
 			Name:      "unfinished_work_seconds",
 			Help:      "How many seconds of work has been done that is in progress and hasn't been observed by scheduling_duration_seconds.",
 		},
-		[]string{
-			ControllerLabel,
-			schedulingIDLabel,
+		[]opmetrics.Label{
+			metrics.Controller,
+			SchedulingID,
 		},
 	)
 	IgnoredPodCount = opmetrics.NewPrometheusGauge(
@@ -78,7 +87,7 @@ var (
 			Name:      "ignored_pods_count",
 			Help:      "Number of pods ignored during scheduling by Karpenter",
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 	UnschedulablePodsCount = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -88,8 +97,8 @@ var (
 			Name:      "unschedulable_pods_count",
 			Help:      "The number of unschedulable Pods.",
 		},
-		[]string{
-			ControllerLabel,
+		[]opmetrics.Label{
+			metrics.Controller,
 		},
 	)
 	PendingPodsByEffectiveZone = opmetrics.NewPrometheusGauge(
@@ -100,9 +109,9 @@ var (
 			Name:      "pending_pods_by_effective_zone_count",
 			Help:      "Pending pods dimensioned by effective zone constraint, or the intersection of pod-level zone signals, volume topology (PVC zones), and topology constraints. Values: specific zone name (e.g., 'us-west-2a'), 'flexible' (multiple zones), or 'none' (no valid intersection).",
 		},
-		[]string{
-			ControllerLabel,
-			"zone",
+		[]opmetrics.Label{
+			metrics.Controller,
+			metrics.Zone,
 		},
 	)
 )

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -497,8 +497,8 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, err
 	controllerName := injection.GetControllerName(ctx)
 	for zone, count := range podCountByZone {
 		PendingPodsByEffectiveZone.Set(float64(count), map[string]string{
-			ControllerLabel: controllerName,
-			"zone":          zone,
+			ControllerLabel:   controllerName,
+			metrics.ZoneLabel: zone,
 		})
 	}
 

--- a/pkg/controllers/state/metrics.go
+++ b/pkg/controllers/state/metrics.go
@@ -37,7 +37,7 @@ var (
 			Name:      "node_count",
 			Help:      "Current count of nodes in cluster state",
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 	ClusterStateSynced = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -47,7 +47,7 @@ var (
 			Name:      "synced",
 			Help:      "Returns 1 if cluster state is synced and 0 otherwise. Synced checks that nodeclaims and nodes that are stored in the APIServer have the same representation as Karpenter's cluster state",
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 	ClusterStateUnsyncedTimeSeconds = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -57,7 +57,7 @@ var (
 			Name:      "unsynced_time_seconds",
 			Help:      "The time for which cluster state is not synced",
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 	PodSchedulingDecisionSeconds = opmetrics.NewPrometheusHistogram(
 		crmetrics.Registry,
@@ -68,6 +68,6 @@ var (
 			Help:      "The time it takes for Karpenter to first try to schedule a pod after it's been seen.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]string{},
+		[]opmetrics.Label{},
 	)
 )

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -26,19 +26,20 @@ const (
 	// Common namespace for application metrics.
 	Namespace = "karpenter"
 
-	NodePoolLabel            = "nodepool"
-	ReasonLabel              = "reason"
-	ResourceTypeLabel        = "resource_type"
-	CapacityTypeLabel        = "capacity_type"
-	ZoneLabel                = "zone"
-	MinValuesRelaxedLabel    = "min_values_relaxed"
-	ConsolidationPolicyLabel = "consolidation_policy"
-	TerminationModeLabel     = "termination_mode"
+	// Metric label-name constants live in labels.go alongside their Label
+	// descriptions (help text and stable values).
 
 	// Reasons for CREATE/DELETE shared metrics
-	ProvisionedReason = "provisioned"
-	ExpiredReason     = "expired"
-	UnhealthyReason   = "unhealthy"
+	ProvisionedReason          = "provisioned"
+	ExpiredReason              = "expired"
+	UnhealthyReason            = "unhealthy"
+	GarbageCollectedReason     = "garbage_collected"
+	InsufficientCapacityReason = "insufficient_capacity"
+	NodeClassNotReadyReason    = "nodeclass_not_ready"
+	// Reasons emitted by the NodeClaim liveness controller when a NodeClaim is
+	// disrupted for failing to register or launch in time.
+	RegistrationTimeoutReason = "registration_timeout"
+	LaunchTimeoutReason       = "launch_timeout"
 
 	// termination_mode label values. Graceful and Eventual are also the canonical
 	// values for the disruption Graceful/Eventual classes in the disruption controller.

--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -1,0 +1,186 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strconv"
+	"strings"
+
+	opmetrics "github.com/awslabs/operatorpkg/metrics"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+)
+
+// BoolValues is the value set for a boolean dimension. The values are
+// self-explanatory, so they carry no help text.
+var BoolValues = []opmetrics.Value{{Name: strconv.FormatBool(true)}, {Name: strconv.FormatBool(false)}}
+
+// reason dimension values, shared across the reason Labels below. A value that
+// applies to more than one reason Label is declared once here and referenced by
+// each Label that emits it.
+var (
+	reasonProvisioned          = opmetrics.Value{Name: ProvisionedReason, Help: "Capacity was provisioned for pending pods."}
+	reasonExpired              = opmetrics.Value{Name: ExpiredReason, Help: "The Node exceeded its expiration."}
+	reasonUnhealthy            = opmetrics.Value{Name: UnhealthyReason, Help: "The node failed a node-repair health check."}
+	reasonGarbageCollected     = opmetrics.Value{Name: GarbageCollectedReason, Help: "The NodeClaim's backing instance was gone and it was garbage collected."}
+	reasonInsufficientCapacity = opmetrics.Value{Name: InsufficientCapacityReason, Help: "The cloud provider had insufficient capacity to launch the NodeClaim."}
+	reasonNodeClassNotReady    = opmetrics.Value{Name: NodeClassNotReadyReason, Help: "The NodeClaim's NodeClass was not ready."}
+	reasonRegistrationTimeout  = opmetrics.Value{Name: RegistrationTimeoutReason, Help: "The NodeClaim's node did not register within the liveness timeout."}
+	reasonLaunchTimeout        = opmetrics.Value{Name: LaunchTimeoutReason, Help: "The NodeClaim's backing instance did not launch within the liveness timeout."}
+	reasonUnderutilized        = opmetrics.Value{Name: strings.ToLower(string(v1.DisruptionReasonUnderutilized)), Help: "The node was underutilized."}
+	reasonEmpty                = opmetrics.Value{Name: strings.ToLower(string(v1.DisruptionReasonEmpty)), Help: "The node had no workload pods."}
+	reasonDrifted              = opmetrics.Value{Name: strings.ToLower(string(v1.DisruptionReasonDrifted)), Help: "The node drifted from its desired specification."}
+)
+
+// disruptionReasonValues are the voluntary-disruption reasons, shared by the
+// disruption metrics and the NodeClaim/Pod disruption counters.
+var disruptionReasonValues = []opmetrics.Value{reasonUnderutilized, reasonEmpty, reasonDrifted}
+
+// nodeClaimDisruptedReasonValues is the union of every reason a NodeClaim is
+// disrupted: the voluntary-disruption reasons plus the involuntary paths.
+var nodeClaimDisruptedReasonValues = []opmetrics.Value{
+	reasonUnhealthy,
+	reasonExpired,
+	reasonGarbageCollected,
+	reasonInsufficientCapacity,
+	reasonNodeClassNotReady,
+	reasonRegistrationTimeout,
+	reasonLaunchTimeout,
+	reasonUnderutilized,
+	reasonEmpty,
+	reasonDrifted,
+}
+
+// Metric dimensions and their values are described with opmetrics.Label /
+// opmetrics.Value (from operatorpkg, so Karpenter and operatorpkg share one type).
+// See AGENTS.md for the conventions.
+
+// Label-name constants, referenced by metric declarations.
+const (
+	NodePoolLabel            = "nodepool"
+	ReasonLabel              = "reason"
+	ResourceTypeLabel        = "resource_type"
+	CapacityTypeLabel        = "capacity_type"
+	ZoneLabel                = "zone"
+	MinValuesRelaxedLabel    = "min_values_relaxed"
+	ConsolidationPolicyLabel = "consolidation_policy"
+	TerminationModeLabel     = "termination_mode"
+	ControllerLabel          = "controller"
+)
+
+// Shared core metric dimensions. Provider packages and core controllers should
+// reference these rather than redeclaring the same dimension.
+var (
+	NodePool = opmetrics.Label{
+		Name: NodePoolLabel,
+		Help: "The name of the NodePool that owns the resource.",
+	}
+	// DisruptionReason is the `reason` dimension for voluntary-disruption metrics.
+	DisruptionReason = opmetrics.Label{
+		Name:   ReasonLabel,
+		Help:   "The voluntary-disruption reason.",
+		Values: disruptionReasonValues,
+	}
+	// NodeClaimCreatedReason is the `reason` dimension for the NodeClaim create
+	// counter: provisioning, plus the disruption reasons (disruption creates
+	// replacement NodeClaims).
+	NodeClaimCreatedReason = opmetrics.Label{
+		Name:   ReasonLabel,
+		Help:   "Why the NodeClaim was created.",
+		Values: append([]opmetrics.Value{reasonProvisioned}, disruptionReasonValues...),
+	}
+	// NodeClaimDisruptedReason is the `reason` dimension for the NodeClaim/Pod
+	// disruption counters: the union of every path that disrupts a NodeClaim.
+	NodeClaimDisruptedReason = opmetrics.Label{
+		Name:   ReasonLabel,
+		Help:   "Why the NodeClaim was disrupted.",
+		Values: nodeClaimDisruptedReasonValues,
+	}
+	ResourceType = opmetrics.Label{
+		Name: ResourceTypeLabel,
+		Help: "The Kubernetes resource type, e.g. `cpu`, `memory`, `pods`.",
+	}
+	CapacityType = opmetrics.Label{
+		Name: CapacityTypeLabel,
+		Help: "The capacity type of the instance.",
+		Values: []opmetrics.Value{
+			{
+				Name: v1.CapacityTypeOnDemand,
+				Help: "On-demand capacity.",
+			},
+			{
+				Name: v1.CapacityTypeSpot,
+				Help: "Spot capacity, which can be reclaimed by the cloud provider.",
+			},
+			{
+				Name: v1.CapacityTypeReserved,
+				Help: "Reserved capacity, backed by a capacity reservation.",
+			},
+		},
+	}
+	Zone = opmetrics.Label{
+		Name: ZoneLabel,
+		Help: "The availability zone of the instance.",
+	}
+	MinValuesRelaxed = opmetrics.Label{
+		Name:   MinValuesRelaxedLabel,
+		Help:   "Whether minValues requirements were relaxed to satisfy scheduling.",
+		Values: BoolValues,
+	}
+	ConsolidationPolicy = opmetrics.Label{
+		Name: ConsolidationPolicyLabel,
+		Help: "The NodePool consolidation policy in effect.",
+		Values: []opmetrics.Value{
+			// Emitted snake-cased: queue.go applies pretty.ToSnakeCase to the policy.
+			{
+				Name: pretty.ToSnakeCase(string(v1.ConsolidationPolicyWhenEmpty)),
+				Help: "Consolidate only empty nodes (nodes running only pods with no disruption cost, e.g. DaemonSets).",
+			},
+			{
+				Name: pretty.ToSnakeCase(string(v1.ConsolidationPolicyBalanced)),
+				Help: "Consolidate nodes where the cost savings outweigh the disruption to running pods.",
+			},
+			{
+				Name: pretty.ToSnakeCase(string(v1.ConsolidationPolicyWhenEmptyOrUnderutilized)),
+				Help: "Consolidate any node that can be removed or replaced to reduce cost.",
+			},
+		},
+	}
+	TerminationMode = opmetrics.Label{
+		Name: TerminationModeLabel,
+		Help: "The termination mode used to disrupt the node.",
+		Values: []opmetrics.Value{
+			{
+				Name: TerminationModeGraceful,
+				Help: "The NodeClaim has no terminationGracePeriod, so termination respects blocking pod PDBs and the do-not-disrupt annotation.",
+			},
+			{
+				Name: TerminationModeEventual,
+				Help: "The NodeClaim has a positive terminationGracePeriod, so termination is bounded by it and overrides blocking pod PDBs and the do-not-disrupt annotation.",
+			},
+			{
+				Name: TerminationModeForceful,
+				Help: "The NodeClaim has a zero (non-positive) terminationGracePeriod, so it is terminated immediately.",
+			},
+		},
+	}
+	Controller = opmetrics.Label{
+		Name: ControllerLabel,
+		Help: "The name of the controller that emitted the metric.",
+	}
+)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -38,10 +38,10 @@ var (
 			Name:      "created_total",
 			Help:      "Number of nodeclaims created in total by Karpenter. Labeled by reason the nodeclaim was created, the owning nodepool, and if min values was relaxed for this nodeclaim.",
 		},
-		[]string{
-			ReasonLabel,
-			NodePoolLabel,
-			MinValuesRelaxedLabel,
+		[]opmetrics.Label{
+			NodeClaimCreatedReason,
+			NodePool,
+			MinValuesRelaxed,
 		},
 	)
 	NodeClaimsTerminatedTotal = opmetrics.NewPrometheusCounter(
@@ -52,10 +52,10 @@ var (
 			Name:      "terminated_total",
 			Help:      "Number of nodeclaims terminated in total by Karpenter. Labeled by the owning nodepool, capacity type, and zone.",
 		},
-		[]string{
-			NodePoolLabel,
-			CapacityTypeLabel,
-			ZoneLabel,
+		[]opmetrics.Label{
+			NodePool,
+			CapacityType,
+			Zone,
 		},
 	)
 	NodeClaimsDisruptedTotal = opmetrics.NewPrometheusCounter(
@@ -66,12 +66,12 @@ var (
 			Name:      "disrupted_total",
 			Help:      "Number of nodeclaims disrupted in total by Karpenter. Labeled by reason the nodeclaim was disrupted, the owning nodepool, the capacity type, the consolidation policy, and the termination mode.",
 		},
-		[]string{
-			ReasonLabel,
-			NodePoolLabel,
-			CapacityTypeLabel,
-			ConsolidationPolicyLabel,
-			TerminationModeLabel,
+		[]opmetrics.Label{
+			NodeClaimDisruptedReason,
+			NodePool,
+			CapacityType,
+			ConsolidationPolicy,
+			TerminationMode,
 		},
 	)
 	PodsDisruptionInitiatedTotal = opmetrics.NewPrometheusCounter(
@@ -82,12 +82,12 @@ var (
 			Name:      "disruption_initiated_total",
 			Help:      "Number of pod disruptions initiated in total by Karpenter, incremented by the reschedulable pod count whenever the underlying nodeclaim is disrupted. Labeled by reason the nodeclaim was disrupted, the owning nodepool, the capacity type, the consolidation policy, and the termination mode. Pods owned by DaemonSets and mirror pods are excluded.",
 		},
-		[]string{
-			ReasonLabel,
-			NodePoolLabel,
-			CapacityTypeLabel,
-			ConsolidationPolicyLabel,
-			TerminationModeLabel,
+		[]opmetrics.Label{
+			NodeClaimDisruptedReason,
+			NodePool,
+			CapacityType,
+			ConsolidationPolicy,
+			TerminationMode,
 		},
 	)
 	NodesCreatedTotal = opmetrics.NewPrometheusCounter(
@@ -98,9 +98,9 @@ var (
 			Name:      "created_total",
 			Help:      "Number of nodes created in total by Karpenter. Labeled by owning nodepool and zone.",
 		},
-		[]string{
-			NodePoolLabel,
-			ZoneLabel,
+		[]opmetrics.Label{
+			NodePool,
+			Zone,
 		},
 	)
 	NodesTerminatedTotal = opmetrics.NewPrometheusCounter(
@@ -111,9 +111,9 @@ var (
 			Name:      "terminated_total",
 			Help:      "Number of nodes terminated in total by Karpenter. Labeled by owning nodepool and zone.",
 		},
-		[]string{
-			NodePoolLabel,
-			ZoneLabel,
+		[]opmetrics.Label{
+			NodePool,
+			Zone,
 		},
 	)
 )

--- a/pkg/metrics/suite_test.go
+++ b/pkg/metrics/suite_test.go
@@ -39,8 +39,8 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testGauge1 = opmetrics.NewPrometheusGauge(crmetrics.Registry, prometheus.GaugeOpts{Name: "test_gauge_1"}, []string{"label_1", "label_2"})
-	testGauge2 = opmetrics.NewPrometheusGauge(crmetrics.Registry, prometheus.GaugeOpts{Name: "test_gauge_2"}, []string{"label_1", "label_2"})
+	testGauge1 = opmetrics.NewPrometheusGauge(crmetrics.Registry, prometheus.GaugeOpts{Name: "test_gauge_1"}, []opmetrics.Label{{Name: "label_1"}, {Name: "label_2"}})
+	testGauge2 = opmetrics.NewPrometheusGauge(crmetrics.Registry, prometheus.GaugeOpts{Name: "test_gauge_2"}, []opmetrics.Label{{Name: "label_1"}, {Name: "label_2"}})
 })
 
 var _ = Describe("Store", func() {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -68,6 +68,15 @@ import (
 
 var AppName = "karpenter"
 
+// build_info metric dimensions. These describe the build the running binary was
+// produced from.
+var (
+	buildVersion   = opmetrics.Label{Name: "version", Help: "The Karpenter version the binary was built from."}
+	buildGoVersion = opmetrics.Label{Name: "goversion", Help: "The Go version the binary was compiled with."}
+	buildGoArch    = opmetrics.Label{Name: "goarch", Help: "The target architecture the binary was compiled for."}
+	buildCommit    = opmetrics.Label{Name: "commit", Help: "The git commit the binary was built from."}
+)
+
 var (
 	BuildInfo = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,
@@ -76,7 +85,7 @@ var (
 			Name:      "build_info",
 			Help:      "A metric with a constant '1' value labeled by version from which karpenter was built.",
 		},
-		[]string{"version", "goversion", "goarch", "commit"},
+		[]opmetrics.Label{buildVersion, buildGoVersion, buildGoArch, buildCommit},
 	)
 )
 

--- a/pkg/state/cost/cost.go
+++ b/pkg/state/cost/cost.go
@@ -48,10 +48,10 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: metrics.NodePoolSubsystem,
 			Name:      "cost_tracker_errors_total",
-			Help:      "Number of errors encountered during cost tracking operations. Labeled by nodepool and nodeclaim.",
+			Help:      "Number of errors encountered during cost tracking operations. Labeled by nodepool.",
 		},
-		[]string{
-			metrics.NodePoolLabel,
+		[]opmetrics.Label{
+			metrics.NodePool,
 		},
 	)
 )


### PR DESCRIPTION
Migrate every Prometheus metric constructor from a []string of label names to []opmetrics.Label, so each dimension carries its help text and, where the value set is bounded, its documented values (opmetrics.Label/Value from operatorpkg). The provider's metrics docs generator reads these to emit per-dimension help and value tables.

- Describe shared dimensions once in pkg/metrics (nodepool, reason, capacity type, zone, consolidation policy, termination mode, ...) and reference them from controllers rather than redeclaring.
- Split the overloaded `reason` dimension into category Labels (DisruptionReason / NodeClaimCreatedReason / NodeClaimDisruptedReason) sharing composed values.
- Enumerate bounded value sets (capacity type, consolidation policy, termination mode, decision, consolidation type, pod phase, booleans, ...) with names sourced from consts, and bump operatorpkg to the label-aware release.

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
