### PR TITLE
feat: price-aware bin-packing for NodePools that allow spot and on-demand

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -399,6 +399,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 
 	opts := []scheduler.Options{
 		scheduler.DisableReservedCapacityFallback,
+		scheduler.PriceAwareBinPacking,
 		scheduler.NumConcurrentReconciles(int(math.Ceil(float64(options.FromContext(ctx).CPURequests) / 1000.0))),
 		scheduler.MinValuesPolicy(options.FromContext(ctx).MinValuesPolicy),
 	}

--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -23,9 +23,11 @@ import (
 	"github.com/mitchellh/hashstructure/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -616,6 +618,145 @@ var _ = Describe("Instance Type Selection", func() {
 		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 		node := ExpectScheduled(ctx, env.Client, pod)
 		Expect(node.Labels[corev1.LabelInstanceTypeStable]).To(Equal("test-instance1"))
+	})
+	Context("PriceAwareBinPacking", func() {
+		var small, large *cloudprovider.InstanceType
+		offering := func(capacityType string, price float64, available bool) cloudprovider.Offering {
+			return cloudprovider.Offering{
+				Available:    available,
+				Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: capacityType, corev1.LabelTopologyZone: "test-zone-1"}),
+				Price:        price,
+			}
+		}
+		nodeClaimCapacityTypes := func(nc *scheduling.NodeClaim) []string {
+			return lo.Uniq(lo.FlatMap(nc.InstanceTypeOptions, func(it *cloudprovider.InstanceType, _ int) []string {
+				return lo.Map(it.Offerings.Available().Compatible(nc.Requirements), func(o *cloudprovider.Offering, _ int) string { return o.CapacityType() })
+			}))
+		}
+		BeforeEach(func() {
+			// small fits up to three 1-CPU pods and is available as spot or on-demand. large fits many more pods, but
+			// its spot offering is unavailable (e.g. an insufficient capacity error), so it can only launch as on-demand.
+			small = fake.NewInstanceType("small",
+				fake.WithResources(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("16Gi"), corev1.ResourcePods: resource.MustParse("100")}),
+				fake.WithOfferings(offering(v1.CapacityTypeSpot, 0.1, true), offering(v1.CapacityTypeOnDemand, 0.4, true)),
+			)
+			large = fake.NewInstanceType("large",
+				fake.WithResources(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("16"), corev1.ResourceMemory: resource.MustParse("64Gi"), corev1.ResourcePods: resource.MustParse("100")}),
+				fake.WithOfferings(offering(v1.CapacityTypeSpot, 0.4, false), offering(v1.CapacityTypeOnDemand, 1.6, true)),
+			)
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{small, large}
+			nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirementWithMinValues{{
+				Key:      v1.CapacityTypeLabelKey,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{v1.CapacityTypeSpot, v1.CapacityTypeOnDemand},
+			}}
+		})
+		It("should not bin-pack pods onto an in-flight NodeClaim if that would remove all spot instance type options", func() {
+			ExpectApplied(ctx, env.Client, nodePool)
+			pods := test.UnschedulablePods(test.PodOptions{
+				ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},
+			}, 4)
+			ExpectApplied(ctx, env.Client, lo.Map(pods, func(p *corev1.Pod, _ int) client.Object { return p })...)
+			results, err := prov.Schedule(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			// Without price-awareness, all four pods would be packed onto a single NodeClaim which only fits "large"
+			// and could therefore only launch as on-demand. Instead, the fourth pod gets its own NodeClaim so that
+			// both NodeClaims keep "small" as an option and remain eligible to launch as spot.
+			Expect(results.NewNodeClaims).To(HaveLen(2))
+			Expect(lo.Map(results.NewNodeClaims, func(nc *scheduling.NodeClaim, _ int) int { return len(nc.Pods) })).To(ConsistOf(3, 1))
+			for _, nc := range results.NewNodeClaims {
+				Expect(nc.InstanceTypeOptions).To(ContainElement(small))
+				Expect(nodeClaimCapacityTypes(nc)).To(ContainElement(v1.CapacityTypeSpot))
+			}
+			// The NodeClaims handed to the cloudprovider must allow spot
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+			Expect(cloudProvider.CreateCalls).To(HaveLen(2))
+			for _, nc := range cloudProvider.CreateCalls {
+				Expect(scheduler.NewNodeSelectorRequirementsWithMinValues(nc.Spec.Requirements...).Get(v1.CapacityTypeLabelKey).Has(v1.CapacityTypeSpot)).To(BeTrue())
+			}
+			for _, p := range pods {
+				ExpectScheduled(ctx, env.Client, p)
+			}
+		})
+		It("should bin-pack pods onto an in-flight NodeClaim which retains spot instance type options", func() {
+			// Make spot available for the large instance type as well, so packing everything onto one NodeClaim
+			// doesn't sacrifice spot.
+			large.Offerings[0].Available = true
+			large.Requirements.Get(v1.CapacityTypeLabelKey).Insert(v1.CapacityTypeSpot)
+			ExpectApplied(ctx, env.Client, nodePool)
+			pods := test.UnschedulablePods(test.PodOptions{
+				ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},
+			}, 4)
+			ExpectApplied(ctx, env.Client, lo.Map(pods, func(p *corev1.Pod, _ int) client.Object { return p })...)
+			results, err := prov.Schedule(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results.NewNodeClaims).To(HaveLen(1))
+			Expect(results.NewNodeClaims[0].Pods).To(HaveLen(4))
+			Expect(results.NewNodeClaims[0].InstanceTypeOptions).To(ConsistOf(large))
+			Expect(nodeClaimCapacityTypes(results.NewNodeClaims[0])).To(ContainElement(v1.CapacityTypeSpot))
+		})
+		It("should bin-pack pods onto an in-flight NodeClaim which already has no spot instance type options", func() {
+			ExpectApplied(ctx, env.Client, nodePool)
+			// The 10-CPU pod is scheduled first (pods are sorted by resource requests) and only fits "large", so the
+			// NodeClaim can only launch as on-demand from the start. The smaller pods should still be packed onto it.
+			pods := append(test.UnschedulablePods(test.PodOptions{
+				ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},
+			}, 3), test.UnschedulablePod(test.PodOptions{
+				ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10")}},
+			}))
+			ExpectApplied(ctx, env.Client, lo.Map(pods, func(p *corev1.Pod, _ int) client.Object { return p })...)
+			results, err := prov.Schedule(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results.NewNodeClaims).To(HaveLen(1))
+			Expect(results.NewNodeClaims[0].Pods).To(HaveLen(4))
+			Expect(results.NewNodeClaims[0].InstanceTypeOptions).To(ConsistOf(large))
+			Expect(nodeClaimCapacityTypes(results.NewNodeClaims[0])).To(ConsistOf(v1.CapacityTypeOnDemand))
+		})
+		It("should schedule a pod which only fits instance types without spot offerings to a new NodeClaim", func() {
+			ExpectApplied(ctx, env.Client, nodePool)
+			pods := append(test.UnschedulablePods(test.PodOptions{
+				ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},
+			}, 2), test.UnschedulablePod(test.PodOptions{
+				ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")}},
+				NodeRequirements:     []corev1.NodeSelectorRequirement{{Key: fake.LabelInstanceSize, Operator: corev1.NodeSelectorOpIn, Values: []string{"large"}}},
+			}))
+			ExpectApplied(ctx, env.Client, lo.Map(pods, func(p *corev1.Pod, _ int) client.Object { return p })...)
+			results, err := prov.Schedule(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			// The 1-CPU pods are scheduled first onto a NodeClaim which can launch as spot. The pod which requires the
+			// large instance type would force that NodeClaim to on-demand, so it gets its own NodeClaim, which is
+			// on-demand since that's the only option for it.
+			Expect(results.NewNodeClaims).To(HaveLen(2))
+			Expect(lo.Map(results.NewNodeClaims, func(nc *scheduling.NodeClaim, _ int) int { return len(nc.Pods) })).To(ConsistOf(2, 1))
+			for _, nc := range results.NewNodeClaims {
+				if len(nc.Pods) == 2 {
+					Expect(nodeClaimCapacityTypes(nc)).To(ContainElement(v1.CapacityTypeSpot))
+				} else {
+					Expect(nc.InstanceTypeOptions).To(ConsistOf(large))
+					Expect(nodeClaimCapacityTypes(nc)).To(ConsistOf(v1.CapacityTypeOnDemand))
+				}
+			}
+			for _, p := range pods {
+				Expect(results.PodErrors).ToNot(HaveKey(p))
+			}
+		})
+		It("should bin-pack pods onto a single NodeClaim when the NodePool only allows on-demand", func() {
+			nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirementWithMinValues{{
+				Key:      v1.CapacityTypeLabelKey,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{v1.CapacityTypeOnDemand},
+			}}
+			ExpectApplied(ctx, env.Client, nodePool)
+			pods := test.UnschedulablePods(test.PodOptions{
+				ResourceRequirements: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}},
+			}, 4)
+			ExpectApplied(ctx, env.Client, lo.Map(pods, func(p *corev1.Pod, _ int) client.Object { return p })...)
+			results, err := prov.Schedule(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results.NewNodeClaims).To(HaveLen(1))
+			Expect(results.NewNodeClaims[0].Pods).To(HaveLen(4))
+			Expect(results.NewNodeClaims[0].InstanceTypeOptions).To(ConsistOf(large))
+		})
 	})
 	Context("MinValues", func() {
 		It("should schedule respecting the minValues from instance-type requirements", func() {

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -60,6 +60,13 @@ type NodeClaim struct {
 	//   this expansion.
 	reservedOfferings    cloudprovider.Offerings
 	reservedOfferingMode ReservedOfferingMode
+	priceAwareBinPacking bool
+
+	// hasSpotOffering tracks whether the NodeClaim, with the pods currently scheduled to it, still has at least one
+	// instance type option with an available spot offering compatible with its requirements. Since the cloudprovider
+	// launches into the cheapest capacity type the NodeClaim's options allow (spot before on-demand), this is the
+	// NodeClaim's expected launch capacity type and is used to keep bin-packing price-aware (see CanAdd).
+	hasSpotOffering bool
 }
 
 // ReservedOfferingError indicates a NodeClaim couldn't be created or a pod couldn't be added to an exxisting NodeClaim
@@ -90,6 +97,7 @@ func NewNodeClaim(
 	instanceTypes []*cloudprovider.InstanceType,
 	reservationManager *ReservationManager,
 	reservedOfferingMode ReservedOfferingMode,
+	priceAwareBinPacking bool,
 ) *NodeClaim {
 	hostname := fmt.Sprintf("hostname-placeholder-%04d", atomic.AddInt64(&nodeID, 1))
 	template := *nodeClaimTemplate
@@ -117,6 +125,7 @@ func NewNodeClaim(
 		reservedOfferings:    cloudprovider.Offerings{},
 		reservationManager:   reservationManager,
 		reservedOfferingMode: reservedOfferingMode,
+		priceAwareBinPacking: priceAwareBinPacking,
 	}
 }
 
@@ -246,6 +255,17 @@ func (n *NodeClaim) tryVolumeAlternative(ctx context.Context, pod *corev1.Pod, p
 			return nil, nil, nil, nil, fmt.Errorf("no instance type satisfies both scheduling and dynamic resource requirements")
 		}
 	}
+	// Price-aware bin-packing: adding a pod to an in-flight NodeClaim tightens its requirements and shrinks its
+	// instance type options (larger pods need larger instance types, pod constraints may exclude offerings). If that
+	// leaves no instance type with an available spot offering, the NodeClaim can only launch as on-demand, which is
+	// typically far more expensive than launching this pod on a separate spot NodeClaim and keeping the current one
+	// spot. Reject the add in that case so the scheduler tries another in-flight NodeClaim or creates a new one. This
+	// only applies once the NodeClaim already has pods: a NodeClaim's first pod is always accepted, so a pod that can
+	// only fit an on-demand instance type still schedules, and NodePools that allow a single capacity type are
+	// unaffected. Reserved offerings are handled separately by offeringsToReserve.
+	if n.priceAwareBinPacking && len(n.Pods) != 0 && n.hasSpotOffering && !hasAvailableOffering(remaining, nodeClaimRequirements, v1.CapacityTypeSpot) {
+		return nil, nil, nil, nil, fmt.Errorf("adding pod would remove all instance type options with an available spot offering")
+	}
 	ofs, err := n.offeringsToReserve(ctx, remaining, nodeClaimRequirements)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -264,6 +284,7 @@ func (n *NodeClaim) Add(ctx context.Context, pod *corev1.Pod, podData *PodData, 
 	// Daemon overhead is excluded here to avoid double-counting
 	n.Spec.Resources.Requests = resources.Merge(n.Spec.Resources.Requests, podData.Requests)
 	n.Requirements = nodeClaimRequirements
+	n.hasSpotOffering = hasAvailableOffering(instanceTypes, nodeClaimRequirements, v1.CapacityTypeSpot)
 	n.topology.Register(corev1.LabelHostname, n.hostname)
 	n.topology.Record(pod, n.Spec.Taints, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
 	hostPorts := scheduling.GetHostPorts(pod)
@@ -648,6 +669,19 @@ func fits(instanceType *cloudprovider.InstanceType, requests corev1.ResourceList
 		}
 	}
 	return false, hasOffering
+}
+
+// hasAvailableOffering returns true if any of the instance types has an available offering of the given capacity type
+// that is compatible with the requirements.
+func hasAvailableOffering(instanceTypes []*cloudprovider.InstanceType, requirements scheduling.Requirements, capacityType string) bool {
+	for _, it := range instanceTypes {
+		for _, o := range it.Offerings {
+			if o.Available && o.CapacityType() == capacityType && requirements.IsCompatible(o.Requirements, scheduling.AllowUndefinedWellKnownLabels) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // filterInstanceTypesByVolumeAttachmentLimits returns the instance types which can support the given volumes. Instance types

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -96,12 +96,22 @@ type options struct {
 	minValuesPolicy         karpopts.MinValuesPolicy
 	numConcurrentReconciles int
 	enforceConsolidateAfter bool
+	priceAwareBinPacking    bool
 }
 
 type Options = option.Function[options]
 
 var DisableReservedCapacityFallback = func(opts *options) {
 	opts.reservedOfferingMode = ReservedOfferingModeStrict
+}
+
+// PriceAwareBinPacking indicates that the scheduler should not add a pod to an in-flight NodeClaim if doing so would
+// remove every instance type option with an available spot offering, forcing the NodeClaim to launch as on-demand.
+// The pod is scheduled to another in-flight NodeClaim or a new NodeClaim instead, so that both remain eligible for
+// spot. This is enabled for provisioning but not for disruption simulations, which require a single replacement
+// NodeClaim and compare launch prices explicitly.
+var PriceAwareBinPacking = func(opts *options) {
+	opts.priceAwareBinPacking = true
 }
 
 var IgnorePreferences = func(opts *options) {
@@ -186,6 +196,7 @@ func NewScheduler(
 		clock:                   clock,
 		reservationManager:      NewReservationManager(instanceTypes),
 		reservedOfferingMode:    option.Resolve(opts...).reservedOfferingMode,
+		priceAwareBinPacking:    option.Resolve(opts...).priceAwareBinPacking,
 		preferencePolicy:        option.Resolve(opts...).preferencePolicy,
 		minValuesPolicy:         minValuesPolicy,
 		numConcurrentReconciles: lo.Ternary(option.Resolve(opts...).numConcurrentReconciles > 0, option.Resolve(opts...).numConcurrentReconciles, 1),
@@ -245,6 +256,7 @@ type Scheduler struct {
 	clock                   clock.Clock
 	reservationManager      *ReservationManager
 	reservedOfferingMode    ReservedOfferingMode
+	priceAwareBinPacking    bool
 	preferencePolicy        PreferencePolicy
 	minValuesPolicy         karpopts.MinValuesPolicy
 	numConcurrentReconciles int
@@ -725,7 +737,7 @@ func (s *Scheduler) addToNewNodeClaim(ctx context.Context, pod *corev1.Pod, volu
 					"total", len(s.nodeClaimTemplates[i].InstanceTypeOptions))
 			}
 		}
-		nodeClaim := NewNodeClaim(s.nodeClaimTemplates[i], s.topology, s.daemonOverheadGroups[s.nodeClaimTemplates[i]], its, s.reservationManager, s.reservedOfferingMode)
+		nodeClaim := NewNodeClaim(s.nodeClaimTemplates[i], s.topology, s.daemonOverheadGroups[s.nodeClaimTemplates[i]], its, s.reservationManager, s.reservedOfferingMode, s.priceAwareBinPacking)
 		r, its, ofs, result, err := nodeClaim.CanAdd(ctx, pod, s.cachedPodData[pod.UID], volumes, s.minValuesPolicy == karpopts.MinValuesPolicyBestEffort, s.allocator)
 		if err != nil {
 			errs[i] = err


### PR DESCRIPTION
Fixes #2117

**Description**

In NodePools that allow both spot and on-demand, packing more pods onto an in-flight NodeClaim can silently eliminate every instance type that has an available spot offering, forcing the NodeClaim to launch as on-demand even though a second spot NodeClaim would have been far cheaper.

This change tracks, per in-flight NodeClaim, whether it still has a spot-capable instance type option, and (behind a new `scheduling.PriceAwareBinPacking` option, enabled for provisioning only) rejects adding a pod that would remove the last one, so the pod goes to another or a new NodeClaim instead. First pods are always accepted, and single-capacity-type NodePools are unaffected.

**How was this change tested?**

New `PriceAwareBinPacking` Ginkgo specs in `instance_selection_test.go` (the spot-drop cases fail on main and pass with this change); full `go test` of the scheduling, provisioning, disruption, and cloudprovider packages; `go vet`/`gofmt` clean.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.