### PR TITLE
docs: add community maintained upcloud providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Karpenter is a multi-cloud project with implementations by the following cloud p
     - [Officially supported and maintained by Oracle](https://github.com/oracle/karpenter-provider-oci)
     - [Maintained by Zoom](https://github.com/zoom/karpenter-oci)
 - [Akamai/Linode](https://github.com/linode/karpenter-provider-linode) (Alpha)
+- UpCloud
+    - [Maintained by kubekanvas](https://github.com/kubekanvas/karpenter-provider-upcloud) (Alpha)
+    - [Maintained by upcloud-tools (community)](https://github.com/upcloud-tools/karpenter-provider-upcloud) (Beta)
 
 ## Community, discussion, contribution, and support
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Adds two available Upcloud providers.

Replaces PR https://github.com/kubernetes-sigs/karpenter/pull/3239

**How was this change tested?**

Not tested; docs change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
