### PR TITLE
fix(capacity buffer): fix trigger when cb is deleted

### DIFF
--- a/pkg/controllers/capacitybuffer/controller.go
+++ b/pkg/controllers/capacitybuffer/controller.go
@@ -46,7 +46,12 @@ import (
 // controller needs — so tests can substitute a fake, and we avoid an import
 // cycle on the provisioner package.
 type ProvisionerTrigger interface {
+	// Trigger wakes the provisioner, deduping repeated triggers for the same
+	// object UID within a batching window.
 	Trigger(uid types.UID)
+	// TriggerReconcile wakes the provisioner without an associated object, for
+	// callers reacting to an event that has no stable object UID to dedupe on.
+	TriggerReconcile()
 }
 
 // Controller reconciles CapacityBuffer resources by resolving their pod template
@@ -76,8 +81,11 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	cb := &autoscalingv1beta1.CapacityBuffer{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, cb); err != nil {
 		if errors.IsNotFound(err) {
-			// The buffer was deleted; drop its virtual pods from the cache.
+			// The buffer was deleted; drop its virtual pods from the cache and
+			// wake the provisioner so it refreshes cluster state (e.g.
+			// bufferPodCounts).
 			c.virtualPodCache.RemoveEntry(req.NamespacedName)
+			c.trigger.TriggerReconcile()
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
@@ -116,10 +124,12 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// Notify the provisioner so it can construct virtual pods and update the
 	// Provisioning condition in the next reconciliation. We trigger on every
 	// successful reconcile (not just status changes) so newly-applied buffers
-	// that already have accurate status still cause a provisioning pass.
-	if c.trigger != nil && resolved {
-		c.trigger.Trigger(cb.UID)
-	}
+	// that already have accurate status still cause a provisioning pass. We
+	// also trigger when the buffer failed to resolve (resolved == false): its
+	// stale entry was just dropped from the cache, and the provisioner must run
+	// to refresh cluster state so empty nodes can be reclaimed on an idle
+	// cluster.
+	c.trigger.Trigger(cb.UID)
 
 	return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 }

--- a/pkg/controllers/capacitybuffer/suite_test.go
+++ b/pkg/controllers/capacitybuffer/suite_test.go
@@ -547,7 +547,7 @@ var _ = Describe("CapacityBuffer Controller", func() {
 			Expect(trigger.calls).To(ContainElement(cb.UID))
 		})
 
-		It("should NOT trigger the provisioner when resolution fails", func() {
+		It("should trigger the provisioner when resolution fails so stale cluster state is refreshed", func() {
 			trigger := &fakeTrigger{}
 			ctrl := NewController(env.Client, trigger, virtualpods.NewVirtualPodCache(env.Client))
 
@@ -561,7 +561,41 @@ var _ = Describe("CapacityBuffer Controller", func() {
 			ExpectApplied(ctx, env.Client, cb)
 			ExpectReconcileSucceeded(ctx, ctrl, client.ObjectKeyFromObject(cb))
 
-			Expect(trigger.calls).To(BeEmpty())
+			// Resolution failed, so the buffer's stale cache entry was dropped;
+			// the provisioner must still be triggered to refresh cluster state
+			// (e.g. bufferPodCounts) so empty nodes can scale down on an idle
+			// cluster.
+			cb = ExpectExists(ctx, env.Client, cb)
+			Expect(trigger.calls).To(ContainElement(cb.UID))
+		})
+
+		It("should trigger the provisioner when the buffer is deleted so empty nodes can scale down", func() {
+			trigger := &fakeTrigger{}
+			ctrl := NewController(env.Client, trigger, virtualpods.NewVirtualPodCache(env.Client))
+
+			pt := &v1.PodTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "del-trig-template", Namespace: "default"},
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{Containers: []v1.Container{{Name: "c", Image: "p"}}},
+				},
+			}
+			cb := &autoscalingv1beta1.CapacityBuffer{
+				ObjectMeta: metav1.ObjectMeta{Name: "del-trig-buffer", Namespace: "default"},
+				Spec: autoscalingv1beta1.CapacityBufferSpec{
+					PodTemplateRef: &autoscalingv1beta1.LocalObjectRef{Name: "del-trig-template"},
+					Replicas:       lo.ToPtr(int32(1)),
+				},
+			}
+			ExpectApplied(ctx, env.Client, pt, cb)
+			key := client.ObjectKeyFromObject(cb)
+
+			// Delete the buffer and reconcile its key; the NotFound branch must
+			// wake the provisioner via the object-less TriggerReconcile, since
+			// the buffer no longer exists to provide a UID.
+			ExpectDeleted(ctx, env.Client, cb)
+			ExpectReconcileSucceeded(ctx, ctrl, key)
+
+			Expect(trigger.reconcileCalls).To(BeNumerically(">=", 1))
 		})
 	})
 
@@ -772,11 +806,17 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 	return nil
 }
 
-// fakeTrigger records which buffer UIDs had Trigger called on them.
+// fakeTrigger records which buffer UIDs had Trigger called on them, and how
+// many times the object-less TriggerReconcile was called.
 type fakeTrigger struct {
-	calls []types.UID
+	calls          []types.UID
+	reconcileCalls int
 }
 
 func (f *fakeTrigger) Trigger(uid types.UID) {
 	f.calls = append(f.calls, uid)
+}
+
+func (f *fakeTrigger) TriggerReconcile() {
+	f.reconcileCalls++
 }

--- a/pkg/controllers/provisioning/batcher.go
+++ b/pkg/controllers/provisioning/batcher.go
@@ -67,6 +67,15 @@ func (b *Batcher[T]) Trigger(elem T) {
 	b.mu.Unlock()
 }
 
+// TriggerNow should be used when there is no reliable dedupe key. Callers with stable trigger keys should
+// prefer Trigger in order to utilize batching semantics to reduce repeated work.
+func (b *Batcher[T]) TriggerNow() {
+	select {
+	case b.trigger <- struct{}{}:
+	default:
+	}
+}
+
 // Wait starts a batching window and continues waiting as long as it continues receiving triggers within
 // the idleDuration, up to the maxDuration
 func (b *Batcher[T]) Wait(ctx context.Context) bool {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -117,6 +117,12 @@ func (p *Provisioner) Trigger(uid types.UID) {
 	p.batcher.Trigger(uid)
 }
 
+// TriggerReconcile wakes the provisioner without associating the trigger with a
+// specific object.
+func (p *Provisioner) TriggerReconcile() {
+	p.batcher.TriggerNow()
+}
+
 func (p *Provisioner) Name() string {
 	return "provisioner"
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->
/kind fix

Fixes #3258 <!-- issue number -->

**Description**

When caching Capacity Buffers, the deletion case was missed. This PR corrects the deletion flow. The fix includes a new trigger method because the existing trigger method mandates having a UUID to de-dupe events, however, delete events do not have a UUID to de-dupe. I also refactored the trigger logic to drop the nil checks, as they were dead code.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
