### PR TITLE
fix: support preferred non-Karpenter node affinity

### DIFF
--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -191,6 +191,37 @@ var _ = Describe("Simulate Scheduling", func() {
 			},
 		})
 	})
+	It("should retain volume topology for pending pods that prefer non-Karpenter capacity", func() {
+		storageClass := test.StorageClass()
+		persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{
+			Zones:            []string{"test-zone-3"},
+			StorageClassName: storageClass.Name,
+		})
+		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+			VolumeName:       persistentVolume.Name,
+			StorageClassName: &storageClass.Name,
+		})
+		pod := test.UnschedulablePod(test.PodOptions{
+			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+		})
+		pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 50,
+					Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: v1.NodePoolLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist},
+					}},
+				},
+			},
+		}}
+		ExpectApplied(ctx, env.Client, nodePool, storageClass, persistentVolume, persistentVolumeClaim, pod)
+
+		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, nil)
+		Expect(err).To(Succeed())
+		Expect(results.PodErrors).To(BeEmpty())
+		Expect(results.NewNodeClaims).To(HaveLen(1))
+		Expect(results.NewNodeClaims[0].Requirements.Get(corev1.LabelTopologyZone).Values()).To(ConsistOf("test-zone-3"))
+	})
 	It("should allow pods on deleting nodes to reschedule to uninitialized nodes", func() {
 		numNodes := 10
 		nodeClaims, nodes := test.NodeClaimsAndNodes(numNodes, v1.NodeClaim{

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -580,12 +580,45 @@ var KarpenterManagedLabelDoesNotExistError = serrors.Wrap(fmt.Errorf("configured
 // validateKarpenterManagedLabelCanExist provides a more clear error message in the event of scheduling a pod that specifically doesn't
 // want to run on a Karpenter node (e.g. a Karpenter controller replica).
 func validateKarpenterManagedLabelCanExist(p *corev1.Pod) error {
-	for _, req := range scheduling.NewPodRequirements(p) {
-		if req.Key == v1.NodePoolLabelKey && req.Operator() == corev1.NodeSelectorOpDoesNotExist {
-			return KarpenterManagedLabelDoesNotExistError
-		}
+	if requiresNonKarpenterNode(p) {
+		return KarpenterManagedLabelDoesNotExistError
 	}
 	return nil
+}
+
+func requiresNonKarpenterNode(p *corev1.Pod) bool {
+	if p.Spec.Affinity == nil ||
+		p.Spec.Affinity.NodeAffinity == nil ||
+		p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return false
+	}
+
+	hasUsableTerm := false
+	for _, term := range p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+		// Unsupported matchFields terms are handled by validateAffinity.
+		if term.MatchFields != nil {
+			return false
+		}
+		// Empty terms match no nodes.
+		if len(term.MatchExpressions) == 0 {
+			continue
+		}
+		hasUsableTerm = true
+
+		requiresLabelAbsent := false
+		for _, requirement := range term.MatchExpressions {
+			if requirement.Key == v1.NodePoolLabelKey && requirement.Operator == corev1.NodeSelectorOpDoesNotExist {
+				requiresLabelAbsent = true
+				break
+			}
+		}
+		// Required node affinity terms are ORed, so any term that permits the
+		// nodepool label makes the pod potentially schedulable by Karpenter.
+		if !requiresLabelAbsent {
+			return false
+		}
+	}
+	return hasUsableTerm
 }
 
 // getVolumeTopologyRequirements collects volume topology requirements for each pod

--- a/pkg/controllers/provisioning/provisioner_internal_test.go
+++ b/pkg/controllers/provisioning/provisioner_internal_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+func testRequirement(key string, operator corev1.NodeSelectorOperator) corev1.NodeSelectorRequirement {
+	requirement := corev1.NodeSelectorRequirement{Key: key, Operator: operator}
+	if operator != corev1.NodeSelectorOpExists && operator != corev1.NodeSelectorOpDoesNotExist {
+		requirement.Values = []string{"1"}
+	}
+	return requirement
+}
+
+func testTerm(requirements ...corev1.NodeSelectorRequirement) corev1.NodeSelectorTerm {
+	return corev1.NodeSelectorTerm{MatchExpressions: requirements}
+}
+
+func testRequiredPod(terms ...corev1.NodeSelectorTerm) *corev1.Pod {
+	return &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: terms},
+	}}}}
+}
+
+type affinityTermCase struct {
+	name        string
+	term        corev1.NodeSelectorTerm
+	usable      bool
+	excludes    bool
+	matchFields bool
+}
+
+func checkAffinityCombination(selected []affinityTermCase) {
+	GinkgoHelper()
+	terms := make([]corev1.NodeSelectorTerm, 0, len(selected))
+	names := make([]string, 0, len(selected))
+	hasUsableTerm := false
+	allUsableTermsExclude := true
+	hasMatchFields := false
+	for _, selectedTerm := range selected {
+		terms = append(terms, selectedTerm.term)
+		names = append(names, selectedTerm.name)
+		hasMatchFields = hasMatchFields || selectedTerm.matchFields
+		if selectedTerm.usable {
+			hasUsableTerm = true
+			allUsableTermsExclude = allUsableTermsExclude && selectedTerm.excludes
+		}
+	}
+	want := !hasMatchFields && hasUsableTerm && allUsableTermsExclude
+
+	Expect(requiresNonKarpenterNode(testRequiredPod(terms...))).To(
+		Equal(want),
+		"required=%v",
+		names,
+	)
+}
+
+func visitAffinityTermCombinations(cases []affinityTermCase, maxTerms int, visit func([]affinityTermCase)) {
+	visit(nil)
+	var generate func(remaining int, selected []affinityTermCase)
+	generate = func(remaining int, selected []affinityTermCase) {
+		if remaining == 0 {
+			visit(selected)
+			return
+		}
+		for _, candidate := range cases {
+			generate(remaining-1, append(selected, candidate))
+		}
+	}
+	for termCount := 1; termCount <= maxTerms; termCount++ {
+		generate(termCount, nil)
+	}
+}
+
+var _ = Describe("Provisioner Affinity Validation", func() {
+	nodePoolDoesNotExist := testRequirement(v1.NodePoolLabelKey, corev1.NodeSelectorOpDoesNotExist)
+	nodePoolIn := testRequirement(v1.NodePoolLabelKey, corev1.NodeSelectorOpIn)
+	zoneIn := testRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn)
+
+	DescribeTable("classifies whether a pod requires a non-Karpenter node",
+		func(pod *corev1.Pod, want bool) {
+			Expect(requiresNonKarpenterNode(pod)).To(Equal(want))
+		},
+		Entry("with no affinity", &corev1.Pod{}, false),
+		Entry("with empty affinity",
+			&corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{}}},
+			false,
+		),
+		Entry("with empty node affinity",
+			&corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{}}}},
+			false,
+		),
+		Entry("when a required exclusion wins over a permissive preference",
+			func() *corev1.Pod {
+				pod := testRequiredPod(testTerm(nodePoolDoesNotExist))
+				pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.PreferredSchedulingTerm{{
+					Weight: 50, Preference: testTerm(zoneIn),
+				}}
+				return pod
+			}(),
+			true,
+		),
+		Entry("when a required alternative permits Karpenter despite an excluding preference",
+			func() *corev1.Pod {
+				pod := testRequiredPod(testTerm(zoneIn))
+				pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.PreferredSchedulingTerm{{
+					Weight: 50, Preference: testTerm(nodePoolDoesNotExist),
+				}}
+				return pod
+			}(),
+			false,
+		),
+		Entry("when a required exclusion is last in an AND term",
+			testRequiredPod(testTerm(zoneIn, nodePoolDoesNotExist)),
+			true,
+		),
+		Entry("when a duplicate contradictory key still explicitly excludes Karpenter",
+			testRequiredPod(testTerm(nodePoolIn, nodePoolDoesNotExist)),
+			true,
+		),
+		Entry("when DoesNotExist on another key does not exclude Karpenter",
+			testRequiredPod(testTerm(testRequirement("example.com/other", corev1.NodeSelectorOpDoesNotExist))),
+			false,
+		),
+		Entry("when empty matchFields is handled by generic affinity validation",
+			testRequiredPod(corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{nodePoolDoesNotExist},
+				MatchFields:      []corev1.NodeSelectorRequirement{},
+			}),
+			false,
+		),
+		Entry("when required pod affinity does not constrain node labels",
+			&corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{PodAffinity: &corev1.PodAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+					LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key: v1.NodePoolLabelKey, Operator: metav1.LabelSelectorOpDoesNotExist,
+					}}},
+					TopologyKey: corev1.LabelHostname,
+				}},
+			}}}},
+			false,
+		),
+		Entry("when required pod anti-affinity does not constrain node labels",
+			&corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{PodAntiAffinity: &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+					LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key: v1.NodePoolLabelKey, Operator: metav1.LabelSelectorOpDoesNotExist,
+					}}},
+					TopologyKey: corev1.LabelHostname,
+				}},
+			}}}},
+			false,
+		),
+	)
+
+	DescribeTable("does not classify other NodePool operators as exclusions",
+		func(operator corev1.NodeSelectorOperator) {
+			requirement := testRequirement(v1.NodePoolLabelKey, operator)
+			Expect(requiresNonKarpenterNode(testRequiredPod(testTerm(requirement)))).To(BeFalse())
+		},
+		Entry(string(corev1.NodeSelectorOpIn), corev1.NodeSelectorOpIn),
+		Entry(string(corev1.NodeSelectorOpNotIn), corev1.NodeSelectorOpNotIn),
+		Entry(string(corev1.NodeSelectorOpExists), corev1.NodeSelectorOpExists),
+		Entry(string(corev1.NodeSelectorOpGt), corev1.NodeSelectorOpGt),
+		Entry(string(corev1.NodeSelectorOpLt), corev1.NodeSelectorOpLt),
+	)
+
+	It("classifies pairwise required term combinations", func() {
+		termCases := []affinityTermCase{
+			{name: "empty", term: corev1.NodeSelectorTerm{}},
+			{name: "nodepool DoesNotExist", term: testTerm(nodePoolDoesNotExist), usable: true, excludes: true},
+			{name: "zone", term: testTerm(zoneIn), usable: true},
+			{
+				name: "matchFields",
+				term: corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{nodePoolDoesNotExist},
+					MatchFields:      []corev1.NodeSelectorRequirement{testRequirement("metadata.name", corev1.NodeSelectorOpIn)},
+				},
+				matchFields: true,
+			},
+		}
+		// Pairwise coverage is sufficient because required terms are a flat OR:
+		// each additional term can only preserve or clear the all-terms-exclude state.
+		visitAffinityTermCombinations(termCases, 2, checkAffinityCombination)
+	})
+
+	It("returns a sentinel-compatible error for a hard Karpenter exclusion", func() {
+		err := validateKarpenterManagedLabelCanExist(testRequiredPod(testTerm(nodePoolDoesNotExist)))
+		Expect(errors.Is(err, KarpenterManagedLabelDoesNotExistError)).To(BeTrue())
+	})
+})

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -2386,6 +2386,43 @@ var _ = Describe("Provisioning", func() {
 	})
 	Context("Preferential Fallback", func() {
 		Context("Required", func() {
+			DescribeTable("should schedule when any required node affinity term allows Karpenter", func(terms []corev1.NodeSelectorTerm) {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: terms,
+				}}}
+
+				ExpectApplied(ctx, env.Client, test.NodePool())
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+			},
+				Entry("with the Karpenter exclusion first", []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: v1.NodePoolLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist}}},
+					{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}},
+				}),
+				Entry("with the Karpenter exclusion last", []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}},
+					{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: v1.NodePoolLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist}}},
+				}),
+			)
+			It("should ignore pods when every required node affinity term excludes Karpenter", func() {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: v1.NodePoolLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist}}},
+						{MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: v1.NodePoolLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist},
+							{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"test-zone-1"}},
+						}},
+					},
+				}}}
+
+				ExpectApplied(ctx, env.Client, test.NodePool())
+				results := ExpectProvisionedResults(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				Expect(results.NewNodeClaims).To(BeEmpty())
+				ExpectMetricGaugeValue(pscheduling.IgnoredPodCount, 1, nil)
+				ExpectNotScheduled(ctx, env.Client, pod)
+			})
 			It("should not relax the final term", func() {
 				pod := test.UnschedulablePod()
 				pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
@@ -2431,6 +2468,40 @@ var _ = Describe("Provisioning", func() {
 			})
 		})
 		Context("Preferences", func() {
+			It("should relax a Karpenter exclusion preference when nodeSelector targets a NodePool", func() {
+				nodePool := test.NodePool()
+				pod := test.UnschedulablePod(test.PodOptions{
+					NodeSelector: map[string]string{v1.NodePoolLabelKey: nodePool.Name},
+				})
+				pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+					{
+						Weight: 50,
+						Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+							Key: v1.NodePoolLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist,
+						}}},
+					},
+				}}}
+
+				ExpectApplied(ctx, env.Client, nodePool)
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(node.Labels).To(HaveKeyWithValue(v1.NodePoolLabelKey, nodePool.Name))
+			})
+			It("should relax a preference for non-Karpenter capacity", func() {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+					{
+						Weight: 50,
+						Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: v1.NodePoolLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist},
+						}},
+					},
+				}}}
+
+				ExpectApplied(ctx, env.Client, test.NodePool())
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+			})
 			It("should relax all node affinity terms", func() {
 				pod := test.UnschedulablePod()
 				pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
@@ -2562,6 +2633,21 @@ var _ = Describe("Provisioning", func() {
 		Context("Ignore Preferences", func() {
 			BeforeEach(func() {
 				ctx = options.ToContext(ctx, test.Options(test.OptionsFields{PreferencePolicy: lo.ToPtr(options.PreferencePolicyIgnore)}))
+			})
+			It("should ignore a preference for non-Karpenter capacity", func() {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+					{
+						Weight: 50,
+						Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: v1.NodePoolLabelKey, Operator: corev1.NodeSelectorOpDoesNotExist},
+						}},
+					},
+				}}}
+
+				ExpectApplied(ctx, env.Client, test.NodePool())
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				ExpectScheduled(ctx, env.Client, pod)
 			})
 			It("should ignore node affinity preferences", func() {
 				zone1Pod := test.UnschedulablePod(test.PodOptions{

--- a/test/suites/regression/affinity_test.go
+++ b/test/suites/regression/affinity_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/test"
+)
+
+func nodeAffinityRequirement(key string, operator corev1.NodeSelectorOperator) corev1.NodeSelectorRequirement {
+	return corev1.NodeSelectorRequirement{
+		Key:      key,
+		Operator: operator,
+	}
+}
+
+func requiredNodeAffinity(terms ...corev1.NodeSelectorTerm) *corev1.Affinity {
+	return &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: terms},
+	}}
+}
+
+func preferredNodeAffinity(requirements ...corev1.NodeSelectorRequirement) *corev1.Affinity {
+	return &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
+			Weight: 100,
+			Preference: corev1.NodeSelectorTerm{
+				MatchExpressions: requirements,
+			},
+		}},
+	}}
+}
+
+var _ = Describe("Node Affinity Classification", func() {
+	DescribeTable("should schedule pods that can run on Karpenter nodes", func(configure func(*corev1.Pod)) {
+		pod := test.Pod()
+		configure(pod)
+
+		env.ExpectCreated(nodeClass, nodePool, pod)
+		env.EventuallyExpectHealthy(pod)
+
+		node := &corev1.Node{}
+		Expect(env.Client.Get(env, client.ObjectKey{Name: pod.Spec.NodeName}, node)).To(Succeed())
+		Expect(node.Labels).To(HaveKeyWithValue(v1.NodePoolLabelKey, nodePool.Name))
+	},
+		Entry("with a preferred DoesNotExist affinity", func(pod *corev1.Pod) {
+			pod.Spec.Affinity = preferredNodeAffinity(
+				nodeAffinityRequirement(v1.NodePoolLabelKey, corev1.NodeSelectorOpDoesNotExist),
+			)
+		}),
+		Entry("with a NodePool nodeSelector and preferred DoesNotExist affinity", func(pod *corev1.Pod) {
+			pod.Spec.NodeSelector = map[string]string{v1.NodePoolLabelKey: nodePool.Name}
+			pod.Spec.Affinity = preferredNodeAffinity(
+				nodeAffinityRequirement(v1.NodePoolLabelKey, corev1.NodeSelectorOpDoesNotExist),
+			)
+		}),
+		Entry("when an excluding required OR term comes first", func(pod *corev1.Pod) {
+			pod.Spec.Affinity = requiredNodeAffinity(
+				corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+					nodeAffinityRequirement(v1.NodePoolLabelKey, corev1.NodeSelectorOpDoesNotExist),
+				}},
+				corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+					nodeAffinityRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpExists),
+				}},
+			)
+		}),
+		Entry("when an excluding required OR term comes last", func(pod *corev1.Pod) {
+			pod.Spec.Affinity = requiredNodeAffinity(
+				corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+					nodeAffinityRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpExists),
+				}},
+				corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+					nodeAffinityRequirement(v1.NodePoolLabelKey, corev1.NodeSelectorOpDoesNotExist),
+				}},
+			)
+		}),
+		Entry("when required affinity permits Karpenter despite a preferred exclusion", func(pod *corev1.Pod) {
+			pod.Spec.Affinity = requiredNodeAffinity(corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					nodeAffinityRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpExists),
+				},
+			})
+			pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = preferredNodeAffinity(
+				nodeAffinityRequirement(v1.NodePoolLabelKey, corev1.NodeSelectorOpDoesNotExist),
+			).NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		}),
+	)
+
+	DescribeTable("should preserve hard exclusions from Karpenter nodes", func(affinity *corev1.Affinity) {
+		pod := test.Pod()
+		pod.Spec.Affinity = affinity
+		env.ExpectCreated(nodeClass, nodePool, pod)
+
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(pod), &corev1.Pod{})).To(Succeed())
+		}).Should(Succeed())
+		Consistently(func(g Gomega) {
+			current := &corev1.Pod{}
+			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(pod), current)).To(Succeed())
+			g.Expect(current.Spec.NodeName).To(BeEmpty())
+
+			nodeClaims := &v1.NodeClaimList{}
+			g.Expect(env.Client.List(env, nodeClaims, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+			g.Expect(nodeClaims.Items).To(BeEmpty())
+		}, 20*time.Second, 2*time.Second).Should(Succeed())
+
+		events := &corev1.EventList{}
+		Expect(env.Client.List(env, events, client.InNamespace(pod.Namespace))).To(Succeed())
+		for _, event := range events.Items {
+			if event.InvolvedObject.Name == pod.Name {
+				Expect(event.Source.Component).ToNot(Equal("karpenter"))
+			}
+		}
+	},
+		Entry("with one required DoesNotExist term", requiredNodeAffinity(
+			corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+				nodeAffinityRequirement(v1.NodePoolLabelKey, corev1.NodeSelectorOpDoesNotExist),
+			}},
+		)),
+	)
+})


### PR DESCRIPTION
Fixes #1265

**Description**
 Karpenter incorrectly rejected pods that preferred nodes without the `karpenter.sh/nodepool` label. The validation path treated preferred node affinity as required, preventing preference relaxation and NodeClaim creation.

This change evaluates the complete required node-affinity expression directly. Pods are rejected only when every usable required term excludes Karpenter nodes. Preferred exclusions remain relaxable, while hard exclusions retain their existing behavior.

**How was this change tested?**
- `make presubmit`
- Added unit, provisioning, disruption, and regression coverage for affinity classification, preference policies, hard exclusions, and persistent-volume topology.
- Validated locally in my EKS Cluster:
  - Reproduced original issue.
  - Verified the fix across 14 scenarios using both [`preferencePolicy`](https://karpenter.sh/docs/reference/settings/#preference-policy) modes: `Respect` and `Ignore`, covering required affinity, hard exclusions, unsupported `matchFields`, and non-affinity controls.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. LLMs assisted me but the contribution is mine.