### PR TITLE
fix: attribute failed disruption validations to a NodePool and policy

### DIFF
--- a/pkg/controllers/disruption/balanced.go
+++ b/pkg/controllers/disruption/balanced.go
@@ -233,10 +233,10 @@ func (e *balancedEvaluator) ApproveCommand(ctx context.Context, cmd Command) (bo
 		if scored && !result.Approved() {
 			moveDecision = string(RejectedDecision)
 		}
-		ConsolidationMovesTotal.Inc(map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, policyLabel: policy})
+		ConsolidationMovesTotal.Inc(map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, PolicyLabel: policy})
 
 		if scored {
-			ConsolidationScoreHistogram.Observe(result.Score(), map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, policyLabel: policy})
+			ConsolidationScoreHistogram.Observe(result.Score(), map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, PolicyLabel: policy})
 			if result.Approved() {
 				e.recorder.Publish(disruptionevents.ConsolidationApproved(
 					candidate.Node, candidate.NodeClaim,
@@ -261,7 +261,7 @@ func (e *balancedEvaluator) EmitMultiNodeEvents(ctx context.Context, cmd Command
 	for poolName, poolCandidates := range byPool {
 		nodePool := poolCandidates[0].NodePool
 		policy := string(nodePool.Spec.Disruption.ConsolidationPolicy)
-		ConsolidationMovesTotal.Inc(map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, policyLabel: policy})
+		ConsolidationMovesTotal.Inc(map[string]string{decisionLabel: moveDecision, metrics.NodePoolLabel: poolName, PolicyLabel: policy})
 
 		result, scored := perPoolResults[poolName]
 		if !scored {
@@ -271,7 +271,7 @@ func (e *balancedEvaluator) EmitMultiNodeEvents(ctx context.Context, cmd Command
 		if !result.Approved() {
 			poolDecision = string(RejectedDecision)
 		}
-		ConsolidationScoreHistogram.Observe(result.Score(), map[string]string{decisionLabel: poolDecision, metrics.NodePoolLabel: poolName, policyLabel: policy})
+		ConsolidationScoreHistogram.Observe(result.Score(), map[string]string{decisionLabel: poolDecision, metrics.NodePoolLabel: poolName, PolicyLabel: policy})
 
 		if result.Approved() {
 			e.recorder.Publish(disruptionevents.ConsolidationApprovedMultiNode(

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -177,6 +177,7 @@ var _ = Describe("Consolidation", func() {
 	Context("Metrics", func() {
 		BeforeEach(func() {
 			disruption.FailedValidationsTotal.Reset()
+			disruption.NodePoolFailedValidationsTotal.Reset()
 		})
 		It("should correctly report eligible nodes", func() {
 			pod := test.Pod(test.PodOptions{
@@ -226,6 +227,12 @@ var _ = Describe("Consolidation", func() {
 
 			Expect(emptyConsolidation.IsConsolidated()).To(BeFalse())
 			ExpectMetricCounterValue(disruption.FailedValidationsTotal, 1, map[string]string{disruption.ConsolidationTypeLabel: emptyConsolidation.ConsolidationType()})
+			// The same failure is attributed to the NodePool that owns the candidate.
+			ExpectMetricCounterValue(disruption.NodePoolFailedValidationsTotal, 1, map[string]string{
+				metrics.NodePoolLabel:             nodePool.Name,
+				disruption.PolicyLabel:            string(nodePool.Spec.Disruption.ConsolidationPolicy),
+				disruption.ConsolidationTypeLabel: emptyConsolidation.ConsolidationType(),
+			})
 		},
 			Entry("when a candidate is blocked by budgets", WithEmptinessBlockingBudget()),
 			Entry("when candidates are filtered out due to pod churn", WithEmptinessChurn()),
@@ -284,6 +291,13 @@ var _ = Describe("Consolidation", func() {
 
 			Expect(multiNodeConsolidation.IsConsolidated()).To(BeFalse())
 			ExpectMetricCounterValue(disruption.FailedValidationsTotal, 2, map[string]string{disruption.ConsolidationTypeLabel: multiNodeConsolidation.ConsolidationType()})
+			// Both candidates belong to the same NodePool, so the per-NodePool
+			// counter carries the whole failure and reconciles with the aggregate.
+			ExpectMetricCounterValue(disruption.NodePoolFailedValidationsTotal, 2, map[string]string{
+				metrics.NodePoolLabel:             nodePool.Name,
+				disruption.PolicyLabel:            string(nodePool.Spec.Disruption.ConsolidationPolicy),
+				disruption.ConsolidationTypeLabel: multiNodeConsolidation.ConsolidationType(),
+			})
 		},
 			Entry("when candidates are blocked by budgets", WithUnderutilizedBlockingBudget()),
 			Entry("when candidates are filtered out due to pod churn", WithUnderutilizedChurn()),
@@ -327,6 +341,11 @@ var _ = Describe("Consolidation", func() {
 
 			Expect(singleNodeConsolidation.IsConsolidated()).To(BeFalse())
 			ExpectMetricCounterValue(disruption.FailedValidationsTotal, 1, map[string]string{disruption.ConsolidationTypeLabel: singleNodeConsolidation.ConsolidationType()})
+			ExpectMetricCounterValue(disruption.NodePoolFailedValidationsTotal, 1, map[string]string{
+				metrics.NodePoolLabel:             nodePool.Name,
+				disruption.PolicyLabel:            string(nodePool.Spec.Disruption.ConsolidationPolicy),
+				disruption.ConsolidationTypeLabel: singleNodeConsolidation.ConsolidationType(),
+			})
 		},
 			Entry("when a candidate is blocked by budgets", WithUnderutilizedBlockingBudget()),
 			Entry("when candidates are filtered out due to pod churn", WithUnderutilizedChurn()),

--- a/pkg/controllers/disruption/metrics.go
+++ b/pkg/controllers/disruption/metrics.go
@@ -29,7 +29,7 @@ const (
 	decisionLabel                = "decision"
 	ConsolidationTypeLabel       = "consolidation_type"
 	CandidatesIneligible         = "candidates_ineligible"
-	policyLabel                  = "policy"
+	PolicyLabel                  = "policy"
 )
 
 var (
@@ -80,7 +80,7 @@ var (
 		},
 	}
 	Policy = opmetrics.Label{
-		Name: policyLabel,
+		Name: PolicyLabel,
 		Help: "The NodePool consolidation policy in effect for the move.",
 	}
 )
@@ -155,6 +155,16 @@ var (
 			Help:      "Number of candidates that were selected for disruption but failed validation. Labeled by consolidation type.",
 		},
 		[]opmetrics.Label{ConsolidationType},
+	)
+	NodePoolFailedValidationsTotal = opmetrics.NewPrometheusCounter(
+		crmetrics.Registry,
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: voluntaryDisruptionSubsystem,
+			Name:      "failed_validations_by_nodepool_total",
+			Help:      "Number of candidates that were selected for disruption but failed validation, by nodepool. Labeled by nodepool name, consolidation policy, and consolidation type. Summing without the nodepool and policy labels gives failed_validations_total.",
+		},
+		[]opmetrics.Label{metrics.NodePool, Policy, ConsolidationType},
 	)
 	NodePoolAllowedDisruptions = opmetrics.NewPrometheusGauge(
 		crmetrics.Registry,

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 )
 
 type ValidationError struct {
@@ -219,6 +220,32 @@ func (c *ConsolidationValidator) isValid(ctx context.Context, cmd Command, valid
 	return nil
 }
 
+// recordFailedValidations records a validation failure for candidates against
+// both the aggregate counter and the per-NodePool counter, so the two cannot
+// drift apart as new validation paths are added.
+//
+// The aggregate keeps its existing meaning, the number of candidates that
+// failed validation. Each candidate is attributed to its own NodePool, so
+// sum without (nodepool, policy) over the per-NodePool counter equals the
+// aggregate. Cardinality is bounded by NodePool count times two policies times
+// three consolidation types; no per-node or per-NodeClaim label is added.
+func recordFailedValidations(validationType string, candidates ...*Candidate) {
+	if len(candidates) == 0 {
+		return
+	}
+	FailedValidationsTotal.Add(float64(len(candidates)), map[string]string{ConsolidationTypeLabel: validationType})
+	for _, c := range candidates {
+		if c == nil || c.NodePool == nil {
+			continue
+		}
+		NodePoolFailedValidationsTotal.Inc(map[string]string{
+			metrics.NodePoolLabel:  c.NodePool.Name,
+			PolicyLabel:            string(c.NodePool.Spec.Disruption.ConsolidationPolicy),
+			ConsolidationTypeLabel: validationType,
+		})
+	}
+}
+
 func (e *EmptinessValidator) validateCandidates(ctx context.Context, candidates ...*Candidate) ([]*Candidate, error) {
 	// This GetCandidates call filters out nodes that were nominated
 	validatedCandidates, err := GetCandidates(ctx, e.cluster, e.kubeClient, e.recorder, e.clock, e.cloudProvider, e.filter, GracefulDisruptionClass, e.queue)
@@ -227,7 +254,7 @@ func (e *EmptinessValidator) validateCandidates(ctx context.Context, candidates 
 	}
 	validatedCandidates = mapCandidates(candidates, validatedCandidates)
 	if len(validatedCandidates) == 0 {
-		FailedValidationsTotal.Add(float64(len(candidates)), map[string]string{ConsolidationTypeLabel: e.validationType})
+		recordFailedValidations(e.validationType, candidates...)
 		return nil, NewChurnValidationError(fmt.Errorf("%d candidates are no longer valid", len(candidates)))
 	}
 	disruptionBudgetMapping, err := BuildDisruptionBudgetMapping(ctx, e.cluster, e.clock, e.kubeClient, e.cloudProvider, e.recorder, e.reason)
@@ -237,11 +264,11 @@ func (e *EmptinessValidator) validateCandidates(ctx context.Context, candidates 
 
 	if valid := lo.Filter(validatedCandidates, func(cn *Candidate, _ int) bool {
 		if e.cluster.IsNodeNominated(cn.ProviderID()) {
-			FailedValidationsTotal.Inc(map[string]string{ConsolidationTypeLabel: e.validationType})
+			recordFailedValidations(e.validationType, cn)
 			return false
 		}
 		if disruptionBudgetMapping[cn.NodePool.Name] == 0 {
-			FailedValidationsTotal.Inc(map[string]string{ConsolidationTypeLabel: e.validationType})
+			recordFailedValidations(e.validationType, cn)
 			return false
 		}
 		disruptionBudgetMapping[cn.NodePool.Name]--
@@ -269,7 +296,7 @@ func (c *ConsolidationValidator) validateCandidates(ctx context.Context, candida
 	validatedCandidates = mapCandidates(candidates, validatedCandidates)
 	// If we filtered out any candidates, return nil as some NodeClaims in the consolidation decision have changed.
 	if len(validatedCandidates) != len(candidates) {
-		FailedValidationsTotal.Add(float64(len(candidates)), map[string]string{ConsolidationTypeLabel: c.validationType})
+		recordFailedValidations(c.validationType, candidates...)
 		return nil, NewChurnValidationError(fmt.Errorf("%d candidates are no longer valid", len(candidates)-len(validatedCandidates)))
 	}
 	disruptionBudgetMapping, err := BuildDisruptionBudgetMapping(ctx, c.cluster, c.clock, c.kubeClient, c.cloudProvider, c.recorder, c.reason)
@@ -281,11 +308,11 @@ func (c *ConsolidationValidator) validateCandidates(ctx context.Context, candida
 	//  b. Disrupting the candidate would violate node disruption budgets
 	for _, vc := range validatedCandidates {
 		if c.cluster.IsNodeNominated(vc.ProviderID()) {
-			FailedValidationsTotal.Add(float64(len(candidates)), map[string]string{ConsolidationTypeLabel: c.validationType})
+			recordFailedValidations(c.validationType, candidates...)
 			return nil, NewBudgetValidationError(fmt.Errorf("a candidate was nominated during validation"))
 		}
 		if disruptionBudgetMapping[vc.NodePool.Name] == 0 {
-			FailedValidationsTotal.Add(float64(len(candidates)), map[string]string{ConsolidationTypeLabel: c.validationType})
+			recordFailedValidations(c.validationType, candidates...)
 			return nil, NewBudgetValidationError(fmt.Errorf("a candidate can no longer be disrupted without violating budgets"))
 		}
 		disruptionBudgetMapping[vc.NodePool.Name]--


### PR DESCRIPTION
Fixes #3171 (the labeling half)

#3171 asks for two things: count the re-validation failures, and make them attributable. #3306 fixes the undercount and says it leaves the `nodepool` / `policy` half open. This is that half. The two do not overlap in intent, and I have kept the diff so they are easy to land in either order (see the note at the bottom).

## Problem

`karpenter_voluntary_disruption_failed_validations_total` carries only `consolidation_type`. On a cluster with more than a couple of NodePools the metric tells you validations are failing but not where, which is the question you actually have at 2am. The reporter said it directly: there is no way to correlate a re-validation failure with a NodePool or with `Balanced` vs `WhenEmptyOrUnderutilized`.

## Why a second metric instead of adding labels

Adding `nodepool` to an existing counter is a breaking change for every query that does not already aggregate it away, and for recording rules and alerts built on it. This file already solved the same problem the other way: `decisions_total` and `decisions_by_nodepool_total` exist side by side. I followed that.

So: `karpenter_voluntary_disruption_failed_validations_by_nodepool_total`, labeled by `nodepool`, `policy`, `consolidation_type`.

## Semantics

Each candidate is attributed to its own NodePool, which keeps the two metrics reconcilable:

```
sum without (nodepool, policy) (karpenter_voluntary_disruption_failed_validations_by_nodepool_total)
  == karpenter_voluntary_disruption_failed_validations_total
```

That matters because a multi-node consolidation command can hold candidates from several NodePools. Attributing per candidate rather than per command is what makes the sum hold; attributing per command would double count.

**Cardinality.** Bounded by `NodePools x 2 policies x 3 consolidation types`. For 50 NodePools that is 300 series in the worst case, and in practice far fewer since only types that actually fail are emitted. No per-node or per-NodeClaim label is introduced, which is the label that would make this unbounded.

## One helper, so the two cannot drift

All six existing increment sites now call `recordFailedValidations(validationType, candidates...)`. The aggregate behaves exactly as before: the two sites that called `Inc()` pass a single candidate, the four that called `Add(float64(len(candidates)))` pass them all. A new validation path only has to call the helper to get both metrics, which is the failure mode #3171 describes: a path that emits an event and forgets the counter.

This is also why the diff touches `balanced.go`: `policyLabel` becomes `PolicyLabel` so the test assertions can name it, matching the already-exported `ConsolidationTypeLabel`.

## Testing

The three existing `should correctly report invalidated commands` tables (emptiness, multi-node, single-node) now also assert the per-NodePool series, across all nine entries: budget-blocked, pod churn, and node nomination. The multi-node case asserts 2, which is the reconciliation check in miniature.

```
KUBEBUILDER_ASSETS=... go test ./pkg/controllers/disruption/
Ran 316 of 316 Specs
310 Passed | 6 Failed
```

The 6 failures are all `no matches for kind "DeviceClass" in version "resource.k8s.io/v1"` in the DRA specs, from running envtest 1.31 locally rather than anything in this change. Every non-DRA spec passes.

The assertions are load-bearing. Making `recordFailedValidations` skip the per-NodePool emission fails all nine entries with `Metric karpenter_voluntary_disruption_failed_validations_by_nodepool_total should be available`.

`gofmt` and `go vet ./pkg/controllers/disruption/` are clean. I could not run `golangci-lint` locally, the installed version refuses a repo targeting Go 1.26.6, so I am relying on CI for that.

## Note on #3306

The two changes touch neighbouring lines in `validation.go`. If #3306 lands first I will rebase and convert its new increment site to `recordFailedValidations`, which gives the scheduling-rejection path the NodePool attribution too and is the case the issue opens with. If this lands first, #3306 becomes a one-line call to the helper. Happy either way, and happy to fold both into one PR if a maintainer prefers that.

I have not added a `reason` label (`scheduling` vs `churn` vs `budget`). It is arguably the third thing #3171 wants and it multiplies cardinality by three more. Say the word and I will add it here rather than in a follow-up.
