### PR TITLE
fix: skip static provisioning when no compatible offering is available

### DIFF
--- a/pkg/controllers/static/provisioning/controller.go
+++ b/pkg/controllers/static/provisioning/controller.go
@@ -47,6 +47,7 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	pscheduling "sigs.k8s.io/karpenter/pkg/scheduling"
 	nodepoolutils "sigs.k8s.io/karpenter/pkg/utils/nodepool"
 	"sigs.k8s.io/karpenter/pkg/utils/resources"
 )
@@ -73,6 +74,7 @@ func (c *Controller) Name() string {
 	return "static.provisioning"
 }
 
+//nolint:gocyclo
 func (c *Controller) Reconcile(ctx context.Context, np *v1.NodePool) (reconcile.Result, error) {
 	ctx = injection.WithControllerName(ctx, c.Name())
 
@@ -92,6 +94,14 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1.NodePool) (reconcile.
 	// Size down of replicas will be handled in deprovisioning controller to drain nodes and delete NodeClaims
 	// If there are drifting NodeClaims we need to count them as Active as disruption controller is in the process of creating replacements
 	if int64(runningNodeClaims)+int64(nodesPendingDisruptionCount) >= desiredReplicas {
+		return reconcile.Result{RequeueAfter: time.Minute}, nil
+	}
+
+	// Static NodeClaims don't go through scheduling, so the CloudProvider only discovers that every compatible offering
+	// is unavailable after the NodeClaim exists, at which point it's deleted and provisioning is immediately retriggered.
+	// Checking availability up-front keeps that failure from becoming an unbounded create/delete loop.
+	if !c.hasAvailableOffering(ctx, np) {
+		log.FromContext(ctx).V(1).Info("skipping provisioning, no compatible offering is currently available")
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
 	}
 
@@ -121,6 +131,24 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1.NodePool) (reconcile.
 	}
 
 	return reconcile.Result{RequeueAfter: time.Minute}, nil
+}
+
+// hasAvailableOffering mirrors the offering filter that CloudProviders apply in Create(). It's intentionally more
+// permissive than that filter so that it can only ever be a superset of what Create() would accept, and it returns
+// true on a CloudProvider error, since an error means availability is unknown rather than exhausted.
+func (c *Controller) hasAvailableOffering(ctx context.Context, np *v1.NodePool) bool {
+	its, err := c.cloudProvider.GetInstanceTypes(ctx, np)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("skipping offering availability check, unable to resolve instance types", "error", err)
+		return true
+	}
+	// Evaluate against the requirements of the NodeClaim that would actually be created, since ToNodeClaim() drops the
+	// requirements that only exist for scheduling simulation.
+	nc := scheduling.NewNodeClaimTemplate(np).ToNodeClaim()
+	reqs := pscheduling.NewNodeSelectorRequirementsWithMinValues(nc.Spec.Requirements...)
+	return lo.ContainsBy(its, func(it *cloudprovider.InstanceType) bool {
+		return it.Requirements.Intersects(reqs) == nil && it.Offerings.Available().HasCompatible(reqs)
+	})
 }
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {

--- a/pkg/controllers/static/provisioning/controller.go
+++ b/pkg/controllers/static/provisioning/controller.go
@@ -97,14 +97,6 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1.NodePool) (reconcile.
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
 	}
 
-	// Static NodeClaims don't go through scheduling, so the CloudProvider only discovers that every compatible offering
-	// is unavailable after the NodeClaim exists, at which point it's deleted and provisioning is immediately retriggered.
-	// Checking availability up-front keeps that failure from becoming an unbounded create/delete loop.
-	if !c.hasAvailableOffering(ctx, np) {
-		log.FromContext(ctx).V(1).Info("skipping provisioning, no compatible offering is currently available")
-		return reconcile.Result{RequeueAfter: time.Minute}, nil
-	}
-
 	limit, ok := np.Spec.Limits[resources.Node]
 	nodeLimit := lo.Ternary(ok, limit.Value(), int64(math.MaxInt64))
 	countNodeClaimsToProvision := c.cluster.NodePoolState.ReserveNodeCount(np.Name, nodeLimit, desiredReplicas-int64(runningNodeClaims))
@@ -112,6 +104,24 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1.NodePool) (reconcile.
 	if countNodeClaimsToProvision <= 0 {
 		log.FromContext(ctx).Info("nodepool node limit reached")
 		return reconcile.Result{RequeueAfter: time.Second * 30}, nil
+	}
+
+	// Static NodeClaims don't go through scheduling, so the CloudProvider only discovers that every compatible offering
+	// is unavailable after the NodeClaim exists, at which point it's deleted and provisioning is immediately retriggered.
+	// Checking availability up-front keeps that failure from becoming an unbounded create/delete loop.
+	available, err := c.hasAvailableOffering(ctx, np)
+	if err != nil || !available {
+		// Only a successful CreateNodeClaims consumes the reservation, so every other path has to hand it back.
+		c.cluster.NodePoolState.ReleaseNodeCount(np.Name, countNodeClaimsToProvision)
+		if cloudprovider.IsUnevaluatedNodePoolError(err) {
+			log.FromContext(ctx).V(1).Info("skipping provisioning, awaiting nodeoverlay evaluation")
+			return reconcile.Result{RequeueAfter: time.Second}, nil
+		}
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("checking offering availability, %w", err)
+		}
+		log.FromContext(ctx).V(1).Info("skipping provisioning, no compatible offering is currently available")
+		return reconcile.Result{RequeueAfter: time.Minute}, nil
 	}
 
 	log.FromContext(ctx).WithValues("current", runningNodeClaims, "desired", desiredReplicas, "provision-count", countNodeClaimsToProvision).
@@ -125,8 +135,7 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1.NodePool) (reconcile.
 		})
 	}
 
-	_, err := c.provisioner.CreateNodeClaims(ctx, nodeClaims, provisioning.WithReason(metrics.ProvisionedReason))
-	if err != nil {
+	if _, err = c.provisioner.CreateNodeClaims(ctx, nodeClaims, provisioning.WithReason(metrics.ProvisionedReason)); err != nil {
 		return reconcile.Result{}, fmt.Errorf("creating nodeclaims, %w", err)
 	}
 
@@ -134,21 +143,21 @@ func (c *Controller) Reconcile(ctx context.Context, np *v1.NodePool) (reconcile.
 }
 
 // hasAvailableOffering mirrors the offering filter that CloudProviders apply in Create(). It's intentionally more
-// permissive than that filter so that it can only ever be a superset of what Create() would accept, and it returns
-// true on a CloudProvider error, since an error means availability is unknown rather than exhausted.
-func (c *Controller) hasAvailableOffering(ctx context.Context, np *v1.NodePool) bool {
+// permissive than that filter so that it can only ever accept a superset of what Create() would accept.
+func (c *Controller) hasAvailableOffering(ctx context.Context, np *v1.NodePool) (bool, error) {
 	its, err := c.cloudProvider.GetInstanceTypes(ctx, np)
 	if err != nil {
-		log.FromContext(ctx).V(1).Info("skipping offering availability check, unable to resolve instance types", "error", err)
-		return true
+		return false, fmt.Errorf("resolving instance types, %w", err)
 	}
 	// Evaluate against the requirements of the NodeClaim that would actually be created, since ToNodeClaim() drops the
 	// requirements that only exist for scheduling simulation.
 	nc := scheduling.NewNodeClaimTemplate(np).ToNodeClaim()
 	reqs := pscheduling.NewNodeSelectorRequirementsWithMinValues(nc.Spec.Requirements...)
 	return lo.ContainsBy(its, func(it *cloudprovider.InstanceType) bool {
-		return it.Requirements.Intersects(reqs) == nil && it.Offerings.Available().HasCompatible(reqs)
-	})
+		return it.Requirements.Intersects(reqs) == nil && lo.ContainsBy(it.Offerings, func(o *cloudprovider.Offering) bool {
+			return o.Available && reqs.IsCompatible(o.Requirements, pscheduling.AllowUndefinedWellKnownLabels)
+		})
+	}), nil
 }
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {

--- a/pkg/controllers/static/provisioning/suite_test.go
+++ b/pkg/controllers/static/provisioning/suite_test.go
@@ -38,6 +38,7 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
@@ -46,12 +47,27 @@ import (
 	static "sigs.k8s.io/karpenter/pkg/controllers/static/provisioning"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
+	pscheduling "sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/state/cost"
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 )
+
+// unavailableOfferings returns the default fake offering shape with every offering marked unavailable.
+func unavailableOfferings() []cloudprovider.Offering {
+	return lo.Map([]string{"test-zone-1", "test-zone-2"}, func(zone string, _ int) cloudprovider.Offering {
+		return cloudprovider.Offering{
+			Available: false,
+			Requirements: pscheduling.NewLabelRequirements(map[string]string{
+				v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+				corev1.LabelTopologyZone: zone,
+			}),
+			Price: 1.0,
+		}
+	})
+}
 
 type failingClient struct {
 	client.Client
@@ -461,7 +477,7 @@ var _ = Describe("Static Provisioning Controller", func() {
 				{Key: "karpenter.k8s.aws/instance-cpu", Operator: corev1.NodeSelectorOpIn, Values: []string{"32"}},
 				{Key: "karpenter.k8s.aws/instance-hypervisor", Operator: corev1.NodeSelectorOpIn, Values: []string{"nitro"}},
 				{Key: "karpenter.k8s.aws/instance-generation", Operator: corev1.NodeSelectorOpGt, Values: []string{"2"}},
-				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-west-2a", "us-west-2b"}},
+				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}},
 				{Key: corev1.LabelArchStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"amd64", "arm64"}},
 				{Key: v1.CapacityTypeLabelKey, Operator: corev1.NodeSelectorOpIn, Values: []string{"on-demand", "reserved", "spot"}},
 			}
@@ -471,7 +487,7 @@ var _ = Describe("Static Provisioning Controller", func() {
 				{Key: "karpenter.k8s.aws/instance-cpu", Operator: corev1.NodeSelectorOpIn, Values: []string{"32"}},
 				{Key: "karpenter.k8s.aws/instance-hypervisor", Operator: corev1.NodeSelectorOpIn, Values: []string{"nitro"}},
 				{Key: "karpenter.k8s.aws/instance-generation", Operator: v1.NodeSelectorOpGte, Values: []string{"3"}}, // GT 2 canonicalized to GTE 3
-				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-west-2a", "us-west-2b"}},
+				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}},
 				{Key: corev1.LabelArchStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"amd64", "arm64"}},
 				{Key: v1.CapacityTypeLabelKey, Operator: corev1.NodeSelectorOpIn, Values: []string{"on-demand", "reserved", "spot"}},
 			}
@@ -584,6 +600,84 @@ var _ = Describe("Static Provisioning Controller", func() {
 			}, 10*time.Second)
 		})
 
+	})
+	Context("Offering Availability", func() {
+		It("should not create nodeclaims when no instance type has an available offering", func() {
+			nodePool := test.StaticNodePool()
+			nodePool.Spec.Replicas = new(int64(3))
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				fake.NewInstanceType("unavailable-instance-type", fake.WithOfferings(unavailableOfferings()...)),
+			}
+			ExpectApplied(ctx, env.Client, nodePool)
+
+			result := ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+			Expect(result.RequeueAfter).To(BeNumerically("~", time.Minute*1, time.Second))
+
+			nodeClaims := &v1.NodeClaimList{}
+			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
+			Expect(nodeClaims.Items).To(HaveLen(0))
+			// The node count reservation must not leak when we skip provisioning
+			ExpectStateNodePoolCount(cluster, nodePool.Name, 0, 0, 0)
+		})
+		It("should not create nodeclaims when the only available offerings belong to an incompatible instance type", func() {
+			nodePool := test.ReplaceRequirements(test.StaticNodePool(), v1.NodeSelectorRequirementWithMinValues{
+				Key:      corev1.LabelInstanceTypeStable,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"unavailable-instance-type"},
+			})
+			nodePool.Spec.Replicas = new(int64(1))
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				fake.NewInstanceType("unavailable-instance-type", fake.WithOfferings(unavailableOfferings()...)),
+				fake.NewInstanceType("available-instance-type"),
+			}
+			ExpectApplied(ctx, env.Client, nodePool)
+
+			result := ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+			Expect(result.RequeueAfter).To(BeNumerically("~", time.Minute*1, time.Second))
+
+			nodeClaims := &v1.NodeClaimList{}
+			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
+			Expect(nodeClaims.Items).To(HaveLen(0))
+		})
+		It("should create nodeclaims when at least one compatible instance type has an available offering", func() {
+			nodePool := test.StaticNodePool()
+			nodePool.Spec.Replicas = new(int64(2))
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				fake.NewInstanceType("unavailable-instance-type", fake.WithOfferings(unavailableOfferings()...)),
+				fake.NewInstanceType("available-instance-type"),
+			}
+			ExpectApplied(ctx, env.Client, nodePool)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+
+			nodeClaims := &v1.NodeClaimList{}
+			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
+			Expect(nodeClaims.Items).To(HaveLen(2))
+		})
+		It("should create nodeclaims when the cloudprovider fails to resolve instance types", func() {
+			nodePool := test.StaticNodePool()
+			nodePool.Spec.Replicas = new(int64(2))
+			cloudProvider.ErrorsForNodePool[nodePool.Name] = fmt.Errorf("failed resolving instance types")
+			ExpectApplied(ctx, env.Client, nodePool)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+
+			nodeClaims := &v1.NodeClaimList{}
+			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
+			Expect(nodeClaims.Items).To(HaveLen(2))
+		})
+		It("should not create nodeclaims when the cloudprovider resolves no instance types", func() {
+			nodePool := test.StaticNodePool()
+			nodePool.Spec.Replicas = new(int64(2))
+			cloudProvider.InstanceTypesForNodePool[nodePool.Name] = []*cloudprovider.InstanceType{}
+			ExpectApplied(ctx, env.Client, nodePool)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+
+			nodeClaims := &v1.NodeClaimList{}
+			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
+			Expect(nodeClaims.Items).To(HaveLen(0))
+		})
 	})
 	Context("Helper Functions", func() {
 		DescribeTable("should detect replica or status changes",

--- a/pkg/controllers/static/provisioning/suite_test.go
+++ b/pkg/controllers/static/provisioning/suite_test.go
@@ -52,6 +52,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	"sigs.k8s.io/karpenter/pkg/utils/resources"
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 )
 
@@ -616,8 +617,28 @@ var _ = Describe("Static Provisioning Controller", func() {
 			nodeClaims := &v1.NodeClaimList{}
 			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
 			Expect(nodeClaims.Items).To(HaveLen(0))
-			// The node count reservation must not leak when we skip provisioning
 			ExpectStateNodePoolCount(cluster, nodePool.Name, 0, 0, 0)
+		})
+		It("should release the node count reservation when no offering is available", func() {
+			nodePool := test.StaticNodePool(v1.NodePool{
+				Spec: v1.NodePoolSpec{Limits: v1.Limits{resources.Node: resource.MustParse("2")}},
+			})
+			nodePool.Spec.Replicas = new(int64(2))
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				fake.NewInstanceType("unavailable-instance-type", fake.WithOfferings(unavailableOfferings()...)),
+			}
+			ExpectApplied(ctx, env.Client, nodePool)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+			nodeClaims := &v1.NodeClaimList{}
+			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
+			Expect(nodeClaims.Items).To(HaveLen(0))
+
+			// A reservation leaked by the skipped attempt would consume the node limit and block this one
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("available-instance-type")}
+			ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
+			Expect(nodeClaims.Items).To(HaveLen(2))
 		})
 		It("should not create nodeclaims when the only available offerings belong to an incompatible instance type", func() {
 			nodePool := test.ReplaceRequirements(test.StaticNodePool(), v1.NodeSelectorRequirementWithMinValues{
@@ -654,17 +675,31 @@ var _ = Describe("Static Provisioning Controller", func() {
 			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
 			Expect(nodeClaims.Items).To(HaveLen(2))
 		})
-		It("should create nodeclaims when the cloudprovider fails to resolve instance types", func() {
+		It("should return an error when the cloudprovider fails to resolve instance types", func() {
 			nodePool := test.StaticNodePool()
 			nodePool.Spec.Replicas = new(int64(2))
 			cloudProvider.ErrorsForNodePool[nodePool.Name] = fmt.Errorf("failed resolving instance types")
 			ExpectApplied(ctx, env.Client, nodePool)
 
-			ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+			err := ExpectObjectReconcileFailed(ctx, env.Client, controller, nodePool)
+			Expect(err.Error()).To(ContainSubstring("checking offering availability"))
 
 			nodeClaims := &v1.NodeClaimList{}
 			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
-			Expect(nodeClaims.Items).To(HaveLen(2))
+			Expect(nodeClaims.Items).To(HaveLen(0))
+		})
+		It("should requeue without erroring when the nodepool is awaiting nodeoverlay evaluation", func() {
+			nodePool := test.StaticNodePool()
+			nodePool.Spec.Replicas = new(int64(2))
+			cloudProvider.ErrorsForNodePool[nodePool.Name] = cloudprovider.NewUnevaluatedNodePoolError(nodePool.Name)
+			ExpectApplied(ctx, env.Client, nodePool)
+
+			result := ExpectObjectReconciled(ctx, env.Client, controller, nodePool)
+			Expect(result.RequeueAfter).To(BeNumerically("~", time.Second, time.Millisecond*100))
+
+			nodeClaims := &v1.NodeClaimList{}
+			Expect(env.Client.List(ctx, nodeClaims)).To(Succeed())
+			Expect(nodeClaims.Items).To(HaveLen(0))
 		})
 		It("should not create nodeclaims when the cloudprovider resolves no instance types", func() {
 			nodePool := test.StaticNodePool()


### PR DESCRIPTION
**Description**

Static NodeClaims bypass scheduling, so the CloudProvider only discovers that every compatible offering is unavailable after the NodeClaim exists. Launch then deletes the NodeClaim, and that deletion immediately retriggers static provisioning, producing an unbounded create/fail/delete loop with no pending pods involved.

Check offering availability before topping up replicas, mirroring the filter CloudProviders apply in Create(). The check is deliberately more permissive than that filter so it can only ever accept a superset of what Create() would accept, and a CloudProvider error is treated as unknown rather than exhausted so a provider hiccup can't stall provisioning.

The check runs before ReserveNodeCount so skipping provisioning cannot leak a node count reservation.

Reported in https://github.com/Azure/karpenter-provider-azure/issues/1854 and https://github.com/kaito-project/kaito/issues/2295

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
