### PR TITLE
test: add microbenchmarks for NewScheduler and NewTopology

### DIFF
--- a/pkg/controllers/provisioning/scheduling/newscheduler_bench_test.go
+++ b/pkg/controllers/provisioning/scheduling/newscheduler_bench_test.go
@@ -1,0 +1,48 @@
+//go:build test_performance
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkNewScheduler(b *testing.B) {
+	run := func(b *testing.B, s Scenario) {
+		f := buildScenario(b, s)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = newSchedulerFromScenario(f)
+		}
+	}
+
+	for _, n := range []int{0, 100, 500, 1000} {
+		s := Scenario{Nodes: n, PodsPerNode: 10, NodePools: 1, DaemonSets: 0}
+		b.Run(fmt.Sprintf("vector=nodes/n=%d", n), func(b *testing.B) { run(b, s) })
+	}
+	for _, np := range []int{1, 5, 20, 50} {
+		s := Scenario{Nodes: 100, PodsPerNode: 10, NodePools: np, DaemonSets: 5}
+		b.Run(fmt.Sprintf("vector=nodepools/np=%d", np), func(b *testing.B) { run(b, s) })
+	}
+	for _, ds := range []int{0, 1, 5, 10, 20} {
+		s := Scenario{Nodes: 100, PodsPerNode: 10, NodePools: 1, DaemonSets: ds}
+		b.Run(fmt.Sprintf("vector=daemonsets/ds=%d", ds), func(b *testing.B) { run(b, s) })
+	}
+}

--- a/pkg/controllers/provisioning/scheduling/perf_fixtures_test.go
+++ b/pkg/controllers/provisioning/scheduling/perf_fixtures_test.go
@@ -1,0 +1,220 @@
+//go:build test_performance
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling_test
+
+// Shared toolkit for the scheduling microbenchmarks. Benches are organized by the
+// function under test; each sweeps one scaling vector and routes through buildScenario.
+//
+// Sub-benchmark naming contract: vector=<name>/<param>=<n> (e.g. vector=nodes/n=500).
+// The benchstat gate parses this to group points by vector and gate on the per-vector
+// growth slope — not a single-point cost — which is what catches regressions that are
+// cheap at small scale but blow up along one axis. Keep the shape exact.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakecr "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/test"
+)
+
+// Scenario is one knob per scaling vector. A benchmark sweeps one field, holds the
+// rest fixed. It's a comparable value, so it doubles as the buildScenario cache key.
+type Scenario struct {
+	Nodes       int
+	PodsPerNode int
+	NodePools   int
+	DaemonSets  int
+}
+
+// ScenarioFixture holds everything scheduling.NewScheduler needs.
+type ScenarioFixture struct {
+	ctx           context.Context
+	client        client.Client
+	cluster       *state.Cluster
+	nodePools     []*v1.NodePool
+	itsByNP       map[string][]*cloudprovider.InstanceType
+	topology      *scheduling.Topology
+	stateNodes    []*state.StateNode
+	daemonSetPods []*corev1.Pod
+	recorder      events.Recorder
+	clk           clock.Clock
+}
+
+func benchCtx() context.Context {
+	return options.ToContext(injection.WithControllerName(context.Background(), "provisioner"), test.Options())
+}
+
+func benchNodePools(count int) []*v1.NodePool {
+	nps := make([]*v1.NodePool, count)
+	for i := range nps {
+		np := test.NodePool(v1.NodePool{
+			Spec: v1.NodePoolSpec{
+				Limits: v1.Limits{
+					corev1.ResourceCPU:    resource.MustParse("10000000"),
+					corev1.ResourceMemory: resource.MustParse("10000000Gi"),
+				},
+			},
+		})
+		np.Spec.Template.Spec.Taints = []corev1.Taint{{
+			Key:    fmt.Sprintf("bench.example.com/pool-%d", i),
+			Value:  "true",
+			Effect: corev1.TaintEffectNoSchedule,
+		}}
+		nps[i] = np
+	}
+	return nps
+}
+
+// benchStateNodes builds initialized+registered StateNodes directly, distributed
+// round-robin across the given NodePools.
+func benchStateNodes(count int, nodePools []*v1.NodePool) []*state.StateNode {
+	rl := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("16"),
+		corev1.ResourceMemory: resource.MustParse("32Gi"),
+		corev1.ResourcePods:   resource.MustParse("110"),
+	}
+	sn := make([]*state.StateNode, 0, count)
+	for i := 0; i < count; i++ {
+		nc := test.NodeClaim(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1.NodePoolLabelKey: nodePools[i%len(nodePools)].Name},
+			},
+			Status: v1.NodeClaimStatus{
+				ProviderID:  test.RandomProviderID(),
+				Capacity:    rl,
+				Allocatable: rl,
+			},
+		})
+		node := test.NodeClaimLinkedNode(nc)
+		node.Labels[corev1.LabelHostname] = fmt.Sprintf("bench-host-%d", i)
+		node.Labels[corev1.LabelTopologyZone] = "test-zone-1"
+		node.Labels[corev1.LabelInstanceTypeStable] = "fake-it-0"
+		node.Labels[v1.NodeRegisteredLabelKey] = "true"
+		node.Labels[v1.NodeInitializedLabelKey] = "true"
+		sn = append(sn, &state.StateNode{Node: node, NodeClaim: nc})
+	}
+	return sn
+}
+
+// benchDaemonSetPods buils distinct daemon-overhead groups, a scaling vector
+// introduced with https://github.com/kubernetes-sigs/karpenter/pull/2975
+func benchDaemonSetPods(count int) []*corev1.Pod {
+	pods := make([]*corev1.Pod, count)
+	for i := 0; i < count; i++ {
+		// keeps every pod compatible with the existing fake-it-0 nodes
+		instanceTypes := []string{"fake-it-0"}
+		if i > 0 {
+			instanceTypes = append(instanceTypes, fmt.Sprintf("fake-it-%d", i))
+		}
+		pods[i] = test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app": fmt.Sprintf("ds-%d", i)},
+				UID:    uuid.NewUUID(),
+			},
+			NodeRequirements: []corev1.NodeSelectorRequirement{
+				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"test-zone-1"}},
+				{Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: instanceTypes},
+			},
+			Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			ResourceRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+			},
+		})
+	}
+	return pods
+}
+
+// Memoized by full Scenario key so -count=N and the framework's b.Run re-invocation
+// don't rebuild the fixture repeatedly
+var scenarioCache = map[Scenario]*ScenarioFixture{}
+
+func buildScenario(tb testing.TB, s Scenario) *ScenarioFixture {
+	tb.Helper()
+	if f, ok := scenarioCache[s]; ok {
+		return f
+	}
+	ctx := benchCtx()
+
+	cp := fake.NewCloudProvider()
+	instanceTypes := fake.InstanceTypes(400)
+	cp.InstanceTypes = instanceTypes
+	c := fakecr.NewFakeClient()
+	clk := &clock.RealClock{}
+	cl := state.NewCluster(clk, c, cp)
+
+	nodePools := benchNodePools(s.NodePools)
+	itsByNP := map[string][]*cloudprovider.InstanceType{}
+	for _, np := range nodePools {
+		itsByNP[np.Name] = instanceTypes
+	}
+	topology, err := scheduling.NewTopology(ctx, c, cl, nil, nodePools, itsByNP, makeDiversePods(s.Nodes*s.PodsPerNode))
+	if err != nil {
+		tb.Fatalf("creating topology: %s", err)
+	}
+	stateNodes := benchStateNodes(s.Nodes, nodePools)
+	daemonSetPods := benchDaemonSetPods(s.DaemonSets)
+
+	f := &ScenarioFixture{
+		ctx: ctx, client: c, cluster: cl, nodePools: nodePools, itsByNP: itsByNP,
+		topology: topology, stateNodes: stateNodes, daemonSetPods: daemonSetPods,
+		recorder: events.NewRecorder(&record.FakeRecorder{}), clk: clk,
+	}
+	scenarioCache[s] = f
+	return f
+}
+
+// newSchedulerFromScenario is the single timed call shared by every NewScheduler sweep.
+func newSchedulerFromScenario(f *ScenarioFixture) *scheduling.Scheduler {
+	return scheduling.NewScheduler(
+		f.ctx,
+		f.client,
+		f.nodePools,
+		f.cluster,
+		f.stateNodes,
+		f.topology,
+		f.itsByNP,
+		f.daemonSetPods,
+		f.recorder,
+		f.clk,
+		nil, // volumeReqsByPod
+		nil, // allocator
+		scheduling.NumConcurrentReconciles(5),
+	)
+}

--- a/pkg/controllers/provisioning/scheduling/topology_bench_test.go
+++ b/pkg/controllers/provisioning/scheduling/topology_bench_test.go
@@ -1,0 +1,118 @@
+//go:build test_performance
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling_test
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+	fakecr "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/test"
+)
+
+func BenchmarkNewTopology(b *testing.B) {
+	for _, np := range []int{1, 5, 20, 50} {
+		b.Run(fmt.Sprintf("vector=nodepools/np=%d", np), func(b *testing.B) {
+			ctx := benchCtx()
+			pods := makeDiversePods(1000)
+
+			cp := fake.NewCloudProvider()
+			instanceTypes := fake.InstanceTypes(400)
+			cp.InstanceTypes = instanceTypes
+
+			client := fakecr.NewFakeClient()
+			clk := &clock.RealClock{}
+			cl := state.NewCluster(clk, client, cp)
+
+			nodePools := benchNodePools(np)
+			itsByNP := map[string][]*cloudprovider.InstanceType{}
+			for _, pool := range nodePools {
+				itsByNP[pool.Name] = instanceTypes
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := scheduling.NewTopology(ctx, client, cl, nil, nodePools, itsByNP, pods); err != nil {
+					b.Fatalf("creating topology: %s", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkForEachDomain(b *testing.B) {
+	cases := []struct {
+		domains     int
+		taintGroups int
+	}{
+		{100, 1}, {400, 1}, {1000, 1}, {400, 5}, {1000, 5},
+	}
+	// reject maens that pod tolerates no taint; tolerate means that pod tolerates every taint
+	for _, mode := range []struct {
+		name      string
+		tolerates bool
+	}{{"reject", false}, {"tolerate", true}} {
+		for _, tc := range cases {
+			b.Run(fmt.Sprintf("%s/vector=domains/d=%d/t=%d", mode.name, tc.domains, tc.taintGroups), func(b *testing.B) {
+				benchmarkForEachDomain(b, tc.domains, tc.taintGroups, mode.tolerates)
+			})
+		}
+	}
+}
+
+func benchmarkForEachDomain(b *testing.B, domains, taintGroupsPerDomain int, tolerates bool) {
+	dg := scheduling.NewTopologyDomainGroup()
+	for d := 0; d < domains; d++ {
+		domain := fmt.Sprintf("test-zone-%d", d)
+		for t := 0; t < taintGroupsPerDomain; t++ {
+			dg.Insert(domain, corev1.Taint{
+				Key:    fmt.Sprintf("bench.example.com/taint-%d", t),
+				Value:  "true",
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+		}
+	}
+	pod := test.Pod()
+	if tolerates {
+		for t := 0; t < taintGroupsPerDomain; t++ {
+			pod.Spec.Tolerations = append(pod.Spec.Tolerations, corev1.Toleration{
+				Key:      fmt.Sprintf("bench.example.com/taint-%d", t),
+				Operator: corev1.TolerationOpExists,
+			})
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		dg.ForEachDomain(pod, corev1.NodeInclusionPolicyHonor, func(domain string) {
+			count++
+		})
+		_ = count
+	}
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- adds allocation microbenchmarks for the two dominant costs - `NewScheduler` construction and `NewTopology`
- each benchmark sweeps scaling vectors like nodes, NodePools, DaemonSets, topology domains 
- adds `perf_fixtures_test.go` - a shared fixture builder that makes adding new scaling-vector benchmarks easy

> Note: these **run** on every PR via the existing workflow but **do not gate yet** . This PR adds the measurement; the CI gate is a follow-up.

**How was this change tested?**
Apple M5 Pro

###### BenchmarkNewScheduler

| vector | sweep → allocs/op |
|---|---|
| nodes | 0 → 585 · 100 → 5,698 · 500 → 26,100 · 1000 → 51,603  (~51 allocs/StateNode) |
| nodepools | 1 → 51,887 · 5 → 152,075 · 20 → 527,789 · 50 → 1,279,199  (super-linear) |
| daemonsets | 0 → 5,698 · 1 → 15,311 · 5 → 51,890 · 10 → 97,692 · 20 → 189,087  (~9,170 allocs/DS) |

###### BenchmarkNewTopology

| nodepools | allocs/op |
|---|---|
| 1 | 2,284,081 |
| 5 | 10,947,419 |
| 20 | 43,427,480 |
| 50 | 108,385,037 |

###### BenchmarkForEachDomain

`reject` = error-building path (the regression hotspot); `tolerate` = 0-alloc guard on the success path.

| domains / taintGroups | reject allocs/op | tolerate allocs/op |
|---|---|---|
| 100 / 1 | 901 | 0 |
| 400 / 1 | 3,601 | 0 |
| 1000 / 1 | 9,001 | 0 |
| 400 / 5 | 18,001 | 0 |
| 1000 / 5 | 45,001 | 0 |


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
